### PR TITLE
Fix broken storage pipeline

### DIFF
--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -172,7 +172,7 @@ const updateOtherProjectDependencySections = (rushPackages, package, depName) =>
 Check rush common-versions for the exact version to replace dev tags for - if that version is present 
 in common-versions - then update common-versions adding the dev version as an exception
 */
-const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, searchVersion, devVersion) => {
+const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, searchVersion) => {
   var allowedAlternativeVersions = commonVersionsConfig["allowedAlternativeVersions"];
   const parsedSearchVersion = semver.parse(searchVersion);
 
@@ -182,7 +182,8 @@ const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, sea
       if (parsedPackageVersion.major == parsedSearchVersion.major &&
         parsedPackageVersion.minor == parsedSearchVersion.minor &&
         parsedPackageVersion.patch == parsedSearchVersion.patch) {
-        allowedAlternativeVersions[package].push(devVersion);
+        var devVersionRange = "^" + parsedSearchVersion.major + "." + parsedSearchVersion.minor + "." + parsedSearchVersion.patch + "-dev";
+        allowedAlternativeVersions[package].push(devVersionRange);
         break;
       }
     }
@@ -225,7 +226,7 @@ async function main(argv) {
     console.log(package);
     rushPackages = updatePackageVersion(rushPackages, package, buildId);
     rushPackages = updateInternalDependencyVersions(rushPackages, package, buildId);
-    await updateCommonVersions(repoRoot, commonVersionsConfig, package, rushPackages[package].json.version, rushPackages[package].newVer);
+    await updateCommonVersions(repoRoot, commonVersionsConfig, package, rushPackages[package].json.version);
     console.log(rushPackages[package].newVer);
   }
 

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -21,6 +21,7 @@ let argv = require("yargs")
 
 const process = require("process");
 const semver = require("semver");
+const path = require("path");
 const packageUtils = require("eng-package-utils");
 
 const commitChanges = async (rushPackages, package) => {
@@ -117,7 +118,6 @@ const updateInternalDependencyVersions = (rushPackages, package, buildId) => {
 };
 
 const makeDependencySectionConsistentForPackage = (rushPackages, dependencySection, depName) => {
-  console.log("Inside make dep");
   if (dependencySection && dependencySection[depName]) {
     depVersionRange = dependencySection[depName];
 
@@ -174,9 +174,14 @@ add a logic checking rush common-versions for the exact version I am replacing d
 */
 const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, searchVersion, devVersion) => {
   var allowedAlternativeVersions = commonVersionsConfig["allowedAlternativeVersions"];
-  if (allowedAlternativeVersions[package].includes(searchVersion)) {
-    allowedAlternativeVersions[package].push(devVersion);
+  console.log("allowed alternative versions");
+  console.log(allowedAlternativeVersions);
+  if (allowedAlternativeVersions[package]) {
+    if (allowedAlternativeVersions[package].includes(searchVersion)) {
+      allowedAlternativeVersions[package].push(devVersion);
+    }
   }
+
   var newConfig = commonVersionsConfig;
   newConfig["allowedAlternativeVersions"] = allowedAlternativeVersions;
   const commonVersionsPath = path.resolve(path.join(repoRoot, "/common/config/rush/common-versions.json"));
@@ -192,6 +197,8 @@ async function main(argv) {
 
   var rushPackages = await packageUtils.getRushPackageJsons(repoRoot);
   const commonVersionsConfig = await packageUtils.getRushCommonVersions(repoRoot);
+  console.log("common versions config");
+  console.dir(commonVersionsConfig);
 
   let targetPackages = [];
   for (const package of Object.keys(rushPackages)) {

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -174,12 +174,18 @@ add a logic checking rush common-versions for the exact version I am replacing d
 */
 const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, searchVersion, devVersion) => {
   var allowedAlternativeVersions = commonVersionsConfig["allowedAlternativeVersions"];
-  console.log("allowed alternative versions");
-  console.log(allowedAlternativeVersions);
+  const parsedSearchVersion = semver.parse(searchVersion);
   if (allowedAlternativeVersions[package]) {
-    if (allowedAlternativeVersions[package].includes(searchVersion)) {
-      allowedAlternativeVersions[package].push(devVersion);
+    for (var version of allowedAlternativeVersions[package]) {
+      const parsedPackageVersion = semver.minVersion(version);
+      if (parsedPackageVersion.major == parsedSearchVersion.major &&
+        parsedPackageVersion.minor == parsedSearchVersion.minor &&
+        parsedPackageVersion.patch == parsedSearchVersion.patch) {
+        allowedAlternativeVersions[package].push(devVersion);
+        break;
+      }
     }
+
   }
 
   var newConfig = commonVersionsConfig;
@@ -197,8 +203,6 @@ async function main(argv) {
 
   var rushPackages = await packageUtils.getRushPackageJsons(repoRoot);
   const commonVersionsConfig = await packageUtils.getRushCommonVersions(repoRoot);
-  console.log("common versions config");
-  console.dir(commonVersionsConfig);
 
   let targetPackages = [];
   for (const package of Object.keys(rushPackages)) {

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -169,12 +169,13 @@ const updateOtherProjectDependencySections = (rushPackages, package, depName) =>
 };
 
 /*
-add a logic checking rush common-versions for the exact version I am replacing dev tags for - if that version is present in common-versions
-- then i might need to update common-versions adding the dev version as well as an exception
+Check rush common-versions for the exact version to replace dev tags for - if that version is present 
+in common-versions - then update common-versions adding the dev version as an exception
 */
 const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, searchVersion, devVersion) => {
   var allowedAlternativeVersions = commonVersionsConfig["allowedAlternativeVersions"];
   const parsedSearchVersion = semver.parse(searchVersion);
+
   if (allowedAlternativeVersions[package]) {
     for (var version of allowedAlternativeVersions[package]) {
       const parsedPackageVersion = semver.minVersion(version);
@@ -185,7 +186,6 @@ const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, sea
         break;
       }
     }
-
   }
 
   var newConfig = commonVersionsConfig;

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -180,6 +180,7 @@ const updateCommonVersions = async (repoRoot, commonVersionsConfig, package, sea
   var newConfig = commonVersionsConfig;
   newConfig["allowedAlternativeVersions"] = allowedAlternativeVersions;
   const commonVersionsPath = path.resolve(path.join(repoRoot, "/common/config/rush/common-versions.json"));
+  console.log("updated common versions config =");
   console.log(newConfig);
   await packageUtils.writePackageJson(commonVersionsPath, newConfig);
 }


### PR DESCRIPTION
- This PR adds logic to check rush common-versions for the exact version the dev tags are being replaced for - if that version is present in common-versions- then update common-versions adding the dev version as an exception too.