### PR TITLE
Fix CustomVision Prediction Example to use ApiKeyCredentials

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
@@ -22,7 +22,7 @@ The following sample predicts and classifies the given image based on your custo
 
 ```javascript
 const { PredictionAPIClient } = require("@azure/cognitiveservices-customvision-prediction");
-const { CognitiveServicesCredentials } = require("@azure/ms-rest-azure-js");
+const { ApiKeyCredentials } = require("@azure/ms-rest-js");
 
 async function main() {
   const customVisionPredictionKey =
@@ -32,8 +32,8 @@ async function main() {
     "<customVisionPredictionEndPoint>";
   const projectId = process.env["projectId"] || "<projectId>";
 
-  const cognitiveServiceCredentials = new CognitiveServicesCredentials(customVisionPredictionKey);
-  const client = new PredictionAPIClient(cognitiveServiceCredentials, customVisionPredictionEndPoint);
+  const credentials = new ApiKeyCredentials({ inHeader: {"Prediction-key": customVisionPredictionKey } });
+  const client = new PredictionAPIClient(credentials, customVisionPredictionEndPoint);
 
   const imageURL =
     "https://www.atlantatrails.com/wp-content/uploads/2019/02/north-georgia-waterfalls-1024x683.jpg";

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-prediction",
   "author": "Microsoft Corporation",
   "description": "PredictionAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-prediction";
-const packageVersion = "5.1.1";
+const packageVersion = "5.1.2";
 
 export class PredictionAPIClientContext extends msRest.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
Fix CustomVision Prediction Example to use ApiKeyCredentials

Related to #10362 , the prediction client example is using the wrong credentials