### PR TITLE
[event-hubs] fixes receiveBatch error handling to preserve received events

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.3.0-preview.2 (Unreleased)
 
-- Fixes isse [#9704](https://github.com/Azure/azure-sdk-for-js/issues/9704)
+- Fixes issue [#9704](https://github.com/Azure/azure-sdk-for-js/issues/9704)
   where events could be _skipped_ while receiving messages.
   Previously this could occur when a retryable error was encountered and retries were exhausted while receiving a batch of events.
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.3.0-preview.2 (Unreleased)
 
+- Fixes isse [#9704](https://github.com/Azure/azure-sdk-for-js/issues/9704)
+  where events could be _skipped_ while receiving messages.
+  Previously this could occur when a retryable error was encountered and retries were exhausted while receiving a batch of events.
 
 ## 5.3.0-preview.1 (2020-07-07)
 

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -746,6 +746,10 @@ export class EventHubReceiver extends LinkEntity {
             }
           },
           (err) => {
+            // restore events to the front of the internal queue.
+            while (receivedEvents.length) {
+              this._internalQueue.unshift(receivedEvents.pop()!);
+            }
             cleanUpBeforeReturn();
             if (err.name === "AbortError") {
               rejectOnAbort();

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -15,11 +15,13 @@ import {
   earliestEventPosition,
   EventHubConsumerClient,
   EventHubProducerClient,
-  Subscription
+  Subscription,
+  EventPosition
 } from "../src";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
 import { EventHubReceiver } from "../src/eventHubReceiver";
+import { translate } from "@azure/core-amqp";
 const env = getEnvVars();
 
 describe("EventHubConsumerClient", function(): void {
@@ -540,6 +542,107 @@ describe("EventHubConsumerClient", function(): void {
 
       await receiver.close();
     });
+
+    it("should not lose messages on error", async () => {
+      const partitionId = partitionIds[0];
+      const { lastEnqueuedSequenceNumber } = await producerClient.getPartitionProperties(
+        partitionId
+      );
+
+      // Ensure the receiver only looks at new messages.
+      const startPosition: EventPosition = {
+        sequenceNumber: lastEnqueuedSequenceNumber,
+        isInclusive: false
+      };
+
+      // Send a message we expect to receive.
+      const message: EventData = { body: "remember me!" };
+      await producerClient.sendBatch([message], { partitionId });
+
+      // Disable retries to make it easier to test scenario.
+      const receiver = new EventHubReceiver(
+        consumerClient["_context"],
+        EventHubConsumerClient.defaultConsumerGroupName,
+        partitionId,
+        startPosition,
+        {
+          retryOptions: {
+            maxRetries: 0
+          }
+        }
+      );
+
+      // Periodically check that the receiver's checkpoint has been updated.
+      const checkpointInterval = setInterval(() => {
+        if (receiver.checkpoint > -1) {
+          clearInterval(checkpointInterval);
+          const error = translate(new Error("I break receivers for fun."));
+          receiver["_onError"]!(error);
+        }
+      }, 50);
+
+      try {
+        // There is only 1 message.
+        // We expect to see an error.
+        await receiver.receiveBatch(2, 60);
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.not.equal("Test failure");
+        receiver.checkpoint.should.be.greaterThan(-1, "Did not see a message come through.");
+      } finally {
+        clearInterval(checkpointInterval);
+      }
+
+      const events = await receiver.receiveBatch(1);
+      events.length.should.equal(1, "Unexpected number of events received.");
+      events[0].body.should.equal(message.body, "Unexpected message received.");
+    });
+
+    it("should not lose messages between retries", async () => {
+      const partitionId = partitionIds[0];
+      const { lastEnqueuedSequenceNumber } = await producerClient.getPartitionProperties(
+        partitionId
+      );
+
+      // Ensure the receiver only looks at new messages.
+      const startPosition: EventPosition = {
+        sequenceNumber: lastEnqueuedSequenceNumber,
+        isInclusive: false
+      };
+
+      // Send a message we expect to receive.
+      const message: EventData = { body: "remember me!" };
+      await producerClient.sendBatch([message], { partitionId });
+
+      // Disable retries to make it easier to test scenario.
+      const receiver = new EventHubReceiver(
+        consumerClient["_context"],
+        EventHubConsumerClient.defaultConsumerGroupName,
+        partitionId,
+        startPosition,
+        {
+          retryOptions: {
+            maxRetries: 1
+          }
+        }
+      );
+
+      // Periodically check that the receiver's checkpoint has been updated.
+      const checkpointInterval = setInterval(() => {
+        if (receiver.checkpoint > -1) {
+          clearInterval(checkpointInterval);
+          const error = translate(new Error("I break receivers for fun.")) as MessagingError;
+          error.retryable = true;
+          receiver["_onError"]!(error);
+        }
+      }, 50);
+
+      // There is only 1 message.
+      const events = await receiver.receiveBatch(2, 20);
+
+      events.length.should.equal(1, "Unexpected number of events received.");
+      events[0].body.should.equal(message.body, "Unexpected message received.");
+    });
   });
 
   describe("subscribe() with trackLastEnqueuedEventProperties", function(): void {
@@ -600,14 +703,12 @@ describe("EventHubConsumerClient", function(): void {
       );
       let subscription: Subscription | undefined;
       const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
-        subscription = badConsumerClient.subscribe(
-          {
-            processEvents: async () => {},
-            processError: async (err) => {
-              resolve(err);
-            }
+        subscription = badConsumerClient.subscribe({
+          processEvents: async () => {},
+          processError: async (err) => {
+            resolve(err);
           }
-        );
+        });
       });
       await subscription!.close();
       await badConsumerClient.close();


### PR DESCRIPTION
Fixes #9704 

## Description
This update fixes an issue with `receiveBatch` where events could fail to make it to the user, appearing to be 'skipped'.

This could happen if the user requested N messages, N - M events arrived, and a retryable error (e.g. network issue) caused the `receiveBatch` call to exhaust its retries.

## Background info on EventHubReceiver?
The `EventHubReceiver` keeps an internal checkpoint of the last event it received so that each `receiveBatch` call knows what position to start receiving events from. It also has an `_internalQueue` that holds any events that were received but haven't been returned by a `receiveBatch` call yet. This internal queue protects us from losing any messages that make it to the client after `receiveBatch` yields.

## So why were messages being lost?
`receiveBatch` collects the specified number of events to be received before yielding (there's also a maximum wait time but that's not important here).

Events collected by `receiveBatch` are no longer part of the `EventHubReceiver`'s internal queue. So if events were collected, and an error occurred before `receiveBatch` had a chance to yield (and retries were exhausted), those events would be 'skpped'. In the case that the error was retryable, `receiveBatch` would be called again, but the receiver's internal checkpoint would see that it had already moved past the 'skipped' messages.

## What's the solution?
When `receiveBatch` encounters an error, we put the events that have been collected thus far back into the front of the receiver's internal queue. Then the next `receiveBatch` call would pull those events from the internal queue before getting more from the service.

## Testing
I've added 2 tests.

The first test ensures that `receiveBatch` collects an event then fails due to encountering an error. The next `receiveBatch` call correctly returns the event that would have been lost before this change. This test would have failed before this change.

The second test ensures that `receiveBatch` collects an event and then triggers a retry due to encountering an error. The `receiveBatch` call eventually returns the event we expected to see. This test would have passed before this change, but wanted to make sure it was in place since we're putting events back in the internal queue on errors now.

