### PR TITLE
[storage] version bump up for stg73 preview release

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -58,6 +58,6 @@
     // Allow packages to continue to use old eslint-plugin-azure-sdk until they can adapt to 3.0.0
     "@azure/eslint-plugin-azure-sdk": ["^2.0.1"],
     // Allow storage-blob-changefeed and storage-file-datalake to use the preview version of storage-blob.
-    "@azure/storage-blob": ["^12.2.0-preview.1"]
+    "@azure/storage-blob": ["^12.2.0-rc.1"]
   }
 }

--- a/sdk/storage/storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/storage-blob-changefeed/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Release History
 
-## 12.0.0-preview.1 (2020.6)
-- This preview is the first release supporting Azure Storage Blob Change Feed.
+## 12.0.0-rc.1 (2020.07)
+
+- This is the first release supporting Azure Storage Blob Change Feed.

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob-changefeed",
   "sdk-type": "client",
-  "version": "12.0.0-preview.1",
+  "version": "12.0.0-rc.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob Change Feed",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob-changefeed/src/index.js",
@@ -96,7 +96,7 @@
     ]
   },
   "dependencies": {
-    "@azure/storage-blob": "^12.2.0-preview.1",
+    "@azure/storage-blob": "^12.2.0-rc.1",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.1.1",
     "@azure/core-lro": "^1.0.2",

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 12.2.0-preview.1 (2020.07)
+## 12.2.0-rc.1 (2020.07)
 
+- Updated Azure Storage Service API version to 2019-12-12.
 - Supported quick query. Added a new API `BlockBlobClient.query()`.
-- Increased the maximum block size for Block Blob from 100MiB to 4000MiB(~4GB). And thereby supporting ~200TB maximum size for Block Blob.
-- Added support for blob versioning.
+- Supported blob versioning.
 - Supported blob tags.
+- Increased the maximum block size for Block Blob from 100MiB to 4000MiB(~4GB). And thereby supporting ~200TB maximum size for Block Blob.
 - Added convenience method `createIfNotExists` for `ContainerClient`, `AppendBlobClient` and `PageBlobClient`.
 - Added convenience method `deleteIfExists` for `ContainerClient` and `BlobClients`.
 

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.2.0-preview.1",
+  "version": "12.2.0-rc.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0-preview.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0-rc.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.2.0-preview.1";
+const packageVersion = "12.2.0-rc.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.2.0-preview.1";
+export const SDK_VERSION: string = "12.2.0-rc.1";
 export const SERVICE_VERSION: string = "2019-12-12";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.1.0-preview.1 (2020.07)
+## 12.1.0-rc.1 (2020.07)
 
 - Increased the maximum block size for file from 100MiB to 4000MiB(~4GB). And thereby supporting ~200TB maximum size for file.
 - Added more mappings for Blob and DFS endpoints. [issue #8744](https://github.com/Azure/azure-sdk-for-js/issues/8744).

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.1.0-preview.1",
+  "version": "12.1.0-rc.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",
@@ -99,7 +99,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.2.0-preview.1",
+    "@azure/storage-blob": "^12.2.0-rc.1",
     "events": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.1.0-preview.1";
+export const SDK_VERSION: string = "12.1.0-rc.1";
 export const SERVICE_VERSION: string = "2019-12-12";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.2.0-preview.1 (2020.07)
+## 12.2.0-rc.1 (2020.07)
 
 - Updated Azure Storage Service API version to 2019-12-12.
 - Support 4 TB files.

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.2.0",
+  "version": "12.2.0-rc.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0-rc.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",

--- a/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-file-share";
-const packageVersion = "12.2.0";
+const packageVersion = "12.2.0-rc.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   version: string;

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.2.0";
+export const SDK_VERSION: string = "12.2.0-rc.1";
 export const SERVICE_VERSION: string = "2019-12-12";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 12.1.0 (unreleased)
+## 12.1.0 (2020.07)
 
+- Updated Azure Storage Service API version to 2019-12-12.
 - Added `exists`, `createIfNotExists` and `deleteIfExists` to `QueueClient`.
 
 ## 12.0.5 (2020.05)

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.0.5",
+  "version": "12.1.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.0.5 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",

--- a/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
@@ -257,7 +257,7 @@ export const version: coreHttp.OperationParameter = {
     required: true,
     isConstant: true,
     serializedName: "x-ms-version",
-    defaultValue: '2019-07-07',
+    defaultValue: '2019-12-12',
     type: {
       name: "String"
     }

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "12.0.5";
+const packageVersion = "12.1.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;
@@ -39,7 +39,7 @@ export class StorageClientContext extends coreHttp.ServiceClient {
 
     super(undefined, options);
 
-    this.version = '2019-07-07';
+    this.version = '2019-12-12';
     this.baseUri = "{url}";
     this.requestContentType = "application/json; charset=utf-8";
     this.url = url;

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.5";
-export const SERVICE_VERSION: string = "2019-07-07";
+export const SDK_VERSION: string = "12.1.0";
+export const SERVICE_VERSION: string = "2019-12-12";
 
 /**
  * The OAuth scope to use with Azure Storage.

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -196,13 +196,13 @@ directive:
       $["x-ms-client-name"] = "queueAnalyticsLogging"
 ```
 
-### Update service version from "2018-03-28" to "2019-07-07"
+### Update service version from "2018-03-28" to "2019-12-12"
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2019-07-07" ];
+    transform: $.enum = [ "2019-12-12" ];
 ```
 
 ### Rename AccessPolicy start -> startsOn


### PR DESCRIPTION
[Discussion in Teams](https://teams.microsoft.com/l/message/19:344f6b5b36ba414daa15473942c7477b@thread.skype/1593573639993?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1593573639993&teamName=Azure%20SDK&channelName=Language%20%E2%80%93%20JS%E2%80%89%EF%BC%86%E2%80%89TS%20%F0%9F%90%B1%E2%80%8D%F0%9F%91%A4&createdTime=1593573639993)

Use "rc" for blob, changefeed, datalake, file.
Queue will be GA.