### PR TITLE
[ai-form-recognizer] Final GA consistency changes

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Renamed `CustomFormField` to `CustomFormModelField` for similarity to other language SDKs.
 - [Breaking] Removed the redundant `expirationDateTimeTicks` property from the `CopyAuthorization` type, as the `expiresOn` property exists.
 - [Breaking] Moved the optional `contentType` parameter of the `FormRecognizerClient` recognition methods (`recognizeContent`, `recognizeCustomForms`, `recognizeReceipts`, and their URL-based variants) to the associated options bag for these methods.
 - [Breaking] Removed exports of several internal types, including most internal poller operation states and some unused types. All client poller implementations now return a smaller subset of fields.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Renamed the `documentName` property of the `TrainingDocumentInfo` type to just `name`.
 - [Breaking] Removed the `containingLine` property of the `FormWord` type.
 - Made the `rowSpan`, `columnSpan`, `isHeader`, and `isFooter` properties of the `FormTableCell` type non-optional to reflect that they have default values.
 - [Breaking] Renamed `CustomFormField` to `CustomFormModelField` for similarity to other language SDKs.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- Added a `pageNumber` property to the `FormTable` and `FormTableCell` types indicating the number of the page where the table/cell appeared within the input document.
 - [Breaking] Renamed the `includeSubFolders` property of the `TrainSourceFilter` type to `includeSubfolders`.
 - [Breaking] Renamed the `documentName` property of the `TrainingDocumentInfo` type to just `name`.
 - [Breaking] Removed the `containingLine` property of the `FormWord` type.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- Made the `rowSpan`, `columnSpan`, `isHeader`, and `isFooter` properties of the `FormTableCell` type non-optional to reflect that they have default values.
 - [Breaking] Renamed `CustomFormField` to `CustomFormModelField` for similarity to other language SDKs.
 - [Breaking] Removed the redundant `expirationDateTimeTicks` property from the `CopyAuthorization` type, as the `expiresOn` property exists.
 - [Breaking] Moved the optional `contentType` parameter of the `FormRecognizerClient` recognition methods (`recognizeContent`, `recognizeCustomForms`, `recognizeReceipts`, and their URL-based variants) to the associated options bag for these methods.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Renamed the `includeSubFolders` property of the `TrainSourceFilter` type to `includeSubfolders`.
 - [Breaking] Renamed the `documentName` property of the `TrainingDocumentInfo` type to just `name`.
 - [Breaking] Removed the `containingLine` property of the `FormWord` type.
 - Made the `rowSpan`, `columnSpan`, `isHeader`, and `isFooter` properties of the `FormTableCell` type non-optional to reflect that they have default values.

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Moved the optional `contentType` parameter of the `FormRecognizerClient` recognition methods (`recognizeContent`, `recognizeCustomForms`, `recognizeReceipts`, and their URL-based variants) to the associated options bag for these methods.
 - [Breaking] Removed exports of several internal types, including most internal poller operation states and some unused types. All client poller implementations now return a smaller subset of fields.
 
 ## 1.0.0-preview.4 (2020-07-07)

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Removed the redundant `expirationDateTimeTicks` property from the `CopyAuthorization` type, as the `expiresOn` property exists.
 - [Breaking] Moved the optional `contentType` parameter of the `FormRecognizerClient` recognition methods (`recognizeContent`, `recognizeCustomForms`, `recognizeReceipts`, and their URL-based variants) to the associated options bag for these methods.
 - [Breaking] Removed exports of several internal types, including most internal poller operation states and some unused types. All client poller implementations now return a smaller subset of fields.
 

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.5 (Unreleased)
 
+- [Breaking] Removed the `containingLine` property of the `FormWord` type.
 - Made the `rowSpan`, `columnSpan`, `isHeader`, and `isFooter` properties of the `FormTableCell` type non-optional to reflect that they have default values.
 - [Breaking] Renamed `CustomFormField` to `CustomFormModelField` for similarity to other language SDKs.
 - [Breaking] Removed the redundant `expirationDateTimeTicks` property from the `CopyAuthorization` type, as the `expiresOn` property exists.

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -35,6 +35,7 @@ export type BeginRecognizeContentOptions = RecognizeContentOptions & {
     updateIntervalInMs?: number;
     onProgress?: (state: RecognizeContentOperationState) => void;
     resumeFrom?: string;
+    contentType?: FormContentType;
 };
 
 // @public
@@ -42,6 +43,7 @@ export type BeginRecognizeFormsOptions = RecognizeFormsOptions & {
     updateIntervalInMs?: number;
     onProgress?: (state: RecognizeFormsOperationState) => void;
     resumeFrom?: string;
+    contentType?: FormContentType;
 };
 
 // @public
@@ -225,11 +227,11 @@ export type FormPollerLike = PollerLike<RecognizeFormsOperationState, Recognized
 // @public
 export class FormRecognizerClient {
     constructor(endpointUrl: string, credential: TokenCredential | KeyCredential, options?: FormRecognizerClientOptions);
-    beginRecognizeContent(form: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
+    beginRecognizeContent(form: FormRecognizerRequestBody, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
     beginRecognizeContentFromUrl(formUrl: string, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
-    beginRecognizeCustomForms(modelId: string, form: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
+    beginRecognizeCustomForms(modelId: string, form: FormRecognizerRequestBody, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
     beginRecognizeCustomFormsFromUrl(modelId: string, formUrl: string, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
-    beginRecognizeReceipts(receipt: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
+    beginRecognizeReceipts(receipt: FormRecognizerRequestBody, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
     beginRecognizeReceiptsFromUrl(receiptUrl: string, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
     readonly endpointUrl: string;
     }

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -248,6 +248,7 @@ export type FormRecognizerRequestBody = Blob | ArrayBuffer | ArrayBufferView | N
 export interface FormTable {
     cells: FormTableCell[];
     columnCount: number;
+    pageNumber: number;
     rowCount: number;
 }
 
@@ -260,6 +261,7 @@ export interface FormTableCell {
     fieldElements?: FormElement[];
     isFooter: boolean;
     isHeader: boolean;
+    pageNumber: number;
     rowIndex: number;
     rowSpan: number;
     text: string;

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -282,7 +282,6 @@ export class FormTrainingClient {
 // @public
 export interface FormWord extends FormElementCommon {
     confidence?: number;
-    containingLine?: FormLine;
     kind: "word";
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -416,7 +416,7 @@ export interface TrainingDocumentInfo {
 // @public
 export type TrainingFileFilter = FormRecognizerOperationOptions & {
     prefix?: string;
-    includeSubFolders?: boolean;
+    includeSubfolders?: boolean;
 };
 
 // @public

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -407,8 +407,8 @@ export { RestResponse }
 
 // @public
 export interface TrainingDocumentInfo {
-    documentName: string;
     errors: FormRecognizerError[];
+    name: string;
     pageCount: number;
     status: TrainingStatus;
 }

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -66,17 +66,12 @@ export interface CommonFieldValue {
 export type ContentPollerLike = PollerLike<PollOperationState<FormPageArray>, FormPageArray>;
 
 // @public
-export interface CopyAuthorization extends CopyAuthorizationResultModel {
+export interface CopyAuthorization {
+    accessToken: string;
     expiresOn: Date;
+    modelId: string;
     resourceId: string;
     resourceRegion: string;
-}
-
-// @public
-export interface CopyAuthorizationResultModel {
-    accessToken: string;
-    expirationDateTimeTicks: number;
-    modelId: string;
 }
 
 // @public

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -255,13 +255,13 @@ export interface FormTable {
 export interface FormTableCell {
     boundingBox: Point2D[];
     columnIndex: number;
-    columnSpan?: number;
+    columnSpan: number;
     confidence: number;
     fieldElements?: FormElement[];
-    isFooter?: boolean;
-    isHeader?: boolean;
+    isFooter: boolean;
+    isHeader: boolean;
     rowIndex: number;
-    rowSpan?: number;
+    rowSpan: number;
     text: string;
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -82,13 +82,6 @@ export type CopyModelOperationState = PollOperationState<CustomFormModel> & {
 // @public
 export type CopyModelOptions = FormRecognizerOperationOptions;
 
-// @public (undocumented)
-export interface CustomFormField {
-    accuracy?: number;
-    label: string | null;
-    name: string;
-}
-
 // @public
 export interface CustomFormModel {
     errors?: FormRecognizerError[];
@@ -98,6 +91,13 @@ export interface CustomFormModel {
     trainingCompletedOn: Date;
     trainingDocuments?: TrainingDocumentInfo[];
     trainingStartedOn: Date;
+}
+
+// @public (undocumented)
+export interface CustomFormModelField {
+    accuracy?: number;
+    label: string | null;
+    name: string;
 }
 
 // @public
@@ -111,9 +111,7 @@ export interface CustomFormModelInfo {
 // @public
 export interface CustomFormSubmodel {
     accuracy?: number;
-    fields: {
-        [propertyName: string]: CustomFormField;
-    };
+    fields: Record<string, CustomFormModelField>;
     formType: string;
 }
 
@@ -169,9 +167,7 @@ export type FormField = {
     value?: FormField[];
     valueType?: "array";
 } | {
-    value?: {
-        [propertyName: string]: FormField;
-    };
+    value?: Record<string, FormField>;
     valueType?: "object";
 });
 
@@ -388,9 +384,7 @@ export type RecognizeContentOptions = FormRecognizerOperationOptions;
 
 // @public
 export interface RecognizedForm {
-    fields: {
-        [propertyName: string]: FormField;
-    };
+    fields: Record<string, FormField>;
     formType: string;
     pageRange: FormPageRange;
     pages: FormPage[];

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/authenticationMethods.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/authenticationMethods.js
@@ -13,9 +13,11 @@ const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-rec
 const { DefaultAzureCredential } = require("@azure/identity");
 
 const fs = require("fs");
+const path = require("path");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
@@ -58,7 +60,7 @@ async function useApiKey() {
  * for content recognition and print its output.
  */
 async function recognizeContentWithClient(client) {
-  const fileName = "assets/Invoice_6.pdf";
+  const fileName = path.join(__dirname, "./assets/Invoice_6.pdf");
 
   if (!fs.existsSync(fileName)) {
     throw new Error(`Expecting file ${fileName} exists`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/copyModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/copyModel.js
@@ -9,22 +9,31 @@
 const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   // information about the source Form Recognizer resource
-  const endpoint = process.env["FORM_RECOGNIZER_SOURCE_ENDPOINT"] || "<source cognitive services endpoint>";
+  const endpoint =
+    process.env["FORM_RECOGNIZER_SOURCE_ENDPOINT"] || "<source cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_SOURCE_API_KEY"] || "<source resource api key>";
-  const sourceModelId = process.env["FORM_RECOGNIZER_SOURCE_MODEL_ID"] || "<source custom model id>"
+  const sourceModelId =
+    process.env["FORM_RECOGNIZER_SOURCE_MODEL_ID"] || "<source custom model id>";
   // information about the target Form Recognizer resource
-  const targetEndpoint = process.env["FORM_RECOGNIZER_TARGET_ENDPOINT"] || "<target cognitive services endpoint>";
+  const targetEndpoint =
+    process.env["FORM_RECOGNIZER_TARGET_ENDPOINT"] || "<target cognitive services endpoint>";
   const targetApiKey = process.env["FORM_RECOGNIZER_TARGET_API_KEY"] || "<target resource api key>";
-  const targetResourceRegion = process.env["FORM_RECOGNIZER_TARGET_REGION"] || "<target resource region>"
-  const targetResourceId = process.env["FORM_RECOGNIZER_TARGET_RESOURCE_ID"] || "<target resource resource id>"
+  const targetResourceRegion =
+    process.env["FORM_RECOGNIZER_TARGET_REGION"] || "<target resource region>";
+  const targetResourceId =
+    process.env["FORM_RECOGNIZER_TARGET_RESOURCE_ID"] || "<target resource resource id>";
 
   const targetClient = new FormTrainingClient(targetEndpoint, new AzureKeyCredential(targetApiKey));
-  const authorization = await targetClient.getCopyAuthorization(targetResourceId, targetResourceRegion);
+  const authorization = await targetClient.getCopyAuthorization(
+    targetResourceId,
+    targetResourceRegion
+  );
 
   const sourceClient = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
   const poller = await sourceClient.beginCopyModel(sourceModelId, authorization, {
@@ -35,7 +44,7 @@ async function main() {
   const result = await poller.pollUntilDone();
 
   if (!result) {
-      throw new Error("Expecting valid result from copy model operation");
+    throw new Error("Expecting valid result from copy model operation");
   }
 
   // now verify that the copy in the target Form Recognizer resource

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/customModelManagement.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/customModelManagement.js
@@ -52,7 +52,7 @@ async function main() {
   console.log(`Model Id: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
   console.log("Documents used in training:");
-  for (const doc of model.trainingDocuments ?? []) {
+  for (const doc of model.trainingDocuments || []) {
     console.log(`- ${doc.name}`);
   }
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/customModelManagement.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/customModelManagement.js
@@ -2,19 +2,21 @@
 // Licensed under the MIT License.
 
 /**
- * This sample demonstrates different ways to iterate through the list of models in
+ * This sample demonstrates how to manage the custom models in
  * a cognitive service account.
  */
 
 const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
+
   const client = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
 
   // First, we see how many custom models we have, and what our limit is
@@ -26,18 +28,14 @@ async function main() {
   // Next, we get a paged async iterator of all of our custom models
   const result = client.listCustomModels();
 
-  // We could print out information about first ten models
-  // and save the first model id for later use
-  let i = 0;
-  let firstModel;
+  // We can iterate over all the models and print their ID
+  // We'll also save the first model to get some detailed information
+  // in the next step;
+  let firstModel = undefined;
   for await (const model of result) {
-    console.log(`model ${i++}:`);
-    console.log(model);
-    if (i === 1) {
+    console.log(`- Model:`, model.modelId);
+    if (firstModel === undefined) {
       firstModel = model;
-    }
-    if (i > 10) {
-      break;
     }
   }
 
@@ -50,13 +48,13 @@ async function main() {
 
   // Now we'll get the first custom model in the paged list
   const model = await client.getCustomModel(firstModel.modelId);
+  console.log("--- First Custom Model ---");
   console.log(`Model Id: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log("Documents used in training: [");
-  for (const doc of model.trainingDocuments || []) {
-    console.log(`  ${doc.documentName}`);
+  console.log("Documents used in training:");
+  for (const doc of model.trainingDocuments ?? []) {
+    console.log(`- ${doc.name}`);
   }
-  console.log("]");
 
   // Finally, we can delete this model if we want (for example, if its status is 'invalid')
   //   await client.deleteModel(firstModel.modelId);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
@@ -3,73 +3,76 @@
 
 /**
  * This sample demonstrates the differences in form recognition using custom
- * models trained with labels and custom models trained without labels.
+ * models trained with labeled and unlabeled data.
  */
 
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
+const path = require("path");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
-  const labeledModelId = process.env["LABELED_CUSTOM_MODEL_ID"] || "<model id from training with labels>";
-  const unlabeledModelId = process.env["UNLABELED_CUSTOM_MODEL_ID"] || "<model id from training without labels>";
+  const labeledModelId = process.env["LABELED_CUSTOM_MODEL_ID"] || "<labeled custom model id>";
+  const unlabeledModelId =
+    process.env["UNLABELED_CUSTOM_MODEL_ID"] || "<unlabeled custom model id>";
   // The form you are recognizing must be of the same type as the forms the custom model was trained on
-  const path = "./assets/Invoice_6.pdf";
+  const fileName = path.join(__dirname, "./assets/Invoice_6.pdf");
 
-  if (!fs.existsSync(path)) {
-    throw new Error(`Expecting file ${path} exists`);
+  if (!fs.existsSync(fileName)) {
+    throw new Error(`Expecting file ${fileName} exists`);
   }
 
-  const formsWithLabels = await recognizeCustomForm(path, endpoint, apiKey, labeledModelId);
-  const forms = await recognizeCustomForm(path, endpoint, apiKey, unlabeledModelId);
+  const formsWithLabels = await recognizeCustomForm(fileName, endpoint, apiKey, labeledModelId);
+  const forms = await recognizeCustomForm(fileName, endpoint, apiKey, unlabeledModelId);
 
   // The main difference is found in the labels of its fields
-  // The form recognized with a model from training with labels will have the labels it was trained with,
-  // The form recognized with a model from training without labels will be denoted with indices
+  // The form recognized with a labeled model will have the labels it was trained with,
+  // the unlabeled one will be denoted with indices
   console.log("# Recognized fields using labeled custom model");
   for (const form of formsWithLabels || []) {
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // With your labeled custom model, you will not get back label data but will get back value data
       // This is because your custom model didn't have to use any machine learning to deduce the label,
-      // the label was directly provided to it
-      const field = form.fields[fieldName];
+      // the label was directly provided to it.
       console.log(
-        `\tField ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
       );
     }
   }
 
   console.log("# Recognized fields using unlabeled custom model");
   for (const form of forms || []) {
-    for (const fieldName in form.fields) {
-      // The recognized form fields with a custom model from training without labels will also include data about recognized labels.
-      const field = form.fields[fieldName];
+    for (const [fieldName, field] of Object.entries(form.fields)) {
+      // The recognized form fields with an unlabeled custom model will also include data about recognized labels.
       console.log(
-        `\tField ${fieldName} has label '${field.labelData.text}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has label '${field.labelData?.text}' with a confidence score of ${field.confidence}`
       );
       console.log(
-        `\tField ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
       );
     }
   }
 }
 
-async function recognizeCustomForm(path, endpoint, apiKey, labeledModelId) {
+async function recognizeCustomForm(fileName, endpoint, apiKey, labeledModelId) {
   console.log("# Recognizing...");
-  const readStream = fs.createReadStream(path);
+  const readStream = fs.createReadStream(fileName);
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(labeledModelId, readStream, "application/pdf", {
+  const poller = await client.beginRecognizeCustomForms(labeledModelId, readStream, {
+    contentType: "application/pdf",
     onProgress: (state) => {
-      console.log(`\tstatus: ${state.status}`);
+      console.log(`  status: ${state.status}`);
     }
   });
   const forms = await poller.pollUntilDone();
-  if (!forms || forms.length <= 0) {
+  if (!forms || forms?.length <= 0) {
     throw new Error("Expecting valid response!");
   }
   return forms;

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/differentiateLabeledUnlabeled.js
@@ -52,7 +52,9 @@ async function main() {
     for (const [fieldName, field] of Object.entries(form.fields)) {
       // The recognized form fields with an unlabeled custom model will also include data about recognized labels.
       console.log(
-        `  Field ${fieldName} has label '${field.labelData?.text}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has label '${
+          field.labelData ? field.labelData.text : undefined
+        }' with a confidence score of ${field.confidence}`
       );
       console.log(
         `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
@@ -72,7 +74,7 @@ async function recognizeCustomForm(fileName, endpoint, apiKey, labeledModelId) {
     }
   });
   const forms = await poller.pollUntilDone();
-  if (!forms || forms?.length <= 0) {
+  if (!forms) {
     throw new Error("Expecting valid response!");
   }
   return forms;

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/getBoundingBoxes.js
@@ -7,47 +7,49 @@
  */
 
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
+const path = require("path");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
   const modelId = process.env["CUSTOM_MODEL_ID"] || "<custom model id>";
-  // The form you are recognizing must be of the same type as the forms the custom model was trained on
-  const path = "./assets/Invoice_6.pdf";
 
-  if (!fs.existsSync(path)) {
-    throw new Error(`Expecting file ${path} exists`);
+  // The form you are recognizing must be of the same type as the forms the custom model was trained on
+  const fileName = path.join(__dirname, "./assets/Invoice_6.pdf");
+
+  if (!fs.existsSync(fileName)) {
+    throw new Error(`Expecting file ${fileName} exists`);
   }
 
-  const readStream = fs.createReadStream(path);
+  const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(modelId, readStream, "application/pdf", {
+  const poller = await client.beginRecognizeCustomForms(modelId, readStream, {
+    contentType: "application/pdf",
     onProgress: (state) => {
       console.log(`status: ${state.status}`);
     }
   });
   const forms = await poller.pollUntilDone();
 
-  console.log("Forms:");
-  let i = 0;
   for (const form of forms || []) {
-    console.log(`  Form #${i++} has type ${form.formType}`);
+    console.log(`- Form has type ${form.formType}`);
     console.log("  Fields:");
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // each field is of type FormField
-      const field = form.fields[fieldName];
       const boundingBox =
         field.valueData && field.valueData.boundingBox
           ? field.valueData.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
           : "N/A";
       console.log(
-        `    Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
+        `    Field '${fieldName}' has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
       );
     }
     console.log("  Pages:");
@@ -63,7 +65,7 @@ async function main() {
           );
           for (const element of cell.fieldElements || []) {
             const boundingBox = element.boundingBox
-              ? element.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
+              ? element.boundingBox.map((p) => `[$.2d{p.x},${p.y}]`).join(", ")
               : "N/A";
             console.log(`        '${element.text}' within bounding box ${boundingBox}`);
           }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/iteratorModels.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/iteratorModels.js
@@ -9,7 +9,8 @@
 const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
@@ -18,27 +19,24 @@ async function main() {
 
   const client = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
 
+  // using `for await` syntax:
   const result = client.listCustomModels();
-  let i = 0;
-  for await (const modelInfo of result) {
-    console.log(`model ${i++}:`);
-    console.log(modelInfo);
+  for await (const model of result) {
+    console.log("- Model:", model.modelId);
   }
 
   // using `iter.next()`
-  i = 1;
   let iter = client.listCustomModels();
   let modelItem = await iter.next();
   while (!modelItem.done) {
-    console.log(`model ${i++}: ${modelItem.value.modelId}`);
+    console.log("- Model:", modelItem.value.modelId);
     modelItem = await iter.next();
   }
 
   // using `byPage()`
-  i = 1;
   for await (const response of client.listCustomModels().byPage()) {
     for (const modelInfo of response.modelList) {
-      console.log(`model ${i++}: ${modelInfo.modelId}`);
+      console.log("- Model:", modelInfo.modelId);
     }
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeContent.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeContent.js
@@ -2,26 +2,29 @@
 // Licensed under the MIT License.
 
 /**
- * Recognize Content
+ * This sample demonstrates how to extract text and layout information from a document
  */
 
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
+const path = require("path");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
-  const path = "./assets/Invoice_6.pdf";
+  const fileName = path.join(__dirname, "./assets/Invoice_6.pdf");
 
-  if (!fs.existsSync(path)) {
-    throw new Error(`Expecting file ${path} exists`);
+  if (!fs.existsSync(fileName)) {
+    throw new Error(`Expecting file ${fileName} exists`);
   }
 
-  const readStream = fs.createReadStream(path);
+  const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
   const poller = await client.beginRecognizeContent(readStream);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceipt.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceipt.js
@@ -6,38 +6,40 @@
  */
 
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
+const path = require("path");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
-  const path = "./assets/contoso-allinone.jpg";
+  const fileName = path.join(__dirname, "./assets/contoso-allinone.jpg");
 
-  if (!fs.existsSync(path)) {
-    throw new Error(`Expecting file ${path} exists`);
+  if (!fs.existsSync(fileName)) {
+    throw new Error(`Expecting file ${fileName} exists`);
   }
 
-  const readStream = fs.createReadStream(path);
+  const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeReceipts(readStream, "image/jpeg", {
+  const poller = await client.beginRecognizeReceipts(readStream, {
+    contentType: "image/jpeg",
     onProgress: (state) => {
       console.log(`status: ${state.status}`);
     }
   });
 
-  const receipts = await poller.pollUntilDone();
+  const [receipt] = await poller.pollUntilDone();
 
-  if (!receipts || receipts.length <= 0) {
+  if (receipt === undefined) {
     throw new Error("Expecting at lease one receipt in analysis result");
   }
 
-  const receipt = receipts[0];
-  console.log("First receipt:");
   // For supported fields recognized by the service, please refer to https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult.
   const receiptTypeField = receipt.fields["ReceiptType"];
   if (receiptTypeField.valueType === "string") {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
@@ -8,11 +8,12 @@
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
-  const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive service endpoint>";
+  const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
@@ -25,14 +26,13 @@ async function main() {
       console.log(`analyzing status: ${state.status}`);
     }
   });
-  const receipts = await poller.pollUntilDone();
 
-  if (!receipts || receipts.length <= 0) {
+  const [receipt] = await poller.pollUntilDone();
+
+  if (receipt === undefined) {
     throw new Error("Expecting at lease one receipt in analysis result");
   }
 
-  const receipt = receipts[0];
-  console.log("First receipt:");
   // For supported fields recognized by the service, please refer to https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult.
   const receiptTypeField = receipt.fields["ReceiptType"];
   if (receiptTypeField.valueType === "string") {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainLabeledModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainLabeledModel.js
@@ -9,16 +9,22 @@
 const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
-  const containerSasUrl = process.env["LABELED_CONTAINER_SAS_URL"] || "<url/path to the labeled training documents>";
+  const containerSasUrl =
+    process.env["LABELED_CONTAINER_SAS_URL"] ||
+    "<url to Azure blob container storing the labeled training documents>";
 
   const trainingClient = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
 
+  // The second positional argument to `beginTraining` indidcates whether or
+  // not the training process should look for label data in the training
+  // container
   const poller = await trainingClient.beginTraining(containerSasUrl, true, {
     onProgress: (state) => {
       console.log(`training status: ${state.status}`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
@@ -3,20 +3,22 @@
 
 /**
  * This sample demonstrates how to train a custom model with unlabeled data.
- * See recognizeForm.js to recognize forms using a custom model.
+ * See recognizeForm.ts to recognize forms using a custom model.
  */
 
 const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
 // Load the .env file if it exists
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 async function main() {
   // You will need to set these environment variables or edit the following values
   const endpoint = process.env["FORM_RECOGNIZER_ENDPOINT"] || "<cognitive services endpoint>";
   const apiKey = process.env["FORM_RECOGNIZER_API_KEY"] || "<api key>";
-
-  const containerSasUrl = process.env["UNLABELED_CONTAINER_SAS_URL"] || "<SAS url to the blob container storing training documents>";
+  const containerSasUrl =
+    process.env["UNLABELED_CONTAINER_SAS_URL"] ||
+    "<url to Azure blob container storing the training documents>";
 
   const trainingClient = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
 
@@ -40,8 +42,7 @@ async function main() {
     for (const submodel of model.submodels) {
       // since the training data is unlabeled, we are unable to return the accuracy of this model
       console.log("We have recognized the following fields");
-      for (const key in submodel.fields) {
-        const field = submodel.fields[key];
+      for (const [_, field] of Object.entries(submodel.fields)) {
         console.log(`The model found field '${field.name}'`);
       }
     }
@@ -49,10 +50,14 @@ async function main() {
   // Training document information
   if (model.trainingDocuments) {
     for (const doc of model.trainingDocuments) {
-      console.log(`Document name: ${doc.documentName}`);
+      console.log(`Document name: ${doc.name}`);
       console.log(`Document status: ${doc.status}`);
       console.log(`Document page count: ${doc.pageCount}`);
-      console.log(`Document errors: ${doc.errors}`);
+      console.log(
+        `Document errors: ${doc.errors
+          .map((e) => `error code ${e.code} '${e.message}'`)
+          .join("\n")}`
+      );
     }
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
@@ -56,7 +56,7 @@ export async function main() {
   console.log(`Status: ${model.status}`);
   console.log("Documents used in training: [");
   for (const doc of model.trainingDocuments || []) {
-    console.log(`  ${doc.documentName}`);
+    console.log(`  ${doc.name}`);
   }
   console.log("]");
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
@@ -52,7 +52,7 @@ export async function main() {
   console.log(`Model Id: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
   console.log("Documents used in training:");
-  for (const doc of model.trainingDocuments ?? []) {
+  for (const doc of model.trainingDocuments || []) {
     console.log(`- ${doc.name}`);
   }
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/customModelManagement.ts
@@ -28,18 +28,14 @@ export async function main() {
   // Next, we get a paged async iterator of all of our custom models
   const result = client.listCustomModels();
 
-  // We could print out information about first ten models
-  // and save the first model id for later use
-  let i = 0;
-  let firstModel;
+  // We can iterate over all the models and print their ID
+  // We'll also save the first model to get some detailed information
+  // in the next step;
+  let firstModel = undefined;
   for await (const model of result) {
-    console.log(`model ${i++}:`);
-    console.log(model);
-    if (i === 1) {
+    console.log(`- Model:`, model.modelId);
+    if (firstModel === undefined) {
       firstModel = model;
-    }
-    if (i > 10) {
-      break;
     }
   }
 
@@ -52,13 +48,13 @@ export async function main() {
 
   // Now we'll get the first custom model in the paged list
   const model = await client.getCustomModel(firstModel.modelId);
+  console.log("--- First Custom Model ---");
   console.log(`Model Id: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log("Documents used in training: [");
-  for (const doc of model.trainingDocuments || []) {
-    console.log(`  ${doc.name}`);
+  console.log("Documents used in training:");
+  for (const doc of model.trainingDocuments ?? []) {
+    console.log(`- ${doc.name}`);
   }
-  console.log("]");
 
   // Finally, we can delete this model if we want (for example, if its status is 'invalid')
   //   await client.deleteModel(firstModel.modelId);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
@@ -56,7 +56,9 @@ export async function main() {
     for (const [fieldName, field] of Object.entries(form.fields)) {
       // The recognized form fields with an unlabeled custom model will also include data about recognized labels.
       console.log(
-        `  Field ${fieldName} has label '${field.labelData?.text}' with a confidence score of ${field.confidence}`
+        `  Field ${fieldName} has label '${
+          field.labelData ? field.labelData.text : undefined
+        }' with a confidence score of ${field.confidence}`
       );
       console.log(
         `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
@@ -81,7 +83,7 @@ async function recognizeCustomForm(
     }
   });
   const forms = await poller.pollUntilDone();
-  if (!forms || forms?.length <= 0) {
+  if (!forms) {
     throw new Error("Expecting valid response!");
   }
   return forms;

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
@@ -41,11 +41,10 @@ export async function main() {
   // the unlabeled one will be denoted with indices
   console.log("# Recognized fields using labeled custom model");
   for (const form of formsWithLabels || []) {
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // With your labeled custom model, you will not get back label data but will get back value data
       // This is because your custom model didn't have to use any machine learning to deduce the label,
       // the label was directly provided to it.
-      const field = form.fields[fieldName];
       console.log(
         `  Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
       );
@@ -54,9 +53,8 @@ export async function main() {
 
   console.log("# Recognized fields using unlabeled custom model");
   for (const form of forms || []) {
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // The recognized form fields with an unlabeled custom model will also include data about recognized labels.
-      const field = form.fields[fieldName];
       console.log(
         `  Field ${fieldName} has label '${field.labelData?.text}' with a confidence score of ${field.confidence}`
       );

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/differentiateLabeledUnlabeled.ts
@@ -76,16 +76,12 @@ async function recognizeCustomForm(
   console.log("# Recognizing...");
   const readStream = fs.createReadStream(fileName);
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(
-    labeledModelId,
-    readStream,
-    "application/pdf",
-    {
-      onProgress: (state) => {
-        console.log(`  status: ${state.status}`);
-      }
+  const poller = await client.beginRecognizeCustomForms(labeledModelId, readStream, {
+    contentType: "application/pdf",
+    onProgress: (state) => {
+      console.log(`  status: ${state.status}`);
     }
-  );
+  });
   const forms = await poller.pollUntilDone();
   if (!forms || forms?.length <= 0) {
     throw new Error("Expecting valid response!");

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
@@ -39,20 +39,17 @@ export async function main() {
   });
   const forms = await poller.pollUntilDone();
 
-  console.log("Forms:");
-  let i = 0;
   for (const form of forms || []) {
-    console.log(`  Form #${i++} has type ${form.formType}`);
+    console.log(`- Form has type ${form.formType}`);
     console.log("  Fields:");
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // each field is of type FormField
-      const field = form.fields[fieldName];
       const boundingBox =
         field.valueData && field.valueData.boundingBox
           ? field.valueData.boundingBox.map((p) => `[${p.x},${p.y}]`).join(", ")
           : "N/A";
       console.log(
-        `    Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
+        `    Field '${fieldName}' has value '${field.value}' with a confidence score of ${field.confidence} within bounding box ${boundingBox}`
       );
     }
     console.log("  Pages:");

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/getBoundingBoxes.ts
@@ -31,7 +31,8 @@ export async function main() {
   const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(modelId, readStream, "application/pdf", {
+  const poller = await client.beginRecognizeCustomForms(modelId, readStream, {
+    contentType: "application/pdf",
     onProgress: (state) => {
       console.log(`status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/iteratorModels.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/iteratorModels.ts
@@ -21,26 +21,22 @@ export async function main() {
 
   // using `for await` syntax:
   const result = client.listCustomModels();
-  let i = 0;
   for await (const model of result) {
-    console.log(`model ${i++}:`);
-    console.log(model);
+    console.log("- Model:", model.modelId);
   }
 
   // using `iter.next()`
-  i = 1;
   let iter = client.listCustomModels();
   let modelItem = await iter.next();
   while (!modelItem.done) {
-    console.log(`model ${i++}: ${modelItem.value.modelId}`);
+    console.log("- Model:", modelItem.value.modelId);
     modelItem = await iter.next();
   }
 
   // using `byPage()`
-  i = 1;
   for await (const response of client.listCustomModels().byPage()) {
     for (const modelInfo of response.modelList!) {
-      console.log(`model ${i++}: ${modelInfo.modelId}`);
+      console.log("- Model:", modelInfo.modelId);
     }
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
@@ -55,11 +55,10 @@ export async function main() {
     }
 
     console.log("Fields:");
-    for (const fieldName in form.fields) {
+    for (const [fieldName, field] of Object.entries(form.fields)) {
       // each field is of type FormField
-      const field = form.fields[fieldName];
       console.log(
-        `Field ${fieldName} has value '${field.value}' with a confidence score of ${field.confidence}`
+        `Field '${fieldName}' has value '${field.value}' with a confidence score of ${field.confidence}`
       );
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeCustomForm.ts
@@ -32,7 +32,8 @@ export async function main() {
   const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(modelId, readStream, "application/pdf", {
+  const poller = await client.beginRecognizeCustomForms(modelId, readStream, {
+    contentType: "application/pdf",
     onProgress: (state) => {
       console.log(`status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceipt.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceipt.ts
@@ -34,14 +34,12 @@ export async function main() {
     }
   });
 
-  const receipts = await poller.pollUntilDone();
+  const [receipt] = await poller.pollUntilDone();
 
-  if (!receipts || receipts.length <= 0) {
+  if (receipt === undefined) {
     throw new Error("Expecting at lease one receipt in analysis result");
   }
 
-  const receipt = receipts[0];
-  console.log("First receipt:");
   // For supported fields recognized by the service, please refer to https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult.
   const receiptTypeField = receipt.fields["ReceiptType"];
   if (receiptTypeField.valueType === "string") {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceipt.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceipt.ts
@@ -27,7 +27,8 @@ export async function main() {
   const readStream = fs.createReadStream(fileName);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeReceipts(readStream, "image/jpeg", {
+  const poller = await client.beginRecognizeReceipts(readStream, {
+    contentType: "image/jpeg",
     onProgress: (state) => {
       console.log(`status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
@@ -26,14 +26,13 @@ export async function main() {
       console.log(`analyzing status: ${state.status}`);
     }
   });
-  const receipts = await poller.pollUntilDone();
 
-  if (!receipts || receipts.length <= 0) {
+  const [receipt] = await poller.pollUntilDone();
+
+  if (receipt === undefined) {
     throw new Error("Expecting at lease one receipt in analysis result");
   }
 
-  const receipt = receipts[0];
-  console.log("First receipt:");
   // For supported fields recognized by the service, please refer to https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult.
   const receiptTypeField = receipt.fields["ReceiptType"];
   if (receiptTypeField.valueType === "string") {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/stronglyTypingRecognizedForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/stronglyTypingRecognizedForm.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * This sample demonstrates how to convert a RecognizedForm into a strongly-typed
+ * This sample demonstrates how to assign a RecognizedForm to a strongly-typed
  * object with known fields.
  *
  * We use the pre-trained receipt model as an example, but a similar approach could
@@ -13,6 +13,7 @@
 import { FormRecognizerClient, AzureKeyCredential, FormField } from "@azure/ai-form-recognizer";
 
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 
 // Load the .env file if it exists
@@ -95,47 +96,38 @@ export async function main() {
   // print "undefined" for any fields that are not present.
 
   console.log(
-    `Receipt Type: "${receipt.ReceiptType?.value}" has confidence ${receipt.ReceiptType?.confidence}`
-  );
-  console.log(
-    `Merchant Name: "${receipt.MerchantName?.value}" has confidence ${receipt.MerchantName?.confidence}`
-  );
-  console.log(
-    `Merchant Address: "${receipt.MerchantAddress?.value}" has confidence ${receipt.MerchantAddress?.confidence}`
-  );
-  console.log(
-    `Merchant Phone Number: "${receipt.MerchantPhoneNumber?.value}" has confidence ${receipt.MerchantPhoneNumber?.confidence}`
-  );
-  console.log(
-    `Transaction Date: ${receipt.TransactionDate?.value} has confidence ${receipt.TransactionDate?.confidence}`
-  );
-  console.log(
-    `Transaction Time: ${receipt.TransactionTime?.value} has confidence ${receipt.TransactionTime?.confidence}`
+    [
+      `Receipt Type: "${receipt.ReceiptType?.value}" has confidence ${receipt.ReceiptType?.confidence}`,
+      `Merchant Name: "${receipt.MerchantName?.value}" has confidence ${receipt.MerchantName?.confidence}`,
+      `Merchant Address: "${receipt.MerchantAddress?.value}" has confidence ${receipt.MerchantAddress?.confidence}`,
+      `Merchant Phone Number: "${receipt.MerchantPhoneNumber?.value}" has confidence ${receipt.MerchantPhoneNumber?.confidence}`,
+      `Transaction Date: ${receipt.TransactionDate?.value} has confidence ${receipt.TransactionDate?.confidence}`,
+      `Transaction Time: ${receipt.TransactionTime?.value} has confidence ${receipt.TransactionTime?.confidence}`
+    ].join(os.EOL)
   );
 
   if (receipt.Items) {
     console.log("Items:");
     for (const { value: item } of receipt.Items) {
-      console.log(item);
-      console.log(`  - Name: "${item.Name?.value}" has confidence ${item.Name?.confidence}`);
       console.log(
-        `    Quantity: ${item.Quantity?.value} has confidence ${item.Quantity?.confidence}`
-      );
-      console.log(
-        `    Individual Item Price: ${item.Price?.value} has confidence ${item.Price?.confidence}`
-      );
-      console.log(
-        `    Total Price: ${item.TotalPrice?.value} has confidence ${item.TotalPrice?.confidence}`
+        [
+          `- Name: "${item.Name?.value}" has confidence ${item.Name?.confidence}`,
+          `  Quantity: ${item.Quantity?.value} has confidence ${item.Quantity?.confidence}`,
+          `  Individual Item Price: ${item.Price?.value} has confidence ${item.Price?.confidence}`,
+          `  Total Price: ${item.TotalPrice?.value} has confidence ${item.TotalPrice?.confidence}`
+        ].join(os.EOL)
       );
     }
   }
 
   console.log(
-    `Subtotal: ${receipt.Subtotal?.value} has confidence ${receipt.Subtotal?.confidence}`
+    [
+      `Subtotal: ${receipt.Subtotal?.value} has confidence ${receipt.Subtotal?.confidence}`,
+      `Tax: ${receipt.Tax?.value} has confidence ${receipt.Tax?.confidence}`,
+      `Tip: ${receipt.Tip?.value} has confidence ${receipt.Tip?.confidence}`,
+      `Total: ${receipt.Total?.value} has confidence ${receipt.Total?.confidence}`
+    ].join(os.EOL)
   );
-  console.log(`Tax: ${receipt.Tax?.value} has confidence ${receipt.Tax?.confidence}`);
-  console.log(`Tip: ${receipt.Tip?.value} has confidence ${receipt.Tip?.confidence}`);
-  console.log(`Total: ${receipt.Total?.value} has confidence ${receipt.Total?.confidence}`);
 }
 
 main().catch((err) => {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainLabeledModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainLabeledModel.ts
@@ -22,6 +22,9 @@ export async function main() {
 
   const trainingClient = new FormTrainingClient(endpoint, new AzureKeyCredential(apiKey));
 
+  // The second positional argument to `beginTraining` indidcates whether or
+  // not the training process should look for label data in the training
+  // container
   const poller = await trainingClient.beginTraining(containerSasUrl, true, {
     onProgress: (state) => {
       console.log(`training status: ${state.status}`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
@@ -42,8 +42,7 @@ export async function main() {
     for (const submodel of model.submodels) {
       // since the training data is unlabeled, we are unable to return the accuracy of this model
       console.log("We have recognized the following fields");
-      for (const key in submodel.fields) {
-        const field = submodel.fields[key];
+      for (const [_, field] of Object.entries(submodel.fields)) {
         console.log(`The model found field '${field.name}'`);
       }
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
@@ -51,7 +51,7 @@ export async function main() {
   // Training document information
   if (model.trainingDocuments) {
     for (const doc of model.trainingDocuments) {
-      console.log(`Document name: ${doc.documentName}`);
+      console.log(`Document name: ${doc.name}`);
       console.log(`Document status: ${doc.status}`);
       console.log(`Document page count: ${doc.pageCount}`);
       console.log(

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -110,7 +110,7 @@ export type BeginCopyModelOptions = FormRecognizerOperationOptions & {
  */
 export type TrainingFileFilter = FormRecognizerOperationOptions & {
   prefix?: string;
-  includeSubFolders?: boolean;
+  includeSubfolders?: boolean;
 };
 
 /**
@@ -683,16 +683,15 @@ async function trainCustomModelInternal(
   );
 
   try {
-    const requestBody = {
-      source: source,
-      sourceFilter: {
-        prefix: realOptions.prefix,
-        includeSubFolders: realOptions.includeSubFolders
-      },
-      useLabelFile
-    };
     return await client.trainCustomModelAsync(
-      requestBody,
+      {
+        source: source,
+        sourceFilter: {
+          prefix: realOptions.prefix,
+          includeSubfolders: realOptions.includeSubfolders
+        },
+        useLabelFile
+      },
       operationOptionsToRequestOptionsBase(finalOptions)
     );
   } catch (e) {

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -28,7 +28,8 @@ import { GeneratedClient } from "./generated/generatedClient";
 import {
   GeneratedClientGetCustomModelCopyResultResponse as GetCustomModelCopyResultResponseModel,
   GeneratedClientCopyCustomModelResponse as CopyCustomModelResponseModel,
-  GeneratedClientTrainCustomModelAsyncResponse
+  GeneratedClientTrainCustomModelAsyncResponse,
+  CopyAuthorizationResult
 } from "./generated/models";
 import { TrainPollerClient, BeginTrainingPoller } from "./lro/train/poller";
 import { PollOperationState, PollerLike } from "@azure/core-lro";
@@ -39,7 +40,6 @@ import {
   CustomFormModel,
   CustomFormModelInfo,
   CopyAuthorization,
-  CopyAuthorizationResultModel,
   ListCustomModelsResponse,
   OperationStatus,
   ModelStatus
@@ -533,14 +533,15 @@ export class FormTrainingClient {
     );
 
     try {
-      const response = await this.client.generateModelCopyAuthorization(
+      const response = (await this.client.generateModelCopyAuthorization(
         operationOptionsToRequestOptionsBase(finalOptions)
-      );
+      )) as CopyAuthorizationResult;
       return {
         resourceId: resourceId,
         resourceRegion: resourceRegion,
         expiresOn: new Date(response.expirationDateTimeTicks * 1000), // Convert to ms
-        ...(response as CopyAuthorizationResultModel)
+        modelId: response.modelId,
+        accessToken: response.accessToken
       };
     } catch (e) {
       span.setStatus({
@@ -619,7 +620,11 @@ export class FormTrainingClient {
         {
           targetResourceId: copyAuthorization.resourceId,
           targetResourceRegion: copyAuthorization.resourceRegion,
-          copyAuthorization: copyAuthorization
+          copyAuthorization: {
+            modelId: copyAuthorization.modelId,
+            accessToken: copyAuthorization.accessToken,
+            expirationDateTimeTicks: copyAuthorization.expiresOn.getTime() / 1000
+          }
         },
         operationOptionsToRequestOptionsBase(finalOptions)
       );

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { GeneratedClientContext } from "./generatedClientContext";
 import {
+  GeneratedClientOptionalParams,
   TrainRequest,
   GeneratedClientTrainCustomModelAsyncResponse,
   GeneratedClientGetCustomModelOptionalParams,
@@ -45,10 +46,7 @@ class GeneratedClient extends GeneratedClientContext {
    *                 https://westus2.api.cognitive.microsoft.com).
    * @param options The parameter options
    */
-  constructor(
-    endpoint: string,
-    options?: Models.GeneratedClientOptionalParams
-  ) {
+  constructor(endpoint: string, options?: GeneratedClientOptionalParams) {
     super(endpoint, options);
   }
 
@@ -158,11 +156,7 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeWithCustomModel$binaryOptionalParams?
         ]
-      | [
-          string,
-          "application/json",
-          GeneratedClientAnalyzeWithCustomModel$jsonOptionalParams?
-        ]
+      | [string, "application/json", GeneratedClientAnalyzeWithCustomModel$jsonOptionalParams?]
   ): Promise<GeneratedClientAnalyzeWithCustomModelResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -187,14 +181,11 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[2]
       };
     } else {
-      throw new TypeError(
-        `"contentType" must be a valid value but instead was "${args[1]}".`
-      );
+      throw new TypeError(`"contentType" must be a valid value but instead was "${args[1]}".`);
     }
-    return this.sendOperationRequest(
-      operationArguments,
-      operationSpec
-    ) as Promise<GeneratedClientAnalyzeWithCustomModelResponse>;
+    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
+      GeneratedClientAnalyzeWithCustomModelResponse
+    >;
   }
 
   /**
@@ -314,10 +305,7 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeReceiptAsync$binaryOptionalParams?
         ]
-      | [
-          "application/json",
-          GeneratedClientAnalyzeReceiptAsync$jsonOptionalParams?
-        ]
+      | ["application/json", GeneratedClientAnalyzeReceiptAsync$jsonOptionalParams?]
   ): Promise<GeneratedClientAnalyzeReceiptAsyncResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -340,14 +328,11 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[1]
       };
     } else {
-      throw new TypeError(
-        `"contentType" must be a valid value but instead was "${args[0]}".`
-      );
+      throw new TypeError(`"contentType" must be a valid value but instead was "${args[0]}".`);
     }
-    return this.sendOperationRequest(
-      operationArguments,
-      operationSpec
-    ) as Promise<GeneratedClientAnalyzeReceiptAsyncResponse>;
+    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
+      GeneratedClientAnalyzeReceiptAsyncResponse
+    >;
   }
 
   /**
@@ -408,10 +393,7 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeLayoutAsync$binaryOptionalParams?
         ]
-      | [
-          "application/json",
-          GeneratedClientAnalyzeLayoutAsync$jsonOptionalParams?
-        ]
+      | ["application/json", GeneratedClientAnalyzeLayoutAsync$jsonOptionalParams?]
   ): Promise<GeneratedClientAnalyzeLayoutAsyncResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -434,14 +416,11 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[1]
       };
     } else {
-      throw new TypeError(
-        `"contentType" must be a valid value but instead was "${args[0]}".`
-      );
+      throw new TypeError(`"contentType" must be a valid value but instead was "${args[0]}".`);
     }
-    return this.sendOperationRequest(
-      operationArguments,
-      operationSpec
-    ) as Promise<GeneratedClientAnalyzeLayoutAsyncResponse>;
+    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
+      GeneratedClientAnalyzeLayoutAsyncResponse
+    >;
   }
 
   /**
@@ -530,6 +509,7 @@ const trainCustomModelAsyncOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.trainRequest,
   urlParameters: [Parameters.endpoint],
   headerParameters: [Parameters.contentType],
+  mediaType: "json",
   serializer
 };
 const getCustomModelOperationSpec: coreHttp.OperationSpec = {
@@ -574,6 +554,7 @@ const analyzeWithCustomModel$binaryOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.includeTextDetails],
   urlParameters: [Parameters.endpoint, Parameters.modelId],
   headerParameters: [Parameters.contentType1],
+  mediaType: "binary",
   serializer
 };
 const analyzeWithCustomModel$jsonOperationSpec: coreHttp.OperationSpec = {
@@ -591,6 +572,7 @@ const analyzeWithCustomModel$jsonOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.includeTextDetails],
   urlParameters: [Parameters.endpoint, Parameters.modelId],
   headerParameters: [Parameters.contentType2],
+  mediaType: "json",
   serializer
 };
 const getAnalyzeFormResultOperationSpec: coreHttp.OperationSpec = {
@@ -621,6 +603,7 @@ const copyCustomModelOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.copyRequest,
   urlParameters: [Parameters.endpoint, Parameters.modelId],
   headerParameters: [Parameters.contentType],
+  mediaType: "json",
   serializer
 };
 const getCustomModelCopyResultOperationSpec: coreHttp.OperationSpec = {
@@ -634,11 +617,7 @@ const getCustomModelCopyResultOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorResponse
     }
   },
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.modelId,
-    Parameters.resultId1
-  ],
+  urlParameters: [Parameters.endpoint, Parameters.modelId, Parameters.resultId],
   serializer
 };
 const generateModelCopyAuthorizationOperationSpec: coreHttp.OperationSpec = {
@@ -672,6 +651,7 @@ const analyzeReceiptAsync$binaryOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.includeTextDetails],
   urlParameters: [Parameters.endpoint],
   headerParameters: [Parameters.contentType1],
+  mediaType: "binary",
   serializer
 };
 const analyzeReceiptAsync$jsonOperationSpec: coreHttp.OperationSpec = {
@@ -689,6 +669,7 @@ const analyzeReceiptAsync$jsonOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.includeTextDetails],
   urlParameters: [Parameters.endpoint],
   headerParameters: [Parameters.contentType2],
+  mediaType: "json",
   serializer
 };
 const getAnalyzeReceiptResultOperationSpec: coreHttp.OperationSpec = {
@@ -719,6 +700,7 @@ const analyzeLayoutAsync$binaryOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.fileStream,
   urlParameters: [Parameters.endpoint],
   headerParameters: [Parameters.contentType1],
+  mediaType: "binary",
   serializer
 };
 const analyzeLayoutAsync$jsonOperationSpec: coreHttp.OperationSpec = {
@@ -735,6 +717,7 @@ const analyzeLayoutAsync$jsonOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.fileStream1,
   urlParameters: [Parameters.endpoint],
   headerParameters: [Parameters.contentType2],
+  mediaType: "json",
   serializer
 };
 const getAnalyzeLayoutResultOperationSpec: coreHttp.OperationSpec = {

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
@@ -156,7 +156,11 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeWithCustomModel$binaryOptionalParams?
         ]
-      | [string, "application/json", GeneratedClientAnalyzeWithCustomModel$jsonOptionalParams?]
+      | [
+          string,
+          "application/json",
+          GeneratedClientAnalyzeWithCustomModel$jsonOptionalParams?
+        ]
   ): Promise<GeneratedClientAnalyzeWithCustomModelResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -181,11 +185,14 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[2]
       };
     } else {
-      throw new TypeError(`"contentType" must be a valid value but instead was "${args[1]}".`);
+      throw new TypeError(
+        `"contentType" must be a valid value but instead was "${args[1]}".`
+      );
     }
-    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
-      GeneratedClientAnalyzeWithCustomModelResponse
-    >;
+    return this.sendOperationRequest(
+      operationArguments,
+      operationSpec
+    ) as Promise<GeneratedClientAnalyzeWithCustomModelResponse>;
   }
 
   /**
@@ -305,7 +312,10 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeReceiptAsync$binaryOptionalParams?
         ]
-      | ["application/json", GeneratedClientAnalyzeReceiptAsync$jsonOptionalParams?]
+      | [
+          "application/json",
+          GeneratedClientAnalyzeReceiptAsync$jsonOptionalParams?
+        ]
   ): Promise<GeneratedClientAnalyzeReceiptAsyncResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -328,11 +338,14 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[1]
       };
     } else {
-      throw new TypeError(`"contentType" must be a valid value but instead was "${args[0]}".`);
+      throw new TypeError(
+        `"contentType" must be a valid value but instead was "${args[0]}".`
+      );
     }
-    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
-      GeneratedClientAnalyzeReceiptAsyncResponse
-    >;
+    return this.sendOperationRequest(
+      operationArguments,
+      operationSpec
+    ) as Promise<GeneratedClientAnalyzeReceiptAsyncResponse>;
   }
 
   /**
@@ -393,7 +406,10 @@ class GeneratedClient extends GeneratedClientContext {
           coreHttp.HttpRequestBody,
           GeneratedClientAnalyzeLayoutAsync$binaryOptionalParams?
         ]
-      | ["application/json", GeneratedClientAnalyzeLayoutAsync$jsonOptionalParams?]
+      | [
+          "application/json",
+          GeneratedClientAnalyzeLayoutAsync$jsonOptionalParams?
+        ]
   ): Promise<GeneratedClientAnalyzeLayoutAsyncResponse> {
     let operationSpec: coreHttp.OperationSpec;
     let operationArguments: coreHttp.OperationArguments;
@@ -416,11 +432,14 @@ class GeneratedClient extends GeneratedClientContext {
         options: args[1]
       };
     } else {
-      throw new TypeError(`"contentType" must be a valid value but instead was "${args[0]}".`);
+      throw new TypeError(
+        `"contentType" must be a valid value but instead was "${args[0]}".`
+      );
     }
-    return this.sendOperationRequest(operationArguments, operationSpec) as Promise<
-      GeneratedClientAnalyzeLayoutAsyncResponse
-    >;
+    return this.sendOperationRequest(
+      operationArguments,
+      operationSpec
+    ) as Promise<GeneratedClientAnalyzeLayoutAsyncResponse>;
   }
 
   /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { GeneratedClientOptionalParams } from "./models";
 
 const packageName = "@azure/ai-form-recognizer";
 const packageVersion = "1.0.0-preview.5";
@@ -21,10 +21,7 @@ export class GeneratedClientContext extends coreHttp.ServiceClient {
    *                 https://westus2.api.cognitive.microsoft.com).
    * @param options The parameter options
    */
-  constructor(
-    endpoint: string,
-    options?: Models.GeneratedClientOptionalParams
-  ) {
+  constructor(endpoint: string, options?: GeneratedClientOptionalParams) {
     if (endpoint === undefined) {
       throw new Error("'endpoint' cannot be null");
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
@@ -37,7 +37,7 @@ export interface TrainSourceFilter {
   /**
    * A flag to indicate if sub folders within the set of prefix folders will also need to be included when searching for content to be preprocessed.
    */
-  includeSubFolders?: boolean;
+  includeSubfolders?: boolean;
 }
 
 export interface ErrorResponse {

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
@@ -128,7 +128,7 @@ export interface TrainingDocumentInfo {
   /**
    * Training document name.
    */
-  documentName: string;
+  name: string;
   /**
    * Total number of pages trained.
    */
@@ -451,6 +451,7 @@ export interface FieldValue {
   valueDate?: Date;
   /**
    * Time value.
+   * This value should be an ISO-8601 formatted string representing time. E.g. "HH:MM:SS" or "HH:MM:SS.mm".
    */
   valueTime?: string;
   /**
@@ -607,6 +608,9 @@ export interface ModelsSummary {
  * Defines headers for GeneratedClient_trainCustomModelAsync operation.
  */
 export interface GeneratedClientTrainCustomModelAsyncHeaders {
+  /**
+   * Location and ID of the model being trained. The status of model training is specified in the status property at the model location.
+   */
   location?: string;
 }
 
@@ -614,6 +618,9 @@ export interface GeneratedClientTrainCustomModelAsyncHeaders {
  * Defines headers for GeneratedClient_analyzeWithCustomModel operation.
  */
 export interface GeneratedClientAnalyzeWithCustomModelHeaders {
+  /**
+   * URL containing the resultId used to track the progress and obtain the result of the analyze operation.
+   */
   operationLocation?: string;
 }
 
@@ -621,6 +628,9 @@ export interface GeneratedClientAnalyzeWithCustomModelHeaders {
  * Defines headers for GeneratedClient_copyCustomModel operation.
  */
 export interface GeneratedClientCopyCustomModelHeaders {
+  /**
+   * URL containing the resultId used to track the progress and obtain the result of the copy operation.
+   */
   operationLocation?: string;
 }
 
@@ -628,6 +638,9 @@ export interface GeneratedClientCopyCustomModelHeaders {
  * Defines headers for GeneratedClient_generateModelCopyAuthorization operation.
  */
 export interface GeneratedClientGenerateModelCopyAuthorizationHeaders {
+  /**
+   * Location and ID of the model being copied. The status of model copy is specified in the status property at the model location.
+   */
   location?: string;
 }
 
@@ -635,6 +648,9 @@ export interface GeneratedClientGenerateModelCopyAuthorizationHeaders {
  * Defines headers for GeneratedClient_analyzeReceiptAsync operation.
  */
 export interface GeneratedClientAnalyzeReceiptAsyncHeaders {
+  /**
+   * URL containing the resultId used to track the progress and obtain the result of the analyze operation.
+   */
   operationLocation?: string;
 }
 
@@ -642,6 +658,9 @@ export interface GeneratedClientAnalyzeReceiptAsyncHeaders {
  * Defines headers for GeneratedClient_analyzeLayoutAsync operation.
  */
 export interface GeneratedClientAnalyzeLayoutAsyncHeaders {
+  /**
+   * URL containing the resultId used to track the progress and obtain the result of the analyze operation.
+   */
   operationLocation?: string;
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
@@ -54,7 +54,7 @@ export const TrainSourceFilter: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      includeSubFolders: {
+      includeSubfolders: {
         serializedName: "includeSubFolders",
         type: {
           name: "Boolean"

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
@@ -239,7 +239,7 @@ export const TrainingDocumentInfo: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "TrainingDocumentInfo",
     modelProperties: {
-      documentName: {
+      name: {
         serializedName: "documentName",
         required: true,
         type: {

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/parameters.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/parameters.ts
@@ -6,10 +6,18 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
-import * as Mappers from "../models/mappers";
+import {
+  OperationParameter,
+  OperationURLParameter,
+  OperationQueryParameter
+} from "@azure/core-http";
+import {
+  TrainRequest as TrainRequestMapper,
+  SourcePath as SourcePathMapper,
+  CopyRequest as CopyRequestMapper
+} from "../models/mappers";
 
-export const contentType: coreHttp.OperationParameter = {
+export const contentType: OperationParameter = {
   parameterPath: ["options", "contentType"],
   mapper: {
     defaultValue: "application/json",
@@ -21,12 +29,12 @@ export const contentType: coreHttp.OperationParameter = {
   }
 };
 
-export const trainRequest: coreHttp.OperationParameter = {
-  parameterPath: "trainRequest",
-  mapper: Mappers.TrainRequest
-};
+export const trainRequest: OperationParameter = {
+         parameterPath: "trainRequest",
+         mapper: TrainRequestMapper
+       };
 
-export const endpoint: coreHttp.OperationURLParameter = {
+export const endpoint: OperationURLParameter = {
   parameterPath: "endpoint",
   mapper: {
     serializedName: "endpoint",
@@ -38,7 +46,7 @@ export const endpoint: coreHttp.OperationURLParameter = {
   skipEncoding: true
 };
 
-export const modelId: coreHttp.OperationURLParameter = {
+export const modelId: OperationURLParameter = {
   parameterPath: "modelId",
   mapper: {
     serializedName: "modelId",
@@ -49,7 +57,7 @@ export const modelId: coreHttp.OperationURLParameter = {
   }
 };
 
-export const includeKeys: coreHttp.OperationQueryParameter = {
+export const includeKeys: OperationQueryParameter = {
   parameterPath: ["options", "includeKeys"],
   mapper: {
     serializedName: "includeKeys",
@@ -59,24 +67,19 @@ export const includeKeys: coreHttp.OperationQueryParameter = {
   }
 };
 
-export const contentType1: coreHttp.OperationParameter = {
-  parameterPath: "contentType",
-  mapper: {
-    serializedName: "Content-Type",
-    required: true,
-    type: {
-      name: "Enum",
-      allowedValues: [
-        "application/pdf",
-        "image/jpeg",
-        "image/png",
-        "image/tiff"
-      ]
-    }
-  }
-};
+export const contentType1: OperationParameter = {
+         parameterPath: "contentType",
+         mapper: {
+           serializedName: "Content-Type",
+           required: true,
+           type: {
+             name: "Enum",
+             allowedValues: ["application/pdf", "image/jpeg", "image/png", "image/tiff"]
+           }
+         }
+       };
 
-export const fileStream: coreHttp.OperationParameter = {
+export const fileStream: OperationParameter = {
   parameterPath: "fileStream",
   mapper: {
     serializedName: "fileStream",
@@ -87,7 +90,7 @@ export const fileStream: coreHttp.OperationParameter = {
   }
 };
 
-export const contentType2: coreHttp.OperationParameter = {
+export const contentType2: OperationParameter = {
   parameterPath: "contentType",
   mapper: {
     defaultValue: "application/json",
@@ -99,12 +102,12 @@ export const contentType2: coreHttp.OperationParameter = {
   }
 };
 
-export const fileStream1: coreHttp.OperationParameter = {
-  parameterPath: ["options", "fileStream"],
-  mapper: Mappers.SourcePath
-};
+export const fileStream1: OperationParameter = {
+         parameterPath: ["options", "fileStream"],
+         mapper: SourcePathMapper
+       };
 
-export const includeTextDetails: coreHttp.OperationQueryParameter = {
+export const includeTextDetails: OperationQueryParameter = {
   parameterPath: ["options", "includeTextDetails"],
   mapper: {
     serializedName: "includeTextDetails",
@@ -114,7 +117,7 @@ export const includeTextDetails: coreHttp.OperationQueryParameter = {
   }
 };
 
-export const resultId: coreHttp.OperationURLParameter = {
+export const resultId: OperationURLParameter = {
   parameterPath: "resultId",
   mapper: {
     serializedName: "resultId",
@@ -125,23 +128,12 @@ export const resultId: coreHttp.OperationURLParameter = {
   }
 };
 
-export const copyRequest: coreHttp.OperationParameter = {
-  parameterPath: "copyRequest",
-  mapper: Mappers.CopyRequest
-};
+export const copyRequest: OperationParameter = {
+         parameterPath: "copyRequest",
+         mapper: CopyRequestMapper
+       };
 
-export const resultId1: coreHttp.OperationURLParameter = {
-  parameterPath: "resultId",
-  mapper: {
-    serializedName: "resultId",
-    required: true,
-    type: {
-      name: "Uuid"
-    }
-  }
-};
-
-export const op: coreHttp.OperationQueryParameter = {
+export const op: OperationQueryParameter = {
   parameterPath: "op",
   mapper: {
     defaultValue: "full",
@@ -153,7 +145,7 @@ export const op: coreHttp.OperationQueryParameter = {
   }
 };
 
-export const op1: coreHttp.OperationQueryParameter = {
+export const op1: OperationQueryParameter = {
   parameterPath: "op",
   mapper: {
     defaultValue: "summary",
@@ -165,7 +157,7 @@ export const op1: coreHttp.OperationQueryParameter = {
   }
 };
 
-export const nextLink: coreHttp.OperationURLParameter = {
+export const nextLink: OperationURLParameter = {
   parameterPath: "nextLink",
   mapper: {
     serializedName: "nextLink",

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/parameters.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/parameters.ts
@@ -30,9 +30,9 @@ export const contentType: OperationParameter = {
 };
 
 export const trainRequest: OperationParameter = {
-         parameterPath: "trainRequest",
-         mapper: TrainRequestMapper
-       };
+  parameterPath: "trainRequest",
+  mapper: TrainRequestMapper
+};
 
 export const endpoint: OperationURLParameter = {
   parameterPath: "endpoint",
@@ -68,16 +68,21 @@ export const includeKeys: OperationQueryParameter = {
 };
 
 export const contentType1: OperationParameter = {
-         parameterPath: "contentType",
-         mapper: {
-           serializedName: "Content-Type",
-           required: true,
-           type: {
-             name: "Enum",
-             allowedValues: ["application/pdf", "image/jpeg", "image/png", "image/tiff"]
-           }
-         }
-       };
+  parameterPath: "contentType",
+  mapper: {
+    serializedName: "Content-Type",
+    required: true,
+    type: {
+      name: "Enum",
+      allowedValues: [
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "image/tiff"
+      ]
+    }
+  }
+};
 
 export const fileStream: OperationParameter = {
   parameterPath: "fileStream",
@@ -103,9 +108,9 @@ export const contentType2: OperationParameter = {
 };
 
 export const fileStream1: OperationParameter = {
-         parameterPath: ["options", "fileStream"],
-         mapper: SourcePathMapper
-       };
+  parameterPath: ["options", "fileStream"],
+  mapper: SourcePathMapper
+};
 
 export const includeTextDetails: OperationQueryParameter = {
   parameterPath: ["options", "includeTextDetails"],
@@ -129,9 +134,9 @@ export const resultId: OperationURLParameter = {
 };
 
 export const copyRequest: OperationParameter = {
-         parameterPath: "copyRequest",
-         mapper: CopyRequestMapper
-       };
+  parameterPath: "copyRequest",
+  mapper: CopyRequestMapper
+};
 
 export const op: OperationQueryParameter = {
   parameterPath: "op",

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/train/poller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/train/poller.ts
@@ -166,7 +166,7 @@ function makeBeginTrainingPollOperation(
           const additionalInfo = model.trainingDocuments
             ?.map(
               (d) =>
-                `  document: ${d.documentName}, status: ${d.status}, errors: ${d.errors
+                `  document: ${d.name}, status: ${d.status}, errors: ${d.errors
                   ?.map((e) => `code ${e.code}, message: '${e.message}'`)
                   .join("\n")}`
             )

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -75,10 +75,6 @@ export interface FormWord extends FormElementCommon {
    * Confidence value.
    */
   confidence?: number;
-  /**
-   * The recognized text line that contains this recognized word
-   */
-  containingLine?: FormLine;
 }
 
 /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -263,7 +263,7 @@ export type FormField = {
       valueType?: "array";
     }
   | {
-      value?: { [propertyName: string]: FormField };
+      value?: Record<string, FormField>;
       valueType?: "object";
     }
 );
@@ -346,7 +346,7 @@ export interface RecognizedForm {
   /**
    * Dictionary of named field values.
    */
-  fields: { [propertyName: string]: FormField };
+  fields: Record<string, FormField>;
   /**
    * Texts and tables extracted from a page in the input
    */
@@ -429,7 +429,7 @@ export interface CustomFormModelInfo {
   trainingCompletedOn: Date;
 }
 
-export interface CustomFormField {
+export interface CustomFormModelField {
   /**
    * Estimated extraction accuracy for this field.
    */
@@ -455,7 +455,7 @@ export interface CustomFormSubmodel {
   /**
    * Form fields
    */
-  fields: { [propertyName: string]: CustomFormField };
+  fields: Record<string, CustomFormModelField>;
   /**
    * Form type
    */

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -388,7 +388,7 @@ export interface TrainingDocumentInfo {
   /**
    * Training document name.
    */
-  documentName: string;
+  name: string;
   /**
    * Total number of pages trained.
    */

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -5,7 +5,6 @@ import * as coreHttp from "@azure/core-http";
 
 import {
   FormFieldsReport,
-  CopyAuthorizationResult as CopyAuthorizationResultModel,
   KeysResult,
   KeyValueElement as KeyValueElementModel,
   KeyValuePair as KeyValuePairModel,
@@ -19,7 +18,6 @@ import {
 } from "./generated/models";
 
 export {
-  CopyAuthorizationResultModel,
   FormFieldsReport,
   KeysResult,
   KeyValueElementModel,
@@ -636,7 +634,15 @@ export interface FormRecognizerError {
 /**
  * Request parameter that contains authorization claims for copy operation.
  */
-export interface CopyAuthorization extends CopyAuthorizationResultModel {
+export interface CopyAuthorization {
+  /**
+   * Model identifier.
+   */
+  modelId: string;
+  /**
+   * Token claim used to authorize the copy request.
+   */
+  accessToken: string;
   /**
    * Target resource Id.
    */

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -132,11 +132,11 @@ export interface FormTableCell {
   /**
    * Number of rows spanned by this cell.
    */
-  rowSpan?: number;
+  rowSpan: number;
   /**
    * Number of columns spanned by this cell.
    */
-  columnSpan?: number;
+  columnSpan: number;
   /**
    * Text content of the cell.
    */
@@ -156,11 +156,11 @@ export interface FormTableCell {
   /**
    * Is the current cell a header cell?
    */
-  isHeader?: boolean;
+  isHeader: boolean;
   /**
    * Is the current cell a footer cell?
    */
-  isFooter?: boolean;
+  isFooter: boolean;
 }
 
 /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -157,6 +157,10 @@ export interface FormTableCell {
    * Is the current cell a footer cell?
    */
   isFooter: boolean;
+  /**
+   * The 1-based page number in the input document where the table cell appears.
+   */
+  pageNumber: number;
 }
 
 /**
@@ -175,6 +179,10 @@ export interface FormTable {
    * List of cells in the data table
    */
   cells: FormTableCell[];
+  /**
+   * The 1-based page number in the input document where the table appears.
+   */
+  pageNumber: number;
 }
 
 /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -119,22 +119,28 @@ export function toFormFieldFromKeyValuePairModel(
   };
 }
 
-export function toFormTable(original: DataTableModel, readResults?: FormPage[]): FormTable {
+export function toFormTable(
+  original: DataTableModel,
+  readResults: FormPage[],
+  pageNumber: number
+): FormTable {
   return {
     rowCount: original.rows,
     columnCount: original.columns,
     cells: original.cells.map((cell) => ({
       boundingBox: toBoundingBox(cell.boundingBox),
       columnIndex: cell.columnIndex,
-      fieldElements: cell.elements?.map((element) => toFormContent(element, readResults!)),
+      fieldElements: cell.elements?.map((element) => toFormContent(element, readResults)),
       rowIndex: cell.rowIndex,
       columnSpan: cell.columnSpan ?? 1,
       rowSpan: cell.rowSpan ?? 1,
       isHeader: cell.isHeader ?? false,
       isFooter: cell.isFooter ?? false,
       confidence: cell.confidence ?? 1,
-      text: cell.text
-    }))
+      text: cell.text,
+      pageNumber
+    })),
+    pageNumber
   };
 }
 
@@ -152,7 +158,9 @@ export function toFormPages(
     if (readResult) {
       const pageResult = pageMap.get(pageNumber);
       if (pageResult) {
-        readResult.tables = pageResult.tables?.map((table) => toFormTable(table, transformed));
+        readResult.tables = pageResult.tables?.map((table) =>
+          toFormTable(table, transformed!, pageNumber)
+        );
         result.push(readResult);
       }
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -129,13 +129,13 @@ export function toFormTable(original: DataTableModel, readResults?: FormPage[]):
     cells: original.cells.map((cell) => ({
       boundingBox: toBoundingBox(cell.boundingBox),
       columnIndex: cell.columnIndex,
-      columnSpan: cell.columnSpan || 1,
-      confidence: cell.confidence || 1,
       fieldElements: cell.elements?.map((element) => toFormContent(element, readResults!)),
-      isFooter: cell.isFooter || false,
-      isHeader: cell.isHeader || false,
       rowIndex: cell.rowIndex,
-      rowSpan: cell.rowSpan || 1,
+      columnSpan: cell.columnSpan ?? 1,
+      rowSpan: cell.rowSpan ?? 1,
+      isHeader: cell.isHeader ?? false,
+      isFooter: cell.isFooter ?? false,
+      confidence: cell.confidence ?? 1,
       text: cell.text
     }))
   };

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -27,7 +27,7 @@ import {
   FormField,
   Point2D,
   FormModelResponse,
-  CustomFormField,
+  CustomFormModelField,
   CustomFormSubmodel
 } from "./models";
 import { RecognizeFormResultResponse, RecognizeContentResultResponse } from "./internalModels";
@@ -396,7 +396,7 @@ export function toFormModelResponse(response: GetCustomModelResponse): FormModel
 
   if (response.trainResult?.averageModelAccuracy || response.trainResult?.fields) {
     // training with forms and labels, populate from trainingResult.fields
-    const fields: { [propertyName: string]: CustomFormField } = {};
+    const fields: Record<string, CustomFormModelField> = {};
     for (const f of response.trainResult.fields!) {
       fields[f.fieldName] = { name: f.fieldName, accuracy: f.accuracy, label: null };
     }
@@ -415,7 +415,7 @@ export function toFormModelResponse(response: GetCustomModelResponse): FormModel
     const submodels: CustomFormSubmodel[] = [];
     for (const clusterKey in response.keys.clusters) {
       const cluster = response.keys.clusters[clusterKey];
-      const fields: { [propertyName: string]: CustomFormField } = {};
+      const fields: Record<string, CustomFormModelField> = {};
 
       for (let i = 0; i < cluster.length; i++) {
         fields[`field-${i}`] = { name: `field-${i}`, label: cluster[i] };

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -57,9 +57,6 @@ export function toTextLine(original: TextLineModel, pageNumber: number): FormLin
       };
     })
   };
-  line.words = line.words.map((w) => {
-    return { ...w, containingLine: line };
-  });
 
   return line;
 }

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -137,3 +137,13 @@ directive:
   where: $.definitions.TrainingDocumentInfo.properties.documentName
   transform: >
     $["x-ms-client-name"] = "name";
+```
+
+### `includeSubFolders` => `includeSubfolders`
+```yaml
+directive:
+- from: swagger-document
+  where: $.definitions.TrainSourceFilter.properties.includeSubFolders
+  transform: >
+    $["x-ms-client-name"] = "includeSubfolders";
+```

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -17,7 +17,7 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
-  "@autorest/typescript": "6.0.0-dev.20200505.1"
+  "@autorest/typescript": "6.0.0-dev.20200717.1"
 ```
 
 ## Customizations for Track 2 Generator
@@ -129,3 +129,11 @@ directive:
         }
     }
 ```
+
+### `documentName` => `name`
+```yaml
+directive:
+- from: swagger-document
+  where: $.definitions.TrainingDocumentInfo.properties.documentName
+  transform: >
+    $["x-ms-client-name"] = "name";

--- a/sdk/formrecognizer/ai-form-recognizer/test/browser/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/browser/formtrainingclient.spec.ts
@@ -40,7 +40,7 @@ describe("FormTrainingClient browser only", () => {
   });
 
   const expectedDocumentInfo: TrainingDocumentInfo = {
-    documentName: "Form_1.jpg",
+    name: "Form_1.jpg",
     errors: [],
     pageCount: 1,
     status: "succeeded"
@@ -91,10 +91,7 @@ describe("FormTrainingClient browser only", () => {
     assert.ok(model.fields["Signature"], "Expecting field with name 'Signature' to be valid");
 
     // TODO: why training with labels is missing `errors` array?
-    assert.deepStrictEqual(
-      response?.trainingDocuments![0].documentName,
-      expectedDocumentInfo.documentName
-    );
+    assert.deepStrictEqual(response?.trainingDocuments![0].name, expectedDocumentInfo.name);
   });
 
   it("trains model with forms and no labels including sub folders", async () => {

--- a/sdk/formrecognizer/ai-form-recognizer/test/browser/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/browser/formtrainingclient.spec.ts
@@ -99,7 +99,7 @@ describe("FormTrainingClient browser only", () => {
     assert.ok(containerSasUrl, "Expect valid container sas url");
 
     const poller = await trainingClient.beginTraining(containerSasUrl, false, {
-      includeSubFolders: true
+      includeSubfolders: true
     });
     const response = await poller.pollUntilDone();
 

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
@@ -21,7 +21,7 @@ describe("FormRecognizerClient NodeJS only", () => {
 
   afterEach(async function() {
     if (recorder) {
-      await recorder.stop();
+      recorder.stop();
     }
   });
 
@@ -29,7 +29,9 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "forms", "Invoice_1.pdf");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeContent(stream, "application/pdf");
+    const poller = await client.beginRecognizeContent(stream, {
+      contentType: "application/pdf"
+    });
     const pages = await poller.pollUntilDone();
 
     assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
@@ -41,7 +43,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "receipt", "contoso-receipt.png");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeContent(stream, "image/png");
+    const poller = await client.beginRecognizeContent(stream, { contentType: "image/png" });
     const pages = await poller.pollUntilDone();
 
     assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
@@ -51,7 +53,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "forms", "Form_1.jpg");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeContent(stream, "image/jpeg");
+    const poller = await client.beginRecognizeContent(stream, { contentType: "image/jpeg" });
     const pages = await poller.pollUntilDone();
 
     assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
@@ -61,7 +63,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "forms", "Invoice_1.tiff");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeContent(stream, "image/tiff");
+    const poller = await client.beginRecognizeContent(stream, { contentType: "image/tiff" });
     const pages = await poller.pollUntilDone();
 
     assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);
@@ -92,7 +94,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "receipt", "contoso-receipt.png");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeReceipts(stream, "image/png");
+    const poller = await client.beginRecognizeReceipts(stream, { contentType: "image/png" });
     const receipts = await poller.pollUntilDone();
 
     assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
@@ -112,7 +114,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "receipt", "contoso-allinone.jpg");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeReceipts(stream, "image/jpeg");
+    const poller = await client.beginRecognizeReceipts(stream, { contentType: "image/jpeg" });
     const receipts = await poller.pollUntilDone();
 
     assert.ok(receipts && receipts.length > 0, `Expect no-empty pages but got ${receipts}`);
@@ -137,7 +139,8 @@ describe("FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "receipt", "multipage_invoice1.pdf");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeReceipts(stream, "application/pdf", {
+    const poller = await client.beginRecognizeReceipts(stream, {
+      contentType: "application/pdf",
       includeFieldElements: true
     });
     const receipts = await poller.pollUntilDone();
@@ -159,7 +162,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
 
   afterEach(async function() {
     if (recorder) {
-      await recorder.stop();
+      recorder.stop();
     }
   });
 
@@ -167,7 +170,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
     const filePath = path.join(ASSET_PATH, "forms", "Invoice_1.pdf");
     const stream = fs.createReadStream(filePath);
 
-    const poller = await client.beginRecognizeContent(stream, "application/pdf");
+    const poller = await client.beginRecognizeContent(stream, { contentType: "application/pdf" });
     const pages = await poller.pollUntilDone();
 
     assert.ok(pages && pages.length > 0, `Expect no-empty pages but got ${pages}`);

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -42,7 +42,7 @@ describe("FormTrainingClient NodeJS only", () => {
   });
 
   const expectedDocumentInfo: TrainingDocumentInfo = {
-    documentName: "Form_1.jpg",
+    name: "Form_1.jpg",
     errors: [],
     pageCount: 1,
     status: "succeeded"
@@ -95,10 +95,7 @@ describe("FormTrainingClient NodeJS only", () => {
     assert.ok(model.fields["Signature"], "Expecting field with name 'Signature' to be valid");
 
     // TODO: why training with labels is missing `errors` array?
-    assert.deepStrictEqual(
-      response?.trainingDocuments![0].documentName,
-      expectedDocumentInfo.documentName
-    );
+    assert.deepStrictEqual(response?.trainingDocuments![0].name, expectedDocumentInfo.name);
   });
 
   it("trains model with forms and no labels including sub folders", async () => {

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -103,7 +103,7 @@ describe("FormTrainingClient NodeJS only", () => {
     assert.ok(containerSasUrl, "Expect valid container sas url");
 
     const poller = await trainingClient.beginTraining(containerSasUrl, false, {
-      includeSubFolders: true
+      includeSubfolders: true
     });
     const response = await poller.pollUntilDone();
 

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -214,8 +214,6 @@ describe("FormTrainingClient NodeJS only", () => {
     const resourceRegion = env.FORM_RECOGNIZER_TARGET_RESOURCE_REGION;
     const targetAuth = await trainingClient.getCopyAuthorization(resourceId, resourceRegion);
 
-    assert.ok(targetAuth.expiresOn.getTime() / 1000 === targetAuth.expirationDateTimeTicks);
-
     assert.ok(labeledModelId, "Expecting valide model id in source");
     const poller = await trainingClient.beginCopyModel(labeledModelId!, targetAuth);
     const result = await poller.pollUntilDone();

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -248,11 +248,9 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
     const stream = fs.createReadStream(filePath);
 
     assert.ok(unlabeledModelId, "Expecting valid model id from training without labels");
-    const poller = await recognizerClient.beginRecognizeCustomForms(
-      unlabeledModelId!,
-      stream,
-      "image/jpeg"
-    );
+    const poller = await recognizerClient.beginRecognizeCustomForms(unlabeledModelId!, stream, {
+      contentType: "image/jpeg"
+    });
     const forms = await poller.pollUntilDone();
 
     assert.ok(forms && forms.length > 0, `Expect no-empty pages but got ${forms}`);
@@ -295,11 +293,9 @@ describe("FormRecognizerClient form recognition NodeJS", () => {
     const stream = fs.createReadStream(filePath);
 
     assert.ok(unlabeledModelId, "Expecting valid model id from training without labels");
-    const poller = await recognizerClient.beginRecognizeCustomForms(
-      labeledModelId!,
-      stream,
-      "image/jpeg"
-    );
+    const poller = await recognizerClient.beginRecognizeCustomForms(labeledModelId!, stream, {
+      contentType: "image/jpeg"
+    });
     const forms = await poller.pollUntilDone();
 
     assert.ok(forms && forms.length > 0, `Expect no-empty pages but got ${forms}`);

--- a/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
@@ -74,9 +74,6 @@ describe("Transforms", () => {
     assert.deepStrictEqual(transformed.words[1].text, originalLine1.words[1].text);
     assert.deepStrictEqual(transformed.words[1].confidence, originalLine1.words[1].confidence);
     assert.deepStrictEqual(transformed.words[1].pageNumber, pageNumber);
-
-    assert.equal(transformed.words[0].containingLine, transformed);
-    assert.equal(transformed.words[1].containingLine, transformed);
   });
 
   const originalLine2 = {

--- a/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/transforms.spec.ts
@@ -445,17 +445,20 @@ describe("Transforms", () => {
       ]
     };
 
-    const transformed = toFormTable(originalTable, formPages);
+    const transformed = toFormTable(originalTable, formPages, 1);
 
     assert.equal(transformed.rowCount, originalTable.rows);
+    assert.equal(transformed.pageNumber, 1);
     assert.equal(transformed.cells[0].text, originalTable.cells[0].text);
     assert.equal(transformed.cells[3].confidence, originalTable.cells[3].confidence);
 
+    assert.equal(transformed.cells[0].pageNumber, 1);
     assert.equal(transformed.cells[0].isHeader, true);
     assert.equal(transformed.cells[0].isFooter, false);
     assert.equal(transformed.cells[0].rowSpan, 1);
     assert.equal(transformed.cells[0].columnSpan, 1);
 
+    assert.equal(transformed.cells[4].pageNumber, 1);
     assert.equal(transformed.cells[4].isHeader, false);
     assert.equal(transformed.cells[4].isFooter, true);
     assert.equal(transformed.cells[4].rowSpan, 1);


### PR DESCRIPTION
This is a set of changes for alignment with other languages on the final Form Recognizer.

- Added a `pageNumber` property to the `FormTable` and `FormTableCell` types indicating the number of the page where the table/cell appeared within the input document.
- [Breaking] Renamed the `includeSubFolders` property of the `TrainSourceFilter` type to `includeSubfolders`.
- [Breaking] Renamed the `documentName` property of the `TrainingDocumentInfo` type to just `name`.
- [Breaking] Removed the `containingLine` property of the `FormWord` type.
- Made the `rowSpan`, `columnSpan`, `isHeader`, and `isFooter` properties of the `FormTableCell` type non-optional to reflect that they have default values.
- [Breaking] Renamed `CustomFormField` to `CustomFormModelField` for similarity to other language SDKs.
- [Breaking] Removed the redundant `expirationDateTimeTicks` property from the `CopyAuthorization` type, as the `expiresOn` property exists.
- [Breaking] Moved the optional `contentType` parameter of the `FormRecognizerClient` recognition methods (`recognizeContent`, `recognizeCustomForms`, `recognizeReceipts`, and their URL-based variants) to the associated options bag for these methods.

In addition, the samples have been updated to reflect the above changes and some code style improvements (see #10234):
- simplified tests of return value lengths for safety
- removed printing of "First receipt" and other such text when only one object is expected in the output
- Replaced uses of `for ... in v` with `for [name, value] of Object.entries(v)` or similar
- Removed most non-idiomatic index tracking variables (such as `let i = 0;` with `i++` in loop body)
- Converted the strongly typed model example to use a type-only coercion (CC @bterlson -- thoughts on `samples/typescript/src/stronglyTypingRecognizedForm.ts` ?)
- Regenerated JS samples to be like the TypeScript samples
