### PR TITLE
[Identity] Renamed the VSCodeCredential to VisualStudioCodeCredential

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0-preview.6 (Unreleased)
 
+- Renamed the `VSCodeCredential` to `VisualStudioCodeCredential`, and its options parameter from `VSCodeCredentialOptions` to `VisualStudioCodeCredentialOptions`.
 
 ## 1.1.0-preview.5 (2020-07-22)
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -164,13 +164,13 @@ export class UsernamePasswordCredential implements TokenCredential {
     }
 
 // @public
-export class VSCodeCredential implements TokenCredential {
-    constructor(options?: VSCodeCredentialOptions);
+export class VisualStudioCodeCredential implements TokenCredential {
+    constructor(options?: VisualStudioCodeCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
 
 // @public
-export interface VSCodeCredentialOptions extends TokenCredentialOptions {
+export interface VisualStudioCodeCredentialOptions extends TokenCredentialOptions {
     tenantId?: string;
 }
 

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
@@ -6,7 +6,7 @@ import { ChainedTokenCredential } from "./chainedTokenCredential";
 import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 import { AzureCliCredential } from "./azureCliCredential";
-import { VSCodeCredential } from "./vscodeCredential";
+import { VisualStudioCodeCredential } from "./visualStudioCodeCredential";
 
 /**
  * Provides a default {@link ChainedTokenCredential} configuration for
@@ -30,7 +30,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     credentials.push(new EnvironmentCredential(tokenCredentialOptions));
     credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
     credentials.push(new AzureCliCredential());
-    credentials.push(new VSCodeCredential(tokenCredentialOptions));
+    credentials.push(new VisualStudioCodeCredential(tokenCredentialOptions));
 
     super(...credentials);
   }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -6,7 +6,7 @@ import { ChainedTokenCredential } from "./chainedTokenCredential";
 import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 import { AzureCliCredential } from "./azureCliCredential";
-import { VSCodeCredential } from "./vscodeCredential";
+import { VisualStudioCodeCredential } from "./visualStudioCodeCredential";
 
 /**
  * Provides options to configure the default Azure credentials.
@@ -45,7 +45,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
       );
     }
     credentials.push(new AzureCliCredential());
-    credentials.push(new VSCodeCredential(tokenCredentialOptions));
+    credentials.push(new VisualStudioCodeCredential(tokenCredentialOptions));
 
     super(...credentials);
     this.UnavailableMessage =

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.browser.ts
@@ -7,10 +7,12 @@ import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http"
 import { TokenCredentialOptions } from "../client/identityClient";
 import { credentialLogger, formatError } from "../util/logging";
 
-const BrowserNotSupportedError = new Error("VSCodeCredential is not supported in the browser.");
-const logger = credentialLogger("VSCodeCredential");
+const BrowserNotSupportedError = new Error(
+  "VisualStudioCodeCredential is not supported in the browser."
+);
+const logger = credentialLogger("VisualStudioCodeCredential");
 
-export class VSCodeCredential implements TokenCredential {
+export class VisualStudioCodeCredential implements TokenCredential {
   constructor(options?: TokenCredentialOptions) {
     logger.info(formatError(BrowserNotSupportedError));
     throw BrowserNotSupportedError;

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -18,12 +18,12 @@ import { credentialLogger, formatSuccess, formatError } from "../util/logging";
 const CommonTenantId = "common";
 const AzureAccountClientId = "aebc6443-996d-45c2-90f0-388ff96faa56"; // VSC: 'aebc6443-996d-45c2-90f0-388ff96faa56'
 const VSCodeUserName = "VS Code Azure";
-const logger = credentialLogger("VSCodeCredential");
+const logger = credentialLogger("VisualStudioCodeCredential");
 
 /**
  * Provides options to configure the Visual Studio Code credential.
  */
-export interface VSCodeCredentialOptions extends TokenCredentialOptions {
+export interface VisualStudioCodeCredentialOptions extends TokenCredentialOptions {
   /**
    * Optionally pass in a Tenant ID to be used as part of the credential
    */
@@ -35,16 +35,16 @@ export interface VSCodeCredentialOptions extends TokenCredentialOptions {
  * Once the user has logged in via the extension, this credential can share the same refresh token
  * that is cached by the extension.
  */
-export class VSCodeCredential implements TokenCredential {
+export class VisualStudioCodeCredential implements TokenCredential {
   private identityClient: IdentityClient;
   private tenantId: string;
 
   /**
-   * Creates an instance of VSCodeCredential to use for automatically authenticating via VSCode.
+   * Creates an instance of VisualStudioCodeCredential to use for automatically authenticating via VSCode.
    *
    * @param options Options for configuring the client which makes the authentication request.
    */
-  constructor(options?: VSCodeCredentialOptions) {
+  constructor(options?: VisualStudioCodeCredentialOptions) {
     this.identityClient = new IdentityClient(options);
     if (options && options.tenantId) {
       this.tenantId = options.tenantId;

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -10,7 +10,10 @@ export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
-export { VSCodeCredential, VSCodeCredentialOptions } from "./credentials/vscodeCredential";
+export {
+  VisualStudioCodeCredential as VSCodeCredential,
+  VisualStudioCodeCredentialOptions as VSCodeCredentialOptions
+} from "./credentials/visualStudioCodeCredential";
 export { AzureCliCredential } from "./credentials/azureCliCredential";
 
 export {

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -11,8 +11,8 @@ export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
 export {
-  VisualStudioCodeCredential as VSCodeCredential,
-  VisualStudioCodeCredentialOptions as VSCodeCredentialOptions
+  VisualStudioCodeCredential,
+  VisualStudioCodeCredentialOptions
 } from "./credentials/visualStudioCodeCredential";
 export { AzureCliCredential } from "./credentials/azureCliCredential";
 


### PR DESCRIPTION
Renamed the VSCodeCredential to VisualStudioCodeCredential.

Fixes #10418