### PR TITLE
[ai-form-recognizer] Anticipating support for non-text field elements

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-preview.4 (Unreleased)
 
 - [Breaking] Rename the `textContent` field of the `FieldData` and `FormTableCell` types to `fieldElements` to mirror the change in its type.
-- [Breaking] Rename the `FormField` type's `labelText` and `valueText` fields to `labelText` and `valueData` respectively, to mirror the change of their type to `FieldData`;
+- [Breaking] Rename the `FormField` type's `labelText` and `valueText` fields to `labelData` and `valueData` respectively, to mirror the change of their type to `FieldData`;
 - [Breaking] Rename the `includeTextContent` request option to `includeFieldElements` to mirror the change to `FieldData` and `FormElement`.
 - [Breaking] Rename `FieldText` to `FieldData` and `FormContent` to `FormElement` to reflect that fields may contain more than textual information.
 - [Breaking] Rename `includeTextDetails` to `includeTextContent` in custom form and receipt recognition options to be consistent with other languages.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-preview.4 (Unreleased)
 
+- [Breaking] Rename the `textContent` field of the `FieldData` and `FormTableCell` types to `fieldElements` to mirror the change in its type.
+- [Breaking] Rename the `FormField` type's `labelText` and `valueText` fields to `labelText` and `valueData` respectively, to mirror the change of their type to `FieldData`;
+- [Breaking] Rename the `includeTextContent` request option to `includeFieldElements` to mirror the change to `FieldData` and `FormElement`.
+- [Breaking] Rename `FieldText` to `FieldData` and `FormContent` to `FormElement` to reflect that fields may contain more than textual information.
 - [Breaking] Rename `includeTextDetails` to `includeTextContent` in custom form and receipt recognition options to be consistent with other languages.
 - [Breaking] Rename properties `requestedOn` to `trainingStartedOn` and `completedOn` to `trainingCompletedOn` in `CustomFormModel` and `CustomFormModelInfo` types.
 

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -143,9 +143,9 @@ export interface BeginTrainingPollState extends PollOperationState<CustomFormMod
 export interface CommonFieldValue {
     boundingBox?: Point2D[];
     confidence?: number;
+    fieldElements?: FormElement[];
     pageNumber?: number;
     text?: string;
-    textContent?: FormContent[];
 }
 
 // @public
@@ -215,32 +215,32 @@ export interface CustomFormSubmodel {
 export type DeleteModelOptions = FormRecognizerOperationOptions;
 
 // @public
-export interface FieldText {
+export interface FieldData {
     boundingBox?: Point2D[];
+    fieldElements?: FormElement[];
     pageNumber: number;
     text?: string;
-    textContent?: FormContent[];
-}
-
-// @public
-export type FormContent = FormWord | FormLine;
-
-// @public
-export interface FormContentCommon {
-    boundingBox: Point2D[];
-    pageNumber: number;
-    text: string;
 }
 
 // @public
 export type FormContentType = "application/pdf" | "image/jpeg" | "image/png" | "image/tiff";
 
 // @public
+export type FormElement = FormWord | FormLine;
+
+// @public
+export interface FormElementCommon {
+    boundingBox: Point2D[];
+    pageNumber: number;
+    text: string;
+}
+
+// @public
 export type FormField = {
     confidence?: number;
-    labelText?: FieldText;
+    labelData?: FieldData;
     name?: string;
-    valueText?: FieldText;
+    valueData?: FieldData;
 } & ({
     value?: string;
     valueType?: "string";
@@ -276,7 +276,7 @@ export interface FormFieldsReport {
 }
 
 // @public
-export interface FormLine extends FormContentCommon {
+export interface FormLine extends FormElementCommon {
     kind: "line";
     words: FormWord[];
 }
@@ -355,12 +355,12 @@ export interface FormTableCell {
     columnIndex: number;
     columnSpan?: number;
     confidence: number;
+    fieldElements?: FormElement[];
     isFooter?: boolean;
     isHeader?: boolean;
     rowIndex: number;
     rowSpan?: number;
     text: string;
-    textContent?: FormContent[];
 }
 
 // @public
@@ -383,7 +383,7 @@ export class FormTrainingClient {
     }
 
 // @public
-export interface FormWord extends FormContentCommon {
+export interface FormWord extends FormElementCommon {
     confidence?: number;
     containingLine?: FormLine;
     kind: "word";
@@ -521,7 +521,7 @@ export interface RecognizedReceiptArray extends Array<RecognizedReceipt> {
 
 // @public
 export type RecognizeFormsOptions = FormRecognizerOperationOptions & {
-    includeTextContent?: boolean;
+    includeFieldElements?: boolean;
 };
 
 // @public
@@ -534,7 +534,7 @@ export type RecognizeReceiptPollerClient = {
 
 // @public
 export type RecognizeReceiptsOptions = FormRecognizerOperationOptions & {
-    includeTextContent?: boolean;
+    includeFieldElements?: boolean;
 };
 
 export { RestResponse }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
@@ -50,7 +50,7 @@ async function main() {
       // The recognized form fields with a custom model from training without labels will also include data about recognized labels.
       const field = form.fields[fieldName];
       console.log(
-        `\tField ${fieldName} has label '${field.labelText.text}' with a confidence score of ${field.confidence}`
+        `\tField ${fieldName} has label '${field.labelData.text}' with a confidence score of ${field.confidence}`
       );
       console.log(
         `\tField ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
@@ -43,8 +43,8 @@ async function main() {
       // each field is of type FormField
       const field = form.fields[fieldName];
       const boundingBox =
-        field.valueText && field.valueText.boundingBox
-          ? field.valueText.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
+        field.valueData && field.valueData.boundingBox
+          ? field.valueData.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
           : "N/A";
       console.log(
         `    Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
@@ -62,7 +62,7 @@ async function main() {
             console.log(
               `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
             );
-            for (const element of cell.textContent || []) {
+            for (const element of cell.fieldElements || []) {
               const boundingBox = element.boundingBox
                 ? element.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
                 : "N/A";

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
@@ -20,7 +20,7 @@ async function main() {
     "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/contoso-allinone.jpg";
 
   const poller = await client.beginRecognizeReceiptsFromUrl(url, {
-    includeTextContent: true,
+    includeFieldElements: true,
     onProgress: (state) => {
       console.log(`analyzing status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
@@ -55,7 +55,7 @@ export async function main() {
       // The recognized form fields with an unlabeled custom model will also include data about recognized labels.
       const field = form.fields[fieldName];
       console.log(
-        `  Field ${fieldName} has label '${field.labelText?.text}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has label '${field.labelData?.text}' with a confidence score of ${field.confidence}`
       );
       console.log(
         `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
@@ -43,8 +43,8 @@ export async function main() {
       // each field is of type FormField
       const field = form.fields[fieldName];
       const boundingBox =
-        field.valueText && field.valueText.boundingBox
-          ? field.valueText.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
+        field.valueData && field.valueData.boundingBox
+          ? field.valueData.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
           : "N/A";
       console.log(
         `    Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
@@ -62,7 +62,7 @@ export async function main() {
             console.log(
               `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
             );
-            for (const element of cell.textContent || []) {
+            for (const element of cell.fieldElements || []) {
               const boundingBox = element.boundingBox
                 ? element.boundingBox.map((p) => `[$.2d{p.x},${p.y}]`).join(", ")
                 : "N/A";

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
@@ -20,7 +20,7 @@ export async function main() {
     "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/contoso-allinone.jpg";
 
   const poller = await client.beginRecognizeReceiptsFromUrl(url, {
-    includeTextContent: true,
+    includeFieldElements: true,
     onProgress: (state) => {
       console.log(`analyzing status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -106,10 +106,7 @@ export type BeginRecognizeContentOptions = RecognizeContentOptions & {
 /**
  * The Long-Running-Operation (LRO) poller that allows you to wait until form content is recognized.
  */
-export type ContentPollerLike = PollerLike<
-  PollOperationState<FormPageArray>,
-  FormPageArray
->;
+export type ContentPollerLike = PollerLike<PollOperationState<FormPageArray>, FormPageArray>;
 
 /**
  * Options for retrieving recognized content data
@@ -123,7 +120,7 @@ export type RecognizeFormsOptions = FormRecognizerOperationOptions & {
   /**
    * Specifies whether to include text lines and element references in the result
    */
-  includeTextContent?: boolean;
+  includeFieldElements?: boolean;
 };
 
 /**
@@ -164,7 +161,7 @@ export type RecognizeReceiptsOptions = FormRecognizerOperationOptions & {
   /**
    * Specifies whether to include text lines and element references in the result
    */
-  includeTextContent?: boolean;
+  includeFieldElements?: boolean;
 };
 
 /**
@@ -627,7 +624,7 @@ export class FormRecognizerClient {
    * const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
    * const poller = await client.beginRecognizeReceiptsFromUrl(
    *   url, {
-   *     includeTextContent: true,
+   *     includeFieldElements: true,
    *     onProgress: (state) => { console.log(`analyzing status: ${state.status}`); }
    * });
    * const receipts = await poller.pollUntilDone();
@@ -771,7 +768,7 @@ async function recognizeCustomFormInternal(
 ): Promise<AnalyzeWithCustomModelResponseModel> {
   const { span, updatedOptions: finalOptions } = createSpan("analyzeCustomFormInternal", {
     ...options,
-    includeTextDetails: options.includeTextContent
+    includeTextDetails: options.includeFieldElements
   });
   const requestBody = await toRequestBody(body);
   const requestContentType = contentType ? contentType : await getContentType(requestBody);
@@ -810,10 +807,10 @@ async function recognizeReceiptInternal(
   options?: RecognizeReceiptsOptions,
   _modelId?: string
 ): Promise<AnalyzeReceiptAsyncResponseModel> {
-  const realOptions = options || { includeTextContent: false };
+  const realOptions = options || { includeFieldElements: false };
   const { span, updatedOptions: finalOptions } = createSpan("analyzeReceiptInternal", {
     ...realOptions,
-    includeTextDetails: realOptions.includeTextContent
+    includeTextDetails: realOptions.includeFieldElements
   });
   const requestBody = await toRequestBody(body);
   const requestContentType =

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -48,9 +48,9 @@ export interface Point2D {
 }
 
 /**
- * Represents common properties of recognized form contents.
+ * Represents common properties of recognized form elements.
  */
-export interface FormContentCommon {
+export interface FormElementCommon {
   /**
    * The 1-based page number in the input document.
    */
@@ -60,15 +60,15 @@ export interface FormContentCommon {
    */
   text: string;
   /**
-   * Bounding box of an recognized word.
+   * Bounding box of a recognized word.
    */
   boundingBox: Point2D[];
 }
 
 /**
- * Represents an recognized word.
+ * Represents a recognized word.
  */
-export interface FormWord extends FormContentCommon {
+export interface FormWord extends FormElementCommon {
   /**
    * Element kind - "word"
    */
@@ -84,9 +84,9 @@ export interface FormWord extends FormContentCommon {
 }
 
 /**
- * Represents an recognized text line.
+ * Represents a recognized text line.
  */
-export interface FormLine extends FormContentCommon {
+export interface FormLine extends FormElementCommon {
   /**
    * Element kind - "line"
    */
@@ -103,9 +103,9 @@ export interface FormLine extends FormContentCommon {
 }
 
 /**
- * Represents an recognized check box
+ * Represents a recognized check box
  */
-// export interface FormCheckBox extends FormContent {
+// export interface FormCheckBox extends FormElement {
 //   /**
 //    * Element kind - "checkbox"
 //    */
@@ -114,10 +114,10 @@ export interface FormLine extends FormContentCommon {
 // }
 
 /**
- * Information about an recognized element in the form. Examples include
+ * Information about a recognized element in the form. Examples include
  * words, lines, checkbox, etc.
  */
-export type FormContent = FormWord | FormLine; // | FormCheckBox;
+export type FormElement = FormWord | FormLine; // | FormCheckBox;
 
 /**
  * Represents a cell in recognized table
@@ -152,9 +152,9 @@ export interface FormTableCell {
    */
   confidence: number;
   /**
-   * When includeTextContent is set to true, a list of references to the text elements constituting this table cell.
+   * When includeFieldElements is set to true, a list of references to the elements constituting this table cell.
    */
-  textContent?: FormContent[];
+  fieldElements?: FormElement[];
   /**
    * Is the current cell a header cell?
    */
@@ -194,11 +194,11 @@ export interface FormTable {
 }
 
 /**
- * Represents recognized text elements of label-value pairs.
+ * Represents recognized elements of label-value pairs.
  * For example, "Work Address" is the label of
  * "Work Address: One Microsoft Way, Redmond, WA"
  */
-export interface FieldText {
+export interface FieldData {
   /**
    * The 1-based page number in the input document.
    */
@@ -208,9 +208,10 @@ export interface FieldText {
    */
   boundingBox?: Point2D[];
   /**
-   * When includeTextContent is set to true, a list of references to the text elements constituting this name or value.
+   * When includeFieldElements is set to true, a list of references to the
+   * form elements that constitute this label-value pair.
    */
-  textContent?: FormContent[];
+  fieldElements?: FormElement[];
   /**
    * The text content of the recognized label or value
    */
@@ -227,49 +228,57 @@ export type FormField = {
    */
   confidence?: number;
   /**
-   * Text of the recognized label of the field.
+   * Contains the recognized field label's text, bounding box, and field elements.
    */
-  labelText?: FieldText;
+  labelData?: FieldData;
   /**
    * A user defined label for the field.
    */
   name?: string;
   /**
-   * Text of the recognized value of the field.
+   * Contains the recognized field value's text, bounding box, and field elements.
    */
-  valueText?: FieldText;
+  valueData?: FieldData;
 } & (
   | {
-    /**
-     * value of the recognized field.
-     */
-    value?: string;
-    /**
-     * Type of the 'value' field
-     */
-    valueType?: "string" }
+      /**
+       * value of the recognized field.
+       */
+      value?: string;
+      /**
+       * Type of the 'value' field
+       */
+      valueType?: "string";
+    }
   | {
-    value?: number;
-    valueType?: "number" }
+      value?: number;
+      valueType?: "number";
+    }
   | {
-    value?: Date;
-    valueType?: "date" }
+      value?: Date;
+      valueType?: "date";
+    }
   | {
-    value?: string;
-    valueType?: "time" }
+      value?: string;
+      valueType?: "time";
+    }
   | {
-    value?: string;
-    valueType?: "phoneNumber" }
+      value?: string;
+      valueType?: "phoneNumber";
+    }
   | {
-    value?: number;
-    valueType?: "integer" }
+      value?: number;
+      valueType?: "integer";
+    }
   | {
-    value?: FormField[];
-    valueType?: "array" }
+      value?: FormField[];
+      valueType?: "array";
+    }
   | {
-    value?: { [propertyName: string]: FormField };
-    valueType?: "object" }
-)
+      value?: { [propertyName: string]: FormField };
+      valueType?: "object";
+    }
+);
 
 /**
  * Represents a Form page range
@@ -316,7 +325,7 @@ export interface FormPage {
    */
   // language?: Language;
   /**
-   * When includeTextContent is set to true, a list of recognized text lines. The maximum number of
+   * When `includeFieldElements` is set to true, a list of recognized text lines. The maximum number of
    * lines returned is 300 per page. The lines are sorted top to bottom, left to right, although in
    * certain cases proximity is treated with higher priority. As the sorting order depends on the
    * detected text, it may change across images and OCR version updates. Thus, business logic
@@ -378,10 +387,10 @@ export interface CommonFieldValue {
    */
   confidence?: number;
   /**
-   * When includeTextContent is set to true, a list of references to the text elements constituting
+   * When includeFieldElements is set to true, a list of references to the elements constituting
    * this field.
    */
-  textContent?: FormContent[];
+  fieldElements?: FormElement[];
   /**
    * The 1-based page number in the input document.
    */
@@ -396,7 +405,7 @@ export type RecognizedReceipt = {
    * Recognized form
    */
   recognizedForm: RecognizedForm;
-}
+};
 
 /*
  * Array of {@link RecognizedReceipt}

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -20,11 +20,11 @@ import {
 import {
   FormPage,
   FormLine,
-  FormContent,
+  FormElement,
   FormTableRow,
   FormTable,
   RecognizedForm,
-  FieldText,
+  FieldData,
   FormField,
   Point2D,
   FormModelResponse,
@@ -84,7 +84,7 @@ export function toFormPage(original: ReadResultModel): FormPage {
 // Note: might need to support other element types in future, e.g., checkbox
 const textPattern = /\/readResults\/(\d+)\/lines\/(\d+)(?:\/words\/(\d+))?/;
 
-export function toFormContent(element: string, readResults: FormPage[]): FormContent {
+export function toFormContent(element: string, readResults: FormPage[]): FormElement {
   const result = textPattern.exec(element);
   if (!result || !result[0] || !result[1] || !result[2]) {
     throw new Error(`Unexpected element reference encountered: ${element}`);
@@ -100,16 +100,16 @@ export function toFormContent(element: string, readResults: FormPage[]): FormCon
   }
 }
 
-export function toFieldText(
+export function toFieldData(
   pageNumber: number,
   original: KeyValueElementModel,
   readResults?: FormPage[]
-): FieldText {
+): FieldData {
   return {
     pageNumber,
     text: original.text,
     boundingBox: original.boundingBox ? toBoundingBox(original.boundingBox) : undefined,
-    textContent: original.elements?.map((element) => toFormContent(element, readResults!))
+    fieldElements: original.elements?.map((element) => toFormContent(element, readResults!))
   };
 }
 
@@ -121,8 +121,8 @@ export function toFormFieldFromKeyValuePairModel(
   return {
     name: original.label,
     confidence: original.confidence || 1,
-    labelText: toFieldText(pageNumber, original.key, readResults),
-    valueText: toFieldText(pageNumber, original.value, readResults),
+    labelData: toFieldData(pageNumber, original.key, readResults),
+    valueData: toFieldData(pageNumber, original.value, readResults),
     value: original.value.text,
     valueType: "string"
   };
@@ -139,7 +139,7 @@ export function toFormTable(original: DataTableModel, readResults?: FormPage[]):
       columnIndex: cell.columnIndex,
       columnSpan: cell.columnSpan || 1,
       confidence: cell.confidence || 1,
-      textContent: cell.elements?.map((element) => toFormContent(element, readResults!)),
+      fieldElements: cell.elements?.map((element) => toFormContent(element, readResults!)),
       isFooter: cell.isFooter || false,
       isHeader: cell.isHeader || false,
       rowIndex: cell.rowIndex,
@@ -217,7 +217,13 @@ export function toFormFieldFromFieldValueModel(
   key: string,
   readResults: FormPage[]
 ): FormField {
-  let value: string | Date | number | FormField[] | { [propertyName: string] : FormField} | undefined;
+  let value:
+    | string
+    | Date
+    | number
+    | FormField[]
+    | { [propertyName: string]: FormField }
+    | undefined;
   switch (original.type) {
     case "string":
       value = original.valueString;
@@ -238,20 +244,24 @@ export function toFormFieldFromFieldValueModel(
       value = original.valuePhoneNumber;
       break;
     case "array":
-      value = original.valueArray?.map((fieldValueModel) => toFormFieldFromFieldValueModel(fieldValueModel, key, readResults));
+      value = original.valueArray?.map((fieldValueModel) =>
+        toFormFieldFromFieldValueModel(fieldValueModel, key, readResults)
+      );
       break;
     case "object":
-      value = original.valueObject ? toFieldsFromFieldValue(original.valueObject, readResults) : undefined;
+      value = original.valueObject
+        ? toFieldsFromFieldValue(original.valueObject, readResults)
+        : undefined;
       break;
   }
   return {
     confidence: original.confidence || 1,
     name: key,
-    valueText: {
-      pageNumber: original.pageNumber || 0,
+    valueData: {
+      pageNumber: original.pageNumber ?? 0,
       text: original.text,
       boundingBox: original.boundingBox ? toBoundingBox(original.boundingBox) : undefined,
-      textContent: original.elements?.map((element) => toFormContent(element, readResults))
+      fieldElements: original.elements?.map((element) => toFormContent(element, readResults))
     },
     valueType: original.type,
     value

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
@@ -32,10 +32,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream, "application/pdf");
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
 
     //TODO: verify table rows column cells etc.
   });
@@ -47,10 +44,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream, "image/png");
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes content from a jpeg file stream", async () => {
@@ -60,10 +54,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream, "image/jpeg");
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes content from a tiff file stream", async () => {
@@ -73,10 +64,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream, "image/tiff");
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes content from a pdf file stream without passing content type", async () => {
@@ -86,10 +74,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream);
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes content from a url", async () => {
@@ -100,10 +85,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContentFromUrl(url);
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes receipt from a png file stream", async () => {
@@ -113,10 +95,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeReceipts(stream, "image/png");
     const receipts = await poller.pollUntilDone();
 
-    assert.ok(
-      receipts && receipts.length > 0,
-      `Expect no-empty pages but got ${receipts}`
-    );
+    assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
     const receipt = receipts![0];
     assert.equal(receipt.recognizedForm.formType, "prebuilt:receipt");
     assert.equal(receipt.recognizedForm.fields["ReceiptType"].valueType, "string");
@@ -136,10 +115,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeReceipts(stream, "image/jpeg");
     const receipts = await poller.pollUntilDone();
 
-    assert.ok(
-      receipts && receipts.length > 0,
-      `Expect no-empty pages but got ${receipts}`
-    );
+    assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
     const receipt = receipts![0];
     assert.equal(receipt.recognizedForm.formType, "prebuilt:receipt");
   });
@@ -152,10 +128,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeReceiptsFromUrl(url);
     const receipts = await poller.pollUntilDone();
 
-    assert.ok(
-      receipts && receipts.length > 0,
-      `Expect no-empty pages but got ${receipts}`
-    );
+    assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
     const receipt = receipts![0];
     assert.equal(receipt.recognizedForm.formType, "prebuilt:receipt");
   });
@@ -165,14 +138,11 @@ describe("FormRecognizerClient NodeJS only", () => {
     const stream = fs.createReadStream(filePath);
 
     const poller = await client.beginRecognizeReceipts(stream, "application/pdf", {
-      includeTextContent: true
+      includeFieldElements: true
     });
     const receipts = await poller.pollUntilDone();
 
-    assert.ok(
-      receipts && receipts.length > 0,
-      `Expect no-empty pages but got ${receipts}`
-    );
+    assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
     const receipt = receipts![0];
     assert.equal(receipt.recognizedForm.formType, "prebuilt:receipt");
   });
@@ -200,10 +170,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContent(stream, "application/pdf");
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
 
     //TODO: verify table rows column cells etc.
   });
@@ -216,10 +183,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeContentFromUrl(url);
     const pages = await poller.pollUntilDone();
 
-    assert.ok(
-      pages && pages.length > 0,
-      `Expect no-empty pages but got ${pages}`
-    );
+    assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
   });
 
   it("recognizes receipt from a url", async () => {
@@ -230,10 +194,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
     const poller = await client.beginRecognizeReceiptsFromUrl(url);
     const receipts = await poller.pollUntilDone();
 
-    assert.ok(
-      receipts && receipts.length > 0,
-      `Expect no-empty pages but got ${receipts}`
-    );
+    assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
     const receipt = receipts![0];
     assert.equal(receipt.recognizedForm.formType, "prebuilt:receipt");
   });

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -370,7 +370,7 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
     assert.equal(
       form.fields["Merchant"].labelData,
       undefined,
-      "Expecting 'Merchant' field has undefined labelText"
+      "Expecting 'Merchant' field has undefined labelData"
     );
     assert.equal(
       form.fields["Merchant"].value,
@@ -380,7 +380,7 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
     assert.equal(
       form.fields["Merchant"].valueData,
       undefined,
-      "Expecting 'Merchant' field has undefined valueText"
+      "Expecting 'Merchant' field has undefined valueData"
     );
     assert.equal(
       form.fields["Merchant"].valueType,

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -368,7 +368,7 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
       "Expecting 'Merchant' field has undefined confidence"
     );
     assert.equal(
-      form.fields["Merchant"].labelText,
+      form.fields["Merchant"].labelData,
       undefined,
       "Expecting 'Merchant' field has undefined labelText"
     );
@@ -378,7 +378,7 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
       "Expecting 'Merchant' field has undefined value"
     );
     assert.equal(
-      form.fields["Merchant"].valueText,
+      form.fields["Merchant"].valueData,
       undefined,
       "Expecting 'Merchant' field has undefined valueText"
     );

--- a/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
@@ -7,7 +7,7 @@ import {
   toTextLine,
   toFormPage,
   toFormContent,
-  toFieldText,
+  toFieldData,
   toFormFieldFromKeyValuePairModel,
   toFormFieldFromFieldValueModel,
   toFieldsFromFieldValue,
@@ -26,10 +26,7 @@ import {
   DataTable as DataTableModel,
   DocumentResult as DocumentResultModel
 } from "../src/generated/models";
-import {
-  Point2D,
-  FormField
-} from "../src/models";
+import { Point2D, FormField } from "../src/models";
 
 describe("Transforms", () => {
   function verifyBoundingBox(transformed: Point2D[], original: number[]): void {
@@ -153,14 +150,14 @@ describe("Transforms", () => {
   };
 
   it("toKeyValueElement() converts original KeyValueElementModel", () => {
-    const transformed = toFieldText(0, originalKeyValueElement1, formPages);
+    const transformed = toFieldData(0, originalKeyValueElement1, formPages);
 
     assert.equal(transformed.pageNumber, 0);
     assert.equal(transformed.text, originalKeyValueElement1.text);
     assert.ok(transformed.boundingBox);
     verifyBoundingBox(transformed.boundingBox!, originalKeyValueElement1.boundingBox);
-    assert.deepStrictEqual(transformed.textContent![0], formPages[0].lines![0].words[0]);
-    assert.deepStrictEqual(transformed.textContent![1], formPages[0].lines![0].words[1]);
+    assert.deepStrictEqual(transformed.fieldElements![0], formPages[0].lines![0].words[0]);
+    assert.deepStrictEqual(transformed.fieldElements![1], formPages[0].lines![0].words[1]);
   });
 
   it("toKeyValuePair() converts original key value pair", () => {
@@ -175,16 +172,22 @@ describe("Transforms", () => {
 
     assert.equal(transformed.name, original.label);
     assert.equal(transformed.confidence, original.confidence);
-    assert.ok(transformed.labelText);
-    assert.ok(transformed.labelText!.boundingBox);
-    assert.equal(transformed.labelText!.pageNumber, 1);
-    assert.ok(transformed.valueText);
-    assert.equal(transformed.valueText!.pageNumber, 1);
-    assert.ok(transformed.valueText!.boundingBox);
-    verifyBoundingBox(transformed.labelText!.boundingBox!, original.key.boundingBox);
-    verifyBoundingBox(transformed.valueText!.boundingBox!, original.value.boundingBox);
-    assert.deepStrictEqual(transformed.labelText!.textContent![0], formPages[0].lines![0].words[0]);
-    assert.deepStrictEqual(transformed.valueText!.textContent![1], formPages[0].lines![0].words[1]);
+    assert.ok(transformed.labelData);
+    assert.ok(transformed.labelData!.boundingBox);
+    assert.equal(transformed.labelData!.pageNumber, 1);
+    assert.ok(transformed.valueData);
+    assert.equal(transformed.valueData!.pageNumber, 1);
+    assert.ok(transformed.valueData!.boundingBox);
+    verifyBoundingBox(transformed.labelData!.boundingBox!, original.key.boundingBox);
+    verifyBoundingBox(transformed.valueData!.boundingBox!, original.value.boundingBox);
+    assert.deepStrictEqual(
+      transformed.labelData!.fieldElements![0],
+      formPages[0].lines![0].words[0]
+    );
+    assert.deepStrictEqual(
+      transformed.valueData!.fieldElements![1],
+      formPages[0].lines![0].words[1]
+    );
   });
 
   const commonProperties = {
@@ -207,8 +210,8 @@ describe("Transforms", () => {
       assert.equal(transformed.name, "keyName");
       assert.equal(transformed.valueType, "string");
       assert.equal(transformed.value, original.valueString);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of date", () => {
@@ -223,8 +226,8 @@ describe("Transforms", () => {
       assert.equal(transformed.name, "keyName");
       assert.equal(transformed.valueType, "date");
       assert.equal(transformed.value, original.valueDate);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of time", () => {
@@ -239,8 +242,8 @@ describe("Transforms", () => {
       assert.equal(transformed.name, "keyName");
       assert.equal(transformed.valueType, "time");
       assert.equal(transformed.value, original.valueTime);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of phoneNumber", () => {
@@ -254,8 +257,8 @@ describe("Transforms", () => {
 
       assert.equal(transformed.valueType, "phoneNumber");
       assert.equal(transformed.value, original.valuePhoneNumber);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of number", () => {
@@ -269,8 +272,8 @@ describe("Transforms", () => {
 
       assert.equal(transformed.valueType, "number");
       assert.equal(transformed.value, original.valueNumber);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of integer", () => {
@@ -284,8 +287,8 @@ describe("Transforms", () => {
 
       assert.equal(transformed.valueType, "integer");
       assert.equal(transformed.value, original.valueInteger);
-      assert.ok(transformed.valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(transformed.valueText!.text, original.text);
+      assert.ok(transformed.valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(transformed.valueData!.text, original.text);
     });
 
     it("converts field value of array", () => {
@@ -311,16 +314,16 @@ describe("Transforms", () => {
       const array = transformed.value as FormField[];
       assert.equal(array![0].valueType, "date");
       assert.equal(array![0].value, originalDate.valueDate);
-      assert.ok(array![0].valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(array![0].valueText!.text, originalDate.text);
+      assert.ok(array![0].valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(array![0].valueData!.text, originalDate.text);
       assert.deepStrictEqual(
-        array![0].valueText!.textContent![0],
+        array![0].valueData!.fieldElements![0],
         formPages[0].lines![0].words[0]
       );
       assert.equal(array![1].valueType, "integer");
       assert.equal(array![1].value, originalInteger.valueInteger);
-      assert.ok(array![1].valueText, "Expecting valid 'transformed.valueText'");
-      assert.equal(array![1].valueText!.text, originalInteger.text);
+      assert.ok(array![1].valueData, "Expecting valid 'transformed.valueData'");
+      assert.equal(array![1].valueData!.text, originalInteger.text);
     });
 
     it("converts field value of object", () => {
@@ -346,8 +349,8 @@ describe("Transforms", () => {
 
       assert.equal(transformed.valueType, "object");
 
-      const obj = transformed.value as { [proertyName: string] : FormField};
-      assert.ok(obj, "Expecting valid transformed.value")
+      const obj = transformed.value as { [proertyName: string]: FormField };
+      assert.ok(obj, "Expecting valid transformed.value");
       assert.equal(obj!["dateProperty"].value, originalDate.valueDate);
       assert.equal(obj!["integerProperty"].value, originalInteger.valueInteger);
     });
@@ -378,7 +381,7 @@ describe("Transforms", () => {
       "Expecting missingField has undefined confidence"
     );
     assert.equal(
-      transformed.missingField.labelText,
+      transformed.missingField.labelData,
       undefined,
       "Expecting missingField has undefined labelText"
     );
@@ -388,7 +391,7 @@ describe("Transforms", () => {
       "Expecting missingField has undefined value"
     );
     assert.equal(
-      transformed.missingField.valueText,
+      transformed.missingField.valueData,
       undefined,
       "Expecting missingField has undefined valueText"
     );

--- a/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
@@ -383,7 +383,7 @@ describe("Transforms", () => {
     assert.equal(
       transformed.missingField.labelData,
       undefined,
-      "Expecting missingField has undefined labelText"
+      "Expecting missingField has undefined labelData"
     );
     assert.equal(
       transformed.missingField.value,
@@ -393,7 +393,7 @@ describe("Transforms", () => {
     assert.equal(
       transformed.missingField.valueData,
       undefined,
-      "Expecting missingField has undefined valueText"
+      "Expecting missingField has undefined valueData"
     );
     assert.equal(
       transformed.missingField.valueType,


### PR DESCRIPTION
We want to support non-text elements (e.g. checkboxes, other types of structured form items) in form fields, but the names we have now heavily suggest that all data are text. This addresses this by giving these fields a more generic name.

Field names:
- labelText -> labelData (on FormField)
- valueText -> valueData (on FormField)
- textContent -> fieldElements (on FieldData, FormTableCell)

Type names:
- FieldText -> FieldData
- FormContent -> FormElement

Client Option:
- includeTextContent -> includeFieldElements