### PR TITLE
Update eslint plugin version to 3.0

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -55,8 +55,6 @@
     // Exception for storage before the preview release
     "@azure/core-http": ["^1.1.1"],
 
-    // Allow packages to continue to use old eslint-plugin-azure-sdk until they can adapt to 3.0.0
-    "@azure/eslint-plugin-azure-sdk": ["^2.0.1"],
     // Allow storage-blob-changefeed and storage-file-datalake to use the preview version of storage-blob.
     "@azure/storage-blob": ["^12.2.0-rc.1"]
   }

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -62,7 +62,7 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/common/setup.ts \"./test/**/*.spec.ts\" --timeout 100000",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix",
+    "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o cosmos-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
@@ -93,7 +93,7 @@
     "uuid": "^8.1.0"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^2.0.1",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -46,7 +46,7 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix",
+    "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o event-processor-host-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
@@ -76,7 +76,7 @@
     "uuid": "^8.1.0"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^2.0.1",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",


### PR DESCRIPTION
This PR updates the last 2 packages in the repo that were still using v2 of the eslint plugin 

