### PR TITLE
[arm-sql] Override sendOperationRequest to always set Accept header

### DIFF
--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-sql",
   "author": "Microsoft Corporation",
   "description": "SqlManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^2.0.1",
     "@azure/ms-rest-js": "^2.0.4",

--- a/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
@@ -25,7 +25,7 @@ export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
    * @param subscriptionId The subscription ID that identifies an Azure subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
+constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -56,5 +56,29 @@ export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
     if(options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
       this.longRunningOperationRetryTimeout = options.longRunningOperationRetryTimeout;
     }
+  }
+
+  /**
+   * NOTE: This is an override added manually to workaround bug Azure/ms-rest-js/issues/395
+   * When this library is regenerated, this override needs to be brought back
+   * This override adds the header "Accept: application/json" to every request
+   */
+  sendOperationRequest(
+    operationArguments: msRest.OperationArguments,
+    operationSpec: msRest.OperationSpec,
+    callback?: msRest.ServiceCallback<any>
+  ): Promise<msRest.RestResponse> {
+    const options = {
+      ...operationArguments,
+      options: {
+        ...operationArguments.options,
+        customHeaders: {
+          ...operationArguments.options?.customHeaders,
+          accept: "application/json",
+        },
+      },
+    };
+
+    return super.sendOperationRequest(options, operationSpec, callback);
   }
 }

--- a/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
@@ -25,7 +25,7 @@ export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
    * @param subscriptionId The subscription ID that identifies an Azure subscription.
    * @param [options] The parameter options
    */
-constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
+ constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }

--- a/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
@@ -13,7 +13,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 
 const packageName = "@azure/arm-sql";
-const packageVersion = "7.0.0";
+const packageVersion = "7.0.1";
 
 export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
   credentials: msRest.ServiceClientCredentials;

--- a/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
@@ -25,7 +25,7 @@ export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
    * @param subscriptionId The subscription ID that identifies an Azure subscription.
    * @param [options] The parameter options
    */
- constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
+  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.SqlManagementClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }


### PR DESCRIPTION
 Override sendOperationRequest to always set Accept header to workaround issue  #10004


Closes #10004