### PR TITLE
Changes Array JSONArray type to ArrayLike

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.7.5 (Unreleased)
 
+- FEATURE: Changes JSONArray type internal from Array to ArrayLike to avoid requiring type coercion for immutable data
 - FEATURE: Adds bulk request to container.items. Allows aggregate bulk request for up to 100 operations on items with the types: Create, Upsert, Read, Replace, Delete
 
 ```js

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -806,7 +806,7 @@ export class Items {
 }
 
 // @public (undocumented)
-export interface JSONArray extends Array<JSONValue> {
+export interface JSONArray extends ArrayLike<JSONValue> {
 }
 
 // @public (undocumented)

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
@@ -36,4 +36,4 @@ export type JSONValue = boolean | number | string | null | JSONArray | JSONObjec
 export interface JSONObject {
   [key: string]: JSONValue;
 }
-export interface JSONArray extends Array<JSONValue> {}
+export interface JSONArray extends ArrayLike<JSONValue> {}


### PR DESCRIPTION
For the `QuerySpec JSONArray`, we're okay to accept any type of array and not force users to coerce types to a rigid `Array` type

See: https://github.com/Azure/azure-sdk-for-js/issues/10354