### PR TITLE
Remove Lazy Index Tests

### DIFF
--- a/sdk/cosmosdb/cosmos/test/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/container.spec.ts
@@ -69,7 +69,6 @@ describe("Containers", function() {
       assert(ranges.length > 0, "container should have at least 1 partition");
 
       // Replacing indexing policy is allowed.
-      containerDef.indexingPolicy.indexingMode = IndexingMode.lazy;
       containerDef.indexingPolicy.spatialIndexes = [
         {
           path: "/region/?",
@@ -82,9 +81,9 @@ describe("Containers", function() {
           }
         }
       ];
+
       containerDef.geospatialConfig.type = GeospatialType.Geometry;
-      const { resource: replacedContainer } = await container.replace(containerDef);
-      assert.equal("lazy", replacedContainer.indexingPolicy.indexingMode);
+      await container.replace(containerDef);
 
       // Replacing partition key is not allowed.
       try {
@@ -200,24 +199,6 @@ describe("Containers", function() {
       );
       await container.delete();
 
-      const lazyContainerDefinition: ContainerDefinition = {
-        id: "lazy container",
-        indexingPolicy: { indexingMode: IndexingMode.lazy }
-      };
-
-      const { resource: lazyContainerDef } = await database.containers.create(
-        lazyContainerDefinition
-      );
-      const lazyContainer = database.container(lazyContainerDef.id);
-
-      assert.equal(
-        lazyContainerDef.indexingPolicy.indexingMode,
-        IndexingMode.lazy,
-        "indexing mode should be lazy"
-      );
-
-      await lazyContainer.delete();
-
       const uniqueKeysContainerDefinition: ContainerDefinition = {
         id: "uniqueKeysContainer",
         uniqueKeyPolicy: { uniqueKeys: [{ paths: ["/foo"] }] }
@@ -311,20 +292,6 @@ describe("Containers", function() {
       );
       checkDefaultIndexingPolicyPaths(containerNoIndexPolicyDef["indexingPolicy"]);
 
-      // create container with partial policy specified.
-      const containerDefinition02: ContainerDefinition = {
-        id: "TestCreateDefaultPolicy02",
-        indexingPolicy: {
-          indexingMode: IndexingMode.lazy,
-          automatic: true
-        }
-      };
-
-      const { resource: containerWithPartialPolicyDef } = await database.containers.create(
-        containerDefinition02
-      );
-      checkDefaultIndexingPolicyPaths((containerWithPartialPolicyDef as any)["indexingPolicy"]);
-
       // create container with default policy.
       const containerDefinition03 = {
         id: "TestCreateDefaultPolicy03",
@@ -398,17 +365,6 @@ describe("Containers", function() {
       });
       assert.notEqual(headers1[Constants.HttpHeaders.IndexTransformationProgress], undefined);
       assert.equal(headers1[Constants.HttpHeaders.LazyIndexingProgress], undefined);
-
-      const lazyContainerDefinition = {
-        id: "lazy_coll",
-        indexingPolicy: { indexingMode: IndexingMode.lazy }
-      };
-      const { headers: headers2 } = await createThenReadcontainer(
-        database,
-        lazyContainerDefinition
-      );
-      assert.notEqual(headers2[Constants.HttpHeaders.IndexTransformationProgress], undefined);
-      assert.notEqual(headers2[Constants.HttpHeaders.LazyIndexingProgress], undefined);
 
       const noneContainerDefinition = {
         id: "none_coll",

--- a/sdk/cosmosdb/cosmos/test/integration/encoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/encoding.spec.ts
@@ -29,7 +29,7 @@ describe("Create And Read Validation", function() {
       const database = await getTestDatabase(databaseId);
       const containerBody = {
         id: "डेटाबेस پایگاه داده 数据库" + dateTime.getTime(),
-        indexingPolicy: { indexingMode: IndexingMode.lazy } // Modes : Lazy, Consistent
+        indexingPolicy: { indexingMode: IndexingMode.consistent }
       };
 
       // Create a container inside the database


### PR DESCRIPTION
The backend recently removed the ability for new containers to use lazy indexing. As a result, some of our tests are failing. We need to keep the IndexingMode.lazy around as some older accounts will still have this ability enabled. Without this change, master tests will start failing soon.