### PR TITLE
Fix sample code on the QnAMaker Readme

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
@@ -26,12 +26,11 @@ npm install @azure/ms-rest-azure-js
 
 ##### Sample code
 
-```typescript
-import {
-  QnAMakerRuntimeClient, 
-  QnAMakerRuntimeModels 
-} from "@azure/cognitiveservices-qnamaker-runtime";
-import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
+```javascript
+const {
+  QnAMakerRuntimeClient 
+} = require("@azure/cognitiveservices-qnamaker-runtime");
+const { CognitiveServicesCredentials } = require("@azure/ms-rest-azure-js");
 
 async function main() {
   const QNAMAKER_KEY = process.env["QNAMAKER_KEY"] || "<QNAMAKER_KEY>";
@@ -49,7 +48,7 @@ async function main() {
   const top = 1;
 
   // Find only answers that contain these metadata
-  const strictFilters: QnAMakerRuntimeModels.MetadataDTO[] = [{ name: "editorial", value: "chitchat" }];
+  const strictFilters = [{ name: "editorial", value: "chitchat" }];
 
   const result = await client.runtime.generateAnswer(
     kbid,

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
@@ -28,7 +28,7 @@ npm install @azure/ms-rest-azure-js
 
 ```typescript
 import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
-import { QnAMakerClient } from "@azure/cognitiveservices-qnamaker";
+import { QnAMakerRuntimeClient } from "@azure/cognitiveservices-qnamaker-runtime";
 
 async function main() {
   const QNAMAKER_KEY = process.env["QNAMAKER_KEY"] || "<QNAMAKER_KEY>";

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
@@ -27,13 +27,16 @@ npm install @azure/ms-rest-azure-js
 ##### Sample code
 
 ```typescript
+import {
+  QnAMakerRuntimeClient, 
+  QnAMakerRuntimeModels 
+} from "@azure/cognitiveservices-qnamaker-runtime";
 import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
-import { QnAMakerRuntimeClient } from "@azure/cognitiveservices-qnamaker-runtime";
 
 async function main() {
   const QNAMAKER_KEY = process.env["QNAMAKER_KEY"] || "<QNAMAKER_KEY>";
   const QNAMAKER_ENDPOINT = process.env["QNAMAKER_ENDPOINT"] || "<QNAMAKER_ENDPOINT>";
-  const kbid = "<QNAMAKER_KNOWLEDGE_BASE_ID>";
+  const kbid = process.env["QNAMAKER_KNOWLEDGE_BASE_ID"] || "<QNAMAKER_KNOWLEDGE_BASE_ID>";
 
   const cognitiveServicesCredentials = new CognitiveServicesCredentials(QNAMAKER_KEY);
   const client = new QnAMakerRuntimeClient(cognitiveServicesCredentials, QNAMAKER_ENDPOINT);
@@ -46,7 +49,7 @@ async function main() {
   const top = 1;
 
   // Find only answers that contain these metadata
-  const strictFilters: MetadataDTO[] = [{ name: "editorial", value: "chitchat" }];
+  const strictFilters: QnAMakerRuntimeModels.MetadataDTO[] = [{ name: "editorial", value: "chitchat" }];
 
   const result = await client.runtime.generateAnswer(
     kbid,
@@ -54,7 +57,7 @@ async function main() {
     { customHeaders }
   );
   console.log(JSON.stringify(result));
-  // Result
+  // Sample Result
   // {
   //   answers: [
   //     {
@@ -80,17 +83,9 @@ async function main() {
 main();
 ```
 
-#### browser - Authentication, client creation and generateAnswer runtime as an example written in JavaScript.
-
-##### Install @azure/ms-rest-browserauth
-
-```bash
-npm install @azure/ms-rest-browserauth
-```
+#### browser - Authentication, client creation and generateAnswer runtime  as an example written in JavaScript.
 
 ##### Sample code
-
-See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to Azure in the browser.
 
 - index.html
 
@@ -102,59 +97,64 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
     <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
     <script src="node_modules/@azure/cognitiveservices-qnamaker-runtime/dist/cognitiveservices-qnamaker-runtime.js"></script>
     <script type="text/javascript">
-      async function main() {
-        const QNAMAKER_KEY = "<QNAMAKER_KEY>";
-        const QNAMAKER_ENDPOINT = "<QNAMAKER_ENDPOINT>";
-        const cognitiveServiceCredentials = new msRest.ApiKeyCredentials({
-          inHeader: {
-            Authorization: `EndpointKey ${QNAMAKER_KEY}`
-          }
+      const QNAMAKER_KEY = "<QNAMAKER_KEY>";
+      const QNAMAKER_ENDPOINT = "<QNAMAKER_ENDPOINT>";
+      const kbid = "<QNAMAKER_KNOWLEDGE_BASE_ID>";
+
+      const cognitiveServiceCredentials = new msRest.ApiKeyCredentials({
+        inHeader: {
+          "Ocp-Apim-Subscription-Key": QNAMAKER_KEY
+        }
+      });
+
+      const client = new Azure.CognitiveservicesQnamakerRuntime.QnAMakerRuntimeClient(
+        cognitiveServiceCredentials,
+        QNAMAKER_ENDPOINT
+      );
+      const customHeaders = { Authorization: `EndpointKey ${QNAMAKER_KEY}` };
+
+      // A question you'd like to get a response for, from the knowledge base. For example
+      const question = "How are you?";
+
+      // Maximum number of answer to retreive
+      const topValue = 1;
+
+      // Find only answers that contain these metadata
+      const strictFilters = [{
+        name: "editorial",
+        value: "chitchat"
+      }];
+
+      client.runtime
+        .generateAnswer(kbid, {question, topValue, strictFilters}, {customHeaders})
+        .then(result => {
+          console.log(JSON.stringify(result));
+          // Sample Result
+          // {
+          //   answers: [
+          //     {
+          //       questions: [
+          //         "How are you?",
+          //         "How is your tuesday?"
+          //       ],
+          //       answer:
+          //         ""I'm doing great, thanks for asking!",
+          //       score: 100,
+          //       id: 90,
+          //       source:
+          //         "qna_chitchat_Friendly.tsv",
+          //       metadata: [{ name: "editorial", value: "chitchat" }],
+          //       context: { isContextOnly: false, prompts: [] }
+          //     }
+          //   ],
+          //   debugInfo: null,
+          //   activeLearningEnabled: false
+          // }
+        })
+        .catch(err => {
+          console.log("An error occurred:");
+          console.error(err);
         });
-
-        const client = new Azure.CognitiveservicesQnamakerRuntime.QnAMakerRuntimeClient(
-          cognitiveServiceCredentials,
-          QNAMAKER_ENDPOINT
-        );
-
-        // A question you'd like to get a response for, from the knowledge base. For example
-        const question = "How are you?";
-
-        // Maximum number of answer to retreive
-        const top = 1;
-
-        // Find only answers that contain these metadata
-        const strictFilters: MetadataDTO[] = [{ name: "editorial", value: "chitchat" }];
-
-        const result = await client.runtime.generateAnswer(
-          kbid,
-          { question, top, strictFilters },
-          { customHeaders }
-        );
-        console.log(JSON.stringify(result));
-        // Result
-        // {
-        //   answers: [
-        //     {
-        //       questions: [
-        //         "How are you?",
-        //         "How is your tuesday?"
-        //       ],
-        //       answer:
-        //         ""I'm doing great, thanks for asking!",
-        //       score: 100,
-        //       id: 90,
-        //       source:
-        //         "qna_chitchat_Friendly.tsv",
-        //       metadata: [{ name: "editorial", value: "chitchat" }],
-        //       context: { isContextOnly: false, prompts: [] }
-        //     }
-        //   ],
-        //   debugInfo: null,
-        //   activeLearningEnabled: false
-        // }
-      }
-
-      main();
     </script>
   </head>
   <body></body>

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker-runtime/README.md
@@ -27,9 +27,7 @@ npm install @azure/ms-rest-azure-js
 ##### Sample code
 
 ```javascript
-const {
-  QnAMakerRuntimeClient 
-} = require("@azure/cognitiveservices-qnamaker-runtime");
+const { QnAMakerRuntimeClient } = require("@azure/cognitiveservices-qnamaker-runtime");
 const { CognitiveServicesCredentials } = require("@azure/ms-rest-azure-js");
 
 async function main() {


### PR DESCRIPTION
This PR is to fix the issue https://github.com/Azure/azure-sdk-for-js/issues/10158. Changes included in this PR:

1. **JS Sample**
    a. Changes TS Code Sample to JS Code Sample
    b. Changed `QnAMakerClient` to `QnAMakerRuntimeClient`

2. **HTML Sample**
    a. Removed the reference to `@azure/ms-rest-browserauth`
    b. `kbid` was not declared which will cause error. So, added a declaration for that.
    c. `cognitiveServiceCredentials` was not defined correctly. Fixed the definition.

I haved tested both the samples and confirmed that the code changes are working fine. 

Interestingly, While testing these samples, I have found another issue with `@azure/ms-rest-js` package(version: 2.0.6). In essence, if you try to run the HTML sample with ms-rest-js version 2.0.6, you are going to hit error. This is true for all the cognitive service sdks samples. So, I have created a separate issue for that. (https://github.com/Azure/ms-rest-js/issues/396)

@ramya-rao-a Please review and approve. **Also, since the issue specifically wants the sample code to be fixed in the npm, do you want me to release a patch version of the package? Please let me know**.

