### PR TITLE
[eventhubs-checkpointstore-blob] fix listCheckpoints performance with versioned containers

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.1 (Unreleased)
 
+- Fixes issue [#10132](https://github.com/Azure/azure-sdk-for-js/issues/10132)
+  where using an Azure Storage Account with soft-deletes or blob versioning enabled
+  would cause `listCheckpoints` to suffer performance penalties proportional to the
+  number of times `updateCheckpoint` was called.
+
 ## 1.0.0 (2020-01-09)
 
 - This release marks the general availability of the `@azure/eventhubs-checkpointstore-blob` package.

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { CheckpointStore, PartitionOwnership, Checkpoint } from "@azure/event-hubs";
-import { ContainerClient, Metadata, RestError } from "@azure/storage-blob";
+import { ContainerClient, Metadata, RestError, BlobSetMetadataResponse } from "@azure/storage-blob";
 import { logger, logErrorStackTrace } from "./log";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
 
@@ -253,21 +253,38 @@ export class BlobCheckpointStore implements CheckpointStore {
     blobName: string,
     metadata: OwnershipMetadata | CheckpointMetadata,
     etag: string | undefined
-  ) {
-    const blobClient = this._containerClient.getBlobClient(blobName);
+  ): Promise<BlobSetMetadataResponse> {
+    const blockBlobClient = this._containerClient.getBlobClient(blobName).getBlockBlobClient();
 
+    // When we have an etag, we know the blob existed.
+    // If we encounter an error we should fail.
     if (etag) {
-      return blobClient.setMetadata(metadata as Metadata, {
+      return blockBlobClient.setMetadata(metadata as Metadata, {
         conditions: {
           ifMatch: etag
         }
       });
     } else {
-      const blockBlobClient = blobClient.getBlockBlobClient();
+      try {
+        // Attempt to set metadata, and fallback to upload if the blob doesn't already exist.
+        // This avoids poor performance in storage accounts with soft-delete or blob versioning enabled.
+        // https://github.com/Azure/azure-sdk-for-js/issues/10132
+        return await blockBlobClient.setMetadata(metadata as Metadata);
+      } catch (err) {
+        // Check if the error is `BlobNotFound` and fallback to `upload` if it is.
+        if (err?.name !== "RestError") {
+          throw err;
+        }
+        const errorDetails = (err as RestError).details as { [field: string]: string } | undefined;
+        const errorCode = errorDetails?.errorCode ?? errorDetails?.Code;
+        if (!errorCode || errorCode !== "BlobNotFound") {
+          throw err;
+        }
 
-      return blockBlobClient.upload("", 0, {
-        metadata: metadata as Metadata
-      });
+        return blockBlobClient.upload("", 0, {
+          metadata: metadata as Metadata
+        });
+      }
     }
   }
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -276,7 +276,7 @@ export class BlobCheckpointStore implements CheckpointStore {
           throw err;
         }
         const errorDetails = (err as RestError).details as { [field: string]: string } | undefined;
-        const errorCode = errorDetails?.errorCode ?? errorDetails?.Code;
+        const errorCode = errorDetails?.errorCode;
         if (!errorCode || errorCode !== "BlobNotFound") {
           throw err;
         }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
@@ -15,7 +15,7 @@ import { ContainerClient, RestError } from "@azure/storage-blob";
 import { PartitionOwnership, Checkpoint, EventHubConsumerClient } from "@azure/event-hubs";
 import { Guid } from "guid-typescript";
 import { parseIntOrThrow } from "../src/blobCheckpointStore";
-import { fail } from 'assert';
+import { fail } from "assert";
 const env = getEnvVars();
 
 describe("Blob Checkpoint Store", function(): void {
@@ -53,21 +53,23 @@ describe("Blob Checkpoint Store", function(): void {
   });
 
   // these errors happen when we have multiple consumers starting up
-  // at the same time and load balancing amongst themselves. This is a 
+  // at the same time and load balancing amongst themselves. This is a
   // normal thing and shouldn't be reported to the user.
   it("claimOwnership ignores errors about etags", async () => {
     const checkpointStore = new BlobCheckpointStore(containerClient);
 
-    const originalClaimedOwnerships = await checkpointStore.claimOwnership([{
-      partitionId: "0",
-      consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
-      fullyQualifiedNamespace: "fqdn",
-      eventHubName: "ehname",
-      ownerId: "me"
-    }]);
+    const originalClaimedOwnerships = await checkpointStore.claimOwnership([
+      {
+        partitionId: "0",
+        consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
+        fullyQualifiedNamespace: "fqdn",
+        eventHubName: "ehname",
+        ownerId: "me"
+      }
+    ]);
 
     const originalETag = originalClaimedOwnerships[0] && originalClaimedOwnerships[0].etag;
-    
+
     const newClaimedOwnerships = await checkpointStore.claimOwnership(originalClaimedOwnerships);
     newClaimedOwnerships.length.should.equal(1);
 
@@ -75,14 +77,16 @@ describe("Blob Checkpoint Store", function(): void {
 
     // we've now invalidated the previous ownership's etag so using the old etag will
     // fail.
-    const shouldNotThrowButNothingWillClaim = await checkpointStore.claimOwnership([{
-      partitionId: "0",
-      consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
-      fullyQualifiedNamespace: "fqdn",
-      eventHubName: "ehname",
-      ownerId: "me",
-      etag: originalETag
-    }]);
+    const shouldNotThrowButNothingWillClaim = await checkpointStore.claimOwnership([
+      {
+        partitionId: "0",
+        consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
+        fullyQualifiedNamespace: "fqdn",
+        eventHubName: "ehname",
+        ownerId: "me",
+        etag: originalETag
+      }
+    ]);
 
     shouldNotThrowButNothingWillClaim.length.should.equal(0);
   });
@@ -94,13 +98,15 @@ describe("Blob Checkpoint Store", function(): void {
     await containerClient.delete();
 
     try {
-      await checkpointStore.claimOwnership([{
-        partitionId: "0",
-        consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
-        fullyQualifiedNamespace: "fqdn",
-        eventHubName: "ehname",
-        ownerId: "me"
-      }]);
+      await checkpointStore.claimOwnership([
+        {
+          partitionId: "0",
+          consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
+          fullyQualifiedNamespace: "fqdn",
+          eventHubName: "ehname",
+          ownerId: "me"
+        }
+      ]);
       fail("Should have thrown an error - this isn't a normal claim collision issue");
     } catch (err) {
       (err instanceof RestError).should.be.ok;
@@ -244,71 +250,141 @@ describe("Blob Checkpoint Store", function(): void {
     ownershipList[2].etag!.should.not.undefined;
   });
 
-  it("updateCheckpoint", async () => {
-    const checkpointStore = new BlobCheckpointStore(containerClient);
+  describe("updateCheckpoint()", () => {
+    it("updates checkpoints successfully", async () => {
+      const checkpointStore = new BlobCheckpointStore(containerClient);
 
-    const eventHubProperties = {
-      fullyQualifiedNamespace: "testNamespace.servicebus.windows.net",
-      eventHubName: "testEventHub",
-      consumerGroup: "testConsumerGroup"
-    };
+      const eventHubProperties = {
+        fullyQualifiedNamespace: "testNamespace.servicebus.windows.net",
+        eventHubName: "testEventHub",
+        consumerGroup: "testConsumerGroup"
+      };
 
-    for (let i = 0; i < 3; ++i) {
+      for (let i = 0; i < 3; ++i) {
+        const checkpoint: Checkpoint = {
+          ...eventHubProperties,
+          partitionId: i.toString(),
+          sequenceNumber: 100 + i,
+          offset: 1023 + i
+        };
+
+        await checkpointStore.updateCheckpoint(checkpoint);
+      }
+
+      let checkpoints = await checkpointStore.listCheckpoints(
+        eventHubProperties.fullyQualifiedNamespace,
+        eventHubProperties.eventHubName,
+        eventHubProperties.consumerGroup
+      );
+
+      checkpoints.length.should.equal(3);
+      checkpoints.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
+
+      for (let i = 0; i < 3; ++i) {
+        const checkpoint = checkpoints[i];
+
+        checkpoint.partitionId.should.equal(i.toString());
+        checkpoint.fullyQualifiedNamespace.should.equal("testNamespace.servicebus.windows.net");
+        checkpoint.consumerGroup.should.equal("testConsumerGroup");
+        checkpoint.eventHubName.should.equal("testEventHub");
+        checkpoint.sequenceNumber!.should.equal(100 + i);
+        checkpoint.offset!.should.equal(1023 + i);
+
+        // now update it
+        checkpoint.offset++;
+        checkpoint.sequenceNumber++;
+
+        await checkpointStore.updateCheckpoint(checkpoint);
+      }
+
+      checkpoints = await checkpointStore.listCheckpoints(
+        eventHubProperties.fullyQualifiedNamespace,
+        eventHubProperties.eventHubName,
+        eventHubProperties.consumerGroup
+      );
+
+      checkpoints.length.should.equal(3);
+      checkpoints.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
+
+      for (let i = 0; i < 3; ++i) {
+        const checkpoint = checkpoints[i];
+
+        checkpoint.partitionId.should.equal(i.toString());
+        checkpoint.fullyQualifiedNamespace.should.equal("testNamespace.servicebus.windows.net");
+        checkpoint.consumerGroup.should.equal("testConsumerGroup");
+        checkpoint.eventHubName.should.equal("testEventHub");
+        checkpoint.sequenceNumber!.should.equal(100 + i + 1);
+        checkpoint.offset!.should.equal(1023 + i + 1);
+      }
+    });
+
+    it("creates a checkpoint where one doesn't already exist", async () => {
+      const checkpointStore = new BlobCheckpointStore(containerClient);
+      const eventHubProperties = {
+        fullyQualifiedNamespace: "testNamespace.servicebus.windows.net",
+        eventHubName: "testEventHub",
+        consumerGroup: "testConsumerGroup"
+      };
+
+      // Ensure that there aren't any checkpoints.
+      let checkpoints = await checkpointStore.listCheckpoints(
+        eventHubProperties.fullyQualifiedNamespace,
+        eventHubProperties.eventHubName,
+        eventHubProperties.consumerGroup
+      );
+
+      checkpoints.length.should.equal(0);
+
+      // Create the checkpoint to add.
       const checkpoint: Checkpoint = {
-        ...eventHubProperties,
-        partitionId: i.toString(),
-        sequenceNumber: 100 + i,
-        offset: 1023 + i
+        consumerGroup: eventHubProperties.consumerGroup,
+        eventHubName: eventHubProperties.eventHubName,
+        fullyQualifiedNamespace: eventHubProperties.fullyQualifiedNamespace,
+        offset: 0,
+        partitionId: "0",
+        sequenceNumber: 1
       };
 
       await checkpointStore.updateCheckpoint(checkpoint);
-    }
 
-    let checkpoints = await checkpointStore.listCheckpoints(
-      eventHubProperties.fullyQualifiedNamespace,
-      eventHubProperties.eventHubName,
-      eventHubProperties.consumerGroup
-    );
+      // Ensure that there is a checkpoint.
+      checkpoints = await checkpointStore.listCheckpoints(
+        eventHubProperties.fullyQualifiedNamespace,
+        eventHubProperties.eventHubName,
+        eventHubProperties.consumerGroup
+      );
 
-    checkpoints.length.should.equal(3);
-    checkpoints.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
+      checkpoints.length.should.equal(1);
+    });
 
-    for (let i = 0; i < 3; ++i) {
-      const checkpoint = checkpoints[i];
+    it("forwards errors", async () => {
+      const checkpointStore = new BlobCheckpointStore(containerClient);
+      const eventHubProperties = {
+        fullyQualifiedNamespace: "testNamespace.servicebus.windows.net",
+        eventHubName: "testEventHub",
+        consumerGroup: "testConsumerGroup"
+      };
 
-      checkpoint.partitionId.should.equal(i.toString());
-      checkpoint.fullyQualifiedNamespace.should.equal("testNamespace.servicebus.windows.net");
-      checkpoint.consumerGroup.should.equal("testConsumerGroup");
-      checkpoint.eventHubName.should.equal("testEventHub");
-      checkpoint.sequenceNumber!.should.equal(100 + i);
-      checkpoint.offset!.should.equal(1023 + i);
+      // now let's induce a bad failure (removing the container)
+      await containerClient.delete();
 
-      // now update it
-      checkpoint.offset++;
-      checkpoint.sequenceNumber++;
+      // Create the checkpoint to add.
+      const checkpoint: Checkpoint = {
+        consumerGroup: eventHubProperties.consumerGroup,
+        eventHubName: eventHubProperties.eventHubName,
+        fullyQualifiedNamespace: eventHubProperties.fullyQualifiedNamespace,
+        offset: 0,
+        partitionId: "0",
+        sequenceNumber: 1
+      };
 
-      await checkpointStore.updateCheckpoint(checkpoint);
-    }
-
-    checkpoints = await checkpointStore.listCheckpoints(
-      eventHubProperties.fullyQualifiedNamespace,
-      eventHubProperties.eventHubName,
-      eventHubProperties.consumerGroup
-    );
-
-    checkpoints.length.should.equal(3);
-    checkpoints.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
-
-    for (let i = 0; i < 3; ++i) {
-      const checkpoint = checkpoints[i];
-
-      checkpoint.partitionId.should.equal(i.toString());
-      checkpoint.fullyQualifiedNamespace.should.equal("testNamespace.servicebus.windows.net");
-      checkpoint.consumerGroup.should.equal("testConsumerGroup");
-      checkpoint.eventHubName.should.equal("testEventHub");
-      checkpoint.sequenceNumber!.should.equal(100 + i + 1);
-      checkpoint.offset!.should.equal(1023 + i + 1);
-    }
+      try {
+        await checkpointStore.updateCheckpoint(checkpoint);
+        throw new Error("Test failure");
+      } catch (err) {
+        err.message.should.not.equal("Test failure");
+      }
+    });
   });
 
   it("Claiming ownership with an empty owner id should be fine (ie, unclaiming)", async function(): Promise<
@@ -431,7 +507,11 @@ describe("Blob Checkpoint Store", function(): void {
       sequenceNumber: 0
     });
 
-    const checkpoints = await checkpointStore.listCheckpoints(commonData.fullyQualifiedNamespace, commonData.eventHubName, commonData.consumerGroup);
+    const checkpoints = await checkpointStore.listCheckpoints(
+      commonData.fullyQualifiedNamespace,
+      commonData.eventHubName,
+      commonData.consumerGroup
+    );
 
     checkpoints.length.should.equal(1);
     checkpoints[0].sequenceNumber.should.equal(0);


### PR DESCRIPTION
Fixes #10132

## Description
This update changes the way `updateCheckpoint` works such that it will always attempt to set blob metadata first, then fallback to creating a new blob if it doesn't already exist.

Previously, we always called `upload` to replace the existing blob. This caused a performance issue when listing checkpoints in Storage Blob Containers that had soft-delete or blob versioning enabled.
