### PR TITLE
[Cosmos] Fail build on lint errors

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -50,7 +50,7 @@
     "build:src": "echo Using TypeScript && tsc --version && tsc -b --pretty",
     "build:test": "tsc",
     "build:types": "downlevel-dts dist/types/latest dist/types/3.1",
-    "build": "npm run clean && npm run lint && npm run extract-api && npm run build:types && node writeSDKVersion.js && npm run bundle",
+    "build": "npm run clean && tslint --project ./tsconfig.json && npm run extract-api && npm run build:types && node writeSDKVersion.js && npm run bundle",
     "bundle": "rollup -c",
     "bundle-types": "node bundle-types.js",
     "check-format": "prettier --list-different --config ../../.prettierrc.json --ignore-path ../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",


### PR DESCRIPTION
In #8936, the `build` script was made to use the `lint` script, but the `lint` script uses eslint and is not yet ready to be turned on due to the multiple errors that still need to be fixed.

This PR gets us back to the temporary fix we had put in place in #5429 so that we continue maintaining status quo for some more time