### PR TITLE
[Identity] Make keytar an optional dependency

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -82,11 +82,13 @@
     "@opentelemetry/api": "^0.6.1",
     "events": "^3.0.0",
     "jws": "^4.0.0",
-    "keytar": "^5.4.0",
     "msal": "^1.0.2",
     "qs": "^6.7.0",
     "tslib": "^2.0.0",
     "uuid": "^8.1.0"
+  },
+  "optionalDependencies": {
+    "keytar": "^5.4.0"
   },
   "devDependencies": {
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/identity/identity/src/credentials/vscodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/vscodeCredential.ts
@@ -5,7 +5,12 @@
 
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { TokenCredentialOptions, IdentityClient } from '../client/identityClient';
-import * as keytar from 'keytar';
+try {
+  var keytar = require('keytar')
+} catch (er) {
+  keytar = null
+}
+
 import { CredentialUnavailable } from "../client/errors";
 
 const CommonTenantId = 'common';
@@ -43,6 +48,10 @@ export class VSCodeCredential implements TokenCredential {
     scopes: string | string[],
     options?: GetTokenOptions
   ): Promise<AccessToken | null> {
+    if (!keytar) {
+      throw new CredentialUnavailable("VSCode credential requires the optional dependency 'keytar' to work correctly");
+    }
+
     let scopeString = typeof scopes === "string" ? scopes : scopes.join(" ");
 
     // Check to make sure the scope we get back is a valid scope


### PR DESCRIPTION
As keytar does not build on all platforms where we support Azure Identity, make keytar an optional dependency. If keytar is not available, fail gracefully with a message telling the user why the VSCode credential could not be used.

Helps to address https://github.com/Azure/azure-sdk-for-js/issues/9288 and related issues, where the given platform may not have the ability to install the dependencies keytar needs (and therefore keytar fails to build), or on a platform where keytar itself isn't support (eg on Linux running without X11/Xorg). 