### PR TITLE
[Text Analytics] Linting

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -6,7 +6,8 @@
   "version": "5.0.1",
   "keywords": [
     "node",
-    "azure",
+    "Azure",
+    "cloud",
     "typescript",
     "browser",
     "isomorphic"
@@ -15,11 +16,8 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/ai-text-analytics.d.ts",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git"
-  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/README.md",
+  "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
@@ -42,13 +40,14 @@
       }
     ]
   },
+  "engines" : { "node" : ">=8.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples prep && cd dist-samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
+    "build": "tsc -p . && npm run lint && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json --ignore-path ../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",
@@ -58,7 +57,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint \"src/**/*.ts\" --fix --fix-type [problem,suggestion]",
-    "lint": "eslint src --ext .ts -f html -o textAnalytics-lintReport.html",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser",

--- a/sdk/textanalytics/ai-text-analytics/test/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/apiKey.spec.ts
@@ -24,9 +24,11 @@ describe("[API Key] TextAnalyticsClient", function() {
 
   const apiKey = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
 
+  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
   beforeEach(function() {
+    // eslint-disable-next-line no-invalid-this
     ({ client, recorder } = createRecordedClient(this, apiKey));
   });
 

--- a/sdk/textanalytics/ai-text-analytics/test/pipelineOptions.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/pipelineOptions.spec.ts
@@ -14,7 +14,7 @@ import { testEnv } from "./utils/recordedClient";
 import { WebResource, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
 
 describe("TextAnalyticsClient Custom PipelineOptions", function() {
-  let credential = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
+  const credential = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
 
   it("use custom HTTPClient", async () => {
     const pipelineTester = new Promise<DetectLanguageResultArray>((resolve) => {
@@ -35,7 +35,7 @@ describe("TextAnalyticsClient Custom PipelineOptions", function() {
         }
       });
 
-      client.detectLanguage(["Hello!"], "us").then((languages) => resolve(languages));
+      return client.detectLanguage(["Hello!"], "us").then((languages) => resolve(languages));
     });
 
     const [result] = await pipelineTester;

--- a/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
@@ -32,9 +32,11 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   let getId: () => string;
 
+  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
   beforeEach(function() {
+    // eslint-disable-next-line no-invalid-this
     ({ client, recorder } = createRecordedClient(this));
     let nextId = 0;
     getId = () => {

--- a/sdk/textanalytics/ai-text-analytics/test/util.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/util.spec.ts
@@ -22,6 +22,6 @@ describe("util.sortByPreviousOrder", () => {
     ];
     assert.throws(() => {
       sortResponseIdObjects(input, output);
-    }, /^A fatal error\!$/);
+    }, /^A fatal error!$/);
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/utils/resultHelper.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/resultHelper.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import { TextAnalyticsResult, TextAnalyticsSuccessResult } from "../../src/index";
 
-export function assertAllSuccess(results: TextAnalyticsResult[]) {
+export function assertAllSuccess(results: TextAnalyticsResult[]): void {
   for (const result of results) {
     assert.ok(isSuccess(result));
   }


### PR DESCRIPTION
- Lints tests. Fixes #10170,
- Lints `package.json` but not `tsconfig.json` (see below). Partially fixes #10172. No changes needed in `api-extractor.json`.
- Updates `package.json` to drop the html report created by the `lint` script and adds the script to the `build` one. Fixes #10173.

`tsconfig.json` extends a base one in `../../../tsconfig` which satisfies the linter but it is not smart enough to look at that file instead. I suggest to update the linter to follow the extension chain or at least be optimistic and fail gracefully if there is an `extends`.