### PR TITLE
Fix errors in running samples

### DIFF
--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -22,13 +22,9 @@ Use the @azure/search-documents client library to:
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/search/search-documents/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/search-documents) |
 [API reference documentation](https://aka.ms/azsdk/js/search/docs) |
-<<<<<<< HEAD
 [REST API documentation](https://docs.microsoft.com/rest/api/searchservice/) |
-[Product documentation](https://docs.microsoft.com/azure/search/)
-=======
 [Product documentation](https://docs.microsoft.com/azure/search/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/search/search-documents/samples)
->>>>>>> 1488623e0... fix link in search-documents
 
 ## Getting started
 

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -15,7 +15,7 @@
     "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json --ignore-path ../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm test-dist temp types *.tgz *.log",
-    "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",
+    "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript/src/readonlyQuery.js dist-samples/typescript/dist/dist-samples/typescript/src/",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json --ignore-path ../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",


### PR DESCRIPTION
This PR is to fix issue https://github.com/Azure/azure-sdk-for-js/issues/9962 

Basically, the run:samples command will fail for several samples (except readOnlyQuery.ts/js) Because, only that file is static and has the endpoint & key defined inside the program. All the other programs need a proper setup of environment variables. So, we should not run those samples in the automated script. 

@xirzec Please review and approve

@ramya-rao-a FYI....