### PR TITLE
[Text Analytics] Regenerating the SDK using the most recent and fixed version of swagger v3.0

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.1 (Unreleased)
 
+- The `text` property of the `SentenceSentiment` interface is no longer optional because the service always returns it. This interface is implemented by output types, so this change does not break existing code that calls the library APIs.
 
 ## 5.0.0 (2020-07-27)
 

--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.0.1 (Unreleased)
 
-- The `text` property of the `SentenceSentiment` interface is no longer optional because the service always returns it. This interface is implemented by output types, so this change does not break existing code that calls the library APIs.
+- The `text` property of the `SentenceSentiment` interface is no longer optional because the service always returns it. This interface is used exclusively as an output type so this change does not break existing code.
 
 ## 5.0.0 (2020-07-27)
 

--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.0.1 (Unreleased)
 
-- The `text` property of the `SentenceSentiment` interface is no longer optional because the service always returns it. This interface is used exclusively as an output type so this change does not break existing code.
+- The `text` property of the `SentenceSentiment` interface is no longer marked as optional because the service has always returned it. This interface is used exclusively as an output type so this change does not break existing code.
 
 ## 5.0.0 (2020-07-27)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -174,7 +174,7 @@ export interface RecognizeLinkedEntitiesSuccessResult extends TextAnalyticsSucce
 export interface SentenceSentiment {
     confidenceScores: SentimentConfidenceScores;
     sentiment: SentenceSentimentLabel;
-    text?: string;
+    text: string;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -457,7 +457,7 @@ export interface SentenceSentiment {
   /**
    * The sentence text.
    */
-  text?: string;
+  text: string;
   /**
    * The predicted Sentiment for the sentence.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -919,6 +919,7 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
     modelProperties: {
       text: {
         serializedName: "text",
+        required: true,
         type: {
           name: "String"
         }

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b2a2f8bdac81a285f541d03f60b452f9fd8fe38a/specification/cognitiveservices/data-plane/TextAnalytics/stable/v3.0/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/TextAnalytics/stable/v3.0/TextAnalytics.json
 add-credentials: false
 package-version: 5.0.1
 v3: true


### PR DESCRIPTION
This changes the `text` property, of the output type `SentenceSentiment`, to be no longer optional. This mirrors the latest fix to the specs for v3.0 stable: https://github.com/Azure/azure-rest-api-specs/pull/10179. I agree with @bterlson that this change should not be considered breaking because it is to an output type.