### PR TITLE
[Service Bus] atomXml.spec.ts has internal tests

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -10,14 +10,14 @@ import {
   AtomXmlSerializer,
   deserializeAtomXmlResponse,
   executeAtomXmlOperation
-} from "../src/util/atomXmlHelper";
-import * as Constants from "../src/util/constants";
-import { ServiceBusManagementClient } from "../src/serviceBusAtomManagementClient";
-import { QueueResourceSerializer } from "../src/serializers/queueResourceSerializer";
+} from "../../src/util/atomXmlHelper";
+import * as Constants from "../../src/util/constants";
+import { ServiceBusManagementClient } from "../../src/serviceBusAtomManagementClient";
+import { QueueResourceSerializer } from "../../src/serializers/queueResourceSerializer";
 import { HttpHeaders, HttpOperationResponse, WebResource } from "@azure/core-http";
-import { TopicResourceSerializer } from "../src/serializers/topicResourceSerializer";
-import { SubscriptionResourceSerializer } from "../src/serializers/subscriptionResourceSerializer";
-import { RuleResourceSerializer } from "../src/serializers/ruleResourceSerializer";
+import { TopicResourceSerializer } from "../../src/serializers/topicResourceSerializer";
+import { SubscriptionResourceSerializer } from "../../src/serializers/subscriptionResourceSerializer";
+import { RuleResourceSerializer } from "../../src/serializers/ruleResourceSerializer";
 
 const queueProperties = [
   Constants.LOCK_DURATION,


### PR DESCRIPTION
The tests in atomXml.spec.ts file are unit tests of sorts, target internal classes and do not need any live test resources.
The right home for these are in the "internal" folder so that they are run as part of PR CI and not just the nightly CI

This separation of internal tests will eventually help us in having a set of tests that test only the public facing api which can then be used for our min/max dependency version testing