### PR TITLE
Use the common Cosmos DB template to start the emulator.

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -1,13 +1,13 @@
 parameters:
-- name: Artifacts
-  type: object
-  default: []
-- name: ServiceDirectory
-  type: string
-  default: not-specified
-- name: RunUnitTests
-  type: boolean
-  default: false
+  - name: Artifacts
+    type: object
+    default: []
+  - name: ServiceDirectory
+    type: string
+    default: not-specified
+  - name: RunUnitTests
+    type: boolean
+    default: false
 
 stages:
   - stage: Build
@@ -27,17 +27,17 @@ stages:
               OSVmImage: "windows-2019"
               NodeTestVersion: "8.x"
               TestType: "node"
-          PreIntegrationSteps: cosmos-integration-public
+          PreIntegrationSteps: cosmos-emulator
           PostIntegrationSteps: cosmos-additional-steps
           EnvVars:
             MOCHA_TIMEOUT: 100000
             NODE_TLS_REJECT_UNAUTHORIZED: 0
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: archetype-js-release.yml
-      parameters:
-        DependsOn: Build
-        ServiceDirectory: ${{parameters.ServiceDirectory}}
-        Artifacts: ${{parameters.Artifacts}}
-        ArtifactName: packages
+  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
+    : - template: archetype-js-release.yml
+        parameters:
+          DependsOn: Build
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
+          Artifacts: ${{parameters.Artifacts}}
+          ArtifactName: packages

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -1,13 +1,13 @@
 parameters:
-  - name: Artifacts
-    type: object
-    default: []
-  - name: ServiceDirectory
-    type: string
-    default: not-specified
-  - name: RunUnitTests
-    type: boolean
-    default: false
+- name: Artifacts
+  type: object
+  default: []
+- name: ServiceDirectory
+  type: string
+  default: not-specified
+- name: RunUnitTests
+  type: boolean
+  default: false
 
 stages:
   - stage: Build
@@ -34,10 +34,10 @@ stages:
             NODE_TLS_REJECT_UNAUTHORIZED: 0
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
-    : - template: archetype-js-release.yml
-        parameters:
-          DependsOn: Build
-          ServiceDirectory: ${{parameters.ServiceDirectory}}
-          Artifacts: ${{parameters.Artifacts}}
-          ArtifactName: packages
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - template: archetype-js-release.yml
+      parameters:
+        DependsOn: Build
+        ServiceDirectory: ${{parameters.ServiceDirectory}}
+        Artifacts: ${{parameters.Artifacts}}
+        ArtifactName: packages

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -27,7 +27,7 @@ stages:
               OSVmImage: "windows-2019"
               NodeTestVersion: "8.x"
               TestType: "node"
-          PreIntegrationSteps: cosmos-emulator
+          PreIntegrationSteps: cosmos-integration-public
           PostIntegrationSteps: cosmos-additional-steps
           EnvVars:
             MOCHA_TIMEOUT: 100000

--- a/eng/pipelines/templates/steps/cosmos-integration-public.yml
+++ b/eng/pipelines/templates/steps/cosmos-integration-public.yml
@@ -2,41 +2,4 @@ parameters:
   EmulatorMsiUrl: "https://aka.ms/cosmosdb-emulator"
 
 steps:
-  - pwsh: |
-      $targetDir = $env:temp
-      Write-Host "Downloading and extracting Cosmos DB Emulator - ${{ parameters.EmulatorMsiUrl }}"
-      Write-Host "Target Dir: $targetDir"
-      msiexec /a ${{ parameters.EmulatorMsiUrl }} TARGETDIR=$targetDir /qn | wait-process
-    displayName: Download and Extract Public Cosmos DB Emulator
-
-  - pwsh: |
-      $emulator = "$env:tmp\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe"
-
-      Write-Host "Launching Cosmos DB Emulator at $emulator"
-      Start-Process $emulator "/NoExplorer /NoUI" -Verb RunAs
-
-      Write-Host "Waiting for emulator to start..."
-      $continueChecking = $true
-      do {
-        $process = Start-Process $emulator -ArgumentList "/getstatus" -PassThru -Wait
-        switch ($process.ExitCode) {
-          1 {
-            Write-Host "Emulator is starting"
-          }
-          2 {
-            Write-Host "Emulator is running"
-            $continueChecking = $false
-          }
-          3 {
-            Write-Host "Emulator is stopped"
-            $continueChecking = $false
-          }
-          default {
-            Write-Host "Unknown exit code: $process.ExitCode"
-            $continueChecking = $false
-          }
-        }
-        Start-Sleep -Seconds 1
-      } while ($continueChecking)
-    displayName: Start Cosmos DB Emulator
-    timeoutInMinutes: 10
+  - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-sdk-tools/issues/778 where the logic to start the Cosmos DB emulator had diverged across JS, Python and Java. With this change the start logic is the same.