### PR TITLE
[Keyvault] Fix warning on unresolved dependencies

### DIFF
--- a/sdk/keyvault/keyvault-keys/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.base.config.js
@@ -30,7 +30,7 @@ const depNames = Object.keys(pkg.dependencies);
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["crypto", "fs", "os", "url", "assert"];
+  const externalNodeBuiltins = ["crypto", "fs", "os", "url", "assert", "constants"];
   const additionalExternals = ["keytar"];
   const baseConfig = {
     input: "dist-esm/keyvault-keys/src/index.js",


### PR DESCRIPTION
This PR fixes the rollup script to avoid the below warning

<img width="579" alt="Screen Shot 2020-07-01 at 6 36 15 PM" src="https://user-images.githubusercontent.com/16890566/86306696-ca97fb80-bbc9-11ea-9d9b-c5299192bcd6.png">
