### PR TITLE
Release Custom Vision Prediction & Training - July 2020

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-prediction",
   "author": "Microsoft Corporation",
   "description": "PredictionAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/index.ts
@@ -10,16 +10,6 @@
 import * as msRest from "@azure/ms-rest-js";
 
 /**
- * Image url.
- */
-export interface ImageUrl {
-  /**
-   * Url of the image.
-   */
-  url: string;
-}
-
-/**
  * Bounding box that defines a region of an image.
  */
 export interface BoundingBox {
@@ -39,6 +29,75 @@ export interface BoundingBox {
    * Height.
    */
   height: number;
+}
+
+/**
+ * An interface representing CustomVisionError.
+ */
+export interface CustomVisionError {
+  /**
+   * The error code. Possible values include: 'NoError', 'BadRequest',
+   * 'BadRequestExceededBatchSize', 'BadRequestNotSupported', 'BadRequestInvalidIds',
+   * 'BadRequestProjectName', 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
+   * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
+   * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
+   * 'BadRequestProjectImagePreprocessingSettings', 'BadRequestProjectDuplicated',
+   * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique',
+   * 'BadRequestIterationDescription', 'BadRequestIterationIsNotTrained',
+   * 'BadRequestIterationValidationFailed', 'BadRequestWorkspaceCannotBeModified',
+   * 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName', 'BadRequestTagNameNotUnique',
+   * 'BadRequestTagDescription', 'BadRequestTagType', 'BadRequestMultipleNegativeTag',
+   * 'BadRequestMultipleGeneralProductTag', 'BadRequestImageTags', 'BadRequestImageRegions',
+   * 'BadRequestNegativeAndRegularTagOnSameImage', 'BadRequestUnsupportedDomain',
+   * 'BadRequestRequiredParamIsNull', 'BadRequestIterationIsPublished',
+   * 'BadRequestInvalidPublishName', 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
+   * 'BadRequestIterationNotPublished', 'BadRequestSubscriptionApi',
+   * 'BadRequestExceedProjectLimit', 'BadRequestExceedIterationPerProjectLimit',
+   * 'BadRequestExceedTagPerProjectLimit', 'BadRequestExceedTagPerImageLimit',
+   * 'BadRequestExceededQuota', 'BadRequestCannotMigrateProjectWithName',
+   * 'BadRequestNotLimitedTrial', 'BadRequestImageBatch', 'BadRequestImageStream',
+   * 'BadRequestImageUrl', 'BadRequestImageFormat', 'BadRequestImageSizeBytes',
+   * 'BadRequestImageDimensions', 'BadRequestImageExceededCount', 'BadRequestTrainingNotNeeded',
+   * 'BadRequestTrainingNotNeededButTrainingPipelineUpdated', 'BadRequestTrainingValidationFailed',
+   * 'BadRequestClassificationTrainingValidationFailed',
+   * 'BadRequestMultiClassClassificationTrainingValidationFailed',
+   * 'BadRequestMultiLabelClassificationTrainingValidationFailed',
+   * 'BadRequestDetectionTrainingValidationFailed', 'BadRequestTrainingAlreadyInProgress',
+   * 'BadRequestDetectionTrainingNotAllowNegativeTag', 'BadRequestInvalidEmailAddress',
+   * 'BadRequestDomainNotSupportedForAdvancedTraining',
+   * 'BadRequestExportPlatformNotSupportedForAdvancedTraining',
+   * 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining',
+   * 'BadRequestExportValidationFailed', 'BadRequestExportAlreadyInProgress',
+   * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
+   * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
+   * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
+   * 'BadRequestInvalidImportToken', 'BadRequestExportWhileTraining', 'BadRequestImageMetadataKey',
+   * 'BadRequestImageMetadataValue', 'BadRequestOperationNotSupported',
+   * 'BadRequestInvalidArtifactUri', 'BadRequestCustomerManagedKeyRevoked', 'BadRequestInvalid',
+   * 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser', 'ForbiddenUserResource',
+   * 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
+   * 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled', 'ForbiddenUserInsufficientCapability',
+   * 'ForbiddenDRModeEnabled', 'ForbiddenInvalid', 'NotFound', 'NotFoundProject',
+   * 'NotFoundProjectDefaultIteration', 'NotFoundIteration', 'NotFoundIterationPerformance',
+   * 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain', 'NotFoundApimSubscription',
+   * 'NotFoundInvalid', 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorIterationCopyFailed',
+   * 'ErrorPreparePerformanceMigrationFailed', 'ErrorProjectInvalidWorkspace',
+   * 'ErrorProjectInvalidPipelineConfiguration', 'ErrorProjectInvalidDomain',
+   * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectImportRequestFailed',
+   * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
+   * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
+   * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
+   * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
+   * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
+   * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
+   * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
+   * 'ErrorRegionProposal', 'ErrorUnknownBaseModel', 'ErrorInvalid'
+   */
+  code: CustomVisionErrorCodes;
+  /**
+   * A message explaining the error reported by the service.
+   */
+  message: string;
 }
 
 /**
@@ -65,6 +124,11 @@ export interface Prediction {
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly boundingBox?: BoundingBox;
+  /**
+   * Type of the predicted tag. Possible values include: 'Regular', 'Negative', 'GeneralProduct'
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tagType?: TagType;
 }
 
 /**
@@ -99,91 +163,19 @@ export interface ImagePrediction {
 }
 
 /**
- * An interface representing CustomVisionError.
+ * Image url.
  */
-export interface CustomVisionError {
+export interface ImageUrl {
   /**
-   * The error code. Possible values include: 'NoError', 'BadRequest',
-   * 'BadRequestExceededBatchSize', 'BadRequestNotSupported', 'BadRequestInvalidIds',
-   * 'BadRequestProjectName', 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
-   * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
-   * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
-   * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique',
-   * 'BadRequestIterationDescription', 'BadRequestIterationIsNotTrained',
-   * 'BadRequestWorkspaceCannotBeModified', 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName',
-   * 'BadRequestTagNameNotUnique', 'BadRequestTagDescription', 'BadRequestTagType',
-   * 'BadRequestMultipleNegativeTag', 'BadRequestImageTags', 'BadRequestImageRegions',
-   * 'BadRequestNegativeAndRegularTagOnSameImage', 'BadRequestRequiredParamIsNull',
-   * 'BadRequestIterationIsPublished', 'BadRequestInvalidPublishName',
-   * 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed', 'BadRequestSubscriptionApi',
-   * 'BadRequestExceedProjectLimit', 'BadRequestExceedIterationPerProjectLimit',
-   * 'BadRequestExceedTagPerProjectLimit', 'BadRequestExceedTagPerImageLimit',
-   * 'BadRequestExceededQuota', 'BadRequestCannotMigrateProjectWithName',
-   * 'BadRequestNotLimitedTrial', 'BadRequestImageBatch', 'BadRequestImageStream',
-   * 'BadRequestImageUrl', 'BadRequestImageFormat', 'BadRequestImageSizeBytes',
-   * 'BadRequestImageExceededCount', 'BadRequestTrainingNotNeeded',
-   * 'BadRequestTrainingNotNeededButTrainingPipelineUpdated', 'BadRequestTrainingValidationFailed',
-   * 'BadRequestClassificationTrainingValidationFailed',
-   * 'BadRequestMultiClassClassificationTrainingValidationFailed',
-   * 'BadRequestMultiLabelClassificationTrainingValidationFailed',
-   * 'BadRequestDetectionTrainingValidationFailed', 'BadRequestTrainingAlreadyInProgress',
-   * 'BadRequestDetectionTrainingNotAllowNegativeTag', 'BadRequestInvalidEmailAddress',
-   * 'BadRequestDomainNotSupportedForAdvancedTraining',
-   * 'BadRequestExportPlatformNotSupportedForAdvancedTraining',
-   * 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining',
-   * 'BadRequestExportValidationFailed', 'BadRequestExportAlreadyInProgress',
-   * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
-   * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
-   * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
-   * 'BadRequestInvalid', 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser',
-   * 'ForbiddenUserResource', 'ForbiddenUserSignupDisabled',
-   * 'ForbiddenUserSignupAllowanceExceeded', 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled',
-   * 'ForbiddenUserInsufficientCapability', 'ForbiddenDRModeEnabled', 'ForbiddenInvalid',
-   * 'NotFound', 'NotFoundProject', 'NotFoundProjectDefaultIteration', 'NotFoundIteration',
-   * 'NotFoundIterationPerformance', 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain',
-   * 'NotFoundApimSubscription', 'NotFoundInvalid', 'Conflict', 'ConflictInvalid', 'ErrorUnknown',
-   * 'ErrorProjectInvalidWorkspace', 'ErrorProjectInvalidPipelineConfiguration',
-   * 'ErrorProjectInvalidDomain', 'ErrorProjectTrainingRequestFailed',
-   * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
-   * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
-   * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
-   * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
-   * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
-   * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
-   * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
-   * 'ErrorRegionProposal', 'ErrorInvalid'
+   * Url of the image.
    */
-  code: CustomVisionErrorCodes;
-  /**
-   * A message explaining the error reported by the service.
-   */
-  message: string;
-}
-
-/**
- * Optional Parameters.
- */
-export interface PredictionAPIClientClassifyImageUrlOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * Optional. Specifies the name of application using the endpoint.
-   */
-  application?: string;
+  url: string;
 }
 
 /**
  * Optional Parameters.
  */
 export interface PredictionAPIClientClassifyImageOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * Optional. Specifies the name of application using the endpoint.
-   */
-  application?: string;
-}
-
-/**
- * Optional Parameters.
- */
-export interface PredictionAPIClientClassifyImageUrlWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
   /**
    * Optional. Specifies the name of application using the endpoint.
    */
@@ -203,7 +195,17 @@ export interface PredictionAPIClientClassifyImageWithNoStoreOptionalParams exten
 /**
  * Optional Parameters.
  */
-export interface PredictionAPIClientDetectImageUrlOptionalParams extends msRest.RequestOptionsBase {
+export interface PredictionAPIClientClassifyImageUrlOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional. Specifies the name of application using the endpoint.
+   */
+  application?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface PredictionAPIClientClassifyImageUrlWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
   /**
    * Optional. Specifies the name of application using the endpoint.
    */
@@ -223,7 +225,7 @@ export interface PredictionAPIClientDetectImageOptionalParams extends msRest.Req
 /**
  * Optional Parameters.
  */
-export interface PredictionAPIClientDetectImageUrlWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
+export interface PredictionAPIClientDetectImageWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
   /**
    * Optional. Specifies the name of application using the endpoint.
    */
@@ -233,7 +235,17 @@ export interface PredictionAPIClientDetectImageUrlWithNoStoreOptionalParams exte
 /**
  * Optional Parameters.
  */
-export interface PredictionAPIClientDetectImageWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
+export interface PredictionAPIClientDetectImageUrlOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional. Specifies the name of application using the endpoint.
+   */
+  application?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface PredictionAPIClientDetectImageUrlWithNoStoreOptionalParams extends msRest.RequestOptionsBase {
   /**
    * Optional. Specifies the name of application using the endpoint.
    */
@@ -247,21 +259,24 @@ export interface PredictionAPIClientDetectImageWithNoStoreOptionalParams extends
  * 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
  * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
  * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
+ * 'BadRequestProjectImagePreprocessingSettings', 'BadRequestProjectDuplicated',
  * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique', 'BadRequestIterationDescription',
- * 'BadRequestIterationIsNotTrained', 'BadRequestWorkspaceCannotBeModified',
- * 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName', 'BadRequestTagNameNotUnique',
- * 'BadRequestTagDescription', 'BadRequestTagType', 'BadRequestMultipleNegativeTag',
- * 'BadRequestImageTags', 'BadRequestImageRegions', 'BadRequestNegativeAndRegularTagOnSameImage',
- * 'BadRequestRequiredParamIsNull', 'BadRequestIterationIsPublished',
- * 'BadRequestInvalidPublishName', 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
- * 'BadRequestSubscriptionApi', 'BadRequestExceedProjectLimit',
+ * 'BadRequestIterationIsNotTrained', 'BadRequestIterationValidationFailed',
+ * 'BadRequestWorkspaceCannotBeModified', 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName',
+ * 'BadRequestTagNameNotUnique', 'BadRequestTagDescription', 'BadRequestTagType',
+ * 'BadRequestMultipleNegativeTag', 'BadRequestMultipleGeneralProductTag', 'BadRequestImageTags',
+ * 'BadRequestImageRegions', 'BadRequestNegativeAndRegularTagOnSameImage',
+ * 'BadRequestUnsupportedDomain', 'BadRequestRequiredParamIsNull',
+ * 'BadRequestIterationIsPublished', 'BadRequestInvalidPublishName',
+ * 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
+ * 'BadRequestIterationNotPublished', 'BadRequestSubscriptionApi', 'BadRequestExceedProjectLimit',
  * 'BadRequestExceedIterationPerProjectLimit', 'BadRequestExceedTagPerProjectLimit',
  * 'BadRequestExceedTagPerImageLimit', 'BadRequestExceededQuota',
  * 'BadRequestCannotMigrateProjectWithName', 'BadRequestNotLimitedTrial', 'BadRequestImageBatch',
  * 'BadRequestImageStream', 'BadRequestImageUrl', 'BadRequestImageFormat',
- * 'BadRequestImageSizeBytes', 'BadRequestImageExceededCount', 'BadRequestTrainingNotNeeded',
- * 'BadRequestTrainingNotNeededButTrainingPipelineUpdated', 'BadRequestTrainingValidationFailed',
- * 'BadRequestClassificationTrainingValidationFailed',
+ * 'BadRequestImageSizeBytes', 'BadRequestImageDimensions', 'BadRequestImageExceededCount',
+ * 'BadRequestTrainingNotNeeded', 'BadRequestTrainingNotNeededButTrainingPipelineUpdated',
+ * 'BadRequestTrainingValidationFailed', 'BadRequestClassificationTrainingValidationFailed',
  * 'BadRequestMultiClassClassificationTrainingValidationFailed',
  * 'BadRequestMultiLabelClassificationTrainingValidationFailed',
  * 'BadRequestDetectionTrainingValidationFailed', 'BadRequestTrainingAlreadyInProgress',
@@ -273,71 +288,44 @@ export interface PredictionAPIClientDetectImageWithNoStoreOptionalParams extends
  * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
  * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
  * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
- * 'BadRequestInvalid', 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser',
- * 'ForbiddenUserResource', 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
+ * 'BadRequestInvalidImportToken', 'BadRequestExportWhileTraining', 'BadRequestImageMetadataKey',
+ * 'BadRequestImageMetadataValue', 'BadRequestOperationNotSupported',
+ * 'BadRequestInvalidArtifactUri', 'BadRequestCustomerManagedKeyRevoked', 'BadRequestInvalid',
+ * 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser', 'ForbiddenUserResource',
+ * 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
  * 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled', 'ForbiddenUserInsufficientCapability',
  * 'ForbiddenDRModeEnabled', 'ForbiddenInvalid', 'NotFound', 'NotFoundProject',
  * 'NotFoundProjectDefaultIteration', 'NotFoundIteration', 'NotFoundIterationPerformance',
  * 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain', 'NotFoundApimSubscription', 'NotFoundInvalid',
- * 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorProjectInvalidWorkspace',
+ * 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorIterationCopyFailed',
+ * 'ErrorPreparePerformanceMigrationFailed', 'ErrorProjectInvalidWorkspace',
  * 'ErrorProjectInvalidPipelineConfiguration', 'ErrorProjectInvalidDomain',
- * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectExportRequestFailed',
- * 'ErrorFeaturizationServiceUnavailable', 'ErrorFeaturizationQueueTimeout',
- * 'ErrorFeaturizationInvalidFeaturizer', 'ErrorFeaturizationAugmentationUnavailable',
- * 'ErrorFeaturizationUnrecognizedJob', 'ErrorFeaturizationAugmentationError',
- * 'ErrorExporterInvalidPlatform', 'ErrorExporterInvalidFeaturizer',
- * 'ErrorExporterInvalidClassifier', 'ErrorPredictionServiceUnavailable',
- * 'ErrorPredictionModelNotFound', 'ErrorPredictionModelNotCached', 'ErrorPrediction',
- * 'ErrorPredictionStorage', 'ErrorRegionProposal', 'ErrorInvalid'
+ * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectImportRequestFailed',
+ * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
+ * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
+ * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
+ * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
+ * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
+ * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
+ * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
+ * 'ErrorRegionProposal', 'ErrorUnknownBaseModel', 'ErrorInvalid'
  * @readonly
  * @enum {string}
  */
-export type CustomVisionErrorCodes = 'NoError' | 'BadRequest' | 'BadRequestExceededBatchSize' | 'BadRequestNotSupported' | 'BadRequestInvalidIds' | 'BadRequestProjectName' | 'BadRequestProjectNameNotUnique' | 'BadRequestProjectDescription' | 'BadRequestProjectUnknownDomain' | 'BadRequestProjectUnknownClassification' | 'BadRequestProjectUnsupportedDomainTypeChange' | 'BadRequestProjectUnsupportedExportPlatform' | 'BadRequestIterationName' | 'BadRequestIterationNameNotUnique' | 'BadRequestIterationDescription' | 'BadRequestIterationIsNotTrained' | 'BadRequestWorkspaceCannotBeModified' | 'BadRequestWorkspaceNotDeletable' | 'BadRequestTagName' | 'BadRequestTagNameNotUnique' | 'BadRequestTagDescription' | 'BadRequestTagType' | 'BadRequestMultipleNegativeTag' | 'BadRequestImageTags' | 'BadRequestImageRegions' | 'BadRequestNegativeAndRegularTagOnSameImage' | 'BadRequestRequiredParamIsNull' | 'BadRequestIterationIsPublished' | 'BadRequestInvalidPublishName' | 'BadRequestInvalidPublishTarget' | 'BadRequestUnpublishFailed' | 'BadRequestSubscriptionApi' | 'BadRequestExceedProjectLimit' | 'BadRequestExceedIterationPerProjectLimit' | 'BadRequestExceedTagPerProjectLimit' | 'BadRequestExceedTagPerImageLimit' | 'BadRequestExceededQuota' | 'BadRequestCannotMigrateProjectWithName' | 'BadRequestNotLimitedTrial' | 'BadRequestImageBatch' | 'BadRequestImageStream' | 'BadRequestImageUrl' | 'BadRequestImageFormat' | 'BadRequestImageSizeBytes' | 'BadRequestImageExceededCount' | 'BadRequestTrainingNotNeeded' | 'BadRequestTrainingNotNeededButTrainingPipelineUpdated' | 'BadRequestTrainingValidationFailed' | 'BadRequestClassificationTrainingValidationFailed' | 'BadRequestMultiClassClassificationTrainingValidationFailed' | 'BadRequestMultiLabelClassificationTrainingValidationFailed' | 'BadRequestDetectionTrainingValidationFailed' | 'BadRequestTrainingAlreadyInProgress' | 'BadRequestDetectionTrainingNotAllowNegativeTag' | 'BadRequestInvalidEmailAddress' | 'BadRequestDomainNotSupportedForAdvancedTraining' | 'BadRequestExportPlatformNotSupportedForAdvancedTraining' | 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining' | 'BadRequestExportValidationFailed' | 'BadRequestExportAlreadyInProgress' | 'BadRequestPredictionIdsMissing' | 'BadRequestPredictionIdsExceededCount' | 'BadRequestPredictionTagsExceededCount' | 'BadRequestPredictionResultsExceededCount' | 'BadRequestPredictionInvalidApplicationName' | 'BadRequestPredictionInvalidQueryParameters' | 'BadRequestInvalid' | 'UnsupportedMediaType' | 'Forbidden' | 'ForbiddenUser' | 'ForbiddenUserResource' | 'ForbiddenUserSignupDisabled' | 'ForbiddenUserSignupAllowanceExceeded' | 'ForbiddenUserDoesNotExist' | 'ForbiddenUserDisabled' | 'ForbiddenUserInsufficientCapability' | 'ForbiddenDRModeEnabled' | 'ForbiddenInvalid' | 'NotFound' | 'NotFoundProject' | 'NotFoundProjectDefaultIteration' | 'NotFoundIteration' | 'NotFoundIterationPerformance' | 'NotFoundTag' | 'NotFoundImage' | 'NotFoundDomain' | 'NotFoundApimSubscription' | 'NotFoundInvalid' | 'Conflict' | 'ConflictInvalid' | 'ErrorUnknown' | 'ErrorProjectInvalidWorkspace' | 'ErrorProjectInvalidPipelineConfiguration' | 'ErrorProjectInvalidDomain' | 'ErrorProjectTrainingRequestFailed' | 'ErrorProjectExportRequestFailed' | 'ErrorFeaturizationServiceUnavailable' | 'ErrorFeaturizationQueueTimeout' | 'ErrorFeaturizationInvalidFeaturizer' | 'ErrorFeaturizationAugmentationUnavailable' | 'ErrorFeaturizationUnrecognizedJob' | 'ErrorFeaturizationAugmentationError' | 'ErrorExporterInvalidPlatform' | 'ErrorExporterInvalidFeaturizer' | 'ErrorExporterInvalidClassifier' | 'ErrorPredictionServiceUnavailable' | 'ErrorPredictionModelNotFound' | 'ErrorPredictionModelNotCached' | 'ErrorPrediction' | 'ErrorPredictionStorage' | 'ErrorRegionProposal' | 'ErrorInvalid';
+export type CustomVisionErrorCodes = 'NoError' | 'BadRequest' | 'BadRequestExceededBatchSize' | 'BadRequestNotSupported' | 'BadRequestInvalidIds' | 'BadRequestProjectName' | 'BadRequestProjectNameNotUnique' | 'BadRequestProjectDescription' | 'BadRequestProjectUnknownDomain' | 'BadRequestProjectUnknownClassification' | 'BadRequestProjectUnsupportedDomainTypeChange' | 'BadRequestProjectUnsupportedExportPlatform' | 'BadRequestProjectImagePreprocessingSettings' | 'BadRequestProjectDuplicated' | 'BadRequestIterationName' | 'BadRequestIterationNameNotUnique' | 'BadRequestIterationDescription' | 'BadRequestIterationIsNotTrained' | 'BadRequestIterationValidationFailed' | 'BadRequestWorkspaceCannotBeModified' | 'BadRequestWorkspaceNotDeletable' | 'BadRequestTagName' | 'BadRequestTagNameNotUnique' | 'BadRequestTagDescription' | 'BadRequestTagType' | 'BadRequestMultipleNegativeTag' | 'BadRequestMultipleGeneralProductTag' | 'BadRequestImageTags' | 'BadRequestImageRegions' | 'BadRequestNegativeAndRegularTagOnSameImage' | 'BadRequestUnsupportedDomain' | 'BadRequestRequiredParamIsNull' | 'BadRequestIterationIsPublished' | 'BadRequestInvalidPublishName' | 'BadRequestInvalidPublishTarget' | 'BadRequestUnpublishFailed' | 'BadRequestIterationNotPublished' | 'BadRequestSubscriptionApi' | 'BadRequestExceedProjectLimit' | 'BadRequestExceedIterationPerProjectLimit' | 'BadRequestExceedTagPerProjectLimit' | 'BadRequestExceedTagPerImageLimit' | 'BadRequestExceededQuota' | 'BadRequestCannotMigrateProjectWithName' | 'BadRequestNotLimitedTrial' | 'BadRequestImageBatch' | 'BadRequestImageStream' | 'BadRequestImageUrl' | 'BadRequestImageFormat' | 'BadRequestImageSizeBytes' | 'BadRequestImageDimensions' | 'BadRequestImageExceededCount' | 'BadRequestTrainingNotNeeded' | 'BadRequestTrainingNotNeededButTrainingPipelineUpdated' | 'BadRequestTrainingValidationFailed' | 'BadRequestClassificationTrainingValidationFailed' | 'BadRequestMultiClassClassificationTrainingValidationFailed' | 'BadRequestMultiLabelClassificationTrainingValidationFailed' | 'BadRequestDetectionTrainingValidationFailed' | 'BadRequestTrainingAlreadyInProgress' | 'BadRequestDetectionTrainingNotAllowNegativeTag' | 'BadRequestInvalidEmailAddress' | 'BadRequestDomainNotSupportedForAdvancedTraining' | 'BadRequestExportPlatformNotSupportedForAdvancedTraining' | 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining' | 'BadRequestExportValidationFailed' | 'BadRequestExportAlreadyInProgress' | 'BadRequestPredictionIdsMissing' | 'BadRequestPredictionIdsExceededCount' | 'BadRequestPredictionTagsExceededCount' | 'BadRequestPredictionResultsExceededCount' | 'BadRequestPredictionInvalidApplicationName' | 'BadRequestPredictionInvalidQueryParameters' | 'BadRequestInvalidImportToken' | 'BadRequestExportWhileTraining' | 'BadRequestImageMetadataKey' | 'BadRequestImageMetadataValue' | 'BadRequestOperationNotSupported' | 'BadRequestInvalidArtifactUri' | 'BadRequestCustomerManagedKeyRevoked' | 'BadRequestInvalid' | 'UnsupportedMediaType' | 'Forbidden' | 'ForbiddenUser' | 'ForbiddenUserResource' | 'ForbiddenUserSignupDisabled' | 'ForbiddenUserSignupAllowanceExceeded' | 'ForbiddenUserDoesNotExist' | 'ForbiddenUserDisabled' | 'ForbiddenUserInsufficientCapability' | 'ForbiddenDRModeEnabled' | 'ForbiddenInvalid' | 'NotFound' | 'NotFoundProject' | 'NotFoundProjectDefaultIteration' | 'NotFoundIteration' | 'NotFoundIterationPerformance' | 'NotFoundTag' | 'NotFoundImage' | 'NotFoundDomain' | 'NotFoundApimSubscription' | 'NotFoundInvalid' | 'Conflict' | 'ConflictInvalid' | 'ErrorUnknown' | 'ErrorIterationCopyFailed' | 'ErrorPreparePerformanceMigrationFailed' | 'ErrorProjectInvalidWorkspace' | 'ErrorProjectInvalidPipelineConfiguration' | 'ErrorProjectInvalidDomain' | 'ErrorProjectTrainingRequestFailed' | 'ErrorProjectImportRequestFailed' | 'ErrorProjectExportRequestFailed' | 'ErrorFeaturizationServiceUnavailable' | 'ErrorFeaturizationQueueTimeout' | 'ErrorFeaturizationInvalidFeaturizer' | 'ErrorFeaturizationAugmentationUnavailable' | 'ErrorFeaturizationUnrecognizedJob' | 'ErrorFeaturizationAugmentationError' | 'ErrorExporterInvalidPlatform' | 'ErrorExporterInvalidFeaturizer' | 'ErrorExporterInvalidClassifier' | 'ErrorPredictionServiceUnavailable' | 'ErrorPredictionModelNotFound' | 'ErrorPredictionModelNotCached' | 'ErrorPrediction' | 'ErrorPredictionStorage' | 'ErrorRegionProposal' | 'ErrorUnknownBaseModel' | 'ErrorInvalid';
 
 /**
- * Contains response data for the classifyImageUrl operation.
+ * Defines values for TagType.
+ * Possible values include: 'Regular', 'Negative', 'GeneralProduct'
+ * @readonly
+ * @enum {string}
  */
-export type ClassifyImageUrlResponse = ImagePrediction & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImagePrediction;
-    };
-};
+export type TagType = 'Regular' | 'Negative' | 'GeneralProduct';
 
 /**
  * Contains response data for the classifyImage operation.
  */
 export type ClassifyImageResponse = ImagePrediction & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImagePrediction;
-    };
-};
-
-/**
- * Contains response data for the classifyImageUrlWithNoStore operation.
- */
-export type ClassifyImageUrlWithNoStoreResponse = ImagePrediction & {
   /**
    * The underlying HTTP response.
    */
@@ -375,9 +363,29 @@ export type ClassifyImageWithNoStoreResponse = ImagePrediction & {
 };
 
 /**
- * Contains response data for the detectImageUrl operation.
+ * Contains response data for the classifyImageUrl operation.
  */
-export type DetectImageUrlResponse = ImagePrediction & {
+export type ClassifyImageUrlResponse = ImagePrediction & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImagePrediction;
+    };
+};
+
+/**
+ * Contains response data for the classifyImageUrlWithNoStore operation.
+ */
+export type ClassifyImageUrlWithNoStoreResponse = ImagePrediction & {
   /**
    * The underlying HTTP response.
    */
@@ -415,9 +423,9 @@ export type DetectImageResponse = ImagePrediction & {
 };
 
 /**
- * Contains response data for the detectImageUrlWithNoStore operation.
+ * Contains response data for the detectImageWithNoStore operation.
  */
-export type DetectImageUrlWithNoStoreResponse = ImagePrediction & {
+export type DetectImageWithNoStoreResponse = ImagePrediction & {
   /**
    * The underlying HTTP response.
    */
@@ -435,9 +443,29 @@ export type DetectImageUrlWithNoStoreResponse = ImagePrediction & {
 };
 
 /**
- * Contains response data for the detectImageWithNoStore operation.
+ * Contains response data for the detectImageUrl operation.
  */
-export type DetectImageWithNoStoreResponse = ImagePrediction & {
+export type DetectImageUrlResponse = ImagePrediction & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImagePrediction;
+    };
+};
+
+/**
+ * Contains response data for the detectImageUrlWithNoStore operation.
+ */
+export type DetectImageUrlWithNoStoreResponse = ImagePrediction & {
   /**
    * The underlying HTTP response.
    */

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/mappers.ts
@@ -9,24 +9,6 @@
 import * as msRest from "@azure/ms-rest-js";
 
 
-export const ImageUrl: msRest.CompositeMapper = {
-  serializedName: "ImageUrl",
-  type: {
-    name: "Composite",
-    className: "ImageUrl",
-    modelProperties: {
-      url: {
-        required: true,
-        nullable: false,
-        serializedName: "url",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const BoundingBox: msRest.CompositeMapper = {
   serializedName: "BoundingBox",
   type: {
@@ -63,6 +45,30 @@ export const BoundingBox: msRest.CompositeMapper = {
         serializedName: "height",
         type: {
           name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const CustomVisionError: msRest.CompositeMapper = {
+  serializedName: "CustomVisionError",
+  type: {
+    name: "Composite",
+    className: "CustomVisionError",
+    modelProperties: {
+      code: {
+        required: true,
+        serializedName: "code",
+        type: {
+          name: "String"
+        }
+      },
+      message: {
+        required: true,
+        serializedName: "message",
+        type: {
+          name: "String"
         }
       }
     }
@@ -106,6 +112,14 @@ export const Prediction: msRest.CompositeMapper = {
         type: {
           name: "Composite",
           className: "BoundingBox"
+        }
+      },
+      tagType: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "tagType",
+        type: {
+          name: "String"
         }
       }
     }
@@ -167,22 +181,16 @@ export const ImagePrediction: msRest.CompositeMapper = {
   }
 };
 
-export const CustomVisionError: msRest.CompositeMapper = {
-  serializedName: "CustomVisionError",
+export const ImageUrl: msRest.CompositeMapper = {
+  serializedName: "ImageUrl",
   type: {
     name: "Composite",
-    className: "CustomVisionError",
+    className: "ImageUrl",
     modelProperties: {
-      code: {
+      url: {
         required: true,
-        serializedName: "code",
-        type: {
-          name: "String"
-        }
-      },
-      message: {
-        required: true,
-        serializedName: "message",
+        nullable: false,
+        serializedName: "url",
         type: {
           name: "String"
         }

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClient.ts
@@ -26,42 +26,6 @@ class PredictionAPIClient extends PredictionAPIClientContext {
   }
 
   /**
-   * @summary Classify an image url and saves the result.
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.ClassifyImageUrlResponse>
-   */
-  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientClassifyImageUrlOptionalParams): Promise<Models.ClassifyImageUrlResponse>;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param callback The callback
-   */
-  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options: Models.PredictionAPIClientClassifyImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientClassifyImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.ClassifyImageUrlResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        publishedName,
-        imageUrl,
-        options
-      },
-      classifyImageUrlOperationSpec,
-      callback) as Promise<Models.ClassifyImageUrlResponse>;
-  }
-
-  /**
    * @summary Classify an image and saves the result.
    * @param projectId The project id.
    * @param publishedName Specifies the name of the model to evaluate against.
@@ -98,6 +62,81 @@ class PredictionAPIClient extends PredictionAPIClientContext {
       },
       classifyImageOperationSpec,
       callback) as Promise<Models.ClassifyImageResponse>;
+  }
+
+  /**
+   * @summary Classify an image without saving the result.
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.ClassifyImageWithNoStoreResponse>
+   */
+  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams): Promise<Models.ClassifyImageWithNoStoreResponse>;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param callback The callback
+   */
+  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.ClassifyImageWithNoStoreResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        publishedName,
+        imageData,
+        options
+      },
+      classifyImageWithNoStoreOperationSpec,
+      callback) as Promise<Models.ClassifyImageWithNoStoreResponse>;
+  }
+
+  /**
+   * @summary Classify an image url and saves the result.
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.ClassifyImageUrlResponse>
+   */
+  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientClassifyImageUrlOptionalParams): Promise<Models.ClassifyImageUrlResponse>;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param callback The callback
+   */
+  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options: Models.PredictionAPIClientClassifyImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  classifyImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientClassifyImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.ClassifyImageUrlResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        publishedName,
+        imageUrl,
+        options
+      },
+      classifyImageUrlOperationSpec,
+      callback) as Promise<Models.ClassifyImageUrlResponse>;
   }
 
   /**
@@ -140,81 +179,6 @@ class PredictionAPIClient extends PredictionAPIClientContext {
   }
 
   /**
-   * @summary Classify an image without saving the result.
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.ClassifyImageWithNoStoreResponse>
-   */
-  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams): Promise<Models.ClassifyImageWithNoStoreResponse>;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param callback The callback
-   */
-  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  classifyImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientClassifyImageWithNoStoreOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.ClassifyImageWithNoStoreResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        publishedName,
-        imageData,
-        options
-      },
-      classifyImageWithNoStoreOperationSpec,
-      callback) as Promise<Models.ClassifyImageWithNoStoreResponse>;
-  }
-
-  /**
-   * @summary Detect objects in an image url and saves the result.
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.DetectImageUrlResponse>
-   */
-  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientDetectImageUrlOptionalParams): Promise<Models.DetectImageUrlResponse>;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param callback The callback
-   */
-  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options: Models.PredictionAPIClientDetectImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientDetectImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.DetectImageUrlResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        publishedName,
-        imageUrl,
-        options
-      },
-      detectImageUrlOperationSpec,
-      callback) as Promise<Models.DetectImageUrlResponse>;
-  }
-
-  /**
    * @summary Detect objects in an image and saves the result.
    * @param projectId The project id.
    * @param publishedName Specifies the name of the model to evaluate against.
@@ -251,6 +215,81 @@ class PredictionAPIClient extends PredictionAPIClientContext {
       },
       detectImageOperationSpec,
       callback) as Promise<Models.DetectImageResponse>;
+  }
+
+  /**
+   * @summary Detect objects in an image without saving the result.
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.DetectImageWithNoStoreResponse>
+   */
+  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams): Promise<Models.DetectImageWithNoStoreResponse>;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param callback The callback
+   */
+  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 4MB.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.DetectImageWithNoStoreResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        publishedName,
+        imageData,
+        options
+      },
+      detectImageWithNoStoreOperationSpec,
+      callback) as Promise<Models.DetectImageWithNoStoreResponse>;
+  }
+
+  /**
+   * @summary Detect objects in an image url and saves the result.
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.DetectImageUrlResponse>
+   */
+  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientDetectImageUrlOptionalParams): Promise<Models.DetectImageUrlResponse>;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param callback The callback
+   */
+  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project id.
+   * @param publishedName Specifies the name of the model to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options: Models.PredictionAPIClientDetectImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  detectImageUrl(projectId: string, publishedName: string, imageUrl: Models.ImageUrl, options?: Models.PredictionAPIClientDetectImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.DetectImageUrlResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        publishedName,
+        imageUrl,
+        options
+      },
+      detectImageUrlOperationSpec,
+      callback) as Promise<Models.DetectImageUrlResponse>;
   }
 
   /**
@@ -291,49 +330,62 @@ class PredictionAPIClient extends PredictionAPIClientContext {
       detectImageUrlWithNoStoreOperationSpec,
       callback) as Promise<Models.DetectImageUrlWithNoStoreResponse>;
   }
-
-  /**
-   * @summary Detect objects in an image without saving the result.
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.DetectImageWithNoStoreResponse>
-   */
-  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams): Promise<Models.DetectImageWithNoStoreResponse>;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param callback The callback
-   */
-  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project id.
-   * @param publishedName Specifies the name of the model to evaluate against.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 0MB.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  detectImageWithNoStore(projectId: string, publishedName: string, imageData: msRest.HttpRequestBody, options?: Models.PredictionAPIClientDetectImageWithNoStoreOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.DetectImageWithNoStoreResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        publishedName,
-        imageData,
-        options
-      },
-      detectImageWithNoStoreOperationSpec,
-      callback) as Promise<Models.DetectImageWithNoStoreResponse>;
-  }
 }
 
 // Operation Specifications
 const serializer = new msRest.Serializer(Mappers);
+const classifyImageOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "{projectId}/classify/iterations/{publishedName}/image",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.publishedName
+  ],
+  queryParameters: [
+    Parameters.application
+  ],
+  formDataParameters: [
+    Parameters.imageData
+  ],
+  contentType: "multipart/form-data",
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImagePrediction
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const classifyImageWithNoStoreOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "{projectId}/classify/iterations/{publishedName}/image/nostore",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.publishedName
+  ],
+  queryParameters: [
+    Parameters.application
+  ],
+  formDataParameters: [
+    Parameters.imageData
+  ],
+  contentType: "multipart/form-data",
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImagePrediction
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
 const classifyImageUrlOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "{projectId}/classify/iterations/{publishedName}/url",
@@ -352,32 +404,7 @@ const classifyImageUrlOperationSpec: msRest.OperationSpec = {
       required: true
     }
   },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImagePrediction
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const classifyImageOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "{projectId}/classify/iterations/{publishedName}/image",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.publishedName
-  ],
-  queryParameters: [
-    Parameters.application
-  ],
-  formDataParameters: [
-    Parameters.imageData
-  ],
-  contentType: "multipart/form-data",
+  contentType: "application/json; charset=utf-8",
   responses: {
     200: {
       bodyMapper: Mappers.ImagePrediction
@@ -407,6 +434,7 @@ const classifyImageUrlWithNoStoreOperationSpec: msRest.OperationSpec = {
       required: true
     }
   },
+  contentType: "application/json; charset=utf-8",
   responses: {
     200: {
       bodyMapper: Mappers.ImagePrediction
@@ -418,9 +446,35 @@ const classifyImageUrlWithNoStoreOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const classifyImageWithNoStoreOperationSpec: msRest.OperationSpec = {
+const detectImageOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{projectId}/classify/iterations/{publishedName}/image/nostore",
+  path: "{projectId}/detect/iterations/{publishedName}/image",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.publishedName
+  ],
+  queryParameters: [
+    Parameters.application
+  ],
+  formDataParameters: [
+    Parameters.imageData
+  ],
+  contentType: "multipart/form-data",
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImagePrediction
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const detectImageWithNoStoreOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "{projectId}/detect/iterations/{publishedName}/image/nostore",
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId,
@@ -462,32 +516,7 @@ const detectImageUrlOperationSpec: msRest.OperationSpec = {
       required: true
     }
   },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImagePrediction
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const detectImageOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "{projectId}/detect/iterations/{publishedName}/image",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.publishedName
-  ],
-  queryParameters: [
-    Parameters.application
-  ],
-  formDataParameters: [
-    Parameters.imageData
-  ],
-  contentType: "multipart/form-data",
+  contentType: "application/json; charset=utf-8",
   responses: {
     200: {
       bodyMapper: Mappers.ImagePrediction
@@ -517,32 +546,7 @@ const detectImageUrlWithNoStoreOperationSpec: msRest.OperationSpec = {
       required: true
     }
   },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImagePrediction
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const detectImageWithNoStoreOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "{projectId}/detect/iterations/{publishedName}/image/nostore",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.publishedName
-  ],
-  queryParameters: [
-    Parameters.application
-  ],
-  formDataParameters: [
-    Parameters.imageData
-  ],
-  contentType: "multipart/form-data",
+  contentType: "application/json; charset=utf-8",
   responses: {
     200: {
       bodyMapper: Mappers.ImagePrediction

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-prediction";
-const packageVersion = "5.0.0";
+const packageVersion = "5.1.0";
 
 export class PredictionAPIClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -42,8 +42,8 @@ export class PredictionAPIClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/customvision/v3.0/prediction";
-    this.requestContentType = "application/json; charset=utf-8";
+    this.baseUri = "{Endpoint}/customvision/v3.1/prediction";
+    this.requestContentType = "multipart/form-data";
     this.endpoint = endpoint;
     this.credentials = credentials;
   }

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-training",
   "author": "Microsoft Corporation",
   "description": "TrainingAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-training",
   "author": "Microsoft Corporation",
   "description": "TrainingAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "6.0.0",
+  "version": "5.1.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/mappers.ts
@@ -368,6 +368,19 @@ export const Image: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      metadata: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "metadata",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "String"
+            }
+          }
+        }
       }
     }
   }
@@ -562,6 +575,18 @@ export const ImageFileCreateBatch: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      metadata: {
+        nullable: true,
+        serializedName: "metadata",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "String"
+            }
+          }
+        }
       }
     }
   }
@@ -635,6 +660,85 @@ export const ImageIdCreateBatch: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      metadata: {
+        nullable: true,
+        serializedName: "metadata",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageMetadataUpdateEntry: msRest.CompositeMapper = {
+  serializedName: "ImageMetadataUpdateEntry",
+  type: {
+    name: "Composite",
+    className: "ImageMetadataUpdateEntry",
+    modelProperties: {
+      imageId: {
+        nullable: false,
+        serializedName: "imageId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      status: {
+        nullable: false,
+        serializedName: "status",
+        type: {
+          name: "String"
+        }
+      },
+      metadata: {
+        nullable: true,
+        serializedName: "metadata",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageMetadataUpdateSummary: msRest.CompositeMapper = {
+  serializedName: "ImageMetadataUpdateSummary",
+  type: {
+    name: "Composite",
+    className: "ImageMetadataUpdateSummary",
+    modelProperties: {
+      isBatchSuccessful: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "isBatchSuccessful",
+        type: {
+          name: "Boolean"
+        }
+      },
+      images: {
+        readOnly: true,
+        serializedName: "images",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageMetadataUpdateEntry"
+            }
+          }
+        }
       }
     }
   }
@@ -677,6 +781,14 @@ export const Prediction: msRest.CompositeMapper = {
         type: {
           name: "Composite",
           className: "BoundingBox"
+        }
+      },
+      tagType: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "tagType",
+        type: {
+          name: "String"
         }
       }
     }
@@ -1313,6 +1425,18 @@ export const ImageUrlCreateBatch: msRest.CompositeMapper = {
           element: {
             type: {
               name: "Uuid"
+            }
+          }
+        }
+      },
+      metadata: {
+        nullable: true,
+        serializedName: "metadata",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "String"
             }
           }
         }

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/parameters.ts
@@ -92,6 +92,18 @@ export const endpoint: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
+export const filter: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "filter"
+  ],
+  mapper: {
+    serializedName: "$filter",
+    type: {
+      name: "String"
+    }
+  }
+};
 export const flavor: msRest.OperationQueryParameter = {
   parameterPath: [
     "options",
@@ -185,6 +197,26 @@ export const imageIds1: msRest.OperationQueryParameter = {
     required: true,
     serializedName: "imageIds",
     constraints: {
+      MaxItems: 256,
+      MinItems: 0
+    },
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "Uuid"
+        }
+      }
+    }
+  },
+  collectionFormat: msRest.QueryCollectionFormat.Csv
+};
+export const imageIds2: msRest.OperationQueryParameter = {
+  parameterPath: "imageIds",
+  mapper: {
+    required: true,
+    serializedName: "imageIds",
+    constraints: {
       MaxItems: 64,
       MinItems: 0
     },
@@ -221,10 +253,22 @@ export const iterationId1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const name: msRest.OperationQueryParameter = {
+export const name0: msRest.OperationQueryParameter = {
   parameterPath: "name",
   mapper: {
     required: true,
+    serializedName: "name",
+    type: {
+      name: "String"
+    }
+  }
+};
+export const name1: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "name"
+  ],
+  mapper: {
     serializedName: "name",
     type: {
       name: "String"
@@ -264,6 +308,28 @@ export const overlapThreshold: msRest.OperationQueryParameter = {
     serializedName: "overlapThreshold",
     type: {
       name: "Number"
+    }
+  }
+};
+export const overwrite: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "overwrite"
+  ],
+  mapper: {
+    serializedName: "overwrite",
+    type: {
+      name: "Boolean"
+    }
+  }
+};
+export const path: msRest.OperationQueryParameter = {
+  parameterPath: "path",
+  mapper: {
+    required: true,
+    serializedName: "path",
+    type: {
+      name: "String"
     }
   }
 };
@@ -363,6 +429,18 @@ export const store: msRest.OperationQueryParameter = {
     defaultValue: true,
     type: {
       name: "Boolean"
+    }
+  }
+};
+export const taggingStatus: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "taggingStatus"
+  ],
+  mapper: {
+    serializedName: "taggingStatus",
+    type: {
+      name: "String"
     }
   }
 };

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClient.ts
@@ -218,6 +218,38 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
+   * @summary Get artifact content from blob storage, based on artifact relative path in the blob.
+   * @param projectId The project id.
+   * @param path The relative path for artifact.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetArtifactResponse>
+   */
+  getArtifact(projectId: string, path: string, options?: msRest.RequestOptionsBase): Promise<Models.GetArtifactResponse>;
+  /**
+   * @param projectId The project id.
+   * @param path The relative path for artifact.
+   * @param callback The callback
+   */
+  getArtifact(projectId: string, path: string, callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param projectId The project id.
+   * @param path The relative path for artifact.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getArtifact(projectId: string, path: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  getArtifact(projectId: string, path: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.GetArtifactResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        path,
+        options
+      },
+      getArtifactOperationSpec,
+      callback) as Promise<Models.GetArtifactResponse>;
+  }
+
+  /**
    * @summary Exports a project.
    * @param projectId The project id of the project to export.
    * @param [options] The optional parameters
@@ -246,9 +278,46 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
+   * This API supports batching and range selection. By default it will only return first 50 images
+   * matching images.
+   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Get images for a given project iteration or workspace.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImagesResponse>
+   */
+  getImages(projectId: string, options?: Models.TrainingAPIClientGetImagesOptionalParams): Promise<Models.GetImagesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getImages(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImages(projectId: string, options: Models.TrainingAPIClientGetImagesOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  getImages(projectId: string, options?: Models.TrainingAPIClientGetImagesOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetImagesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getImagesOperationSpec,
+      callback) as Promise<Models.GetImagesResponse>;
+  }
+
+  /**
    * This API accepts body content as multipart/form-data and application/octet-stream. When using
    * multipart
-   * multiple image files can be sent at once, with a maximum of 64 files
+   * multiple image files can be sent at once, with a maximum of 64 files.
+   * If all images are successful created, 200(OK) status code will be returned.
+   * Otherwise, 207 (Multi-Status) status code will be returned and detail status for each image will
+   * be listed in the response payload.
    * @summary Add the provided images to the set of training images.
    * @param projectId The project id.
    * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
@@ -346,8 +415,42 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Get the number of images.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImageCountResponse>
+   */
+  getImageCount(projectId: string, options?: Models.TrainingAPIClientGetImageCountOptionalParams): Promise<Models.GetImageCountResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getImageCount(projectId: string, callback: msRest.ServiceCallback<number>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImageCount(projectId: string, options: Models.TrainingAPIClientGetImageCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
+  getImageCount(projectId: string, options?: Models.TrainingAPIClientGetImageCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetImageCountResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getImageCountOperationSpec,
+      callback) as Promise<Models.GetImageCountResponse>;
+  }
+
+  /**
    * This API accepts a batch of files, and optionally tags, to create images. There is a limit of 64
    * images and 20 tags.
+   * If all images are successful created, 200(OK) status code will be returned.
+   * Otherwise, 207 (Multi-Status) status code will be returned and detail status for each image will
+   * be listed in the response payload.
    * @summary Add the provided batch of images to the set of training images.
    * @param projectId The project id.
    * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
@@ -411,24 +514,68 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
+   * This API accepts a batch of image Ids, and metadata, to update images. There is a limit of 64
+   * images.
+   * @summary Update metadata of images.
+   * @param projectId The project id.
+   * @param imageIds The list of image ids to update. Limited to 64.
+   * @param metadata The metadata to be updated to the specified images. Limited to 50 key-value
+   * pairs per image. The length of key is limited to 256. The length of value is limited to 512.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.UpdateImageMetadataResponse>
+   */
+  updateImageMetadata(projectId: string, imageIds: string[], metadata: { [propertyName: string]: string }, options?: msRest.RequestOptionsBase): Promise<Models.UpdateImageMetadataResponse>;
+  /**
+   * @param projectId The project id.
+   * @param imageIds The list of image ids to update. Limited to 64.
+   * @param metadata The metadata to be updated to the specified images. Limited to 50 key-value
+   * pairs per image. The length of key is limited to 256. The length of value is limited to 512.
+   * @param callback The callback
+   */
+  updateImageMetadata(projectId: string, imageIds: string[], metadata: { [propertyName: string]: string }, callback: msRest.ServiceCallback<Models.ImageMetadataUpdateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param imageIds The list of image ids to update. Limited to 64.
+   * @param metadata The metadata to be updated to the specified images. Limited to 50 key-value
+   * pairs per image. The length of key is limited to 256. The length of value is limited to 512.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  updateImageMetadata(projectId: string, imageIds: string[], metadata: { [propertyName: string]: string }, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageMetadataUpdateSummary>): void;
+  updateImageMetadata(projectId: string, imageIds: string[], metadata: { [propertyName: string]: string }, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageMetadataUpdateSummary>, callback?: msRest.ServiceCallback<Models.ImageMetadataUpdateSummary>): Promise<Models.UpdateImageMetadataResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageIds,
+        metadata,
+        options
+      },
+      updateImageMetadataOperationSpec,
+      callback) as Promise<Models.UpdateImageMetadataResponse>;
+  }
+
+  /**
    * This API creates a batch of images from predicted images specified. There is a limit of 64
    * images and 20 tags.
+   * If all images are successful created, 200(OK) status code will be returned.
+   * Otherwise, 207 (Multi-Status) status code will be returned and detail status for each image will
+   * be listed in the response payload.
    * @summary Add the specified predicted images to the set of training images.
    * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param [options] The optional parameters
    * @returns Promise<Models.CreateImagesFromPredictionsResponse>
    */
   createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromPredictionsResponse>;
   /**
    * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param callback The callback
    */
   createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
   /**
    * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param options The optional parameters
    * @param callback The callback
    */
@@ -448,6 +595,9 @@ class TrainingAPIClient extends TrainingAPIClientContext {
    * This API accepts a batch of image regions, and optionally tags, to update existing images with
    * region information.
    * There is a limit of 64 entries in the batch.
+   * If all regions are successful created, 200(OK) status code will be returned.
+   * Otherwise, 207 (Multi-Status) status code will be returned and detail status for each region
+   * will be listed in the response payload.
    * @summary Create a set of image regions.
    * @param projectId The project id.
    * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
@@ -787,22 +937,25 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   /**
    * This API accepts a batch of urls, and optionally tags, to create images. There is a limit of 64
    * images and 20 tags.
+   * If all images are successful created, 200(OK) status code will be returned.
+   * Otherwise, 207 (Multi-Status) status code will be returned and detail status for each image will
+   * be listed in the response payload.
    * @summary Add the provided images urls to the set of training images.
    * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image urls, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param [options] The optional parameters
    * @returns Promise<Models.CreateImagesFromUrlsResponse>
    */
   createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromUrlsResponse>;
   /**
    * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image urls, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param callback The callback
    */
   createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
   /**
    * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param batch Image urls, tag ids, and metadata. Limited to 64 images and 20 tags per batch.
    * @param options The optional parameters
    * @param callback The callback
    */
@@ -1133,7 +1286,7 @@ class TrainingAPIClient extends TrainingAPIClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.PublishIterationResponse>
    */
-  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options?: msRest.RequestOptionsBase): Promise<Models.PublishIterationResponse>;
+  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options?: Models.TrainingAPIClientPublishIterationOptionalParams): Promise<Models.PublishIterationResponse>;
   /**
    * @param projectId The project id.
    * @param iterationId The iteration id.
@@ -1150,8 +1303,8 @@ class TrainingAPIClient extends TrainingAPIClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.PublishIterationResponse> {
+  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options: Models.TrainingAPIClientPublishIterationOptionalParams, callback: msRest.ServiceCallback<boolean>): void;
+  publishIteration(projectId: string, iterationId: string, publishName: string, predictionId: string, options?: Models.TrainingAPIClientPublishIterationOptionalParams | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.PublishIterationResponse> {
     return this.sendOperationRequest(
       {
         projectId,
@@ -1564,7 +1717,7 @@ class TrainingAPIClient extends TrainingAPIClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImportProjectResponse>
    */
-  importProject(token: string, options?: msRest.RequestOptionsBase): Promise<Models.ImportProjectResponse>;
+  importProject(token: string, options?: Models.TrainingAPIClientImportProjectOptionalParams): Promise<Models.ImportProjectResponse>;
   /**
    * @param token Token generated from the export project call.
    * @param callback The callback
@@ -1575,8 +1728,8 @@ class TrainingAPIClient extends TrainingAPIClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  importProject(token: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Project>): void;
-  importProject(token: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Project>, callback?: msRest.ServiceCallback<Models.Project>): Promise<Models.ImportProjectResponse> {
+  importProject(token: string, options: Models.TrainingAPIClientImportProjectOptionalParams, callback: msRest.ServiceCallback<Models.Project>): void;
+  importProject(token: string, options?: Models.TrainingAPIClientImportProjectOptionalParams | msRest.ServiceCallback<Models.Project>, callback?: msRest.ServiceCallback<Models.Project>): Promise<Models.ImportProjectResponse> {
     return this.sendOperationRequest(
       {
         token,
@@ -1670,7 +1823,7 @@ const createProjectOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.name,
+    Parameters.name0,
     Parameters.description,
     Parameters.domainId1,
     Parameters.classificationType,
@@ -1746,6 +1899,30 @@ const updateProjectOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
+const getArtifactOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/artifacts",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.path
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Stream"
+        }
+      }
+    },
+    default: {}
+  },
+  serializer
+};
+
 const exportProjectOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "projects/{projectId}/export",
@@ -1756,6 +1933,44 @@ const exportProjectOperationSpec: msRest.OperationSpec = {
   responses: {
     200: {
       bodyMapper: Mappers.ProjectExport
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getImagesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.tagIds0,
+    Parameters.taggingStatus,
+    Parameters.filter,
+    Parameters.orderBy,
+    Parameters.take,
+    Parameters.skip
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Image"
+            }
+          }
+        }
+      }
     },
     default: {
       bodyMapper: Mappers.CustomVisionError
@@ -1780,6 +1995,9 @@ const createImagesFromDataOperationSpec: msRest.OperationSpec = {
   contentType: "multipart/form-data",
   responses: {
     200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    207: {
       bodyMapper: Mappers.ImageCreateSummary
     },
     default: {
@@ -1830,6 +2048,35 @@ const getImageRegionProposalsOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
+const getImageCountOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/count",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.taggingStatus,
+    Parameters.filter,
+    Parameters.tagIds1
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Number"
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
 const createImagesFromFilesOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "projects/{projectId}/images/files",
@@ -1846,6 +2093,9 @@ const createImagesFromFilesOperationSpec: msRest.OperationSpec = {
   },
   responses: {
     200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    207: {
       bodyMapper: Mappers.ImageCreateSummary
     },
     default: {
@@ -1888,6 +2138,45 @@ const getImagesByIdsOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
+const updateImageMetadataOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/metadata",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.imageIds1
+  ],
+  requestBody: {
+    parameterPath: "metadata",
+    mapper: {
+      required: true,
+      serializedName: "metadata",
+      type: {
+        name: "Dictionary",
+        value: {
+          type: {
+            name: "String"
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageMetadataUpdateSummary
+    },
+    207: {
+      bodyMapper: Mappers.ImageMetadataUpdateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
 const createImagesFromPredictionsOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "projects/{projectId}/images/predictions",
@@ -1904,6 +2193,9 @@ const createImagesFromPredictionsOperationSpec: msRest.OperationSpec = {
   },
   responses: {
     200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    207: {
       bodyMapper: Mappers.ImageCreateSummary
     },
     default: {
@@ -1929,6 +2221,9 @@ const createImageRegionsOperationSpec: msRest.OperationSpec = {
   },
   responses: {
     200: {
+      bodyMapper: Mappers.ImageRegionCreateSummary
+    },
+    207: {
       bodyMapper: Mappers.ImageRegionCreateSummary
     },
     default: {
@@ -2119,7 +2414,7 @@ const deleteImageTagsOperationSpec: msRest.OperationSpec = {
     Parameters.projectId
   ],
   queryParameters: [
-    Parameters.imageIds1,
+    Parameters.imageIds2,
     Parameters.tagIds2
   ],
   responses: {
@@ -2208,6 +2503,9 @@ const createImagesFromUrlsOperationSpec: msRest.OperationSpec = {
   },
   responses: {
     200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    207: {
       bodyMapper: Mappers.ImageCreateSummary
     },
     default: {
@@ -2457,7 +2755,8 @@ const publishIterationOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.publishName,
-    Parameters.predictionId
+    Parameters.predictionId,
+    Parameters.overwrite
   ],
   responses: {
     200: {
@@ -2631,7 +2930,7 @@ const createTagOperationSpec: msRest.OperationSpec = {
     Parameters.projectId
   ],
   queryParameters: [
-    Parameters.name,
+    Parameters.name0,
     Parameters.description,
     Parameters.type
   ],
@@ -2720,7 +3019,7 @@ const suggestTagsAndRegionsOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.iterationId1,
-    Parameters.imageIds1
+    Parameters.imageIds2
   ],
   responses: {
     200: {
@@ -2782,7 +3081,8 @@ const importProjectOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.token
+    Parameters.token,
+    Parameters.name1
   ],
   responses: {
     200: {

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-training";
-const packageVersion = "5.0.0";
+const packageVersion = "6.0.0";
 
 export class TrainingAPIClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -42,7 +42,7 @@ export class TrainingAPIClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/customvision/v3.2/training";
+    this.baseUri = "{Endpoint}/customvision/v3.3/training";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
     this.credentials = credentials;

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-training";
-const packageVersion = "6.0.0";
+const packageVersion = "5.1.0";
 
 export class TrainingAPIClientContext extends msRest.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
**Commands Used**

```autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=5.1.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/16178fee3c9288bd43fd4db804e4b010257f1414/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.md
AutoRest code generation utility [version: 2.0.4283; node: v10.15.3]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/usr/local/lib/node_modules/@microsoft.azure/autorest-core/dist' (2.0.4417)
   Loading AutoRest extension '@microsoft.azure/autorest.typescript' (4.2.4->4.2.4)
   Loading AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.51->2.3.51)
```

```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=6.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/16178fee3c9288bd43fd4db804e4b010257f1414/specification/cognitiveservices/data-plane/CustomVision/Training/readme.md 
AutoRest code generation utility [version: 2.0.4283; node: v10.15.3]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/usr/local/lib/node_modules/@microsoft.azure/autorest-core/dist' (2.0.4417)
   Loading AutoRest extension '@microsoft.azure/autorest.typescript' (4.2.4->4.2.4)
   Loading AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.51->2.3.51)
```

Notes:

1. I do not see any breaking changes in Prediction SDK (A lot of rearrangements. We should probably take a look at it. The autorest version, autorest.typescript & autorest.modeler versions are all same. So, why is the code rearranged. It was a pain to rearrange and check what has changed). So, I have updated only the minor version

2. There was a breaking change in training SDK. So, I have updated the major version.  

3. This is related to Issue https://github.com/Azure/sdk-release-request/issues/438 

@ramya-rao-a Please review and approve. Thanks