### PR TITLE
[service-bus] Fix issue with live tests failing on session-based tests

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/receiverInit.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiverInit.spec.ts
@@ -6,9 +6,9 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
-import { ClientEntityContext } from "../src/clientEntityContext";
-import { BatchingReceiver } from "../src/core/batchingReceiver";
-import { MessageReceiver, ReceiverType } from "../src/core/messageReceiver";
+import { ClientEntityContext } from "../../src/clientEntityContext";
+import { BatchingReceiver } from "../../src/core/batchingReceiver";
+import { MessageReceiver, ReceiverType } from "../../src/core/messageReceiver";
 
 describe("init() and close() interactions", () => {
   function fakeContext(): ClientEntityContext {

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -393,6 +393,7 @@ describe("Session Lock Renewal", () => {
   function getTestMessage(): ServiceBusMessage {
     const baseMessage = TestMessage.getSessionSample();
     baseMessage.sessionId = sessionId;
+    baseMessage.partitionKey = sessionId;
     return baseMessage;
   }
 });

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -756,7 +756,7 @@ describe("Streaming with sessions", () => {
           body: "test",
           label: `${num}`,
           sessionId: TestMessage.sessionId,
-          partitionKey: "dummy" // Ensures all messages go to same partition to make peek work reliably
+          partitionKey: TestMessage.sessionId // Ensures all messages go to same partition to make peek work reliably
         };
         num++;
         messages.push(message);

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -35,7 +35,7 @@ export class TestMessage {
     return {
       body: `message body ${randomNumber}`,
       messageId: `message id ${randomNumber}`,
-      partitionKey: `partition key ${randomNumber}`,
+      partitionKey: TestMessage.sessionId,
       contentType: `content type ${randomNumber}`,
       correlationId: `correlation id ${randomNumber}`,
       timeToLive: 60 * 60 * 24,


### PR DESCRIPTION
A service-side change made it so setting the partition id and session id to different values an error in some cases where, before, it would have been incorrect but harmless.

This fixes our test data so we don't run afoul of that rule. I've filed an issue (#10326) to deal with two problems that came out as a result of this.