### PR TITLE
[Identity] Fix warning on unresolved dependencies

### DIFF
--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -12,7 +12,7 @@ const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["crypto", "events", "fs", "child-process"];
+  const externalNodeBuiltins = ["crypto", "events", "fs", "child_process"];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),


### PR DESCRIPTION
This PR fixes the rollup script to avoid the below warning

<img width="576" alt="Screen Shot 2020-07-01 at 6 27 58 PM" src="https://user-images.githubusercontent.com/16890566/86306249-9cfe8280-bbc8-11ea-8703-ca3c905f3686.png">
