### PR TITLE
[Storage] avoid importing fs directly in exporting modules

### DIFF
--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as fs from "fs";
 import { Readable } from "stream";
 
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -123,7 +122,12 @@ import {
   toBlobTags,
   toTags
 } from "./utils/utils.common";
-import { fsStat, readStreamToLocalFile, streamToBuffer } from "./utils/utils.node";
+import {
+  fsStat,
+  readStreamToLocalFile,
+  streamToBuffer,
+  fsCreateReadStream
+} from "./utils/utils.node";
 import { Batch } from "./utils/Batch";
 import { createSpan } from "./utils/tracing";
 import { CommonOptions, StorageClient } from "./StorageClient";
@@ -4314,7 +4318,7 @@ export class BlockBlobClient extends BlobClient {
       const size = (await fsStat(filePath)).size;
       return await this.uploadResetableStream(
         (offset, count) =>
-          fs.createReadStream(filePath, {
+          fsCreateReadStream(filePath, {
             autoClose: true,
             end: count ? offset + count - 1 : Infinity,
             start: offset
@@ -6380,7 +6384,7 @@ export interface ContainerDeleteBlobOptions extends BlobDeleteOptions {
   /**
    * An opaque DateTime value that, when present, specifies the version
    * of the blob to delete. It's for service version 2019-10-10 and newer.
-   * 
+   *
    * @type {string}
    * @memberof ContainerDeleteBlobOptions
    */

--- a/sdk/storage/storage-blob/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.browser.ts
@@ -44,3 +44,5 @@ export function streamToBuffer2() {}
 export function readStreamToLocalFile() {}
 
 export const fsStat = function stat() {};
+
+export const fsCreateReadStream = function createReadStream() {};

--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -144,3 +144,5 @@ export async function readStreamToLocalFile(
  * Promisified version of fs.stat().
  */
 export const fsStat = util.promisify(fs.stat);
+
+export const fsCreateReadStream = fs.createReadStream;

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -78,8 +78,7 @@ import {
 } from "./utils/constants";
 import { BufferScheduler } from "./utils/BufferScheduler";
 import { Batch } from "./utils/Batch";
-import { fsStat } from "./utils/utils.node";
-import * as fs from "fs";
+import { fsStat, fsCreateReadStream } from "./utils/utils.node";
 
 /**
  * A DataLakePathClient represents a URL to the Azure Storage path (directory or file).
@@ -1316,7 +1315,7 @@ export class DataLakeFileClient extends DataLakePathClient {
       return await this.uploadData(
         (offset: number, size: number) => {
           return () =>
-            fs.createReadStream(filePath, {
+            fsCreateReadStream(filePath, {
               autoClose: true,
               end: offset + size - 1,
               start: offset

--- a/sdk/storage/storage-file-datalake/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.browser.ts
@@ -38,3 +38,5 @@ export async function blobToString(blob: Blob): Promise<string> {
 }
 
 export const fsStat = function stat() {};
+
+export const fsCreateReadStream = function createReadStream() {};

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -180,3 +180,5 @@ export async function readStreamToLocalFile(
  * Promisified version of fs.stat().
  */
 export const fsStat = util.promisify(isNode ? fs.stat : function stat() {});
+
+export const fsCreateReadStream = fs.createReadStream;

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as fs from "fs";
 import { HttpRequestBody, HttpResponse, isNode, TransferProgressEvent } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/api";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -56,7 +55,12 @@ import { Batch } from "./utils/Batch";
 import { BufferScheduler } from "./utils/BufferScheduler";
 import { Readable } from "stream";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
-import { readStreamToLocalFile, streamToBuffer, fsStat } from "./utils/utils.node";
+import {
+  readStreamToLocalFile,
+  streamToBuffer,
+  fsStat,
+  fsCreateReadStream
+} from "./utils/utils.node";
 import { FileSystemAttributes } from "./FileSystemAttributes";
 import { getShareNameAndPathFromUrl } from "./utils/utils.common";
 import { createSpan } from "./utils/tracing";
@@ -2004,7 +2008,7 @@ export class ShareFileClient extends StorageClient {
       const size = (await fsStat(filePath)).size;
       return await this.uploadResetableStream(
         (offset, count) =>
-          fs.createReadStream(filePath, {
+          fsCreateReadStream(filePath, {
             autoClose: true,
             end: count ? offset + count - 1 : Infinity,
             start: offset

--- a/sdk/storage/storage-file-share/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.browser.ts
@@ -24,3 +24,5 @@ export function streamToBuffer() {}
 export function readStreamToLocalFile() {}
 
 export const fsStat = function stat() {};
+
+export const fsCreateReadStream = function createReadStream() {};

--- a/sdk/storage/storage-file-share/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.node.ts
@@ -99,3 +99,5 @@ export async function readStreamToLocalFile(
  * Promisified version of fs.stat().
  */
 export const fsStat = util.promisify(fs.stat);
+
+export const fsCreateReadStream = fs.createReadStream;


### PR DESCRIPTION
Put them in utils.node instead, and add stubs for browsers.