### PR TITLE
Regenerate Cognitive Services Anomaly Detector SDK 

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/LICENSE.txt
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Microsoft
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/README.md
@@ -26,14 +26,11 @@ npm install @azure/ms-rest-azure-js
 ##### Sample code
 The following sample determines anamolies with the given time series. To know more, refer to the [Azure Documentation on Anomaly Detectors](https://docs.microsoft.com/en-us/azure/cognitive-services/anomaly-detector/)
 
-```typescript
-import {
-  AnomalyDetectorClient,
-  AnomalyDetectorModels
-} from "@azure/cognitiveservices-anomalydetector";
-import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
+```javascript
+const { AnomalyDetectorClient } = require("@azure/cognitiveservices-anomalydetector");
+const { CognitiveServicesCredentials } = require("@azure/ms-rest-azure-js");
 
-async function main(): Promise<void> {
+async function main() {
   const anomalyDetectorKey = process.env["anomalyDetectorKey"] || "<anomalyDetectorKey>";
   const anomalyDetectorEndPoint =
     process.env["anomalyDetectorEndPoint"] || "<anomalyDetectorEndPoint>";
@@ -42,7 +39,7 @@ async function main(): Promise<void> {
 
   const client = new AnomalyDetectorClient(cognitiveServiceCredentials, anomalyDetectorEndPoint);
 
-  const body: AnomalyDetectorModels.Request = {
+  const body = {
     series: [
       {
         timestamp: new Date("December 15, 2018"),

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-anomalydetector",
   "author": "Microsoft Corporation",
   "description": "AnomalyDetectorClient Library with typescript type definitions for node.js and browser.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/anomalyDetectorClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/anomalyDetectorClient.ts
@@ -93,6 +93,38 @@ class AnomalyDetectorClient extends AnomalyDetectorClientContext {
       lastDetectOperationSpec,
       callback) as Promise<Models.LastDetectResponse2>;
   }
+
+  /**
+   * Evaluate change point score of every series point
+   * @summary Detect change point for the entire series
+   * @param body Time series points and granularity is needed. Advanced model parameters can also be
+   * set in the request if needed.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.ChangePointDetectResponse2>
+   */
+  changePointDetect(body: Models.ChangePointDetectRequest, options?: msRest.RequestOptionsBase): Promise<Models.ChangePointDetectResponse2>;
+  /**
+   * @param body Time series points and granularity is needed. Advanced model parameters can also be
+   * set in the request if needed.
+   * @param callback The callback
+   */
+  changePointDetect(body: Models.ChangePointDetectRequest, callback: msRest.ServiceCallback<Models.ChangePointDetectResponse>): void;
+  /**
+   * @param body Time series points and granularity is needed. Advanced model parameters can also be
+   * set in the request if needed.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  changePointDetect(body: Models.ChangePointDetectRequest, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ChangePointDetectResponse>): void;
+  changePointDetect(body: Models.ChangePointDetectRequest, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ChangePointDetectResponse>, callback?: msRest.ServiceCallback<Models.ChangePointDetectResponse>): Promise<Models.ChangePointDetectResponse2> {
+    return this.sendOperationRequest(
+      {
+        body,
+        options
+      },
+      changePointDetectOperationSpec,
+      callback) as Promise<Models.ChangePointDetectResponse2>;
+  }
 }
 
 // Operation Specifications
@@ -137,6 +169,30 @@ const lastDetectOperationSpec: msRest.OperationSpec = {
   responses: {
     200: {
       bodyMapper: Mappers.LastDetectResponse
+    },
+    default: {
+      bodyMapper: Mappers.APIError
+    }
+  },
+  serializer
+};
+
+const changePointDetectOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "timeseries/changePoint/detect",
+  urlParameters: [
+    Parameters.endpoint
+  ],
+  requestBody: {
+    parameterPath: "body",
+    mapper: {
+      ...Mappers.ChangePointDetectRequest,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ChangePointDetectResponse
     },
     default: {
       bodyMapper: Mappers.APIError

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/anomalyDetectorClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/anomalyDetectorClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-anomalydetector";
-const packageVersion = "2.0.0";
+const packageVersion = "2.1.0";
 
 export class AnomalyDetectorClientContext extends msRest.ServiceClient {
   endpoint: string;

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/models/index.ts
@@ -48,9 +48,8 @@ export interface Request {
    */
   series: Point[];
   /**
-   * Can only be one of yearly, monthly, weekly, daily, hourly or minutely. Granularity is used for
-   * verify whether input series is valid. Possible values include: 'yearly', 'monthly', 'weekly',
-   * 'daily', 'hourly', 'minutely'
+   * Possible values include: 'yearly', 'monthly', 'weekly', 'daily', 'hourly', 'minutely',
+   * 'secondly'
    */
   granularity: Granularity;
   /**
@@ -170,12 +169,70 @@ export interface LastDetectResponse {
 }
 
 /**
+ * An interface representing ChangePointDetectRequest.
+ */
+export interface ChangePointDetectRequest {
+  /**
+   * Time series data points. Points should be sorted by timestamp in ascending order to match the
+   * change point detection result.
+   */
+  series: Point[];
+  /**
+   * Can only be one of yearly, monthly, weekly, daily, hourly, minutely or secondly. Granularity
+   * is used for verify whether input series is valid. Possible values include: 'yearly',
+   * 'monthly', 'weekly', 'daily', 'hourly', 'minutely', 'secondly'
+   */
+  granularity: Granularity;
+  /**
+   * Custom Interval is used to set non-standard time interval, for example, if the series is 5
+   * minutes, request can be set as {"granularity":"minutely", "customInterval":5}.
+   */
+  customInterval?: number;
+  /**
+   * Optional argument, periodic value of a time series. If the value is null or does not present,
+   * the API will determine the period automatically.
+   */
+  period?: number;
+  /**
+   * Optional argument, advanced model parameter, a default stableTrendWindow will be used in
+   * detection.
+   */
+  stableTrendWindow?: number;
+  /**
+   * Optional argument, advanced model parameter, between 0.0-1.0, the lower the value is, the
+   * larger the trend error will be which means less change point will be accepted.
+   */
+  threshold?: number;
+}
+
+/**
+ * An interface representing ChangePointDetectResponse.
+ */
+export interface ChangePointDetectResponse {
+  /**
+   * Frequency extracted from the series, zero means no recurrent pattern has been found.
+   */
+  period: number;
+  /**
+   * isChangePoint contains change point properties for each input point. True means an anomaly
+   * either negative or positive has been detected. The index of the array is consistent with the
+   * input series.
+   */
+  isChangePoint: boolean[];
+  /**
+   * the change point confidence of each point
+   */
+  confidenceScores: number[];
+}
+
+/**
  * Defines values for Granularity.
- * Possible values include: 'yearly', 'monthly', 'weekly', 'daily', 'hourly', 'minutely'
+ * Possible values include: 'yearly', 'monthly', 'weekly', 'daily', 'hourly', 'minutely',
+ * 'secondly'
  * @readonly
  * @enum {string}
  */
-export type Granularity = 'yearly' | 'monthly' | 'weekly' | 'daily' | 'hourly' | 'minutely';
+export type Granularity = 'yearly' | 'monthly' | 'weekly' | 'daily' | 'hourly' | 'minutely' | 'secondly';
 
 /**
  * Contains response data for the entireDetect operation.
@@ -214,5 +271,25 @@ export type LastDetectResponse2 = LastDetectResponse & {
        * The response body as parsed JSON or XML
        */
       parsedBody: LastDetectResponse;
+    };
+};
+
+/**
+ * Contains response data for the changePointDetect operation.
+ */
+export type ChangePointDetectResponse2 = ChangePointDetectResponse & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ChangePointDetectResponse;
     };
 };

--- a/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-anomalydetector/src/models/mappers.ts
@@ -76,6 +76,7 @@ export const Request: msRest.CompositeMapper = {
       },
       granularity: {
         required: true,
+        nullable: false,
         serializedName: "granularity",
         type: {
           name: "Enum",
@@ -85,7 +86,8 @@ export const Request: msRest.CompositeMapper = {
             "weekly",
             "daily",
             "hourly",
-            "minutely"
+            "minutely",
+            "secondly"
           ]
         }
       },
@@ -266,6 +268,111 @@ export const LastDetectResponse: msRest.CompositeMapper = {
         serializedName: "isPositiveAnomaly",
         type: {
           name: "Boolean"
+        }
+      }
+    }
+  }
+};
+
+export const ChangePointDetectRequest: msRest.CompositeMapper = {
+  serializedName: "ChangePointDetectRequest",
+  type: {
+    name: "Composite",
+    className: "ChangePointDetectRequest",
+    modelProperties: {
+      series: {
+        required: true,
+        serializedName: "series",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Point"
+            }
+          }
+        }
+      },
+      granularity: {
+        required: true,
+        nullable: false,
+        serializedName: "granularity",
+        type: {
+          name: "Enum",
+          allowedValues: [
+            "yearly",
+            "monthly",
+            "weekly",
+            "daily",
+            "hourly",
+            "minutely",
+            "secondly"
+          ]
+        }
+      },
+      customInterval: {
+        serializedName: "customInterval",
+        type: {
+          name: "Number"
+        }
+      },
+      period: {
+        serializedName: "period",
+        type: {
+          name: "Number"
+        }
+      },
+      stableTrendWindow: {
+        serializedName: "stableTrendWindow",
+        type: {
+          name: "Number"
+        }
+      },
+      threshold: {
+        serializedName: "threshold",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const ChangePointDetectResponse: msRest.CompositeMapper = {
+  serializedName: "ChangePointDetectResponse",
+  type: {
+    name: "Composite",
+    className: "ChangePointDetectResponse",
+    modelProperties: {
+      period: {
+        required: true,
+        serializedName: "period",
+        type: {
+          name: "Number"
+        }
+      },
+      isChangePoint: {
+        required: true,
+        serializedName: "isChangePoint",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Boolean"
+            }
+          }
+        }
+      },
+      confidenceScores: {
+        required: true,
+        serializedName: "confidenceScores",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Number"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This is for the issue: https://github.com/Azure/sdk-release-request/issues/573 

1. Regenerated AnomalyDetector SDK
2. Changes TS Sample to JS Sample
3. Validated both JS & HTML Samples. Working fine

**Version change**

There are no breaking changes except one line. `granularity` is set `nullable:false` in this change. It did not have that property previously. 

But, even without this `nullable` property set to false, in the previous code, we cannot send in a Request with no granularity or null/undefined granularity. The service will throw an error with the message `granularity` is required. I have validated this with the previous SDK. 

There is a possibility that if the service is updated now for throwing the error. But, I doubt that is the case. The Azure portal still mentions this as Preview. The GA release is only on 9/21.

With all these in consideration, I am not updating the major version of the SDK. I am updating only the minor version. Please let me know your thoughts. 

@ramya-rao-a Please review and approve