### PR TITLE
[Cosmos] Add missing copyright text

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/ItemDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/ItemDefinition.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Items in Cosmos DB are simply JSON objects.
  * Most of the Item operations allow for your to provide your own type

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @ignore
  */

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -1,6 +1,8 @@
-/// <reference lib="esnext.asynciterable" />
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+/// <reference lib="esnext.asynciterable" />
+
 import { ClientContext } from "./ClientContext";
 import { getPathFromLink, ResourceType, StatusCodes } from "./common";
 import {

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/timeSpan.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/timeSpan.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // Ported this implementation to javascript:
 // https://referencesource.microsoft.com/#mscorlib/system/timespan.cs,83e476c1ae112117
 /** @hidden */

--- a/sdk/cosmosdb/cosmos/src/utils/atob.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/atob.browser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 if ("function" !== typeof atob) {
   throw new Error("Your browser environment is missing the global `atob` function");
 }

--- a/sdk/cosmosdb/cosmos/src/utils/atob.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/atob.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export default function atob(str: string) {
   return Buffer.from(str, "base64").toString("binary");
 }

--- a/sdk/cosmosdb/cosmos/src/utils/digest.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/digest.browser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { encodeUTF8 } from "./encode";
 import { globalCrypto } from "./globalCrypto";
 

--- a/sdk/cosmosdb/cosmos/src/utils/digest.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/digest.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { createHash } from "crypto";
 
 export async function digest(str: string) {

--- a/sdk/cosmosdb/cosmos/src/utils/encode.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/encode.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export function encodeUTF8(str: string): Uint8Array {
   const bytes = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {

--- a/sdk/cosmosdb/cosmos/src/utils/globalCrypto.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/globalCrypto.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 const globalRef: any = typeof self === "undefined" ? window : self;
 
 if (!globalRef) {

--- a/sdk/cosmosdb/cosmos/src/utils/hashObject.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashObject.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { digest } from "./digest";
 import stableStringify from "fast-json-stable-stringify";
 

--- a/sdk/cosmosdb/cosmos/src/utils/headers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/headers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { hmac } from "./hmac";
 import { HTTPMethod, ResourceType, Constants } from "../common";
 

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { encodeUTF8, encodeBase64 } from "./encode";
 import atob from "./atob";
 import { globalCrypto } from "./globalCrypto";

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { createHmac } from "crypto";
 
 export async function hmac(key: string, message: string) {

--- a/sdk/cosmosdb/cosmos/src/utils/types.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/types.ts
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // Shim for Omit added in TypeScript 3.5
 export type VerboseOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;

--- a/sdk/cosmosdb/cosmos/src/utils/user-agent.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/user-agent.browser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export function userAgent(): string {
   return navigator.userAgent;
 }

--- a/sdk/cosmosdb/cosmos/src/utils/user-agent.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/user-agent.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import osName from "os-name";
 
 export function userAgent(): string {

--- a/sdk/cosmosdb/cosmos/test/mocha.env.ts
+++ b/sdk/cosmosdb/cosmos/test/mocha.env.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /*
  * Specify test tsconfig file for Windows
  */

--- a/sdk/cosmosdb/cosmos/test/unit/auth.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/unit/auth.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { getAuthorizationTokenUsingResourceTokens } from "../../src/auth";
 import assert from "assert";
 


### PR DESCRIPTION
This PR adds the copyright text to files in the cosmos package that are missing it.

This is a step towards fixing the linter errors from the common eslint plugin used in this repo.

