### PR TITLE
Recover content-length header which is previously removed for Axios.

### DIFF
--- a/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -79,13 +79,6 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
       `SharedKey ${this.factory.accountName}:${signature}`
     );
 
-    // Workaround for https://github.com/axios/axios/issues/2107
-    // We should always keep the 'content-length' header once the issue is solved
-    // For a better explanation about this workaround, look here: https://github.com/Azure/azure-sdk-for-js/pull/3273
-    if (typeof request.body !== "function" && !(request.body && request.onUploadProgress)) {
-      request.headers.remove(HeaderConstants.CONTENT_LENGTH);
-    }
-
     // console.log(`[URL]:${request.url}`);
     // console.log(`[HEADERS]:${request.headers.toString()}`);
     // console.log(`[STRING TO SIGN]:${JSON.stringify(stringToSign)}`);

--- a/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -79,13 +79,6 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
       `SharedKey ${this.factory.accountName}:${signature}`
     );
 
-    // Workaround for https://github.com/axios/axios/issues/2107
-    // We should always keep the 'content-length' header once the issue is solved
-    // For a better explanation about this workaround, look here: https://github.com/Azure/azure-sdk-for-js/pull/3273
-    if (typeof request.body !== "function" && !(request.body && request.onUploadProgress)) {
-      request.headers.remove(HeaderConstants.CONTENT_LENGTH);
-    }
-
     // Workaround for node-fetch which will set content-type for dfs append data operations based on Patch
     if (typeof request.body !== "function" && !request.headers.get(HeaderConstants.CONTENT_TYPE)) {
       request.headers.set(HeaderConstants.CONTENT_TYPE, "");

--- a/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -79,13 +79,6 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
       `SharedKey ${this.factory.accountName}:${signature}`
     );
 
-    // Workaround for https://github.com/axios/axios/issues/2107
-    // We should always keep the 'content-length' header once the issue is solved
-    // For a better explanation about this workaround, look here: https://github.com/Azure/azure-sdk-for-js/pull/3273
-    if (typeof request.body !== "function" && !(request.body && request.onUploadProgress)) {
-      request.headers.remove(HeaderConstants.CONTENT_LENGTH);
-    }
-
     // console.log(`[URL]:${request.url}`);
     // console.log(`[HEADERS]:${request.headers.toString()}`);
     // console.log(`[STRING TO SIGN]:${JSON.stringify(stringToSign)}`);

--- a/sdk/storage/storage-queue/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -79,13 +79,6 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
       `SharedKey ${this.factory.accountName}:${signature}`
     );
 
-    // Workaround for https://github.com/axios/axios/issues/2107
-    // We should always keep the 'content-length' header once the issue is solved
-    // For a better explanation about this workaround, look here: https://github.com/Azure/azure-sdk-for-js/pull/3273
-    if (typeof request.body !== "function" && !(request.body && request.onUploadProgress)) {
-      request.headers.remove(HeaderConstants.CONTENT_LENGTH);
-    }
-
     // console.log(`[URL]:${request.url}`);
     // console.log(`[HEADERS]:${request.headers.toString()}`);
     // console.log(`[STRING TO SIGN]:${JSON.stringify(stringToSign)}`);


### PR DESCRIPTION
Fix issue #9300. Recover content-length header which is previously removed for Axios known issue(https://github.com/axios/axios/issues/2107).