### PR TITLE
update dependencies version in appinsights and botservice packages

### DIFF
--- a/sdk/applicationinsights/arm-appinsights/package.json
+++ b/sdk/applicationinsights/arm-appinsights/package.json
@@ -4,8 +4,8 @@
   "description": "ApplicationInsightsManagementClient Library with typescript type definitions for node.js and browser.",
   "version": "2.1.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.1.0",
-    "@azure/ms-rest-js": "^1.1.0",
+    "@azure/ms-rest-azure-js": "2.0.1",
+    "@azure/ms-rest-js": "2.0.7",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/applicationinsights/arm-appinsights/tsconfig.json
+++ b/sdk/applicationinsights/arm-appinsights/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": ["es6"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/sdk/botservice/arm-botservice/package.json
+++ b/sdk/botservice/arm-botservice/package.json
@@ -4,8 +4,8 @@
   "description": "AzureBotService Library with typescript type definitions for node.js and browser.",
   "version": "1.0.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/ms-rest-azure-js": "2.0.1",
+    "@azure/ms-rest-js": "2.0.7",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/botservice/arm-botservice/tsconfig.json
+++ b/sdk/botservice/arm-botservice/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": ["es6"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Because of the ms-rest-js package is out of dated in appinsights and botservice packages. It cause problem when I use those two package with the newest ms-rest-js package.

ref to #10045 