### PR TITLE
[Event Hubs] Remove workaround for bug 8598 in test

### DIFF
--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -606,8 +606,7 @@ describe("EventHubConsumerClient", function(): void {
             processError: async (err) => {
               resolve(err);
             }
-          },
-          { maxWaitTimeInSeconds: 0 } // TODO: Remove after https://github.com/Azure/azure-sdk-for-js/pull/9543 is merged
+          }
         );
       });
       await subscription!.close();


### PR DESCRIPTION
There was a maxWaitTime of 0 seconds put in place for a test case as a workaround for bug #8598.
The bug was then fixed in #9543 which was closed in favor of #9567
Therefore, removing the workaround