### PR TITLE
fixing test-utils-recorder package.json

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@azure/test-utils-recorder",
   "version": "1.0.0",
+  "sdk-type": "client",
   "description": "This library provides interfaces and helper methods to provide recording and playback capabilities for the tests in Azure JS/TS SDKs",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",


### PR DESCRIPTION
Adding sdk-type = client to package.json of test-utils-recorder - otherwise rush-runner script doesn't detect this package for tests and runs tests for all packages under rush.json