### PR TITLE
[core-http] Fix a regression in exponential retry policy

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix issue with flattened model serialization, where constant properties are being dropped [PR #8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 - Switch to use `x-ms-useragent` header key for passing user agent info in browsers [PR #9490](https://github.com/Azure/azure-sdk-for-js/pull/9490)
 - Refactor `ExponentialRetryPolicy` and `SystemErrorRetryPolicy` to share common code [PR #9667](https://github.com/Azure/azure-sdk-for-js/pull/9490)
-- Fix a regression in ExponentialRetryPolicy where we retried when response is undefined.
+- Fix a regression in ExponentialRetryPolicy where we retried when response is undefined [PR #9852](https://github.com/Azure/azure-sdk-for-js/pull/9852)
 
 ## 1.1.3 (2020-06-03)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 1.1.4 (2020-06-30)
+## 1.1.4 (2020-07-02)
 
 - Fix issue with flattened model serialization, where constant properties are being dropped [PR #8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 - Switch to use `x-ms-useragent` header key for passing user agent info in browsers [PR #9490](https://github.com/Azure/azure-sdk-for-js/pull/9490)
 - Refactor `ExponentialRetryPolicy` and `SystemErrorRetryPolicy` to share common code [PR #9667](https://github.com/Azure/azure-sdk-for-js/pull/9490)
+- Fix a regression in ExponentialRetryPolicy where we retried when response is undefined.
 
 ## 1.1.3 (2020-06-03)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Fix issue with flattened model serialization, where constant properties are being dropped [PR #8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 - Switch to use `x-ms-useragent` header key for passing user agent info in browsers [PR #9490](https://github.com/Azure/azure-sdk-for-js/pull/9490)
 - Refactor `ExponentialRetryPolicy` and `SystemErrorRetryPolicy` to share common code [PR #9667](https://github.com/Azure/azure-sdk-for-js/pull/9490)
-- Fix a regression in ExponentialRetryPolicy where we retried when response is undefined [PR #9852](https://github.com/Azure/azure-sdk-for-js/pull/9852)
 
 ## 1.1.3 (2020-06-03)
 

--- a/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
@@ -141,7 +141,7 @@ async function retry(
   requestError?: RetryError
 ): Promise<HttpOperationResponse> {
   function shouldPolicyRetry(response?: HttpOperationResponse): boolean {
-    const statusCode = response && response.status;
+    const statusCode = response?.status;
     if (
       statusCode === undefined ||
         (statusCode < 500 && statusCode !== 408) ||

--- a/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
@@ -141,16 +141,14 @@ async function retry(
   requestError?: RetryError
 ): Promise<HttpOperationResponse> {
   function shouldPolicyRetry(response?: HttpOperationResponse): boolean {
-    if (response) {
-      const statusCode = response.status;
-      if (
-        statusCode === undefined ||
+    const statusCode = response && response.status;
+    if (
+      statusCode === undefined ||
         (statusCode < 500 && statusCode !== 408) ||
         statusCode === 501 ||
         statusCode === 505
-      ) {
-        return false;
-      }
+    ) {
+      return false;
     }
     return true;
   }
@@ -168,9 +166,9 @@ async function retry(
   const isAborted: boolean | undefined = request.abortSignal && request.abortSignal.aborted;
   if (!isAborted && shouldRetry(policy.retryCount, shouldPolicyRetry, retryData, response)) {
     logger.info(`Retrying request in ${retryData.retryInterval}`);
-    await utils.delay(retryData.retryInterval);
-    const res = await policy._nextPolicy.sendRequest(request.clone());
     try {
+      await utils.delay(retryData.retryInterval);
+      const res = await policy._nextPolicy.sendRequest(request.clone());
       return retry(policy, request, res, retryData);
     } catch (err) {
       return retry(policy, request, response, retryData, err);

--- a/sdk/core/core-http/test/policies/exponentialRetryPolicyTests.spec.ts
+++ b/sdk/core/core-http/test/policies/exponentialRetryPolicyTests.spec.ts
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { ExponentialRetryPolicy } from "../../src/policies/exponentialRetryPolicy";
+import { WebResource } from "../../src/webResource";
+import { HttpOperationResponse } from "../../src/httpOperationResponse";
+import { HttpHeaders, RequestPolicyOptions } from "../../src/coreHttp";
+
+describe("ExponentialRetryPolicy", () => {
+  class PassThroughPolicy {
+    constructor(private _response: HttpOperationResponse) { }
+    public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+      const response = {
+        ...this._response,
+        request: request
+      };
+
+      return Promise.resolve(response);
+    }
+  }
+
+  // Return response with the given status code on first sendRequest()
+  class FailFirstRequestPolicy {
+    public count = 0;
+    constructor(private _response: HttpOperationResponse, private statusCode: number) { }
+    public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+      this.count++;
+      if (this.count === 1) {
+        const res = {
+          status: this.statusCode,
+          request: request,
+          headers: new HttpHeaders()
+        };
+        return Promise.resolve(res);
+      }
+
+      return Promise.resolve({ ...this._response, request: request });
+    }
+  }
+
+  const defaultResponse = {
+    status: 200,
+    request: new WebResource(),
+    headers: new HttpHeaders()
+  };
+
+  function createDefaultExponentialRetryPolicy(
+    response?: HttpOperationResponse
+  ): ExponentialRetryPolicy {
+    if (!response) {
+      response = defaultResponse;
+    }
+
+    const passThroughPolicy = new PassThroughPolicy(response);
+    return new ExponentialRetryPolicy(passThroughPolicy, new RequestPolicyOptions());
+  }
+
+  describe("sendRequest", () => {
+    it("should clone the request", async () => {
+      const request = new WebResource();
+      const nextPolicy = {
+        sendRequest: (requestToSend: WebResource): Promise<HttpOperationResponse> => {
+          assert(request !== requestToSend);
+          return Promise.resolve(defaultResponse);
+        }
+      };
+      const policy = new ExponentialRetryPolicy(nextPolicy, new RequestPolicyOptions());
+      await policy.sendRequest(request);
+    });
+
+    it("should not modify the request", async () => {
+      const request = new WebResource();
+      request.url = "http://url";
+      request.method = "PATCH";
+      request.body = { someProperty: "someValue" };
+      request.headers = new HttpHeaders({ header: "abc" });
+      request.query = { q: "param" };
+
+      const policy = createDefaultExponentialRetryPolicy();
+      const response = await policy.sendRequest(request);
+      delete response.request.requestId;
+      delete request.requestId;
+
+      assert.deepEqual(response.request, request);
+    });
+
+    [408, 502, 506].forEach((code) => {
+      it(`should retry if the status code is ${code}`, async () => {
+        const request = new WebResource();
+        const mockResponse = {
+          status: 200,
+          headers: new HttpHeaders(),
+          request: request
+        };
+
+        const faultyPolicy = new FailFirstRequestPolicy(mockResponse, code);
+        const policy = new ExponentialRetryPolicy(
+          faultyPolicy,
+          new RequestPolicyOptions(),
+          3,
+          10,
+          20
+        );
+
+        const response = await policy.sendRequest(request);
+        delete request.requestId;
+        delete response.request.requestId;
+        assert.deepEqual(response, mockResponse, "Expecting response matches after retrying");
+        assert.ok(faultyPolicy.count > 1, "Retry should have happened");
+      });
+    });
+
+    [404, 501, 505].forEach((code) => {
+      it("should do nothing when status code is retriable", async () => {
+        const request = new WebResource();
+        const response = {
+          status: code,
+          request: request,
+          headers: new HttpHeaders(),
+        }
+        const faultyPolicy = new FailFirstRequestPolicy(response, code);
+        const policy = new ExponentialRetryPolicy(
+          faultyPolicy,
+          new RequestPolicyOptions(),
+          3,
+          10,
+          20
+        );
+
+        const result = await policy.sendRequest(request);
+        assert.equal(result.status, code, "Unexpected response status code")
+        assert.equal(faultyPolicy.count, 1, "Retry should NOT have happened");
+      });
+    });
+
+    [408, 502, 506].forEach((code) => {
+      it(`should return after max retry count for retriable status code ${code}`, async () => {
+        class FailEveryRequestPolicy {
+          public count = 0;
+          constructor(private code: number) { }
+          public sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
+            this.count++;
+            const response = {
+              status: this.code,
+              request: new WebResource(),
+              headers: new HttpHeaders()
+            };
+            return Promise.resolve(response);
+          }
+        }
+        const request = new WebResource();
+        const faultyPolicy = new FailEveryRequestPolicy(code);
+        const policy = new ExponentialRetryPolicy(
+          faultyPolicy,
+          new RequestPolicyOptions(),
+          3,
+          10,
+          20
+        );
+
+        const res = await policy.sendRequest(request);
+        assert.equal(res.status, code, "Unexpected response status code");
+        assert.ok(faultyPolicy.count > 1, "Retry should have happened");
+      });
+    });
+
+    it("should not retry when error is thrown", async () => {
+      class FailRequestPolicy {
+        public count = 0;
+        public sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
+          this.count++;
+          return Promise.reject(new Error("Unknown Error"));
+        }
+      }
+      const request = new WebResource();
+      const faultyPolicy = new FailRequestPolicy();
+      const policy = new ExponentialRetryPolicy(
+        faultyPolicy,
+        new RequestPolicyOptions(),
+        3,
+        10,
+        20
+      );
+
+      try {
+        await policy.sendRequest(request);
+        assert.fail("Expecting that an error has been thrown");
+      } catch (err) {
+        assert.equal((err as Error).message, "Unknown Error");
+        assert.equal(faultyPolicy.count, 1, "Retry should NOT have happened");
+      }
+    });
+  });
+}).timeout(60000);

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -136,7 +136,7 @@ describe("Certificates client - list certificates in various ways", () => {
 
   if (isNode && !isPlaybackMode()) {
     // On playback mode, the tests happen too fast for the timeout to work
-    it("can get several inserted certificates with requestOptions timeout", async function() {
+    it.only("can get several inserted certificates with requestOptions timeout", async function() {
       const iter = client.listPropertiesOfCertificates({ requestOptions: { timeout: 1 } });
       await assertThrowsAbortError(async () => {
         await iter.next();
@@ -170,7 +170,7 @@ describe("Certificates client - list certificates in various ways", () => {
   });
 
   // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it("list deleted certificates with requestOptions timeout", async function() {
+  it.only("list deleted certificates with requestOptions timeout", async function() {
     recorder.skip("browser", "Timeout tests don't work on playback mode.");
     const iter = client.listDeletedCertificates({ requestOptions: { timeout: 1 } });
     await assertThrowsAbortError(async () => {
@@ -225,7 +225,7 @@ describe("Certificates client - list certificates in various ways", () => {
   });
 
   // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it("can get the versions of a certificate with requestOptions timeout", async function() {
+  it.only("can get the versions of a certificate with requestOptions timeout", async function() {
     recorder.skip("browser", "Timeout tests don't work on playback mode.");
     const iter = client.listPropertiesOfCertificateVersions("doesn't matter", {
       requestOptions: { timeout: 1 }

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -136,7 +136,7 @@ describe("Certificates client - list certificates in various ways", () => {
 
   if (isNode && !isPlaybackMode()) {
     // On playback mode, the tests happen too fast for the timeout to work
-    it.only("can get several inserted certificates with requestOptions timeout", async function() {
+    it("can get several inserted certificates with requestOptions timeout", async function() {
       const iter = client.listPropertiesOfCertificates({ requestOptions: { timeout: 1 } });
       await assertThrowsAbortError(async () => {
         await iter.next();
@@ -170,7 +170,7 @@ describe("Certificates client - list certificates in various ways", () => {
   });
 
   // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it.only("list deleted certificates with requestOptions timeout", async function() {
+  it("list deleted certificates with requestOptions timeout", async function() {
     recorder.skip("browser", "Timeout tests don't work on playback mode.");
     const iter = client.listDeletedCertificates({ requestOptions: { timeout: 1 } });
     await assertThrowsAbortError(async () => {
@@ -225,7 +225,7 @@ describe("Certificates client - list certificates in various ways", () => {
   });
 
   // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it.only("can get the versions of a certificate with requestOptions timeout", async function() {
+  it("can get the versions of a certificate with requestOptions timeout", async function() {
     recorder.skip("browser", "Timeout tests don't work on playback mode.");
     const iter = client.listPropertiesOfCertificateVersions("doesn't matter", {
       requestOptions: { timeout: 1 }


### PR DESCRIPTION
The refactoring in PR #9667 introduce a behavior change: when the response is
undefined we retry.  This is different from the previous behavior that we don't
retry on undefined response or response.status.

Also the `delay()` and `_nextPolicy.sendRequest()` call should be inside the
try-block.