### PR TITLE
[Identity] Remove exporting the DAC credentials list

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -73,7 +73,6 @@ export class CredentialUnavailable extends Error {
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
     constructor(tokenCredentialOptions?: TokenCredentialOptions);
-    static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[];
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -22,11 +22,11 @@ import { TokenCredential } from "@azure/core-http";
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
   /**
-   * Returns the list of credentials DefaultAzureCredential will use to authenticate.
+   * Creates an instance of the DefaultAzureCredential class.
    *
    * @param options Options for configuring the client which makes the authentication request.
    */
-  static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[] {
+  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
     let credentials = [];
     credentials.push(new EnvironmentCredential(tokenCredentialOptions));
     credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
@@ -38,15 +38,6 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     credentials.push(new AzureCliCredential());
     credentials.push(new VSCodeCredential(tokenCredentialOptions));
 
-    return credentials;
-  }
-  /**
-   * Creates an instance of the DefaultAzureCredential class.
-   *
-   * @param options Options for configuring the client which makes the authentication request.
-   */
-  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
-    let credentials = DefaultAzureCredential.credentials(tokenCredentialOptions);
     super(
       ...credentials
     );


### PR DESCRIPTION
After the arch board yesterday, and some conversations today, looks like the simplest way forward for 1.1 is to remove the export of the DAC credentials. We'll review customer feedback as 1.1 ships to see what delta from here we need to ensure that the transition from DAC to ChainedTokenCredential is as smooth as possible.