### PR TITLE
[service-bus] Fixing sample to only recover when .retryable is true (ie, "escaped" errors)

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -2,19 +2,13 @@
   Copyright (c) Microsoft Corporation. All rights reserved.
   Licensed under the MIT Licence.
 
-  This sample demonstrates how the receive() function can be used to receive Service Bus messages
+  This sample demonstrates how the registerMessageHandler() function can be used to receive Service Bus messages
   in a stream.
 
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
 */
 
-const {
-  OnMessage,
-  OnError,
-  ServiceBusClient,
-  ReceiveMode,
-  MessagingError
-} = require("@azure/service-bus");
+const { ServiceBusClient, ReceiveMode } = require("@azure/service-bus");
 
 // Load the .env file if it exists
 const dotenv = require("dotenv");
@@ -46,8 +40,8 @@ async function main() {
       };
 
       const onErrorHandler = (err) => {
-        if (err.retryable === false) {
-          console.log("Receiver will be recreated. A fatal error occurred:", err);
+        if (err.retryable === true) {
+          console.log("Receiver will be recreated. A recoverable error occurred:", err);
           resolve();
         } else {
           console.log("Non-fatal error occurred: ", err);

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -44,7 +44,7 @@ async function main() {
           console.log("Receiver will be recreated. A recoverable error occurred:", err);
           resolve();
         } else {
-          console.log("Non-fatal error occurred: ", err);
+          console.log("Error occurred: ", err);
         }
       };
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -2,7 +2,7 @@
   Copyright (c) Microsoft Corporation. All rights reserved.
   Licensed under the MIT Licence.
 
-  This sample demonstrates how the receive() function can be used to receive Service Bus messages
+  This sample demonstrates how the registerMessageHandler() function can be used to receive Service Bus messages
   in a stream.
 
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
@@ -46,8 +46,8 @@ export async function main() {
       };
 
       const onErrorHandler: OnError = (err) => {
-        if ((err as MessagingError).retryable === false) {
-          console.log("Receiver will be recreated. A fatal error occurred:", err);
+        if ((err as MessagingError).retryable === true) {
+          console.log("Receiver will be recreated. A recoverable error occurred:", err);
           resolve();
         } else {
           console.log("Non-fatal error occurred: ", err);

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -50,7 +50,7 @@ export async function main() {
           console.log("Receiver will be recreated. A recoverable error occurred:", err);
           resolve();
         } else {
-          console.log("Non-fatal error occurred: ", err);
+          console.log("Error occurred: ", err);
         }
       };
 


### PR DESCRIPTION
Fixing sample to only recover when .retryable is true (ie, "escaped" retryable errors).

Still a partial fix for #9958 in that it demonstrates the recovery technique.