### PR TITLE
Only fetch query plan for item queries

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -13,7 +13,7 @@ import {
   getInitialHeader,
   mergeHeaders,
   PipelinedQueryExecutionContext,
-  SqlQuerySpec
+  SqlQuerySpec,
 } from "./queryExecutionContext";
 import { Response } from "./request";
 import { ErrorResponse, PartitionedQueryExecutionInfo } from "./request/ErrorResponse";
@@ -244,7 +244,7 @@ export class QueryIterator<T> {
   }
 
   private needsQueryPlan(error: any): error is ErrorResponse {
-    return error.code === StatusCodes.BadRequest;
+    return error.code === StatusCodes.BadRequest && this.resourceType === ResourceType.item;
   }
 
   private initPromise: Promise<void>;


### PR DESCRIPTION
The query iterator should only go down the cross partition code path if its querying items. Other resources should re-throw the error returned by the backend. For example, upcoming features will throw when querying offers and the iterator was incorrectly going to fetch a query plan.

Again like I said in https://github.com/Azure/azure-sdk-for-js/pull/7333, QueryIterator probably needs to be split up. Items are a special case.