### PR TITLE
[Identity] Rename argument to AggregateAuthenticationError

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -13,7 +13,7 @@ export { AccessToken }
 
 // @public
 export class AggregateAuthenticationError extends Error {
-    constructor(errors: any[], errMsg?: string);
+    constructor(errors: any[], errorMessage?: string);
     errors: any[];
 }
 

--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -152,11 +152,11 @@ export class AggregateAuthenticationError extends Error {
    */
   public errors: any[];
 
-  constructor(errors: any[], errMsg?: string) {
+  constructor(errors: any[], errorMessage?: string) {
     let errorDetail =
       errors
         .join("\n");
-    super(`${errMsg}\n\n${errorDetail}`);
+    super(`${errorMessage}\n\n${errorDetail}`);
     this.errors = errors;
 
     // Ensure that this type reports the correct name


### PR DESCRIPTION
Rename the argument to the constructor to AggregateAuthenticationError based on arch board feedback.

cc @bterlson