### PR TITLE
Fix TS 4.0 breaks

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -66,7 +66,7 @@ const getTypeOfParam = (
   ) as TypeReference;
 
   // if array, extract type from array
-    const typeNode = typeChecker.typeToTypeNode(type, undefined, undefined);
+  const typeNode = typeChecker.typeToTypeNode(type, undefined, undefined);
   if (typeNode !== undefined && isArrayTypeNode(typeNode)) {
     const elementTypeReference = typeNode.elementType as TypeReferenceNode;
     const typeName = elementTypeReference.typeName as any;
@@ -105,7 +105,7 @@ const addSeenSymbols = (symbol: TSSymbol, symbols: TSSymbol[], typeChecker: Type
     .getPropertiesOfType(typeChecker.getDeclaredTypeOfSymbol(symbol))
     .forEach((element: TSSymbol): void => {
       const memberType = typeChecker.getTypeAtLocation(element.valueDeclaration);
-        const memberTypeNode = typeChecker.typeToTypeNode(memberType, undefined, undefined);
+      const memberTypeNode = typeChecker.typeToTypeNode(memberType, undefined, undefined);
 
       // extract type of member
       let memberSymbol: TSSymbol | undefined;

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -66,7 +66,7 @@ const getTypeOfParam = (
   ) as TypeReference;
 
   // if array, extract type from array
-  const typeNode = typeChecker.typeToTypeNode(type);
+    const typeNode = typeChecker.typeToTypeNode(type, undefined, undefined);
   if (typeNode !== undefined && isArrayTypeNode(typeNode)) {
     const elementTypeReference = typeNode.elementType as TypeReferenceNode;
     const typeName = elementTypeReference.typeName as any;
@@ -105,7 +105,7 @@ const addSeenSymbols = (symbol: TSSymbol, symbols: TSSymbol[], typeChecker: Type
     .getPropertiesOfType(typeChecker.getDeclaredTypeOfSymbol(symbol))
     .forEach((element: TSSymbol): void => {
       const memberType = typeChecker.getTypeAtLocation(element.valueDeclaration);
-      const memberTypeNode = typeChecker.typeToTypeNode(memberType);
+        const memberTypeNode = typeChecker.typeToTypeNode(memberType, undefined, undefined);
 
       // extract type of member
       let memberSymbol: TSSymbol | undefined;

--- a/sdk/appconfiguration/app-configuration/test/policies/throttlingRetryPolicyTests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/policies/throttlingRetryPolicyTests.spec.ts
@@ -65,8 +65,8 @@ describe("ThrottlingRetryPolicy", () => {
       const policy = createDefaultThrottlingRetryPolicy();
       const response = await policy.sendRequest(request);
       // requestId is unique, even across retries.
-      delete response.request.requestId;
-      delete request.requestId;
+      delete (response as any).request.requestId;
+      delete (request as any).requestId;
       chai.assert.deepEqual(response.request, request);
     });
 

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -99,7 +99,7 @@ Headers: {
       "x-ms-safe-header": "It me",
       "x-ms-oh-noes": ":-p"
     });
-    delete request.requestId;
+    delete (request as any).requestId;
     assertLog(request, expected, done);
   });
 
@@ -123,7 +123,7 @@ Headers: {
 `;
 
     const request = new WebResource("https://foo.com", "PUT", { a: 1 });
-    delete request.requestId;
+    delete (request as any).requestId;
     assertLog(request, expected, done, {
       "x-ms-safe-header": "It me",
       "x-ms-oh-noes": ":-p"
@@ -153,7 +153,7 @@ Headers: {
       "Capitalized-Header": "Don't redact me, bro",
       "x-ms-safe-header": "It me"
     });
-    delete request.requestId;
+    delete (request as any).requestId;
     assertLog(request, expected, done);
   });
 
@@ -183,7 +183,7 @@ Headers: {
       { a: 1 },
       { "api-version": "1.0", secret: "goose" }
     );
-    delete request.requestId;
+    delete (request as any).requestId;
     assertLog(request, expected, done);
   });
 
@@ -206,7 +206,7 @@ Headers: {
     const request = new WebResource("https://foo.com?api-version=1.0&secret=goose", "PUT", {
       a: 1
     });
-    delete request.requestId;
+    delete (request as any).requestId;
     assertLog(request, expected, done);
   });
 });

--- a/sdk/core/core-http/test/policies/exponentialRetryPolicyTests.spec.ts
+++ b/sdk/core/core-http/test/policies/exponentialRetryPolicyTests.spec.ts
@@ -79,8 +79,8 @@ describe("ExponentialRetryPolicy", () => {
 
       const policy = createDefaultExponentialRetryPolicy();
       const response = await policy.sendRequest(request);
-      delete response.request.requestId;
-      delete request.requestId;
+      delete (response as any).request.requestId;
+      delete (request as any).requestId;
 
       assert.deepEqual(response.request, request);
     });
@@ -104,8 +104,8 @@ describe("ExponentialRetryPolicy", () => {
         );
 
         const response = await policy.sendRequest(request);
-        delete request.requestId;
-        delete response.request.requestId;
+        delete (request as any).requestId;
+        delete (response as any).request.requestId;
         assert.deepEqual(response, mockResponse, "Expecting response matches after retrying");
         assert.ok(faultyPolicy.count > 1, "Retry should have happened");
       });

--- a/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
+++ b/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
@@ -85,8 +85,8 @@ describe("SystemErrorRetryPolicy", () => {
 
       const policy = createDefaultSystemErrorRetryPolicy();
       const response = await policy.sendRequest(request);
-      delete response.request.requestId;
-      delete request.requestId;
+      delete (response as any).request.requestId;
+      delete (request as any).requestId;
 
       assert.deepEqual(response.request, request);
     });
@@ -111,8 +111,8 @@ describe("SystemErrorRetryPolicy", () => {
         );
 
         const response = await policy.sendRequest(request);
-        delete request.requestId;
-        delete response.request.requestId;
+        delete (request as any).requestId;
+        delete (response as any).request.requestId;
         assert.deepEqual(response, mockResponse, "Expecting response matches after retrying");
       });
     });

--- a/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
@@ -65,8 +65,8 @@ describe("ThrottlingRetryPolicy", () => {
 
       const policy = createDefaultThrottlingRetryPolicy();
       const response = await policy.sendRequest(request);
-      delete response.request.requestId;
-      delete request.requestId;
+      delete (response.request as any).requestId;
+      delete (request as any).requestId;
 
       assert.deepEqual(response.request, request);
     });
@@ -85,8 +85,8 @@ describe("ThrottlingRetryPolicy", () => {
       });
 
       const response = await policy.sendRequest(request);
-      delete request.requestId;
-      delete response.request.requestId;
+      delete (request as any).requestId;
+      delete (response.request as any).requestId;
 
       assert.deepEqual(response, mockResponse);
     });
@@ -101,15 +101,15 @@ describe("ThrottlingRetryPolicy", () => {
         request: request
       };
       const policy = createDefaultThrottlingRetryPolicy(mockResponse, (_, response) => {
-        delete response.request.requestId;
-        delete mockResponse.request.requestId;
+        delete (response as any).request.requestId;
+        delete (mockResponse as any).request.requestId;
         assert.deepEqual(response, mockResponse);
         return Promise.resolve(response);
       });
 
       const response = await policy.sendRequest(request);
-      delete request.requestId;
-      delete response.request.requestId;
+      delete (request as any).requestId;
+      delete (response as any).request.requestId;
       assert.deepEqual(response, mockResponse);
     });
   });


### PR DESCRIPTION
1. Pass `undefined` to now-required parameters of typeToTypeNode.
2. Fix new error "operand of `delete` must be optional".

Typescript 4.0 only allows deletion of properties that are marked as optional. This allows control flow to narrow the type after deletion to `undefined`, preventing use-after-delete:

```ts
declare var o: { p?: number }
o.p // p: number | undefined

o.p = 12
o.p // p: number
o.p++ // OK

delete o.p
o.p // p: undefined
o.p++ // ERROR
```

Unfortunately, for this to work, the property must include `undefined` in its type. Currently, this PR doesn't actually make properties optional. It just casts the object operand to `any`, which silences the error. Please use this PR as a starting point for an actual fix, which may end up pretty complex.

Fixes #10414, although casting to `any` is *not* a good long-term fix for problem (2).
Edit: I just noticed that all the `delete`s happen in tests, to eliminate unique ids before testing equality, so probably casting to `any` is good enough.

This PR does not upgrade azure-sdk to TS 4.0. We'll have to manually upgrade the repo to 4.0 to test this. I can provide the instructions I used if needed, although they're pretty hacky.