### PR TITLE
[Service Bus] Renaming `userProperties` to `properties` - Both ServiceBusMessage and ATOM API

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.0.0-preview.5 (Unreleased)
 
+- `userProperties` attribute under the `ServiceBusMessage`(and `ReceivedMessage`, `ReceivedMessageWithLock`) has been renamed to `properties`. Same change has been made to the `userProperties` attribute in the correlation-rule filter.
+  [PR 10003](https://github.com/Azure/azure-sdk-for-js/pull/10003)
 
 ## 7.0.0-preview.4 (2020-07-07)
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -38,11 +38,11 @@ export interface CorrelationRuleFilter {
     correlationId?: string;
     label?: string;
     messageId?: string;
+    properties?: any;
     replyTo?: string;
     replyToSessionId?: string;
     sessionId?: string;
     to?: string;
-    userProperties?: any;
 }
 
 // @public
@@ -338,15 +338,15 @@ export interface ServiceBusMessage {
     label?: string;
     messageId?: string | number | Buffer;
     partitionKey?: string;
+    properties?: {
+        [key: string]: any;
+    };
     replyTo?: string;
     replyToSessionId?: string;
     scheduledEnqueueTimeUtc?: Date;
     sessionId?: string;
     timeToLive?: number;
     to?: string;
-    userProperties?: {
-        [key: string]: any;
-    };
     viaPartitionKey?: string;
 }
 

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -113,7 +113,7 @@ export interface CorrelationRuleFilter {
   /**
    * Value to be matched with the user properties of the incoming message.
    */
-  userProperties?: any;
+  properties?: any;
 }
 
 /**
@@ -129,7 +129,7 @@ const correlationProperties = [
   "sessionId",
   "replyToSessionId",
   "contentType",
-  "userProperties"
+  "properties"
 ];
 
 /**
@@ -1213,7 +1213,7 @@ export class ManagementClient extends LinkEntity {
               sessionId: this._safelyGetTypedValueFromArray(filtersRawData.value, 5),
               replyToSessionId: this._safelyGetTypedValueFromArray(filtersRawData.value, 6),
               contentType: this._safelyGetTypedValueFromArray(filtersRawData.value, 7),
-              userProperties: this._safelyGetTypedValueFromArray(filtersRawData.value, 8)
+              properties: this._safelyGetTypedValueFromArray(filtersRawData.value, 8)
             };
             break;
           default:
@@ -1346,7 +1346,7 @@ export class ManagementClient extends LinkEntity {
             "session-id": filter.sessionId,
             "reply-to-session-id": filter.replyToSessionId,
             "content-type": filter.contentType,
-            properties: filter.userProperties
+            properties: filter.properties
           };
           break;
       }

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -59,7 +59,7 @@ function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
       sessionId: getStringOrUndefined(value["SessionId"]),
       messageId: getStringOrUndefined(value["MessageId"]),
       contentType: getStringOrUndefined(value["ContentType"]),
-      userProperties: getUserPropertiesOrUndefined(value["Properties"])
+      properties: getUserPropertiesOrUndefined(value["Properties"])
     };
   }
   return result;

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -188,7 +188,7 @@ export class RuleResourceSerializer implements AtomXmlSerializer {
           ContentType: correlationFilter.contentType,
           SessionId: correlationFilter.sessionId,
           MessageId: correlationFilter.messageId,
-          Properties: getRawUserProperties(correlationFilter.userProperties)
+          Properties: getRawUserProperties(correlationFilter.properties)
         };
         resource.Filter[Constants.XML_METADATA_MARKER] = {
           "p4:type": "CorrelationFilter",

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -417,7 +417,7 @@ export function getRawSqlParameters(
 /**
  * @internal
  * @ignore
- * Helper utility to extract array of userProperties key-value instances from given input,
+ * Helper utility to extract array of user properties key-value instances from given input,
  * or undefined if not passed in.
  * @param value
  */
@@ -434,7 +434,7 @@ export function getRawUserProperties(
     Object.entries(parameters).length < 1
   ) {
     throw new TypeError(
-      `Unsupported value for the userProperties ${JSON.stringify(
+      `Unsupported value for the properties ${JSON.stringify(
         parameters
       )}, expected a JSON object with key-value pairs.`
     );

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -219,7 +219,7 @@ export interface ServiceBusMessage {
    * @property The application specific properties which can be
    * used for custom message metadata.
    */
-  userProperties?: { [key: string]: any };
+  properties?: { [key: string]: any };
 }
 
 /**
@@ -288,8 +288,8 @@ export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
     body: msg.body,
     message_annotations: {}
   };
-  if (msg.userProperties != null) {
-    amqpMsg.application_properties = msg.userProperties;
+  if (msg.properties != null) {
+    amqpMsg.application_properties = msg.properties;
   }
   if (msg.contentType != null) {
     amqpMsg.content_type = msg.contentType;
@@ -574,7 +574,7 @@ export function fromAmqpMessage(
   };
 
   if (msg.application_properties != null) {
-    sbmsg.userProperties = msg.application_properties;
+    sbmsg.properties = msg.application_properties;
   }
   if (msg.content_type != null) {
     sbmsg.contentType = msg.content_type;
@@ -692,7 +692,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   /**
    * @property The application specific properties.
    */
-  userProperties?: { [key: string]: any };
+  properties?: { [key: string]: any };
   /**
    * @property The message identifier is an
    * application-defined value that uniquely identifies the message and its payload. The identifier
@@ -1022,7 +1022,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
       sessionId: this.sessionId,
       timeToLive: this.timeToLive,
       to: this.to,
-      userProperties: this.userProperties,
+      properties: this.properties,
       viaPartitionKey: this.viaPartitionKey
     };
 

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1532,7 +1532,7 @@ describe("Atom management - Authentication", function(): void {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: {
+        properties: {
           randomState: "WA",
           randomCountry: "US",
           randomCount: 25,
@@ -1551,7 +1551,7 @@ describe("Atom management - Authentication", function(): void {
         replyToSessionId: "",
         sessionId: "",
         to: "",
-        userProperties: {
+        properties: {
           randomState: "WA",
           randomCountry: "US",
           randomCount: 25,
@@ -2095,7 +2095,7 @@ describe("Atom management - Authentication", function(): void {
         replyToSessionId: "",
         sessionId: "",
         to: "",
-        userProperties: undefined
+        properties: undefined
       },
       action: {
         sqlExpression: "SET sys.label='RED'",

--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -573,7 +573,7 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: {
+        properties: {
           message: ["hello"]
         }
       }
@@ -589,7 +589,7 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: {
+        properties: {
           message: {}
         }
       }
@@ -605,7 +605,7 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: {
+        properties: {
           message: undefined
         }
       }
@@ -621,11 +621,11 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: 123
+        properties: 123
       }
     },
     output: {
-      testErrorMessage: `Unsupported value for the userProperties 123, expected a JSON object with key-value pairs.`,
+      testErrorMessage: `Unsupported value for the properties 123, expected a JSON object with key-value pairs.`,
       testErrorType: Error
     }
   },
@@ -635,11 +635,11 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: "abcd"
+        properties: "abcd"
       }
     },
     output: {
-      testErrorMessage: `Unsupported value for the userProperties "abcd", expected a JSON object with key-value pairs.`,
+      testErrorMessage: `Unsupported value for the properties "abcd", expected a JSON object with key-value pairs.`,
       testErrorType: Error
     }
   },
@@ -649,11 +649,11 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: ["abcd"]
+        properties: ["abcd"]
       }
     },
     output: {
-      testErrorMessage: `Unsupported value for the userProperties ["abcd"], expected a JSON object with key-value pairs.`,
+      testErrorMessage: `Unsupported value for the properties ["abcd"], expected a JSON object with key-value pairs.`,
       testErrorType: Error
     }
   },
@@ -663,11 +663,11 @@ class MockSerializer implements AtomXmlSerializer {
     input: {
       filter: {
         correlationId: "abcd",
-        userProperties: {}
+        properties: {}
       }
     },
     output: {
-      testErrorMessage: `Unsupported value for the userProperties {}, expected a JSON object with key-value pairs.`,
+      testErrorMessage: `Unsupported value for the properties {}, expected a JSON object with key-value pairs.`,
       testErrorType: Error
     }
   }

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -153,9 +153,9 @@ describe("dead lettering", () => {
     const deadLetterMessages = await deadLetterReceiver.receiveMessages(1);
     should.exist(deadLetterMessages[0]);
 
-    const reason = deadLetterMessages[0]!.userProperties!["DeadLetterReason"];
-    const description = deadLetterMessages[0]!.userProperties!["DeadLetterErrorDescription"];
-    const customProperty = deadLetterMessages[0]!.userProperties!["customProperty"];
+    const reason = deadLetterMessages[0]!.properties!["DeadLetterReason"];
+    const description = deadLetterMessages[0]!.properties!["DeadLetterErrorDescription"];
+    const customProperty = deadLetterMessages[0]!.properties!["customProperty"];
 
     should.equal(reason, expected.reason);
     should.equal(description, expected.description);
@@ -282,7 +282,7 @@ describe("abandoning", () => {
   ) {
     should.exist(abandonedMessage);
 
-    const customProperty = abandonedMessage.userProperties!["customProperty"];
+    const customProperty = abandonedMessage.properties!["customProperty"];
 
     should.equal(customProperty, expected.customProperty);
   }
@@ -400,7 +400,7 @@ describe("deferring", () => {
 
     should.exist(deferredMessage);
 
-    const customProperty = deferredMessage!.userProperties!["customProperty"];
+    const customProperty = deferredMessage!.properties!["customProperty"];
 
     should.equal(customProperty, expected.customProperty);
   }

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -22,7 +22,7 @@ export class TestMessage {
       to: `to ${randomNumber}`,
       replyTo: `reply to ${randomNumber}`,
       scheduledEnqueueTimeUtc: new Date(),
-      userProperties: {
+      properties: {
         propOne: 1,
         propTwo: "two",
         propThree: true
@@ -43,7 +43,7 @@ export class TestMessage {
       to: `to ${randomNumber}`,
       replyTo: `reply to ${randomNumber}`,
       scheduledEnqueueTimeUtc: new Date(),
-      userProperties: {
+      properties: {
         propOne: 1,
         propTwo: "two",
         propThree: true
@@ -63,13 +63,13 @@ export class TestMessage {
     useSessions?: boolean,
     usePartitions?: boolean
   ): void {
-    if (sent.userProperties) {
-      if (!received.userProperties) {
+    if (sent.properties) {
+      if (!received.properties) {
         chai.assert.fail("Received message doesnt have any user properties");
         return;
       }
-      const expectedUserProperties = sent.userProperties;
-      const receivedUserProperties = received.userProperties;
+      const expectedUserProperties = sent.properties;
+      const receivedUserProperties = received.properties;
       Object.keys(expectedUserProperties).forEach((key) => {
         chai.assert.equal(
           receivedUserProperties[key],


### PR DESCRIPTION
Renaming the `userProperties` attribute to `properties` in both ServiceBusMessage and CorrelationFilter to stay consistent with .NET, Java and python SDKs.