### PR TITLE
examples folder is not present and gives bad link

### DIFF
--- a/sdk/monitor/opentelemetry-exporter/README.md
+++ b/sdk/monitor/opentelemetry-exporter/README.md
@@ -61,7 +61,7 @@ Coming Soon
 
 ## Examples
 
-Please take a look at the [examples](../examples) to see how to add the Azure Monitor Exporter to your existing OpenTelemetry instrumented project.
+Please take a look at the `examples` to see how to add the Azure Monitor Exporter to your existing OpenTelemetry instrumented project.
 
 ## Key concepts
 

--- a/sdk/monitor/opentelemetry-exporter/README.md
+++ b/sdk/monitor/opentelemetry-exporter/README.md
@@ -61,7 +61,7 @@ Coming Soon
 
 ## Examples
 
-Please take a look at the `examples` to see how to add the Azure Monitor Exporter to your existing OpenTelemetry instrumented project.
+Coming soon // TODO: Update this with link to samples when we have some
 
 ## Key concepts
 


### PR DESCRIPTION
Opentelemetry looks like newly migrated into our repo and doesn't have the samples/ examplesfolder yet. Let's avoid adding links to non-exisiting folders that happened as a result of this PR - https://github.com/Azure/azure-sdk-for-js/pull/10104 - cc: @markwolff @xirzec 