### PR TITLE
[service-bus] Change MessageSession over to using the .NET receiveMessages algorithm

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,7 @@
   message, rather than how long to wait for an entire set of messages. This change allows for a faster return
   of messages to your application.
   [PR 9968](https://github.com/Azure/azure-sdk-for-js/pull/9968)
+  [PR 10107](https://github.com/Azure/azure-sdk-for-js/pull/10107)
 - `userProperties` attribute under the `ServiceBusMessage`(and `ReceivedMessage`, `ReceivedMessageWithLock`) has been renamed to `properties`. Same change has been made to the `userProperties` attribute in the correlation-rule filter.
   [PR 10003](https://github.com/Azure/azure-sdk-for-js/pull/10003)
 

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -466,6 +466,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
  * The default time to wait for messages _after_ the first message
  * has been received.
  *
+ * This timeout only applies to receiveMessages()
+ *
  * @internal
  * @ignore
  */

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -278,7 +278,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       const receivedMessages = await this._context.batchingReceiver.receive(
         maxMessageCount,
         options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs,
-        defaultMaxTimeAfterFirstMessageMs,
+        defaultMaxTimeAfterFirstMessageForBatchingMs,
         options?.abortSignal
       );
       return (receivedMessages as unknown) as ReceivedMessageT[];
@@ -469,4 +469,4 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
  * @internal
  * @ignore
  */
-export const defaultMaxTimeAfterFirstMessageMs = 1000;
+export const defaultMaxTimeAfterFirstMessageForBatchingMs = 1000;

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -278,7 +278,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       const receivedMessages = await this._context.batchingReceiver.receive(
         maxMessageCount,
         options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs,
-        maxTimeAfterFirstMessageMs,
+        defaultMaxTimeAfterFirstMessageMs,
         options?.abortSignal
       );
       return (receivedMessages as unknown) as ReceivedMessageT[];
@@ -469,4 +469,4 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
  * @internal
  * @ignore
  */
-export const maxTimeAfterFirstMessageMs = 1000;
+export const defaultMaxTimeAfterFirstMessageMs = 1000;

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -465,7 +465,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
 /**
  * The default time to wait for messages _after_ the first message
  * has been received.
- * 
+ *
  * @internal
  * @ignore
  */

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -465,5 +465,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
 /**
  * The default time to wait for messages _after_ the first message
  * has been received.
+ * 
+ * @internal
+ * @ignore
  */
-const maxTimeAfterFirstMessageMs = 1000;
+export const maxTimeAfterFirstMessageMs = 1000;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -26,7 +26,7 @@ import * as log from "../log";
 import { OnError, OnMessage } from "../core/messageReceiver";
 import { assertValidMessageHandlers, getMessageIterator, wrapProcessErrorHandler } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
-import { Receiver, defaultMaxTimeAfterFirstMessageMs } from "./receiver";
+import { Receiver, defaultMaxTimeAfterFirstMessageForBatchingMs } from "./receiver";
 import Long from "long";
 import { ReceivedMessageWithLock, ServiceBusMessageImpl } from "../serviceBusMessage";
 import {
@@ -394,7 +394,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       const receivedMessages = await this._messageSession!.receiveMessages(
         maxMessageCount,
         options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs,
-        defaultMaxTimeAfterFirstMessageMs
+        defaultMaxTimeAfterFirstMessageForBatchingMs
       );
 
       return (receivedMessages as any) as ReceivedMessageT[];

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -26,7 +26,7 @@ import * as log from "../log";
 import { OnError, OnMessage } from "../core/messageReceiver";
 import { assertValidMessageHandlers, getMessageIterator, wrapProcessErrorHandler } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
-import { Receiver } from "./receiver";
+import { Receiver, defaultMaxTimeAfterFirstMessageMs } from "./receiver";
 import Long from "long";
 import { ReceivedMessageWithLock, ServiceBusMessageImpl } from "../serviceBusMessage";
 import {
@@ -393,7 +393,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
     const receiveBatchOperationPromise = async () => {
       const receivedMessages = await this._messageSession!.receiveMessages(
         maxMessageCount,
-        options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs
+        options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs,
+        defaultMaxTimeAfterFirstMessageMs
       );
 
       return (receivedMessages as any) as ReceivedMessageT[];

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -85,38 +85,14 @@ export interface SessionMessageHandlerOptions {
    */
   maxConcurrentCalls?: number;
 }
-/**
- * @internal
- * Describes the options for creating a Session Manager.
- */
-export interface SessionManagerOptions extends SessionMessageHandlerOptions {
-  /**
-   * @property {number} [maxConcurrentSessions] The maximum number of sessions that the user wants to
-   * handle concurrently.
-   * - **Default**: `2000`.
-   */
-  maxConcurrentSessions?: number;
-  /**
-   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
-   * message is received in this time, then the receiver will be closed.
-   *
-   * If this option is not provided, then receiver link will stay open until manually closed.
-   *
-   * **Caution**: When setting this value, take into account the time taken to process messages. Once
-   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
-   * invoked on messages.
-   */
-  newMessageWaitTimeoutInMs?: number;
-}
 
 /**
  * @internal
  * Describes all the options that can be set while instantiating a MessageSession object.
  */
-export type MessageSessionOptions = SessionManagerOptions &
-  SessionReceiverOptions & {
-    receiveMode?: ReceiveMode;
-  };
+export type MessageSessionOptions = SessionReceiverOptions & {
+  receiveMode?: ReceiveMode;
+};
 
 /**
  * @internal

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -563,7 +563,9 @@ export class MessageSession extends LinkEntity {
       if (receiverError) {
         const sbError = translate(receiverError) as MessagingError;
         if (sbError.code === "SessionLockLostError") {
-          sbError.message = `The session lock has expired on the session with id ${this.sessionId}.`;
+          sbError.message = `The session lock has expired on the session with id ${
+            this.sessionId
+          }.`;
         }
         log.error(
           "[%s] An error occurred for Receiver '%s': %O.",
@@ -775,7 +777,9 @@ export class MessageSession extends LinkEntity {
         this._newMessageReceivedTimer = setTimeout(async () => {
           const msg =
             `MessageSession '${this.sessionId}' with name '${this.name}' did not receive ` +
-            `any messages in the last ${this.newMessageWaitTimeoutInMs} milliseconds. Hence closing it.`;
+            `any messages in the last ${
+              this.newMessageWaitTimeoutInMs
+            } milliseconds. Hence closing it.`;
           log.error("[%s] %s", this._context.namespace.connectionId, msg);
 
           if (this.callee === SessionCallee.sessionManager) {
@@ -810,12 +814,8 @@ export class MessageSession extends LinkEntity {
         }
 
         resetTimerOnNewMessageReceived();
-        const bMessage: ServiceBusMessageImpl = new ServiceBusMessageImpl(
-          this._context,
-          context.message!,
-          context.delivery!,
-          true
-        );
+        const bMessage = this._getServiceBusMessage(context);
+
         try {
           await this._onMessage(bMessage);
         } catch (err) {
@@ -967,12 +967,8 @@ export class MessageSession extends LinkEntity {
       const onReceiveMessage: OnAmqpEventAsPromise = async (context: EventContext) => {
         resetTimerOnNewMessageReceived();
         try {
-          const data: ServiceBusMessageImpl = new ServiceBusMessageImpl(
-            this._context,
-            context.message!,
-            context.delivery!,
-            true
-          );
+          const data = this._getServiceBusMessage(context);
+
           if (brokeredMessages.length < maxMessageCount) {
             brokeredMessages.push(data);
           }
@@ -1071,7 +1067,9 @@ export class MessageSession extends LinkEntity {
                 this._newMessageReceivedTimer = setTimeout(async () => {
                   const msg =
                     `MessageSession '${this.sessionId}' with name '${this.name}' did not receive ` +
-                    `any messages in the last ${this.newMessageWaitTimeoutInMs} milliseconds. Hence closing it.`;
+                    `any messages in the last ${
+                      this.newMessageWaitTimeoutInMs
+                    } milliseconds. Hence closing it.`;
                   log.error("[%s] %s", this._context.namespace.connectionId, msg);
                   finalAction();
                   if (this.callee === SessionCallee.sessionManager) {
@@ -1180,6 +1178,10 @@ export class MessageSession extends LinkEntity {
         delivery.reject(error);
       }
     });
+  }
+
+  private _getServiceBusMessage(context: EventContext): ServiceBusMessageImpl {
+    return new ServiceBusMessageImpl(this._context, context.message!, context.delivery!, true);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -535,9 +535,7 @@ export class MessageSession extends LinkEntity {
       if (receiverError) {
         const sbError = translate(receiverError) as MessagingError;
         if (sbError.code === "SessionLockLostError") {
-          sbError.message = `The session lock has expired on the session with id ${
-            this.sessionId
-          }.`;
+          sbError.message = `The session lock has expired on the session with id ${this.sessionId}.`;
         }
         log.error(
           "[%s] An error occurred for Receiver '%s': %O.",

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -164,7 +164,10 @@ describe("BatchingReceiver unit tests", () => {
         } as EventContext);
 
         const messages = await receivePromise;
-        assert.deepEqual(messages.map((m) => m.body), ["the message"]);
+        assert.deepEqual(
+          messages.map((m) => m.body),
+          ["the message"]
+        );
       }).timeout(5 * 1000);
 
       // in the new world the overall timeout firing means we've received _no_ messages
@@ -221,10 +224,10 @@ describe("BatchingReceiver unit tests", () => {
           clock.tick(1); // make the "no new message arrived within time limit" timer fire.
 
           const messages = await receivePromise;
-          assert.deepEqual(messages.map((m) => m.body), [
-            "the first message",
-            "the second message"
-          ]);
+          assert.deepEqual(
+            messages.map((m) => m.body),
+            ["the first message", "the second message"]
+          );
         }
       ).timeout(5 * 1000);
 
@@ -268,10 +271,10 @@ describe("BatchingReceiver unit tests", () => {
           // ...we can see that we didn't resolve earlier - we only resolved after the `maxWaitTimeInMs`
           // timer fired.
           const messages = await receivePromise;
-          assert.deepEqual(messages.map((m) => m.body), [
-            "the first message",
-            "the second message"
-          ]);
+          assert.deepEqual(
+            messages.map((m) => m.body),
+            ["the first message", "the second message"]
+          );
         }
       ).timeout(5 * 1000);
 
@@ -282,51 +285,52 @@ describe("BatchingReceiver unit tests", () => {
       (lockMode === ReceiveMode.peekLock ? it : it.skip)(
         "4. sanity check that we're using getRemainingWaitTimeInMs",
         async () => {
-        const receiver = new BatchingReceiver(createClientEntityContextForTests(), {
-          receiveMode: lockMode
-        });
+          const receiver = new BatchingReceiver(createClientEntityContextForTests(), {
+            receiveMode: lockMode
+          });
 
-        const { receiveIsReady, emitter } = setupFakeReceiver(receiver);
+          const { receiveIsReady, emitter } = setupFakeReceiver(receiver);
 
-        let wasCalled = false;
+          let wasCalled = false;
 
-        const arbitraryAmountOfTimeInMs = 40;
+          const arbitraryAmountOfTimeInMs = 40;
 
-        receiver["_getRemainingWaitTimeInMsFn"] = (
-          maxWaitTimeInMs: number,
-          maxTimeAfterFirstMessageMs: number
-        ) => {
-          // sanity check that the timeouts are passed in correctly....
-          assert.equal(maxWaitTimeInMs, bigTimeout + 1);
-          assert.equal(maxTimeAfterFirstMessageMs, bigTimeout + 2);
+          receiver["_getRemainingWaitTimeInMsFn"] = (
+            maxWaitTimeInMs: number,
+            maxTimeAfterFirstMessageMs: number
+          ) => {
+            // sanity check that the timeouts are passed in correctly....
+            assert.equal(maxWaitTimeInMs, bigTimeout + 1);
+            assert.equal(maxTimeAfterFirstMessageMs, bigTimeout + 2);
 
-          return () => {
-            // and we'll make sure that we did ask the callback from the amount
-            // of time to wait...
-            wasCalled = true;
-            return arbitraryAmountOfTimeInMs;
+            return () => {
+              // and we'll make sure that we did ask the callback from the amount
+              // of time to wait...
+              wasCalled = true;
+              return arbitraryAmountOfTimeInMs;
+            };
           };
-        };
 
-        const receivePromise = receiver.receive(3, bigTimeout + 1, bigTimeout + 2);
-        await receiveIsReady;
+          const receivePromise = receiver.receive(3, bigTimeout + 1, bigTimeout + 2);
+          await receiveIsReady;
 
-        emitter.emit(ReceiverEvents.message, {
-          message: {
-            body: "the second message"
-          } as RheaMessage
-        } as EventContext);
+          emitter.emit(ReceiverEvents.message, {
+            message: {
+              body: "the second message"
+            } as RheaMessage
+          } as EventContext);
 
-        // and just to be _really_ sure we'll only tick the `arbitraryAmountOfTimeInMs`.
-        // if we resolve() then we know that we ignored the passed in timeouts in favor
-        // of what our getRemainingWaitTimeInMs function calculated.
-        clock.tick(arbitraryAmountOfTimeInMs);
+          // and just to be _really_ sure we'll only tick the `arbitraryAmountOfTimeInMs`.
+          // if we resolve() then we know that we ignored the passed in timeouts in favor
+          // of what our getRemainingWaitTimeInMs function calculated.
+          clock.tick(arbitraryAmountOfTimeInMs);
 
-        const messages = await receivePromise;
-        assert.equal(messages.length, 1);
+          const messages = await receivePromise;
+          assert.equal(messages.length, 1);
 
-        assert.isTrue(wasCalled);
-      }).timeout(5 * 1000);
+          assert.isTrue(wasCalled);
+        }
+      ).timeout(5 * 1000);
 
       function setupFakeReceiver(
         batchingReceiver: BatchingReceiver
@@ -370,11 +374,13 @@ describe("BatchingReceiver unit tests", () => {
               credits += _credits;
             }
           },
-          get credit() { return credits }
+          get credit() {
+            return credits;
+          }
         } as RheaReceiver;
 
         batchingReceiver["_receiver"] = fakeRheaReceiver;
-        
+
         batchingReceiver["_getServiceBusMessage"] = (eventContext) => {
           return {
             body: eventContext.message?.body

--- a/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { MessageSession } from "../../src/session/messageSession";
+import { createClientEntityContextForTests, defer } from "./unittestUtils";
+import sinon from "sinon";
+import { EventEmitter } from 'events';
+import { ReceiverEvents, Receiver as RheaReceiver, EventContext, Message as RheaMessage } from 'rhea-promise';
+import { OnAmqpEventAsPromise } from '../../src/core/messageReceiver';
+import { ServiceBusMessageImpl, ReceiveMode } from '../../src/serviceBusMessage';
+
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+describe("Message session unit tests", () => {
+  describe("receiveMessages", () => {
+    let clock: ReturnType<typeof sinon.useFakeTimers>;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    [ReceiveMode.peekLock, ReceiveMode.receiveAndDelete].forEach((lockMode) => {
+      describe(`${ReceiveMode[lockMode]} receive, exit paths`, () => {
+        const bigTimeout = 60 * 1000;
+        const littleTimeout = 30 * 1000;
+        let clock: ReturnType<typeof sinon.useFakeTimers>;
+
+        beforeEach(() => {
+          clock = sinon.useFakeTimers();
+        });
+
+        afterEach(() => {
+          clock.restore();
+        });
+
+        it("1. We received 'max messages'", async () => {
+          const receiver = new MessageSession(createClientEntityContextForTests(), {
+            receiveMode: lockMode
+          });
+
+          const { receiveIsReady, emitter } = setupFakeReceiver(receiver as any);
+
+          const receivePromise = receiver.receiveMessages(1, bigTimeout, bigTimeout);
+          await receiveIsReady;
+
+          // batch fulfillment is checked when we receive a message...
+          emitter.emit(ReceiverEvents.message, {
+            message: { body: "the message" } as RheaMessage
+          } as EventContext);
+
+          const messages = await receivePromise;
+          assert.deepEqual(messages.map((m) => m.body), ["the message"]);
+        }).timeout(5 * 1000);
+
+        // in the new world the overall timeout firing means we've received _no_ messages
+        // because otherwise it'd be one of the others.
+        it("2. We've waited 'max wait time'", async () => {
+          const receiver = new MessageSession(createClientEntityContextForTests(), {
+            receiveMode: lockMode
+          });
+
+          const { receiveIsReady } = setupFakeReceiver(receiver);
+
+          const receivePromise = receiver.receiveMessages(1, littleTimeout, bigTimeout);
+
+          // force the overall timeout to fire
+          clock.tick(littleTimeout);
+
+          await receiveIsReady;
+          const messages = await receivePromise;
+          assert.isEmpty(messages);
+        }).timeout(5 * 1000);
+
+        // TODO: there's a bug that needs some more investigation where receiveAndDelete loses messages if we're
+        // too aggressive about returning early. In that case we just revert to using the older behavior of waiting for
+        // the duration of time given (or max messages) with no idle timer.
+        // When we eliminate that bug we can remove this check.
+        (lockMode === ReceiveMode.peekLock ? it : it.skip)(
+          `3a. (with idle timeout) We've received 1 message and _now_ have exceeded 'max wait time past first message'`,
+          async () => {
+            const receiver = new MessageSession(createClientEntityContextForTests(), {
+              receiveMode: lockMode
+            });
+
+            const { receiveIsReady, emitter } = setupFakeReceiver(receiver);
+
+            const receivePromise = receiver.receiveMessages(3, bigTimeout, littleTimeout);
+            await receiveIsReady;
+
+            // batch fulfillment is checked when we receive a message...
+            emitter.emit(ReceiverEvents.message, {
+              message: { body: "the first message" } as RheaMessage
+            } as EventContext);
+
+            // advance the timeout to _just_ before the expiration of the first one (which must have been set
+            // since we just received a message). This'll make it more obvious if I scheduled it a second time.
+            clock.tick(littleTimeout - 1);
+
+            // now emit a second message - this second message should _not_ change any existing timers
+            // or start new ones.
+            emitter.emit(ReceiverEvents.message, {
+              message: { body: "the second message" } as RheaMessage
+            } as EventContext);
+
+            // now we'll advance the clock to 'littleTimeout' which should now fire off our timer.
+            clock.tick(1); // make the "no new message arrived within time limit" timer fire.
+
+            const messages = await receivePromise;
+            assert.deepEqual(messages.map((m) => m.body), [
+              "the first message",
+              "the second message"
+            ]);
+          }
+        ).timeout(5 * 1000);
+
+        // TODO: there's a bug that needs some more investigation where receiveAndDelete loses messages if we're
+        // too aggressive about returning early. In that case we just revert to using the older behavior of waiting for
+        // the duration of time given (or max messages) with no idle timer.
+        // When we eliminate that bug we can remove this test in favor of the idle timeout test above.
+        (lockMode === ReceiveMode.receiveAndDelete ? it : it.skip)(
+          `3b. (without idle timeout)`,
+          async () => {
+            const receiver = new MessageSession(createClientEntityContextForTests(), {
+              receiveMode: lockMode
+            });
+
+            const { receiveIsReady, emitter } = setupFakeReceiver(receiver);
+
+            const receivePromise = receiver.receiveMessages(3, bigTimeout, littleTimeout);
+            await receiveIsReady;
+
+            // batch fulfillment is checked when we receive a message...
+            emitter.emit(ReceiverEvents.message, {
+              message: {
+                body: "the first message"
+              } as RheaMessage
+            } as EventContext);
+
+            // In the peekLock algorithm we would've resolved the promise here but_ we disable
+            // that in receiveAndDelete. So we'll advance here....
+            clock.tick(littleTimeout);
+
+            // ...and emit another message _after_ the idle timer would have fired. Now when we advance
+            // the time all the way....
+            emitter.emit(ReceiverEvents.message, {
+              message: {
+                body: "the second message"
+              } as RheaMessage
+            } as EventContext);
+
+            clock.tick(bigTimeout);
+
+            // ...we can see that we didn't resolve earlier - we only resolved after the `maxWaitTimeInMs`
+            // timer fired.
+            const messages = await receivePromise;
+            assert.deepEqual(messages.map((m) => m.body), [
+              "the first message",
+              "the second message"
+            ]);
+          }
+        ).timeout(5 * 1000);
+
+        // TODO: there's a bug that needs some more investigation where receiveAndDelete loses messages if we're
+        // too aggressive about returning early. In that case we just revert to using the older behavior of waiting for
+        // the duration of time given (or max messages) with no idle timer.
+        // When we eliminate that bug we can enable this test for all modes.
+        (lockMode === ReceiveMode.peekLock ? it : it.skip)(
+          "4. sanity check that we're using getRemainingWaitTimeInMs",
+          async () => {
+            const receiver = new MessageSession(createClientEntityContextForTests(), {
+              receiveMode: lockMode
+            });
+
+            const { receiveIsReady, emitter } = setupFakeReceiver(receiver);
+
+            let wasCalled = false;
+
+            const arbitraryAmountOfTimeInMs = 40;
+
+            receiver["_getRemainingWaitTimeInMsFn"] = (
+              maxWaitTimeInMs: number,
+              maxTimeAfterFirstMessageMs: number
+            ) => {
+              // sanity check that the timeouts are passed in correctly....
+              assert.equal(maxWaitTimeInMs, bigTimeout + 1);
+              assert.equal(maxTimeAfterFirstMessageMs, bigTimeout + 2);
+
+              return () => {
+                // and we'll make sure that we did ask the callback from the amount
+                // of time to wait...
+                wasCalled = true;
+                return arbitraryAmountOfTimeInMs;
+              };
+            };
+
+            const receivePromise = receiver.receiveMessages(3, bigTimeout + 1, bigTimeout + 2);
+            await receiveIsReady;
+
+            emitter.emit(ReceiverEvents.message, {
+              message: {
+                body: "the second message"
+              } as RheaMessage
+            } as EventContext);
+
+            // and just to be _really_ sure we'll only tick the `arbitraryAmountOfTimeInMs`.
+            // if we resolve() then we know that we ignored the passed in timeouts in favor
+            // of what our getRemainingWaitTimeInMs function calculated.
+            clock.tick(arbitraryAmountOfTimeInMs);
+
+            const messages = await receivePromise;
+            assert.equal(messages.length, 1);
+
+            assert.isTrue(wasCalled);
+          }).timeout(5 * 1000);
+      });
+    });
+    
+    function setupFakeReceiver(
+      messageSession: MessageSession
+    ): {
+      receiveIsReady: Promise<void>;
+      emitter: EventEmitter;
+    } {
+      const emitter = new EventEmitter();
+      const { promise: receiveIsReady, resolve: resolvePromiseIsReady } = defer<void>();
+      let credits = 0;
+
+      const fakeRheaReceiver = {
+        on(evt: ReceiverEvents, handler: OnAmqpEventAsPromise) {
+          emitter.on(evt, handler);
+
+          if (evt === ReceiverEvents.receiverDrained) {
+            // this also happens to be the final thing the Promise does
+            // as part of it's initialization.
+            resolvePromiseIsReady();
+          }
+          
+          if (evt === ReceiverEvents.message) {
+            --credits;
+          }
+        },
+        removeListener(evt: ReceiverEvents, handler: OnAmqpEventAsPromise) {
+          emitter.removeListener(evt, handler);
+        },
+        isOpen: () => true,
+        addCredit: (_credits: number) => {
+          if (_credits === 1 && fakeRheaReceiver.drain === true) {
+            // special case - if we're draining we should initiate a drain
+            emitter.emit(ReceiverEvents.receiverDrained, undefined);
+          } else {
+            credits += _credits;
+          }
+        },
+        get credit() { return credits }
+      } as RheaReceiver;
+
+      messageSession["_receiver"] = fakeRheaReceiver;
+        
+      messageSession["_getServiceBusMessage"] = (eventContext) => {
+        return {
+          body: eventContext.message?.body
+        } as ServiceBusMessageImpl;
+      };
+
+      return {
+        receiveIsReady,
+        emitter
+      };
+    }
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
@@ -6,10 +6,15 @@ import chaiAsPromised from "chai-as-promised";
 import { MessageSession } from "../../src/session/messageSession";
 import { createClientEntityContextForTests, defer } from "./unittestUtils";
 import sinon from "sinon";
-import { EventEmitter } from 'events';
-import { ReceiverEvents, Receiver as RheaReceiver, EventContext, Message as RheaMessage } from 'rhea-promise';
-import { OnAmqpEventAsPromise } from '../../src/core/messageReceiver';
-import { ServiceBusMessageImpl, ReceiveMode } from '../../src/serviceBusMessage';
+import { EventEmitter } from "events";
+import {
+  ReceiverEvents,
+  Receiver as RheaReceiver,
+  EventContext,
+  Message as RheaMessage
+} from "rhea-promise";
+import { OnAmqpEventAsPromise } from "../../src/core/messageReceiver";
+import { ServiceBusMessageImpl, ReceiveMode } from "../../src/serviceBusMessage";
 
 chai.use(chaiAsPromised);
 const assert = chai.assert;
@@ -56,7 +61,10 @@ describe("Message session unit tests", () => {
           } as EventContext);
 
           const messages = await receivePromise;
-          assert.deepEqual(messages.map((m) => m.body), ["the message"]);
+          assert.deepEqual(
+            messages.map((m) => m.body),
+            ["the message"]
+          );
         }).timeout(5 * 1000);
 
         // in the new world the overall timeout firing means we've received _no_ messages
@@ -113,10 +121,10 @@ describe("Message session unit tests", () => {
             clock.tick(1); // make the "no new message arrived within time limit" timer fire.
 
             const messages = await receivePromise;
-            assert.deepEqual(messages.map((m) => m.body), [
-              "the first message",
-              "the second message"
-            ]);
+            assert.deepEqual(
+              messages.map((m) => m.body),
+              ["the first message", "the second message"]
+            );
           }
         ).timeout(5 * 1000);
 
@@ -160,10 +168,10 @@ describe("Message session unit tests", () => {
             // ...we can see that we didn't resolve earlier - we only resolved after the `maxWaitTimeInMs`
             // timer fired.
             const messages = await receivePromise;
-            assert.deepEqual(messages.map((m) => m.body), [
-              "the first message",
-              "the second message"
-            ]);
+            assert.deepEqual(
+              messages.map((m) => m.body),
+              ["the first message", "the second message"]
+            );
           }
         ).timeout(5 * 1000);
 
@@ -218,10 +226,11 @@ describe("Message session unit tests", () => {
             assert.equal(messages.length, 1);
 
             assert.isTrue(wasCalled);
-          }).timeout(5 * 1000);
+          }
+        ).timeout(5 * 1000);
       });
     });
-    
+
     function setupFakeReceiver(
       messageSession: MessageSession
     ): {
@@ -241,7 +250,7 @@ describe("Message session unit tests", () => {
             // as part of it's initialization.
             resolvePromiseIsReady();
           }
-          
+
           if (evt === ReceiverEvents.message) {
             --credits;
           }
@@ -258,11 +267,13 @@ describe("Message session unit tests", () => {
             credits += _credits;
           }
         },
-        get credit() { return credits }
+        get credit() {
+          return credits;
+        }
       } as RheaReceiver;
 
       messageSession["_receiver"] = fakeRheaReceiver;
-        
+
       messageSession["_getServiceBusMessage"] = (eventContext) => {
         return {
           body: eventContext.message?.body


### PR DESCRIPTION
[sessions] Changing our receiveMessages() algorithm to match .NET's.

The new version works like this:

receive(maxMessages, maxWaitTime)

Internally we then wait for:
1. maxMessages to arrive
2. maxWaitTime to expire
or
3. An internal 1 second timeout that will fire _after_ the first message
   has been received _or_ the remaining time left from `maxWaitTime` (whichever one
   is smaller)

Complements #9968 and is the final change for #9718