### PR TITLE
Add code owners for QnA Maker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,9 @@
 
 /sdk/search/ @xirzec @sarangan12
 
+/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/ @bingisbestest @nerajput1607
+/sdk/cognitiveservices/cognitiveservices-qnamaker/ @bingisbestest @nerajput1607
+
 # Smoke Tests
 /common/smoke-test/ @ramya-rao-a @chradek @jonathandturner @sadasant @jeremymeng @southpolesteve
 


### PR DESCRIPTION
Adding @bingisbestest and @nerajput1607 as code owners for the qna maker packages as per https://github.com/Azure/azure-sdk-for-js/issues/10161#issuecomment-662648547