### PR TITLE
[service-bus] Add in receiver restart into the standard sample for .registerMessageHandler

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -1,17 +1,24 @@
 /*
-Copyright (c) Microsoft Corporation. All rights reserved.
-Licensed under the MIT Licence.
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
 
-This sample demonstrates how the receive() function can be used to receive Service Bus messages
-in a stream.
+  This sample demonstrates how the receive() function can be used to receive Service Bus messages
+  in a stream.
 
-Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
+  Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
 */
 
-const { delay, ServiceBusClient, ReceiveMode } = require("@azure/service-bus");
+const {
+  OnMessage,
+  OnError,
+  ServiceBusClient,
+  ReceiveMode,
+  MessagingError
+} = require("@azure/service-bus");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 // Define connection string and related Service Bus entity names here
 const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
@@ -23,31 +30,47 @@ async function main() {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
   const queueClient = sbClient.createQueueClient(queueName);
 
-  // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
+  // To receive messages from sessions, use createSessionReceiver instead of createReceiver or look at
   // the sample in sessions.ts file
-  const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
 
-  const onMessageHandler = async (brokeredMessage) => {
-    console.log(`Received message: ${brokeredMessage.body}`);
-    await brokeredMessage.complete();
-  };
-  const onErrorHandler = (err) => {
-    console.log("Error occurred: ", err);
-  };
+  // controls whether we continue to recover from fatal Receiver failures.
+  let enableReceiverRecovery = true;
 
-  try {
-    receiver.registerMessageHandler(onMessageHandler, onErrorHandler, {
-      autoComplete: false
+  do {
+    const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
+
+    const receiverPromise = new Promise((resolve, _reject) => {
+      const onMessageHandler = async (brokeredMessage) => {
+        console.log(`Received message: ${brokeredMessage.body}`);
+        await brokeredMessage.complete();
+      };
+
+      const onErrorHandler = (err) => {
+        if (err.retryable === false) {
+          console.log("Receiver will be recreated. A fatal error occurred:", err);
+          resolve();
+        } else {
+          console.log("Non-fatal error occurred: ", err);
+        }
+      };
+
+      receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
     });
 
-    // Waiting long enough before closing the receiver to receive messages
-    await delay(5000);
+    // This will only resolve if our receiver has failed in a way that is not recoverable.
+    await receiverPromise;
 
+    // the Service Bus package is intended to be resilient in the face of transitive issues, like network
+    // interruptions. If there are continual restarts this might indicate a more serious issue, like a network
+    // outage.
+    console.log(`Closing previous receiver and recreating - a fatal error has occurred.`);
+
+    // we can close the old receiver and just let the loop start again.
     await receiver.close();
-    await queueClient.close();
-  } finally {
-    await sbClient.close();
-  }
+  } while (enableReceiverRecovery);
+
+  await queueClient.close();
+  await sbClient.close();
 }
 
 main().catch((err) => {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -8,7 +8,13 @@
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
 */
 
-import { OnMessage, OnError, delay, ServiceBusClient, ReceiveMode } from "@azure/service-bus";
+import {
+  OnMessage,
+  OnError,
+  ServiceBusClient,
+  ReceiveMode,
+  MessagingError
+} from "@azure/service-bus";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -24,29 +30,47 @@ export async function main() {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
   const queueClient = sbClient.createQueueClient(queueName);
 
-  // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
+  // To receive messages from sessions, use createSessionReceiver instead of createReceiver or look at
   // the sample in sessions.ts file
-  const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
 
-  const onMessageHandler: OnMessage = async (brokeredMessage) => {
-    console.log(`Received message: ${brokeredMessage.body}`);
-    await brokeredMessage.complete();
-  };
-  const onErrorHandler: OnError = (err) => {
-    console.log("Error occurred: ", err);
-  };
+  // controls whether we continue to recover from fatal Receiver failures.
+  let enableReceiverRecovery = true;
 
-  try {
-    receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
+  do {
+    const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
 
-    // Waiting long enough before closing the receiver to receive messages
-    await delay(5000);
+    const receiverPromise = new Promise((resolve, _reject) => {
+      const onMessageHandler: OnMessage = async (brokeredMessage) => {
+        console.log(`Received message: ${brokeredMessage.body}`);
+        await brokeredMessage.complete();
+      };
 
+      const onErrorHandler: OnError = (err) => {
+        if ((err as MessagingError).retryable === false) {
+          console.log("Receiver will be recreated. A fatal error occurred:", err);
+          resolve();
+        } else {
+          console.log("Non-fatal error occurred: ", err);
+        }
+      };
+
+      receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
+    });
+
+    // This will only resolve if our receiver has failed in a way that is not recoverable.
+    await receiverPromise;
+
+    // the Service Bus package is intended to be resilient in the face of transitive issues, like network
+    // interruptions. If there are continual restarts this might indicate a more serious issue, like a network
+    // outage.
+    console.log(`Closing previous receiver and recreating - a fatal error has occurred.`);
+
+    // we can close the old receiver and just let the loop start again.
     await receiver.close();
-    await queueClient.close();
-  } finally {
-    await sbClient.close();
-  }
+  } while (enableReceiverRecovery);
+
+  await queueClient.close();
+  await sbClient.close();
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Receivers can die if they exceed the maximum number of retries that we configure internally.

This is by design in track 1 (ie, 1.1.x) and we're hesitant to change that behavior since the library is already established and doing so might destabilize customers. This is being revisited in track 2 but for now we're going to release a sample that shows how to properly recover from these kinds of errors.

Partial addressing of #9958