### PR TITLE
Revert core auth changelog

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.4 (Unreleased)
 
+- Updated to use OpenTelemetry 0.10.2 via `@azure/core-tracing`
 
 ## 1.1.3 (2020-06-30)
 

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Release History
 
-## 1.1.4 (2020-08-04)
+## 1.1.4 (Unreleased)
 
-- Updated to use OpenTelemetry 0.10.2 via `@azure/core-tracing`
 
 ## 1.1.3 (2020-06-30)
 


### PR DESCRIPTION
As we are not releasing core-auth for August cycle.

This reverts commit 3b19404a0976baa77832974cb53df71b8e97db83.