### PR TITLE
[Identity] Fix warning on unresolved dependencies when building tests

### DIFF
--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -41,7 +41,7 @@ export function nodeConfig(test = false) {
     baseConfig.output.file = "test-dist/index.js";
 
     // mark assert as external
-    baseConfig.external.push("assert");
+    baseConfig.external.push("assert", "path");
 
     // Disable tree-shaking of test code.  In rollup-plugin-node-resolve@5.0.0, rollup started respecting
     // the "sideEffects" field in package.json.  Since our package.json sets "sideEffects=false", this also


### PR DESCRIPTION
This PR fixes the rollup script to avoid the below warning when building test code

<img width="931" alt="Screen Shot 2020-07-05 at 1 58 13 PM" src="https://user-images.githubusercontent.com/16890566/86542124-9ec98e00-bec7-11ea-8d3c-03a18c0d6f8a.png">
