### PR TITLE
[Service Bus] [Event Hubs] Use Record instead of {[key: string]: string}

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -87,7 +87,7 @@ export interface EventDataInternal {
   /**
    * @property [properties] The application specific properties.
    */
-  properties?: { [property: string]: any };
+  properties?: Record<string, any>;
   /**
    * @property [lastSequenceNumber] The last sequence number of the event within the partition stream of the Event Hub.
    */
@@ -107,7 +107,7 @@ export interface EventDataInternal {
   /**
    * @property [systemProperties] The properties set by the service.
    */
-  systemProperties?: { [property: string]: any };
+  systemProperties?: Record<string, any>;
 }
 
 const messagePropertiesMap = {

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -868,7 +868,7 @@ describe("Event Processor", function(): void {
       let processedAtLeastOneEvent = new Set();
       const checkpointSequenceNumbers: Map<string, number> = new Map();
 
-      let partionCount: { [x: string]: number } = {};
+      let partionCount: Record<string, number> = {};
 
       class FooPartitionProcessor {
         async processEvents(events: ReceivedEventData[], context: PartitionContext) {

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -34,7 +34,7 @@ describe("EventHub Sender", function(): void {
   };
   let producerClient: EventHubProducerClient;
   let consumerClient: EventHubConsumerClient;
-  let startPosition: { [partitionId: string]: EventPosition };
+  let startPosition: Record<string, EventPosition>;
 
   before("validate environment", function(): void {
     should.exist(

--- a/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
@@ -19,7 +19,7 @@ import { loopUntil } from "./testUtils";
 const should = chai.should();
 
 export interface HandlerAndPositions {
-  startPosition: { [partitionId: string]: EventPosition };
+  startPosition: Record<string, EventPosition>;
   subscriptionEventHandler: SubscriptionHandlerForTests;
 }
 
@@ -31,7 +31,7 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
     client: EventHubProducerClient | EventHubConsumerClient
   ): Promise<HandlerAndPositions> {
     const partitionIds = await client.getPartitionIds({});
-    const startPosition: { [partitionId: string]: EventPosition } = {};
+    const startPosition: Record<string, EventPosition> = {};
 
     for (const partitionId of partitionIds) {
       const props = await client.getPartitionProperties(partitionId);

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -72,7 +72,7 @@ export async function getStartingPositionsForTests(
 ): Promise<{ [partitionId: string]: EventPosition }> {
   const eventHubProperties = await client.getEventHubProperties();
 
-  const startingPositions: { [partitionId: string]: EventPosition } = {};
+  const startingPositions: Record<string, EventPosition> = {};
 
   for (const partitionId of eventHubProperties.partitionIds) {
     startingPositions[partitionId] = {

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -184,16 +184,12 @@ export interface ReceivedMessage extends ServiceBusMessage {
 
 // @public
 export interface ReceivedMessageWithLock extends ReceivedMessage {
-    abandon(propertiesToModify?: {
-        [key: string]: any;
-    }): Promise<void>;
+    abandon(propertiesToModify?: Record<string, any>): Promise<void>;
     complete(): Promise<void>;
     deadLetter(options?: DeadLetterOptions & {
         [key: string]: any;
     }): Promise<void>;
-    defer(propertiesToModify?: {
-        [key: string]: any;
-    }): Promise<void>;
+    defer(propertiesToModify?: Record<string, any>): Promise<void>;
     renewLock(): Promise<Date>;
 }
 
@@ -332,9 +328,7 @@ export interface ServiceBusMessage {
     label?: string;
     messageId?: string | number | Buffer;
     partitionKey?: string;
-    properties?: {
-        [key: string]: any;
-    };
+    properties?: Record<string, any>;
     replyTo?: string;
     replyToSessionId?: string;
     scheduledEnqueueTimeUtc?: Date;

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -52,7 +52,7 @@ export interface ClientEntityContextBase {
    * @property messageSessions A dictionary of the MessageSession
    * objects associated with this client.
    */
-  messageSessions: { [name: string]: MessageSession };
+  messageSessions: Record<string, MessageSession>;
   /**
    * @property {MessageSender} [sender] The ServiceBus sender associated with the client entity.
    */
@@ -314,7 +314,7 @@ export namespace ClientEntityContext {
  * @ignore
  */
 function getManagementClient(
-  clients: { [name: string]: ClientEntityContext },
+  clients: Record<string, ClientEntityContext>,
   entityPath: string
 ): ManagementClient | undefined {
   let result: ManagementClient | undefined;

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -28,7 +28,7 @@ export interface ConnectionContext extends ConnectionContextBase {
    * @property A dictionary of ClientEntityContext
    * objects for each of the client in the `clients` dictionary
    */
-  clientContexts: { [name: string]: ClientEntityContext };
+  clientContexts: Record<string, ClientEntityContext>;
 
   /**
    * Function returning a promise that resolves once the connectionContext is ready to open an AMQP link.

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -142,7 +142,7 @@ export interface DispositionStatusOptions extends OperationOptionsBase {
    * @property [propertiesToModify] A dictionary of Service Bus brokered message properties
    * to modify.
    */
-  propertiesToModify?: { [key: string]: any };
+  propertiesToModify?: Record<string, any>;
   /**
    * @property [deadLetterReason] The deadletter reason. May be set if disposition status
    * is set to suspended.

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -318,7 +318,7 @@ function getSqlParametersOrUndefined(value: any): SqlParameter[] | undefined {
  * or undefined if not passed in.
  * @param value
  */
-function getUserPropertiesOrUndefined(value: any): { [key: string]: any } | undefined {
+function getUserPropertiesOrUndefined(value: any): Record<string, any> | undefined {
   if (!value) {
     return undefined;
   }
@@ -422,7 +422,7 @@ export function getRawSqlParameters(
  * @param value
  */
 export function getRawUserProperties(
-  parameters: { [key: string]: any } | undefined
+  parameters: Record<string, any> | undefined
 ): InternalRawKeyValuePairs | undefined {
   if (parameters == undefined) {
     return undefined;

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -2414,7 +2414,7 @@ export class ServiceBusManagementClient extends ServiceClient {
       options
     );
     try {
-      const queryParams: { [key: string]: string } = {};
+      const queryParams: Record<string, string> = {};
       if (options) {
         if (options.skip) {
           queryParams["$skip"] = options.skip.toString();
@@ -2466,7 +2466,7 @@ export class ServiceBusManagementClient extends ServiceClient {
     }
   }
 
-  private getUrl(path: string, queryParams?: { [key: string]: string }): string {
+  private getUrl(path: string, queryParams?: Record<string, string>): string {
     const baseUri = `https://${this.endpoint}/${path}`;
 
     const requestUrl: URLBuilder = URLBuilder.parse(baseUri);

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -219,7 +219,7 @@ export interface ServiceBusMessage {
    * @property The application specific properties which can be
    * used for custom message metadata.
    */
-  properties?: { [key: string]: any };
+  properties?: Record<string, any>;
 }
 
 /**
@@ -495,7 +495,7 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
    *
    * @return Promise<void>.
    */
-  abandon(propertiesToModify?: { [key: string]: any }): Promise<void>;
+  abandon(propertiesToModify?: Record<string, any>): Promise<void>;
 
   /**
    * Defers the processing of the message. Save the `sequenceNumber` of the message, in order to
@@ -521,7 +521,7 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
    *
    * @returns Promise<void>
    */
-  defer(propertiesToModify?: { [key: string]: any }): Promise<void>;
+  defer(propertiesToModify?: Record<string, any>): Promise<void>;
 
   /**
    * Moves the message to the deadletter sub-queue. To receive a deadletted message, create a new
@@ -704,7 +704,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   /**
    * @property The application specific properties.
    */
-  properties?: { [key: string]: any };
+  properties?: Record<string, any>;
   /**
    * @property The message identifier is an
    * application-defined value that uniquely identifies the message and its payload. The identifier
@@ -925,7 +925,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   /**
    * See ReceivedMessageWithLock.abandon().
    */
-  async abandon(propertiesToModify?: { [key: string]: any }): Promise<void> {
+  async abandon(propertiesToModify?: Record<string, any>): Promise<void> {
     // TODO: Figure out a mechanism to convert specified properties to message_annotations.
     log.message(
       "[%s] Abandoning the message with id '%s'.",
@@ -940,7 +940,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   /**
    * See ReceivedMessageWithLock.defer().
    */
-  async defer(propertiesToModify?: { [key: string]: any }): Promise<void> {
+  async defer(propertiesToModify?: Record<string, any>): Promise<void> {
     log.message(
       "[%s] Deferring the message with id '%s'.",
       this._context.namespace.connectionId,

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -140,18 +140,18 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * Generates an AMQP message that contains the provided encoded messages and annotations.
    *
    * @private
-   * @param {Buffer[]} encodedMessages The already encoded messages to include in the AMQP batch.
-   * @param {MessageAnnotations} [annotations] The message annotations to set on the batch.
-   * @param {{ [key: string]: any }} [applicationProperties] The application properties to set on the batch.
-   * @param {{ [key: string]: string }} [messageProperties] The message properties to set on the batch.
+   * @param encodedMessages The already encoded messages to include in the AMQP batch.
+   * @param annotations The message annotations to set on the batch.
+   * @param applicationProperties The application properties to set on the batch.
+   * @param messageProperties The message properties to set on the batch.
    * @returns {Buffer}
    * @memberof ServiceBusMessageBatchImpl
    */
   private _generateBatch(
     encodedMessages: Buffer[],
     annotations?: MessageAnnotations,
-    applicationProperties?: { [key: string]: any },
-    messageProperties?: { [key: string]: string }
+    applicationProperties?: Record<string, any>,
+    messageProperties?: Record<string, string>
   ): Buffer {
     const batchEnvelope: AmqpMessage = {
       body: RheaMessageUtil.data_sections(encodedMessages),
@@ -198,13 +198,13 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * This will reflect the message properties on the first message
    * that was added to the batch.
    */
-  private _batchMessageProperties?: { [key: string]: string };
+  private _batchMessageProperties?: Record<string, string>;
   /**
    * The application properties to apply on the batch envelope.
    * This will reflect the application properties on the first message
    * that was added to the batch.
    */
-  private _batchApplicationProperties?: { [key: string]: any };
+  private _batchApplicationProperties?: Record<string, any>;
 
   /**
    * Tries to add a message to the batch if permitted by the batch's size limit.

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -231,7 +231,7 @@ export class ServiceBusTestHelpers {
       // From the sentMessages array, creating a set of all the `session-id`s
       const setOfSessionIds: Set<string> = new Set();
       // numOfMsgsWithSessionId - To keep track of number of messages sent per session in the sent messages
-      const numOfMsgsWithSessionId: { [sessionId: string]: number } = {};
+      const numOfMsgsWithSessionId: Record<string, number> = {};
       sentMessages.forEach((msg) => {
         setOfSessionIds.add(msg.sessionId!);
         numOfMsgsWithSessionId[msg.sessionId!] = numOfMsgsWithSessionId[msg.sessionId!]


### PR DESCRIPTION
Because @bterlson said so :)
https://twitter.com/bterlson/status/1283124069680836610

Opening the discussion on simple objects vs `{[key: string]: string}` vs `Map`

What value does this provide over `{[key: string]: string}`?

I see the value of using `Record` if the key is of restricted "type" with fixed values. Then we can use `Record` to enforce that it contains entries for all those fixed values. If that is the main value add, then that is not what get with the changes in this PR

From https://fnune.com/typescript/2019/01/30/typescript-series-1-record-is-usually-not-the-best-choice/

> Ideal use of the Record type requires knowledge during development of the specific keys that will be used.