### PR TITLE
[Service Bus] Remove redundant docs between interfaces and implementations

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -207,7 +207,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
    * duration as specified during the Queue/Subscription creation.
    *
    * When the lock on the session expires
-   * - The current receiver can no longer be used to receive mode messages.
+   * - The current receiver can no longer be used to receive more messages.
    * Create a new receiver using the `ServiceBusClient.createSessionReceiver()`.
    * - Messages that were received in `peekLock` mode with this receiver but not yet settled
    * will land back in the Queue/Subscription with their delivery count incremented.

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -206,6 +206,12 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
    * Everytime `renewSessionLock()` is called, this time gets updated to current time plus the lock
    * duration as specified during the Queue/Subscription creation.
    *
+   * When the lock on the session expires
+   * - The current receiver can no longer be used to receive mode messages.
+   * Create a new receiver using the `ServiceBusClient.createSessionReceiver()`.
+   * - Messages that were received in `peekLock` mode with this receiver but not yet settled
+   * will land back in the Queue/Subscription with their delivery count incremented.
+   *
    * @readonly
    */
   public get sessionLockedUntilUtc(): Date | undefined {
@@ -215,6 +221,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
   /**
    * Renews the lock on the session for the duration as specified during the Queue/Subscription
    * creation. You can check the `sessionLockedUntilUtc` property for the time when the lock expires.
+   *
    * When the lock on the session expires
    * - The current receiver can no longer be used to receive mode messages.
    * Create a new receiver using the `ServiceBusClient.createSessionReceiver()`.


### PR DESCRIPTION
The `Receiver` interface is what the user would get as the return type and therefore the docs on the methods in the interface is what gets shown in the editor or API references.

This PR makes the below changes
- Updates the docs on the methods in the interface `Receiver` to reflect the current state of changes
- Removes the docs on the corresponding methods in the implementation. Maintaining two sets of docs would result in one of them getting stale at some point or the other.