### PR TITLE
Use UNIX LF line endings everywhere, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@ yarn.lock                    merge=binary
 #
 *.json            linguist-language=JSON-with-Comments
 
-# Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+# Use unix line endings everywhere, even on Windows
+* text=auto eol=lf
 
 # Mark recordings as auto generated
 **/recordings/**/*.js linguist-generated=true


### PR DESCRIPTION
The new Prettier-based formatting commit hook is incompatible with Windows CRLF line endings so enforce Unix LF everywhere.

The .gitattributes prior to this change causes these conversions even if core.autocrlf is false. This configuration, in contrast, works irrespective of the global git configuration. It also prevents files from being committed with Windows line endings accidentally.

* Git 2.10 (release 2016-09-03) or later required

* Earlier versions of git will incorrectly apply eol=lf to binary files unless explicitly called out as binary in .gitattributes

* Existing working copies on Windows will not have their existing line endings corrected, and you will get `warning: CRLF will be replaced by LF in <file>` when you edit them.

* To convert all of the files in an existing working copy to avoid these warnings:

1. **MAKE SURE** all your work is committed and pushed somewhere as a backup
2. **MAKE SURE** `git status` reports "nothing to commit, working tree clean"
3. Run the following from working copy root:
```
git rm --cached -r .
git reset --hard
```