### PR TITLE
[service-bus] fix uncaught TypeError

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -201,11 +201,9 @@ export namespace ConnectionContext {
           // Wait for the disconnected event that indicates the underlying socket has closed.
           await this.waitForDisconnectedEvent();
         }
-        // Check if the connection is currently in the process of disconnecting.
-        if (waitForDisconnectPromise) {
-          // Wait for the connection to be reset.
-          await this.waitForConnectionReset();
-        }
+
+        // Wait for the connection to be reset.
+        await this.waitForConnectionReset();
       },
       waitForDisconnectedEvent() {
         return new Promise((resolve) => {
@@ -218,6 +216,7 @@ export namespace ConnectionContext {
         });
       },
       waitForConnectionReset() {
+        // Check if the connection is currently in the process of disconnecting.
         if (waitForDisconnectPromise) {
           return waitForDisconnectPromise;
         }

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -184,8 +184,8 @@ export namespace ConnectionContext {
     };
     connectionContext.managementSession = new ManagementClient(connectionContext, mOptions);
 
-    let waitForDisconnectResolve: () => void;
-    let waitForDisconnectPromise: Promise<void> | undefined;
+    let waitForConnectionRefreshResolve: () => void;
+    let waitForConnectionRefreshPromise: Promise<void> | undefined;
 
     Object.assign<ConnectionContext, ConnectionContextMethods>(connectionContext, {
       isConnectionClosing() {
@@ -217,8 +217,8 @@ export namespace ConnectionContext {
       },
       waitForConnectionReset() {
         // Check if the connection is currently in the process of disconnecting.
-        if (waitForDisconnectPromise) {
-          return waitForDisconnectPromise;
+        if (waitForConnectionRefreshPromise) {
+          return waitForConnectionRefreshPromise;
         }
         return Promise.resolve();
       },
@@ -265,11 +265,11 @@ export namespace ConnectionContext {
     };
 
     const onDisconnected: OnAmqpEvent = async (context: EventContext) => {
-      if (waitForDisconnectPromise) {
+      if (waitForConnectionRefreshPromise) {
         return;
       }
-      waitForDisconnectPromise = new Promise((resolve) => {
-        waitForDisconnectResolve = resolve;
+      waitForConnectionRefreshPromise = new Promise((resolve) => {
+        waitForConnectionRefreshResolve = resolve;
       });
 
       logger.verbose(
@@ -336,8 +336,8 @@ export namespace ConnectionContext {
       }
 
       await refreshConnection(connectionContext);
-      waitForDisconnectResolve();
-      waitForDisconnectPromise = undefined;
+      waitForConnectionRefreshResolve();
+      waitForConnectionRefreshPromise = undefined;
     };
 
     const protocolError: OnAmqpEvent = async (context: EventContext) => {

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -193,6 +193,12 @@ export class LinkEntity {
     if (!this._tokenTimeoutInMs) {
       return;
     }
+    // Clear the existing token renewal timer.
+    // This scenario can happen if the connection goes down and is brought back up
+    // before the `nextRenewalTimeout` was reached.
+    if (this._tokenRenewalTimer) {
+      clearTimeout(this._tokenRenewalTimer);
+    }
     this._tokenRenewalTimer = setTimeout(async () => {
       try {
         await this._negotiateClaim(true);

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - `userProperties` attribute under the `ServiceBusMessage`(and `ReceivedMessage`, `ReceivedMessageWithLock`) has been renamed to `properties`. Same change has been made to the `userProperties` attribute in the correlation-rule filter.
   [PR 10003](https://github.com/Azure/azure-sdk-for-js/pull/10003)
+- Fixes [bug 9926](https://github.com/Azure/azure-sdk-for-js/issues/9926)
+  where attempting to create AMQP links when the AMQP connection was in the
+  process of closing resulted in a `TypeError` in an uncaught exception.
 
 ## 7.0.0-preview.4 (2020-07-07)
 

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -137,11 +137,9 @@ export namespace ConnectionContext {
           // Wait for the disconnected event that indicates the underlying socket has closed.
           await this.waitForDisconnectedEvent();
         }
-        // Check if the connection is currently in the process of disconnecting.
-        if (waitForDisconnectPromise) {
-          // Wait for the connection to be reset.
-          await this.waitForConnectionReset();
-        }
+
+        // Wait for the connection to be reset.
+        await this.waitForConnectionReset();
         log.error(`[${this.connectionId}] Connection is ready to open link.`);
       },
       waitForDisconnectedEvent() {
@@ -155,6 +153,7 @@ export namespace ConnectionContext {
         });
       },
       waitForConnectionReset() {
+        // Check if the connection is currently in the process of disconnecting.
         if (waitForDisconnectPromise) {
           return waitForDisconnectPromise;
         }

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -27,8 +27,64 @@ export interface ConnectionContext extends ConnectionContextBase {
    * @property A dictionary of ClientEntityContext
    * objects for each of the client in the `clients` dictionary
    */
-  clientContexts: { [name: string]: ClientEntityContext }
+  clientContexts: { [name: string]: ClientEntityContext };
+
+  /**
+   * Function returning a promise that resolves once the connectionContext is ready to open an AMQP link.
+   * ConnectionContext will be ready to open an AMQP link when:
+   * - The AMQP connection is already open on both sides.
+   * - The AMQP connection has been closed or disconnected. In this case, a new AMQP connection is expected
+   * to be created first.
+   * An AMQP link cannot be opened if the AMQP connection
+   * is in the process of closing or disconnecting.
+   */
+  readyToOpenLink(): Promise<void>;
 }
+
+/**
+ * Describes the members on the ConnectionContext that are only
+ * used by it internally.
+ * @ignore
+ * @internal
+ */
+export interface ConnectionContextInternalMembers extends ConnectionContext {
+  /**
+   * Indicates whether the connection is in the process of closing.
+   * When this returns `true`, a `disconnected` event will be received
+   * after the connection is closed.
+   *
+   */
+  isConnectionClosing(): boolean;
+  /**
+   * Resolves once the context's connection emits a `disconnected` event.
+   */
+  waitForDisconnectedEvent(): Promise<void>;
+  /**
+   * Resolves once the connection has finished being reset.
+   * Connections are reset as part of reacting to a `disconnected` event.
+   */
+  waitForConnectionReset(): Promise<void>;
+}
+
+/**
+ * Helper type to get the names of all the functions on an object.
+ */
+type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+/**
+ * Helper type to get the types of all the functions on an object.
+ */
+type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
+/**
+ * Helper type to get the types of all the functions on ConnectionContext
+ * and the internal methods from ConnectionContextInternalMembers.
+ * Note that this excludes the functions that ConnectionContext inherits.
+ * Each function also has its `this` type set as `ConnectionContext`.
+ */
+type ConnectionContextMethods = Omit<
+  FunctionProperties<ConnectionContextInternalMembers>,
+  FunctionPropertyNames<ConnectionContextBase>
+> &
+  ThisType<ConnectionContextInternalMembers>;
 
 /**
  * @internal
@@ -64,6 +120,48 @@ export namespace ConnectionContext {
     const connectionContext = ConnectionContextBase.create(parameters) as ConnectionContext;
     connectionContext.clientContexts = {};
 
+    let waitForDisconnectResolve: () => void;
+    let waitForDisconnectPromise: Promise<void> | undefined;
+    Object.assign<ConnectionContext, ConnectionContextMethods>(connectionContext, {
+      isConnectionClosing() {
+        // When the connection is not open, but the remote end is open,
+        // then the rhea connection is in the process of terminating.
+        return Boolean(!this.connection.isOpen() && this.connection.isRemoteOpen());
+      },
+      async readyToOpenLink() {
+        log.error(`[${this.connectionId}] Waiting until the connection is ready to open link.`);
+        // Check that the connection isn't in the process of closing.
+        // This can happen when the idle timeout has been reached but
+        // the underlying socket is waiting to be destroyed.
+        if (this.isConnectionClosing()) {
+          // Wait for the disconnected event that indicates the underlying socket has closed.
+          await this.waitForDisconnectedEvent();
+        }
+        // Check if the connection is currently in the process of disconnecting.
+        if (waitForDisconnectPromise) {
+          // Wait for the connection to be reset.
+          await this.waitForConnectionReset();
+        }
+        log.error(`[${this.connectionId}] Connection is ready to open link.`);
+      },
+      waitForDisconnectedEvent() {
+        return new Promise((resolve) => {
+          log.error(
+            `[${this.connectionId}] Attempting to reinitialize connection` +
+              ` but the connection is in the process of closing.` +
+              ` Waiting for the disconnect event before continuing.`
+          );
+          this.connection.once(ConnectionEvents.disconnected, resolve);
+        });
+      },
+      waitForConnectionReset() {
+        if (waitForDisconnectPromise) {
+          return waitForDisconnectPromise;
+        }
+        return Promise.resolve();
+      }
+    });
+
     // Define listeners to be added to the connection object for
     // "connection_open" and "connection_error" events.
     const onConnectionOpen: OnAmqpEvent = () => {
@@ -76,6 +174,13 @@ export namespace ConnectionContext {
     };
 
     const disconnected: OnAmqpEvent = async (context: EventContext) => {
+      if (waitForDisconnectPromise) {
+        return;
+      }
+      waitForDisconnectPromise = new Promise((resolve) => {
+        waitForDisconnectResolve = resolve;
+      });
+
       const connectionError =
         context.connection && context.connection.error ? context.connection.error : undefined;
       if (connectionError) {
@@ -117,6 +222,8 @@ export namespace ConnectionContext {
       }
 
       await refreshConnection(connectionContext);
+      waitForDisconnectResolve();
+      waitForDisconnectPromise = undefined;
       // The connection should always be brought back up if the sdk did not call connection.close()
       // and there was atleast one sender/receiver link on the connection before it went down.
       log.error("[%s] state: %O", connectionContext.connectionId, state);

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -109,6 +109,8 @@ export class LinkEntity {
    * @return {Promise<void>} Promise<void>
    */
   protected async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {
+    // Wait for the connectionContext to be ready to open the link.
+    await this._context.namespace.readyToOpenLink();
     // Acquire the lock and establish a cbs session if it does not exist on the connection.
     // Although node.js is single threaded, we need a locking mechanism to ensure that a
     // race condition does not happen while creating a shared resource (in this case the
@@ -187,6 +189,12 @@ export class LinkEntity {
   protected _ensureTokenRenewal(): void {
     if (!this._tokenTimeout) {
       return;
+    }
+    // Clear the existing token renewal timer in case it hasn't already fired.
+    // This scenario can happen if the connection goes down and is brought back up
+    // before the `nextRenewalTimeout` was reached.
+    if (this._tokenRenewalTimer) {
+      clearTimeout(this._tokenRenewalTimer);
     }
     this._tokenRenewalTimer = setTimeout(async () => {
       try {

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -190,7 +190,7 @@ export class LinkEntity {
     if (!this._tokenTimeout) {
       return;
     }
-    // Clear the existing token renewal timer in case it hasn't already fired.
+    // Clear the existing token renewal timer in case the previous timeout hasn't been reached.
     // This scenario can happen if the connection goes down and is brought back up
     // before the `nextRenewalTimeout` was reached.
     if (this._tokenRenewalTimer) {

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -190,7 +190,7 @@ export class LinkEntity {
     if (!this._tokenTimeout) {
       return;
     }
-    // Clear the existing token renewal timer in case the previous timeout hasn't been reached.
+    // Clear the existing token renewal timer.
     // This scenario can happen if the connection goes down and is brought back up
     // before the `nextRenewalTimeout` was reached.
     if (this._tokenRenewalTimer) {

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -910,9 +910,6 @@ describe(noSessionTestClientType + ": Batch Receiver - disconnects", function():
       "_connection"
     ].idle();
 
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
     // send a second message to trigger the message handler again.
     await sender.sendMessages(TestMessage.getSample());
 

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -3,7 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ReceivedMessageWithLock, Receiver, Sender, delay } from "../src";
+import { ReceivedMessageWithLock, Receiver, Sender } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 chai.should();
@@ -62,10 +62,6 @@ describe("ManagementClient - disconnects", function(): void {
     // Simulate a disconnect being called with a non-retryable error.
     connectionContext.connection["_connection"].idle();
 
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
-
     // peek additional messages
     messages = await receiver.peekMessages(1);
     peekedMessageCount += messages.length;
@@ -98,10 +94,6 @@ describe("ManagementClient - disconnects", function(): void {
 
     // Simulate a disconnect being called with a non-retryable error.
     connectionContext.connection["_connection"].idle();
-
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
 
     // peek additional messages
     const [deliveryId] = await sender.scheduleMessages(

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -398,9 +398,6 @@ describe.skip("SessionReceiver - disconnects", function(): void {
     // Simulate a disconnect being called with a non-retryable error.
     (receiver as any)["_context"].namespace.connection["_connection"].idle();
 
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
     // send a second message to trigger the message handler again.
     await sender.sendMessages(TestMessage.getSessionSample());
     console.log("Waiting for 2nd message");

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -1140,9 +1140,6 @@ describe(testClientType + ": Streaming - disconnects", function(): void {
     // Simulate a disconnect being called with a non-retryable error.
     (receiver as any)["_context"].namespace.connection["_connection"].idle();
 
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
     // send a second message to trigger the message handler again.
     await sender.sendMessages(TestMessage.getSample());
 


### PR DESCRIPTION
Addresses #9914 for service bus 7.x
Fixes #9926 `TypeError: Cannot read property 'idle_time_out' of undefined`.
Similar PR for service bus 1.x: https://github.com/Azure/azure-sdk-for-js/pull/10046

## Summary
This change ports the uncaught TypeError fixes that were made in event-hubs in #8884. It also ensures that existing token renewal timeouts are cleared when an entity receiver/sender is brought back up.

## Additional background
https://github.com/Azure/azure-sdk-for-js/pull/8884#issue-417044472 contains a detailed description for the changes made to `ConnectionContext` to ensure that the connection has been refreshed before attempting to bring a connection back up.

## Why do we need to clear `_tokenRenewalTimer` in `_ensureTokenRenewal`?
When a client is brought back up after a disconnect, `_ensureTokenRenewal` is called. Since we weren't clearing the existing timer before replacing it, the original timer would hang around even after the user explicitly closed the client.

This change ensures that there's only one timer per client (sender, receiver).

## What's up with the tests removing the 2 second delays?
When I originally added the 2 second delays in the disconnect tests, it was because I was seeing weird behaviour with `rhea` when calling `idle()`. At the time, I attributed this to the ~1 second timeout between when idle is called and when the underlying socket is actually destroyed and the fact I was calling a non-documented API. rhea has since been updated to properly destroy the socket (though still with a 1 second timeout) since then. Also, in #8884 we discovered we do need to properly handle that 1 second timeout in our package to prevent uncaught TypeErrors.

It turns out that without these delays, we can reliably reproduce the idle_time_out is undefined error, so the existing tests cover what this change is meant to fix now that the delays are removed.

