### PR TITLE
[core-amqp] remove stream-browserify dependency

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -24,8 +24,7 @@
   "browser": {
     "./dist-esm/src/util/checkNetworkConnection.js": "./dist-esm/src/util/checkNetworkConnection.browser.js",
     "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js",
-    "buffer": "buffer",
-    "stream": "stream-browserify"
+    "buffer": "buffer"
   },
   "files": [
     "dist/",
@@ -83,7 +82,6 @@
     "process": "^0.11.10",
     "rhea": "^1.0.21",
     "rhea-promise": "^1.0.0",
-    "stream-browserify": "^3.0.0",
     "tslib": "^2.0.0",
     "url": "^0.11.0",
     "util": "^0.12.1"


### PR DESCRIPTION
Fixes #9313 

I tested this by running the event hubs live tests (uses rollup) and the event hubs browser sample (uses webpack).

/cc @HarshaNalluru This can wait until after the impending core-amqp release to be merged, there's no rush.