### PR TITLE
[Service Bus] ATOM API: Retain the status code in the response from the service for MessageEntityNotFoundError

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -2382,7 +2382,7 @@ export class ServiceBusManagementClient extends ServiceClient {
         const err = new RestError(
           `The messaging entity "${name}" being requested cannot be found.`,
           "MessageEntityNotFoundError",
-          404,
+          response.status,
           stripRequest(webResource),
           stripResponse(response)
         );

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1119,7 +1119,6 @@ describe("Atom management - Authentication", function(): void {
           error = err;
         }
 
-        should.equal(error.statusCode, 404);
         should.equal(error.code, "MessageEntityNotFoundError", `Unexpected error code found.`);
         should.equal(
           error.message.startsWith("The messaging entity") ||
@@ -1139,7 +1138,6 @@ describe("Atom management - Authentication", function(): void {
           error = err;
         }
 
-        should.equal(error.statusCode, 404, "Unexpected status code found.");
         should.equal(error.code, "MessageEntityNotFoundError", `Unexpected error code found.`);
         should.equal(
           error.message.startsWith("The messaging entity") ||
@@ -1196,7 +1194,6 @@ describe("Atom management - Authentication", function(): void {
             throw new Error("TestError: Unrecognized EntityType");
         }
 
-        should.equal(error.statusCode, 404, "Unexpected status code found.");
         should.equal(error.code, "MessageEntityNotFoundError", `Unexpected error code found.`);
         should.equal(
           error.message.startsWith("The messaging entity") ||


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-sdk-for-js/issues/10144