### PR TITLE
[test,recorder] Change to target es5

### DIFF
--- a/sdk/test-utils/recorder/tsconfig.json
+++ b/sdk/test-utils/recorder/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
     "declarationDir": "./typings",
+    "target": "es5",
     "outDir": "./dist-esm",
     "lib": ["dom", "es5", "es6", "es7", "esnext"]
   },


### PR DESCRIPTION
so that bundled storage browser tests can run on IE11