### PR TITLE
[Cosmos] Attempts to add correct undefined check for header merge

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
@@ -68,7 +68,7 @@ export function mergeHeaders(headers: CosmosHeaders, toBeMergedHeaders: CosmosHe
     const toBeMergedHeaderQueryMetrics = toBeMergedHeaders[Constants.HttpHeaders.QueryMetrics];
 
     for (const partitionId in toBeMergedHeaderQueryMetrics) {
-      if (partitionId in headerQueryMetrics) {
+      if (headerQueryMetrics[partitionId]) {
         const combinedQueryMetrics = headerQueryMetrics[partitionId].add([
           toBeMergedHeaderQueryMetrics[partitionId]
         ]);


### PR DESCRIPTION
We're currently checking if the partition key is a property of `headerQueryMetrics` but not if the value is valid so we have the potential of unhandled exceptions.

See https://github.com/Azure/azure-sdk-for-js/issues/10275 for more detail