### PR TITLE
[Service Bus] Exposing `deadLetterErrorDescription` and `deadLetterReason` on the `ReceivedMessage`

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 7.0.0-preview.5 (Unreleased)
 
+- Adding `deadLetterErrorDescription` and `deadLetterReason` properties on the received messages. Previously, they were under the `properties` in the message.
+  OLD: `message.properties["DeadLetterReason"]` and `message.properties["DeadLetterErrorDescription"]`
+  NEW: `message.deadLetterReason` and `message.deadLetterErrorDescription`
+  [PR 10106](https://github.com/Azure/azure-sdk-for-js/pull/10106)
+
 ### Breaking Changes
 
 - Added Async iterable iterators with pagination support for all the listing methods like `getQueues()`, `getTopics()`,`getQueuesRuntimeInfo()`, etc.

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -174,6 +174,8 @@ export interface QueueRuntimePropertiesResponse extends QueueRuntimeProperties, 
 // @public
 export interface ReceivedMessage extends ServiceBusMessage {
     readonly _amqpMessage: AmqpMessage;
+    readonly deadLetterErrorDescription?: string;
+    readonly deadLetterReason?: string;
     readonly deadLetterSource?: string;
     readonly deliveryCount?: number;
     readonly enqueuedSequenceNumber?: number;

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -363,6 +363,16 @@ export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
  */
 export interface ReceivedMessage extends ServiceBusMessage {
   /**
+   * @property The reason for deadlettering the message.
+   * @readonly
+   */
+  readonly deadLetterReason?: string;
+  /**
+   * @property The error description for deadlettering the message.
+   * @readonly
+   */
+  readonly deadLetterErrorDescription?: string;
+  /**
    * @property The lock token is a reference to the lock that is being held by the broker in
    * `ReceiveMode.PeekLock` mode. Locks are used internally settle messages as explained in the
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
@@ -557,7 +567,7 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
 
 /**
  * @ignore
- * Converts given AmqpMessage to ReceivedMessageInfo
+ * Converts given AmqpMessage to ReceivedMessage
  */
 export function fromAmqpMessage(
   msg: AmqpMessage,
@@ -661,7 +671,9 @@ export function fromAmqpMessage(
           )
         : undefined,
     ...sbmsg,
-    ...props
+    ...props,
+    deadLetterReason: sbmsg.properties?.DeadLetterReason,
+    deadLetterErrorDescription: sbmsg.properties?.DeadLetterErrorDescription
   };
 
   log.message("AmqpMessage to ReceivedSBMessage: %O", rcvdsbmsg);
@@ -857,6 +869,16 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
    * @readonly
    */
   readonly _amqpMessage: AmqpMessage;
+  /**
+   * @property The reason for deadlettering the message.
+   * @readonly
+   */
+  readonly deadLetterReason?: string;
+  /**
+   * @property The error description for deadlettering the message.
+   * @readonly
+   */
+  readonly deadLetterErrorDescription?: string;
   /**
    * @property Boolean denoting if the message has already been settled.
    * @readonly

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -151,8 +151,8 @@ describe("dead lettering", () => {
     const deadLetterMessages = await deadLetterReceiver.receiveMessages(1);
     should.exist(deadLetterMessages[0]);
 
-    const reason = deadLetterMessages[0]!.properties!["DeadLetterReason"];
-    const description = deadLetterMessages[0]!.properties!["DeadLetterErrorDescription"];
+    const reason = deadLetterMessages[0].deadLetterReason;
+    const description = deadLetterMessages[0].deadLetterErrorDescription;
     const customProperty = deadLetterMessages[0]!.properties!["customProperty"];
 
     should.equal(reason, expected.reason);


### PR DESCRIPTION
### Issue #10052 
As the title says..