### PR TITLE
[core-http] set minRetryInterval to 50ms for exponential retry

### DIFF
--- a/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
@@ -158,7 +158,7 @@ async function retry(
   retryData = updateRetryData(
     {
       retryInterval: policy.retryInterval,
-      minRetryInterval: 0,
+      minRetryInterval: 50,
       maxRetryInterval: policy.maxRetryInterval
     },
     retryData,


### PR DESCRIPTION
In PR #9667 the initial retry delay was reduced, which result in the initial
delay being zero for exponential retry policy. While retrying immediately should
work in real world scenarios, it caused some Key Vault tests to fail (on MacOS only) 
when they cancel the request in 1 millisecond then expect an `AbortError`.
Immediate retry leads to a different error than `AbortError`.

This change sets minRetryInterval to 50 so we don't retry immediately.