### PR TITLE
[ai-form-recognizer] Revert table rows -> cells only

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -225,10 +225,8 @@ async function main() {
       `Page ${page.pageNumber}: width ${page.width} and height ${page.height} with unit ${page.unit}`
     );
     for (const table of page.tables) {
-      for (const row of table.rows) {
-        for (const cell of row.cells) {
-          console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
-        }
+      for (const cell of table.cells) {
+        console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
       }
     }
   }
@@ -320,10 +318,8 @@ async function main() {
       console.log(`Page number: ${page.pageNumber}`);
       console.log("Tables");
       for (const table of page.tables || []) {
-        for (const row of table.rows) {
-          for (const cell of row.cells) {
-            console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
-          }
+        for (const cell of table.cells) {
+          console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
         }
       }
     }

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -253,9 +253,9 @@ export type FormRecognizerRequestBody = Blob | ArrayBuffer | ArrayBufferView | N
 
 // @public
 export interface FormTable {
+    cells: FormTableCell[];
     columnCount: number;
     rowCount: number;
-    rows: FormTableRow[];
 }
 
 // @public
@@ -270,11 +270,6 @@ export interface FormTableCell {
     rowIndex: number;
     rowSpan?: number;
     text: string;
-}
-
-// @public
-export interface FormTableRow {
-    cells: FormTableCell[];
 }
 
 // @public

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/authenticationMethods.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/authenticationMethods.js
@@ -78,10 +78,8 @@ async function recognizeContentWithClient(client) {
       `Page ${page.pageNumber}: width ${page.width} and height ${page.height} with unit ${page.unit}`
     );
     for (const table of page.tables) {
-      for (const row of table.rows) {
-        for (const cell of row.cells) {
-          console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
-        }
+      for (const cell of table.cells) {
+        console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
       }
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
@@ -57,17 +57,15 @@ async function main() {
       );
       console.log("    Tables");
       for (const table of page.tables || []) {
-        for (const row of table.rows) {
-          for (const cell of row.cells) {
-            console.log(
-              `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
-            );
-            for (const element of cell.fieldElements || []) {
-              const boundingBox = element.boundingBox
-                ? element.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
-                : "N/A";
-              console.log(`        '${element.text}' within bounding box ${boundingBox}`);
-            }
+        for (const cell of table.cells) {
+          console.log(
+            `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
+          );
+          for (const element of cell.fieldElements || []) {
+            const boundingBox = element.boundingBox
+              ? element.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
+              : "N/A";
+            console.log(`        '${element.text}' within bounding box ${boundingBox}`);
           }
         }
       }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeContent.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeContent.js
@@ -36,10 +36,8 @@ async function main() {
       `Page ${page.pageNumber}: width ${page.width} and height ${page.height} with unit ${page.unit}`
     );
     for (const table of page.tables) {
-      for (const row of table.rows) {
-        for (const cell of row.cells) {
-          console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
-        }
+      for (const cell of table.cells) {
+        console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
       }
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeCustomForm.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeCustomForm.js
@@ -40,10 +40,8 @@ async function main() {
       console.log(`Page number: ${page.pageNumber}`);
       console.log("Tables");
       for (const table of page.tables || []) {
-        for (const row of table.rows) {
-          for (const cell of row.cells) {
-            console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
-          }
+        for (const cell of table.cells) {
+          console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
         }
       }
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/authenticationMethods.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/authenticationMethods.ts
@@ -80,10 +80,8 @@ async function recognizeContentWithClient(client: FormRecognizerClient) {
       `Page ${page.pageNumber}: width ${page.width} and height ${page.height} with unit ${page.unit}`
     );
     for (const table of page.tables!) {
-      for (const row of table.rows) {
-        for (const cell of row.cells) {
-          console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
-        }
+      for (const cell of table.cells) {
+        console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
       }
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
@@ -61,17 +61,15 @@ export async function main() {
       );
       console.log("    Tables");
       for (const table of page.tables || []) {
-        for (const row of table.rows) {
-          for (const cell of row.cells) {
-            console.log(
-              `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
-            );
-            for (const element of cell.fieldElements || []) {
-              const boundingBox = element.boundingBox
-                ? element.boundingBox.map((p) => `[$.2d{p.x},${p.y}]`).join(", ")
-                : "N/A";
-              console.log(`        '${element.text}' within bounding box ${boundingBox}`);
-            }
+        for (const cell of table.cells) {
+          console.log(
+            `      Cell[${cell.rowIndex},${cell.columnIndex}] has text ${cell.text} with confidence ${cell.confidence} based on the following words:`
+          );
+          for (const element of cell.fieldElements || []) {
+            const boundingBox = element.boundingBox
+              ? element.boundingBox.map((p) => `[$.2d{p.x},${p.y}]`).join(", ")
+              : "N/A";
+            console.log(`        '${element.text}' within bounding box ${boundingBox}`);
           }
         }
       }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeContent.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeContent.ts
@@ -39,10 +39,8 @@ export async function main() {
       `Page ${page.pageNumber}: width ${page.width} and height ${page.height} with unit ${page.unit}`
     );
     for (const table of page.tables!) {
-      for (const row of table.rows) {
-        for (const cell of row.cells) {
-          console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
-        }
+      for (const cell of table.cells) {
+        console.log(`cell [${cell.rowIndex},${cell.columnIndex}] has text ${cell.text}`);
       }
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
@@ -47,10 +47,8 @@ export async function main() {
       console.log(`Page number: ${page.pageNumber}`);
       console.log("Tables");
       for (const table of page.tables || []) {
-        for (const row of table.rows) {
-          for (const cell of row.cells) {
-            console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
-          }
+        for (const cell of table.cells) {
+          console.log(`cell (${cell.rowIndex},${cell.columnIndex}) ${cell.text}`);
         }
       }
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -166,16 +166,6 @@ export interface FormTableCell {
 }
 
 /**
- * Represents a row of data table cells in recognized table.
- */
-export interface FormTableRow {
-  /**
-   * List of data table cells in a {@link FormTableRow}
-   */
-  cells: FormTableCell[];
-}
-
-/**
  * Information about the recognized table contained in a page.
  */
 export interface FormTable {
@@ -188,9 +178,9 @@ export interface FormTable {
    */
   columnCount: number;
   /**
-   * List of rows in the data table
+   * List of cells in the data table
    */
-  rows: FormTableRow[];
+  cells: FormTableCell[];
 }
 
 /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -21,7 +21,6 @@ import {
   FormPage,
   FormLine,
   FormElement,
-  FormTableRow,
   FormTable,
   RecognizedForm,
   FieldData,
@@ -124,12 +123,10 @@ export function toFormFieldFromKeyValuePairModel(
 }
 
 export function toFormTable(original: DataTableModel, readResults?: FormPage[]): FormTable {
-  const rows: FormTableRow[] = [];
-  for (let i = 0; i < original.rows; i++) {
-    rows.push({ cells: [] });
-  }
-  for (const cell of original.cells) {
-    rows[cell.rowIndex].cells.push({
+  return {
+    rowCount: original.rows,
+    columnCount: original.columns,
+    cells: original.cells.map((cell) => ({
       boundingBox: toBoundingBox(cell.boundingBox),
       columnIndex: cell.columnIndex,
       columnSpan: cell.columnSpan || 1,
@@ -140,12 +137,7 @@ export function toFormTable(original: DataTableModel, readResults?: FormPage[]):
       rowIndex: cell.rowIndex,
       rowSpan: cell.rowSpan || 1,
       text: cell.text
-    });
-  }
-  return {
-    rowCount: original.rows,
-    columnCount: original.columns,
-    rows: rows
+    }))
   };
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
@@ -450,19 +450,19 @@ describe("Transforms", () => {
 
     const transformed = toFormTable(originalTable, formPages);
 
-    assert.equal(transformed.rows.length, originalTable.rows);
-    assert.equal(transformed.rows[0].cells[0].text, originalTable.cells[0].text);
-    assert.equal(transformed.rows[1].cells[1].confidence, originalTable.cells[3].confidence);
+    assert.equal(transformed.rowCount, originalTable.rows);
+    assert.equal(transformed.cells[0].text, originalTable.cells[0].text);
+    assert.equal(transformed.cells[3].confidence, originalTable.cells[3].confidence);
 
-    assert.equal(transformed.rows[0].cells[0].isHeader, true);
-    assert.equal(transformed.rows[0].cells[0].isFooter, false);
-    assert.equal(transformed.rows[0].cells[0].rowSpan, 1);
-    assert.equal(transformed.rows[0].cells[0].columnSpan, 1);
+    assert.equal(transformed.cells[0].isHeader, true);
+    assert.equal(transformed.cells[0].isFooter, false);
+    assert.equal(transformed.cells[0].rowSpan, 1);
+    assert.equal(transformed.cells[0].columnSpan, 1);
 
-    assert.equal(transformed.rows[2].cells[0].isHeader, false);
-    assert.equal(transformed.rows[2].cells[0].isFooter, true);
-    assert.equal(transformed.rows[2].cells[0].rowSpan, 1);
-    assert.equal(transformed.rows[2].cells[0].columnSpan, 2);
+    assert.equal(transformed.cells[4].isHeader, false);
+    assert.equal(transformed.cells[4].isFooter, true);
+    assert.equal(transformed.cells[4].rowSpan, 1);
+    assert.equal(transformed.cells[4].columnSpan, 2);
   });
 
   it("toRecognizedForm() should handle empty page", () => {


### PR DESCRIPTION
Closes #10033 

We've decided not to use a "rows" array for the GA release of the library. This patch reverts to the same "cells"-only design that the service returns.