### PR TITLE
[Git Hook] Ignore YAML files

### DIFF
--- a/sdk/.prettierignore
+++ b/sdk/.prettierignore
@@ -1,1 +1,3 @@
 src/generated/
+*.yml
+*.yaml


### PR DESCRIPTION
It was reported that `prettier` produces valid YAML files for Azure Pipelines templates yet Azure DevOps could not process them. This PR is conservative and stops prettying all YAML files for now. I opened #10353.