### PR TITLE
[Test Recorder] Fix browser custom console logging when recording

### DIFF
--- a/sdk/test-utils/recorder/src/customConsoleLog.ts
+++ b/sdk/test-utils/recorder/src/customConsoleLog.ts
@@ -26,10 +26,14 @@ import { isBrowser } from "./utils";
 // - Example - console.warn("hello"); -> console.log({ warn: "hello" });
 // - Example - console.log("hello"); -> console.log({ log: "hello" });
 
-let consoleLog: (msg: any, ...args: any[]) => void;
+export let consoleLog: (msg: any, ...args: any[]) => void;
 
 if (isBrowser()) {
   consoleLog = window.console.log;
+}
+
+export function setConsoleLogForTesting(func: (msg: any, ...args: any[]) => void) {
+  consoleLog = func;
 }
 
 /**

--- a/sdk/test-utils/recorder/src/customConsoleLog.ts
+++ b/sdk/test-utils/recorder/src/customConsoleLog.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+import { isBrowser } from "./utils";
+
 // Converting content corresponding to all the console statements
 // into (JSON.stringify)-ed content in record mode for browser tests.
 //
@@ -24,12 +26,17 @@
 // - Example - console.warn("hello"); -> console.log({ warn: "hello" });
 // - Example - console.log("hello"); -> console.log({ log: "hello" });
 
+let consoleLog: (msg: any, ...args: any[]) => void;
+
+if (isBrowser()) {
+  consoleLog = window.console.log;
+}
+
 /**
  * Converts content corresponding to all the console statements into (JSON.stringify)-ed content in record mode for browser tests.
  * This allows filtering certain console.logs to generate the recordings for browser tests.
  */
 export function customConsoleLog() {
-  const consoleLog = window.console.log;
   for (const method in window.console) {
     if (
       window.console.hasOwnProperty(method) &&

--- a/sdk/test-utils/recorder/test/browser/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/recorder.spec.ts
@@ -3,7 +3,7 @@ import { record, TestContextInterface, TestContext, TestContextTest } from "../.
 import xhrMock from "xhr-mock";
 import MD5 from "md5";
 import chai from "chai";
-import { consoleLog, setConsoleLogForTesting } from '../../src/customConsoleLog';
+import { consoleLog, setConsoleLogForTesting } from "../../src/customConsoleLog";
 const { expect } = chai;
 
 const expectedHttpResponse = "Hello World!";
@@ -74,9 +74,9 @@ describe("The recorder's public API, on a browser", () => {
     const savedConsoleLogParams: any[] = [];
     setConsoleLogForTesting((...params: any[]) => {
       if (params && params.length > 0) {
-        try{
-          if (JSON.parse(params[0]).writeFile){
-          savedConsoleLogParams.push(params);
+        try {
+          if (JSON.parse(params[0]).writeFile) {
+            savedConsoleLogParams.push(params);
           }
         } catch (err) {}
       }
@@ -215,14 +215,13 @@ describe("The recorder's public API, on a browser", () => {
     const savedConsoleLogParams: any[] = [];
     setConsoleLogForTesting((...params: any[]) => {
       if (params && params.length > 0) {
-        try{
-          if (JSON.parse(params[0]).writeFile){
-          savedConsoleLogParams.push(params);
+        try {
+          if (JSON.parse(params[0]).writeFile) {
+            savedConsoleLogParams.push(params);
           }
         } catch (err) {}
       }
     });
-
 
     // The recorder should start in the beforeEach call.
     // To emulate that behavior while keeping the test code as contained as possible,

--- a/sdk/test-utils/recorder/test/browser/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/recorder.spec.ts
@@ -3,6 +3,7 @@ import { record, TestContextInterface, TestContext, TestContextTest } from "../.
 import xhrMock from "xhr-mock";
 import MD5 from "md5";
 import chai from "chai";
+import { consoleLog, setConsoleLogForTesting } from '../../src/customConsoleLog';
 const { expect } = chai;
 
 const expectedHttpResponse = "Hello World!";
@@ -69,11 +70,17 @@ describe("The recorder's public API, on a browser", () => {
 
     // The recorder outputs files into the console,
     // so we need to mock the console.log function to capture and test the recorder output.
-    const originalConsoleLog = console.log;
+    const originalConsoleLog = consoleLog;
     const savedConsoleLogParams: any[] = [];
-    console.log = (...params: any[]) => {
-      savedConsoleLogParams.push(params);
-    };
+    setConsoleLogForTesting((...params: any[]) => {
+      if (params && params.length > 0) {
+        try{
+          if (JSON.parse(params[0]).writeFile){
+          savedConsoleLogParams.push(params);
+          }
+        } catch (err) {}
+      }
+    });
 
     // The recorder should start in the beforeEach call.
     // We have to do this to emulate that.
@@ -97,7 +104,7 @@ describe("The recorder's public API, on a browser", () => {
     // Cleaning everything before we continue verifying the results.
     xhrMock.teardown();
     recorder.stop();
-    console.log = originalConsoleLog;
+    setConsoleLogForTesting(originalConsoleLog);
 
     // Here we confirm that the recorder generated an expected output on the console.logs.
     // This output is used to generate the recording files in the filesystem, though here we're only
@@ -203,12 +210,19 @@ describe("The recorder's public API, on a browser", () => {
     const originalXHR = XMLHttpRequest;
 
     // The recorder outputs files into the console,
-    // so we need to mock the console.log function to capture and test the recorder output.
-    const originalConsoleLog = console.log;
+    // so we need to override the consoleLog function to capture and test the recorder output.
+    const originalConsoleLog = consoleLog;
     const savedConsoleLogParams: any[] = [];
-    console.log = (...params: any) => {
-      savedConsoleLogParams.push(params);
-    };
+    setConsoleLogForTesting((...params: any[]) => {
+      if (params && params.length > 0) {
+        try{
+          if (JSON.parse(params[0]).writeFile){
+          savedConsoleLogParams.push(params);
+          }
+        } catch (err) {}
+      }
+    });
+
 
     // The recorder should start in the beforeEach call.
     // To emulate that behavior while keeping the test code as contained as possible,
@@ -234,7 +248,7 @@ describe("The recorder's public API, on a browser", () => {
     // Cleaning everything before we continue verifying the results.
     xhrMock.teardown();
     recorder.stop();
-    console.log = originalConsoleLog;
+    setConsoleLogForTesting(originalConsoleLog);
 
     // Now we check the hash has changed in the recorded console.log output.
 


### PR DESCRIPTION
In function `customConsoleLog()` we save `window.console.log` to a
local variable and use this variable to log to real console.  The
problem is that when `customConsoleLog()` is called multiple times,
`window.console.log` is no longer the original one, and we end up
nesting the modified `log` function again and again.

This PR saves the original console log function to a module level
variable instead so it's not wrapped multiple times.

Fixes #6475