### PR TITLE
[core-amqp] close session after sender and receiver in requestResponseLink

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.5 (Unreleased)
 
+- Fixes issue [9615](https://github.com/Azure/azure-sdk-for-js/issues/9615)
+  where closing the `RequestResponseLink` session before closing the receiver
+  could cause the service to report a missing session channel.
 
 ## 1.1.4 (2020-06-30)
 

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -235,8 +235,8 @@ export class RequestResponseLink implements ReqResLink {
    * @returns {Promise<void>} Promise<void>
    */
   async close(): Promise<void> {
-    await this.sender.close();
-    await this.receiver.close();
+    await this.sender.close({ closeSession: false });
+    await this.receiver.close({ closeSession: false });
     await this.session.close();
   }
 


### PR DESCRIPTION
Fixes #9615 

## Description
This change ensures that when a `RequestResponseLink` is closed, the sender and receiver are closed before the session.

## What was happening before?
Previously, when `this.sender.close()` was called, the session was also closed. 

## Why was this a problem?
Interestingly, after the sender and session were closed, I'd see a new see a new message arrive on the (cbs) receiver followed immediately by a new session being created. This appears to be in response to the EventHubConsumerClient calling `receiveBatch`, and triggering a race condition where the cbs receiver hasn't been explicitly closed yet, but the session has been.

Next `this.receiver.close()` is called, and viewed as already being closed.

I can tell from the logs that the session the cbs receiver was attached to was session 0, and the error from the service says it can't find the session channel '0', so I believe we're hitting a race condition where there's still some activity on the receiver link just after/while the session is being closed.

## The fix?
`rhea-promise` let's us opt out of closing the session when calling `sender.close()` or `receiver.close()`. This leads to a more graceful close of the RequestResponseLink as we can be sure all in-flight bytes on the sender and receiver links are handled before closing the session.
