### PR TITLE
[Cosmos] Throws when connection endpoint is invalid in client init

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.7.5 (Unreleased)
 
+- FEATURE: Throws when initializing ClientContext with an invalid endpoint
 
 ## 3.7.4 (2020-6-30)
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -63,6 +63,11 @@ export class CosmosClient {
       optionsOrConnectionString = parseConnectionString(optionsOrConnectionString);
     }
 
+    const endpoint = new URL(optionsOrConnectionString.endpoint);
+    if (!endpoint) {
+      throw new Error("Invalid endpoint specified");
+    }
+
     optionsOrConnectionString.connectionPolicy = Object.assign(
       {},
       defaultConnectionPolicy,

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -10,6 +10,7 @@ import { CosmosClientOptions } from "./CosmosClientOptions";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
 import { RequestOptions, ResourceResponse } from "./request";
+import { URL } from "url";
 
 /**
  * Provides a client-side logical representation of the Azure Cosmos DB database account.

--- a/sdk/cosmosdb/cosmos/test/functional/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/client.spec.ts
@@ -49,6 +49,9 @@ describe("NodeJS CRUD Tests", function () {
     it("throws on a bad connection string", function () {
       assert.throws(() => new CosmosClient(`bad;Connection=string;`));
     });
+    it("throws on a bad endpoint", function () {
+      assert.throws(() => new CosmosClient({ endpoint: "asda=asda;asada;" }));
+    });
   });
   describe("Validate user passed AbortController.signal", function () {
     it("should throw exception if aborted during the request", async function () {


### PR DESCRIPTION
When initializing the client with an invalid endpoint, we currently default to localhost which causes unexpected failures that aren't related to an invalid endpoint. We now parse the endpoint as a URL to immediately throw an error that gives an immediate understanding of the failure.

Closes https://github.com/Azure/azure-sdk-for-js/issues/4822