### PR TITLE
Preventing dev feed for private package on script level and with artifact parameter option in pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -189,7 +189,7 @@ stages:
     dependsOn: ${{parameters.DependsOn}}
     jobs:
     - job: PublishPackages
-      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),ne(variables['Skip.PublishDevFeed'], 'true')))
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
       displayName: Publish package to daily feed
       pool:
         vmImage: ubuntu-18.04

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -189,7 +189,7 @@ stages:
     dependsOn: ${{parameters.DependsOn}}
     jobs:
     - job: PublishPackages
-      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),ne(variables['Skip.PublishDevFeed'], 'true')))
       displayName: Publish package to daily feed
       pool:
         vmImage: ubuntu-18.04
@@ -199,6 +199,7 @@ stages:
           artifact: ${{parameters.ArtifactName}}
           timeoutInMinutes: 5
         - ${{ each artifact in parameters.Artifacts }}:
+          - ${{if ne(artifact.options.skipPublishDevFeed, 'true')}}:
             - pwsh: |
                 $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*-dev*.tgz
                 echo "##vso[task.setvariable variable=Package.Archive]$detectedPackageName"

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -179,7 +179,8 @@ async function main(argv) {
   for (const package of Object.keys(rushPackages)) {
     if (
       ["client", "core"].includes(rushPackages[package].versionPolicy) &&
-      rushPackages[package].projectFolder.startsWith(`sdk/${service}`)
+      rushPackages[package].projectFolder.startsWith(`sdk/${service}`) &&
+      !rushPackages[package].json["private"]
     ) {
       targetPackages.push(package);
     }

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -30,3 +30,5 @@ extends:
     Artifacts:
       - name: azure-tables
         safeName: azuretables
+        options:
+          skipPublishDevFeed: true

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -31,4 +31,4 @@ extends:
       - name: azure-tables
         safeName: azuretables
         options:
-          skipPublishDevFeed: true
+          skipPublishDevFeed: true

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -29,5 +29,3 @@ extends:
     Artifacts:
       - name: azure-template
         safeName: azuretemplate
-        options:
-          skipPublishDevFeed: true

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -29,4 +29,5 @@ extends:
     Artifacts:
       - name: azure-template
         safeName: azuretemplate
-        skipPublishDevFeed: true
+        options:
+          skipPublishDevFeed: true

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -29,3 +29,4 @@ extends:
     Artifacts:
       - name: azure-template
         safeName: azuretemplate
+        skipPublishDevFeed: true


### PR DESCRIPTION
- Prevent private packages from being published to dev feed or failing at npm step- as such packages  won't get the dev tag
- Adding an option with the artifact parameter in ci.yml 
- Example of this is done in tables ci.yml in this PR and this works - https://dev.azure.com/azure-sdk/public/_build/results?buildId=453563&view=results