### PR TITLE
[Service Bus] Improve err msg when failing to senders and receivers

### DIFF
--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -337,6 +337,12 @@ export class MessageReceiver extends LinkEntity {
         this.name,
         err
       );
+
+      // Fix the unhelpful error messages for the OperationTimeoutError that comes from `rhea-promise`.
+      if ((err as MessagingError).code === "OperationTimeoutError") {
+        err.message = "Failed to create a receiver within allocated time and retry attempts.";
+      }
+
       throw err;
     }
   }

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -460,6 +460,10 @@ export class MessageSender extends LinkEntity {
           this.name,
           err
         );
+        // Fix the unhelpful error messages for the OperationTimeoutError that comes from `rhea-promise`.
+        if ((err as MessagingError).code === "OperationTimeoutError") {
+          err.message = "Failed to create a sender within allocated time and retry attempts.";
+        }
         throw err;
       } finally {
         this.isConnecting = false;


### PR DESCRIPTION
Creating of receivers and senders can fail due to OperationTimeoutError from `rhea-promise` which gives error messages like `Unable to create the amqp receiver 'queuename-a979a00f-0fae-3745-bb4a-3c9acabd6ead' on amqp session 'local-1_remote-1_connection-1' due to operation timeout.` See #9775

Creating of session receivers can pass, but fail to get lock on sessionId we want. The error message in this case can be improved as well. See #7618

This PR attempts to improve error messages in both these cases