### PR TITLE
Lower case keywords in package.json across packages

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -49,11 +49,11 @@
   "keywords": [
     "azure",
     "aborter",
-    "abortSignal",
+    "abortsignal",
     "cancellation",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -47,14 +47,14 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Aborter",
-    "AbortSignal",
-    "Cancellation",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "azure",
+    "aborter",
+    "abortSignal",
+    "cancellation",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -8,7 +8,6 @@
   "keywords": [
     "azure",
     "amqp",
-    "azure",
     "cloud"
   ],
   "main": "./dist/index.js",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "azure",
     "amqp",
-    "Azure",
+    "azure",
     "cloud"
   ],
   "main": "./dist/index.js",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -52,7 +52,6 @@
   "keywords": [
     "azure",
     "authentication",
-    "Azure",
     "cloud"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -62,8 +62,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",
-    "cloud",
-    "Azure"
+    "cloud"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -24,7 +24,7 @@
     "microsoft",
     "autorest",
     "clientruntime",
-    "Azure",
+    "azure",
     "cloud"
   ],
   "main": "dist/index.js",

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -66,8 +66,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",
-    "cloud",
-    "Azure"
+    "cloud"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -46,7 +46,6 @@
   "keywords": [
     "azure",
     "tracing",
-    "azure",
     "cloud"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -46,7 +46,7 @@
   "keywords": [
     "azure",
     "tracing",
-    "Azure",
+    "azure",
     "cloud"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -51,14 +51,14 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Log",
-    "Logger",
-    "Logging",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "azure",
+    "log",
+    "logger",
+    "logging",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -56,8 +56,8 @@
     "logger",
     "logging",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -12,7 +12,7 @@
     "nosql",
     "database",
     "cloud",
-    "Azure"
+    "azure"
   ],
   "author": "Microsoft Corporation",
   "main": "./dist/index.js",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -59,7 +59,7 @@
   },
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
-    "Azure",
+    "azure",
     "cloud",
     "active directory",
     "authentication",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -9,7 +9,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",
-    "Azure",
+    "azure",
     "cloud",
     "typescript",
     "browser",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -9,7 +9,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",
-    "Azure",
+    "azure",
     "cloud",
     "typescript",
     "browser",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -9,7 +9,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",
-    "Azure",
+    "azure",
     "cloud",
     "typescript",
     "browser",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -9,7 +9,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "node",
-    "Azure",
+    "azure",
     "cloud",
     "typescript",
     "browser",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -5,8 +5,7 @@
   "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
-  "browser": {
-  },
+  "browser": {},
   "types": "types/schema-registry.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
@@ -51,7 +50,7 @@
   "keywords": [
     "azure",
     "cloud",
-    "Azure",
+    "azure",
     "typescript"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -50,7 +50,6 @@
   "keywords": [
     "azure",
     "cloud",
-    "azure",
     "typescript"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/schemaregistry/schema-registry/samples/javascript/README.md
+++ b/sdk/schemaregistry/schema-registry/samples/javascript/README.md
@@ -54,7 +54,7 @@ npx cross-env ENDPOINT="<endpoint>" API_KEY="<api key>" node schemaRegistrySampl
 
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
-[schemaRegistrySample]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/schemaregistry/schema-registry/samples/javascript/sampleschema-registry.js
+[schemaRegistrySample]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/schemaregistry/schema-registry/samples/javascript/schemaRegistrySample.js
 [apiref]: https://docs.microsoft.com/javascript/api
 [freesub]: https://azure.microsoft.com/free/
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry/README.md

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -12,7 +12,7 @@
     "cloud",
     "service bus",
     "AMQP",
-    "Azure"
+    "azure"
   ],
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -78,10 +78,12 @@
   },
   "sideEffects": false,
   "//metadata": {
-    "constantPaths": [{
-      "path": "src/util/constants.ts",
-      "prefix": "version"
-    }]
+    "constantPaths": [
+      {
+        "path": "src/util/constants.ts",
+        "prefix": "version"
+      }
+    ]
   },
   "//smokeTestConfiguration": {
     "skip": [

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -71,14 +71,14 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Storage",
-    "Blob",
-    "Change feed",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "azure",
+    "storage",
+    "blob",
+    "change feed",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -76,8 +76,8 @@
     "blob",
     "change feed",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -74,7 +74,7 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
+    "azure",
     "Storage",
     "Blob",
     "Node.js",
@@ -90,10 +90,12 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "//metadata": {
-    "constantPaths": [{
-      "path": "src/utils/constants.ts",
-      "prefix": "SDK_VERSION"
-    }]
+    "constantPaths": [
+      {
+        "path": "src/utils/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
   },
   "//smokeTestConfiguration": {
     "skip": [

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -75,12 +75,12 @@
   },
   "keywords": [
     "azure",
-    "Storage",
-    "Blob",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "atorage",
+    "alob",
+    "node.js",
+    "typescript",
+    "javascript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -69,15 +69,15 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Storage",
+    "azure",
+    "storage",
     "ADLS",
     "DFS",
-    "DataLake",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "dataLake",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -73,10 +73,10 @@
     "storage",
     "ADLS",
     "DFS",
-    "dataLake",
+    "datalake",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -71,13 +71,13 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Storage",
-    "File",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "azure",
+    "storage",
+    "file",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -87,7 +87,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "//metadata": {
-    "constantPaths": [{
+    "constantPaths": [
+      {
         "path": "src/generated/src/storageClientContext.ts",
         "prefix": "packageVersion"
       },

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -75,8 +75,8 @@
     "storage",
     "file",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -68,13 +68,13 @@
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
   },
   "keywords": [
-    "Azure",
-    "Storage",
-    "Queue",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
+    "azure",
+    "storage",
+    "queue",
+    "node.js",
+    "typeScript",
+    "javaScript",
+    "browser"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -84,7 +84,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "//metadata": {
-    "constantPaths": [{
+    "constantPaths": [
+      {
         "path": "src/generated/src/storageClientContext.ts",
         "prefix": "packageVersion"
       },

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -72,8 +72,8 @@
     "storage",
     "queue",
     "node.js",
-    "typeScript",
-    "javaScript",
+    "typescript",
+    "javascript",
     "browser"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/tables/azure-tables/package.json
+++ b/sdk/tables/azure-tables/package.json
@@ -52,7 +52,7 @@
   "keywords": [
     "azure",
     "cloud",
-    "Azure"
+    "azure"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/tables/azure-tables/package.json
+++ b/sdk/tables/azure-tables/package.json
@@ -51,8 +51,7 @@
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",
-    "cloud",
-    "azure"
+    "cloud"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -51,7 +51,6 @@
   "keywords": [
     "azure",
     "cloud",
-    "azure",
     "typescript"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -51,7 +51,7 @@
   "keywords": [
     "azure",
     "cloud",
-    "Azure",
+    "azure",
     "typescript"
   ],
   "author": "Microsoft Corporation",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -6,7 +6,7 @@
   "version": "5.0.1",
   "keywords": [
     "node",
-    "Azure",
+    "azure",
     "cloud",
     "typescript",
     "browser",
@@ -29,7 +29,8 @@
     "LICENSE"
   ],
   "//metadata": {
-    "constantPaths": [{
+    "constantPaths": [
+      {
         "path": "src/generated/generatedClientContext.ts",
         "prefix": "packageVersion"
       },
@@ -40,7 +41,7 @@
     ]
   },
   "engines": {
-    "node": ">=8.0.0" 
+    "node": ">=8.0.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true


### PR DESCRIPTION
The linter enforces the existence of certain keywords and for them to be lower case. This PR lower case all keywords in `package.json` files across packages that are not doing that already.