### PR TITLE
[Identity] Changes for the out-of-band identity release

### DIFF
--- a/common/smoke-test/KeyVault.ts
+++ b/common/smoke-test/KeyVault.ts
@@ -2,7 +2,7 @@
 // Copyright(c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------
-import { DefaultAzureCredential, KnownAuthorityHosts } from "@azure/identity";
+import { DefaultAzureCredential, AzureAuthorityHosts } from "@azure/identity";
 import { SecretClient } from "@azure/keyvault-secrets";
 
 const uuidv1 = require("uuid/v1");
@@ -13,10 +13,10 @@ export class KeyVaultSecrets {
   private static secretValue: string;
 
   private static authorityHostMap: { [alias: string]: string } = {
-    AzureCloud: KnownAuthorityHosts.AzurePublicCloud,
-    AzureChinaCloud: KnownAuthorityHosts.AzureChina,
-    AzureGermanCloud: KnownAuthorityHosts.AzureGermany,
-    AzureUSGovernment: KnownAuthorityHosts.AzureGovernment
+    AzureCloud: AzureAuthorityHosts.AzurePublicCloud,
+    AzureChinaCloud: AzureAuthorityHosts.AzureChina,
+    AzureGermanCloud: AzureAuthorityHosts.AzureGermany,
+    AzureUSGovernment: AzureAuthorityHosts.AzureGovernment
   };
 
   static async Run() {
@@ -32,7 +32,7 @@ export class KeyVaultSecrets {
 
     const authorityHost = this.getAuthorityHost(
       process.env["AZURE_CLOUD"] || "",
-      KnownAuthorityHosts.AzurePublicCloud
+      AzureAuthorityHosts.AzurePublicCloud
     );
 
     // DefaultAzureCredential expects the following three environment variables:

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Release History
 
-## 1.1.0-preview.5 (Unreleased)
+## 1.1.0-preview.5 (2020-07-22)
+
+- Make the keytar dependency optional, allowing for building and running on platforms not supported by keytar [PR #10142](https://github.com/Azure/azure-sdk-for-js/pull/10142)
+- DefaultAzureCredential and VSCodeCrential can now take a tenant id as part of the options object
+- KnownAuthorityHosts has been renamed to AzureAuthorityHosts
 
 ## 1.1.0-preview.4 (2020-06-09)
+
 - Switch to using CredentialUnavailable to differentiate from expected and unexpected errors during DefaultAzureCredential startup. [PR #8172](https://github.com/Azure/azure-sdk-for-js/pull/8127)
 - Make all developer credentials public as well as the list used by DefaultAzureCredential [PR #9274](https://github.com/Azure/azure-sdk-for-js/pull/9274)
 
@@ -14,7 +19,7 @@
 
 ## 1.1.0-preview.2 (2020-04-07)
 
-- Make KnownAuthorityHosts constants available
+- Make AzureAuthorityHosts constants available
 - Extended DefaultAzureCredential with an experimental credential that uses the login credential from VSCode's Azure Account extension
 
 ## 1.1.0-preview1 (2020-03-10)

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## 1.1.0-preview.2 (2020-04-07)
 
-- Make AzureAuthorityHosts constants available
+- Make KnownAuthorityHosts constants available
 - Extended DefaultAzureCredential with an experimental credential that uses the login credential from VSCode's Azure Account extension
 
 ## 1.1.0-preview1 (2020-03-10)

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -85,8 +85,13 @@ export class CredentialUnavailable extends Error {
 
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
-    // Warning: (ae-forgotten-export) The symbol "DefaultAzureCredentialOptions" needs to be exported by the entry point index.d.ts
     constructor(tokenCredentialOptions?: DefaultAzureCredentialOptions);
+}
+
+// @public
+export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
+    // (undocumented)
+    tenantId?: string;
 }
 
 // @public
@@ -166,10 +171,15 @@ export class UsernamePasswordCredential implements TokenCredential {
 
 // @public
 export class VSCodeCredential implements TokenCredential {
-    // Warning: (ae-forgotten-export) The symbol "VSCodeCredentialOptions" needs to be exported by the entry point index.d.ts
     constructor(options?: VSCodeCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
+
+// @public
+export interface VSCodeCredentialOptions extends TokenCredentialOptions {
+    // (undocumented)
+    tenantId?: string;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -39,6 +39,18 @@ export class AuthorizationCodeCredential implements TokenCredential {
     }
 
 // @public
+export enum AzureAuthorityHosts {
+    // (undocumented)
+    AzureChina = "https://login.chinacloudapi.cn",
+    // (undocumented)
+    AzureGermany = "https://login.microsoftonline.de",
+    // (undocumented)
+    AzureGovernment = "https://login.microsoftonline.us",
+    // (undocumented)
+    AzurePublicCloud = "https://login.microsoftonline.com"
+}
+
+// @public
 export class AzureCliCredential implements TokenCredential {
     constructor();
     protected getAzureCliAccessToken(resource: string): Promise<unknown>;
@@ -73,7 +85,8 @@ export class CredentialUnavailable extends Error {
 
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
-    constructor(tokenCredentialOptions?: TokenCredentialOptions);
+    // Warning: (ae-forgotten-export) The symbol "DefaultAzureCredentialOptions" needs to be exported by the entry point index.d.ts
+    constructor(tokenCredentialOptions?: DefaultAzureCredentialOptions);
 }
 
 // @public
@@ -117,7 +130,7 @@ export { GetTokenOptions }
 export class InteractiveBrowserCredential implements TokenCredential {
     constructor(options?: InteractiveBrowserCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
-    }
+}
 
 // @public
 export interface InteractiveBrowserCredentialOptions extends TokenCredentialOptions {
@@ -126,18 +139,6 @@ export interface InteractiveBrowserCredentialOptions extends TokenCredentialOpti
     postLogoutRedirectUri?: string | (() => string);
     redirectUri?: string | (() => string);
     tenantId?: string;
-}
-
-// @public
-export enum KnownAuthorityHosts {
-    // (undocumented)
-    AzureChina = "https://login.chinacloudapi.cn",
-    // (undocumented)
-    AzureGermany = "https://login.microsoftonline.de",
-    // (undocumented)
-    AzureGovernment = "https://login.microsoftonline.us",
-    // (undocumented)
-    AzurePublicCloud = "https://login.microsoftonline.com"
 }
 
 // @public
@@ -165,7 +166,8 @@ export class UsernamePasswordCredential implements TokenCredential {
 
 // @public
 export class VSCodeCredential implements TokenCredential {
-    constructor(options?: TokenCredentialOptions);
+    // Warning: (ae-forgotten-export) The symbol "VSCodeCredentialOptions" needs to be exported by the entry point index.d.ts
+    constructor(options?: VSCodeCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -40,13 +40,9 @@ export class AuthorizationCodeCredential implements TokenCredential {
 
 // @public
 export enum AzureAuthorityHosts {
-    // (undocumented)
     AzureChina = "https://login.chinacloudapi.cn",
-    // (undocumented)
     AzureGermany = "https://login.microsoftonline.de",
-    // (undocumented)
     AzureGovernment = "https://login.microsoftonline.us",
-    // (undocumented)
     AzurePublicCloud = "https://login.microsoftonline.com"
 }
 
@@ -90,7 +86,6 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
 // @public
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
-    // (undocumented)
     tenantId?: string;
 }
 
@@ -177,7 +172,6 @@ export class VSCodeCredential implements TokenCredential {
 
 // @public
 export interface VSCodeCredentialOptions extends TokenCredentialOptions {
-    // (undocumented)
     tenantId?: string;
 }
 

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -19,9 +19,9 @@ export const DeveloperSignOnClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
 export const DefaultTenantId = "common";
 
 /**
- * A list of known authority hosts
+ * A list of known Azure authority hosts
  */
-export enum KnownAuthorityHosts {
+export enum AzureAuthorityHosts {
   AzureChina = "https://login.chinacloudapi.cn",
   AzureGermany = "https://login.microsoftonline.de",
   AzureGovernment = "https://login.microsoftonline.us",

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -22,8 +22,20 @@ export const DefaultTenantId = "common";
  * A list of known Azure authority hosts
  */
 export enum AzureAuthorityHosts {
+  /**
+   * China-based Azure Authority Host
+   */
   AzureChina = "https://login.chinacloudapi.cn",
+  /**
+   * Germany-based Azure Authority Host
+   */
   AzureGermany = "https://login.microsoftonline.de",
+  /**
+   * US Government Azure Authority Host
+   */
   AzureGovernment = "https://login.microsoftonline.us",
+  /**
+   * Public Cloud Azure Authority Host
+   */
   AzurePublicCloud = "https://login.microsoftonline.com"
 }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -13,6 +13,9 @@ import { TokenCredential } from "@azure/core-http";
  * Provides options to configure the default Azure credentials.
  */
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
+  /**
+   * Optionally pass in a Tenant ID to be used as part of the credential 
+   */
   tenantId?: string;
 }
 

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -10,6 +10,13 @@ import { VSCodeCredential } from "./vscodeCredential";
 import { TokenCredential } from "@azure/core-http";
 
 /**
+ * Provides options to configure the default Azure credentials.
+ */
+export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
+  tenantId?: string;
+}
+
+/**
  * Provides a default {@link ChainedTokenCredential} configuration for
  * applications that will be deployed to Azure.  The following credential
  * types will be tried, in order:
@@ -26,7 +33,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
    *
    * @param options Options for configuring the client which makes the authentication request.
    */
-  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
+  constructor(tokenCredentialOptions?: DefaultAzureCredentialOptions) {
     let credentials = [];
     credentials.push(new EnvironmentCredential(tokenCredentialOptions));
     credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));

--- a/sdk/identity/identity/src/credentials/vscodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/vscodeCredential.ts
@@ -20,20 +20,33 @@ const VSCodeUserName = "VS Code Azure";
 const logger = credentialLogger("VSCodeCredential");
 
 /**
+ * Provides options to configure the Visual Studio Code credential.
+ */
+export interface VSCodeCredentialOptions extends TokenCredentialOptions {
+    tenantId?: string;
+}
+
+/**
  * Connect to Azure using the credential provided by the VSCode extension 'Azure Account'.
  * Once the user has logged in via the extension, this credential can share the same refresh token
  * that is cached by the extension.
  */
 export class VSCodeCredential implements TokenCredential {
   private identityClient: IdentityClient;
+  private tenantId: string;
 
   /**
    * Creates an instance of VSCodeCredential to use for automatically authenicating via VSCode.
    *
    * @param options Options for configuring the client which makes the authentication request.
    */
-  constructor(options?: TokenCredentialOptions) {
+  constructor(options?: VSCodeCredentialOptions) {
     this.identityClient = new IdentityClient(options);
+    if (options && options.tenantId) {
+      this.tenantId = options.tenantId;
+    } else {
+      this.tenantId = CommonTenantId;
+    }
   }
 
   /**
@@ -70,7 +83,7 @@ export class VSCodeCredential implements TokenCredential {
     let refreshToken = await keytar.findPassword(VSCodeUserName);
     if (refreshToken) {
       let tokenResponse = await this.identityClient.refreshAccessToken(
-        CommonTenantId,
+        this.tenantId,
         AzureAccountClientId,
         scopeString,
         refreshToken,

--- a/sdk/identity/identity/src/credentials/vscodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/vscodeCredential.ts
@@ -23,7 +23,10 @@ const logger = credentialLogger("VSCodeCredential");
  * Provides options to configure the Visual Studio Code credential.
  */
 export interface VSCodeCredentialOptions extends TokenCredentialOptions {
-    tenantId?: string;
+  /**
+   * Optionally pass in a Tenant ID to be used as part of the credential 
+   */
+  tenantId?: string;
 }
 
 /**

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -10,7 +10,7 @@ export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
-export { VSCodeCredential } from "./credentials/vscodeCredential";
+export { VSCodeCredential, VSCodeCredentialOptions } from "./credentials/vscodeCredential";
 export { AzureCliCredential } from "./credentials/azureCliCredential";
 
 export {
@@ -24,7 +24,7 @@ export {
   DeviceCodeInfo
 } from "./credentials/deviceCodeCredential";
 
-export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
+export { DefaultAzureCredential, DefaultAzureCredentialOptions } from "./credentials/defaultAzureCredential";
 export { UsernamePasswordCredential } from "./credentials/usernamePasswordCredential";
 export { AuthorizationCodeCredential } from "./credentials/authorizationCodeCredential";
 export {

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -39,7 +39,7 @@ export {
 export { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 export { logger } from "./util/logging";
 
-export { KnownAuthorityHosts } from "./constants";
+export { AzureAuthorityHosts } from "./constants";
 
 /**
  * Returns a new instance of the {@link DefaultAzureCredential}.


### PR DESCRIPTION
This is a small batch of changes ahead of the out-of-band release. These include:

* Renaming KnownAuthorityHost to AzureAuthorityHost
* Making tenant id part of the option bag for DAC and VSCodeCredential
* Update the changelog