### PR TITLE
[Key Vault] apiVersion parameter to serviceVersion

### DIFF
--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -80,7 +80,7 @@ export class CertificateClient {
 
 // @public
 export interface CertificateClientOptions extends coreHttp.PipelineOptions {
-    apiVersion?: "7.0" | "7.1";
+    serviceVersion?: "7.0" | "7.1";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -89,7 +89,7 @@ export interface CertificateClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  apiVersion?: "7.0" | "7.1";
+  serviceVersion?: "7.0" | "7.1";
 }
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -471,7 +471,7 @@ export class CertificateClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.apiVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
   }
 
   private async *listPropertiesOfCertificatesPage(

--- a/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
@@ -9,7 +9,7 @@ import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from 
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
 
-describe("The Certificates client should set the apiVersion", () => {
+describe("The Certificates client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
 
   const mockHttpClient: HttpClient = {
@@ -62,9 +62,9 @@ describe("The Certificates client should set the apiVersion", () => {
 
   it("it should allow us to specify an API version from a specific set of versions", async function() {
     const versions: ApIVersions[] = ["7.0", "7.1"];
-    for (const apiVersion in versions) {
+    for (const serviceVersion in versions) {
       const client = new CertificateClient(keyVaultUrl, credential, {
-        apiVersion: apiVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApIVersions,
         httpClient: mockHttpClient
       });
       await client.getCertificate("certificateName");
@@ -73,7 +73,7 @@ describe("The Certificates client should set the apiVersion", () => {
       const lastCall = calls[calls.length - 1];
       assert.equal(
         lastCall.args[0].url,
-        `https://keyVaultName.vault.azure.net/certificates/certificateName/?api-version=${apiVersion}`
+        `https://keyVaultName.vault.azure.net/certificates/certificateName/?api-version=${serviceVersion}`
       );
     }
   });

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -175,7 +175,7 @@ export class KeyClient {
 
 // @public
 export interface KeyClientOptions extends coreHttp.PipelineOptions {
-    apiVersion?: "7.0" | "7.1";
+    serviceVersion?: "7.0" | "7.1";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -709,7 +709,7 @@ export class CryptographyClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.apiVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
 
     let parsed;
     if (typeof key === "string") {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -239,7 +239,7 @@ export class KeyClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.apiVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
   }
 
   /**

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -83,7 +83,7 @@ export interface KeyClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  apiVersion?: "7.0" | "7.1";
+  serviceVersion?: "7.0" | "7.1";
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
@@ -9,7 +9,7 @@ import { HttpClient, HttpOperationResponse, WebResourceLike, HttpHeaders } from 
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
 
-describe("The Keys client should set the apiVersion", () => {
+describe("The Keys client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
 
   const mockHttpClient: HttpClient = {
@@ -63,9 +63,9 @@ describe("The Keys client should set the apiVersion", () => {
 
   it("it should allow us to specify an API version from a specific set of versions", async function() {
     const versions: ApIVersions[] = ["7.0", "7.1"];
-    for (const apiVersion in versions) {
+    for (const serviceVersion in versions) {
       const client = new KeyClient(keyVaultUrl, credential, {
-        apiVersion: apiVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApIVersions,
         httpClient: mockHttpClient
       });
       await client.createKey("keyName", "RSA");
@@ -74,7 +74,7 @@ describe("The Keys client should set the apiVersion", () => {
       const lastCall = calls[calls.length - 1];
       assert.equal(
         lastCall.args[0].url,
-        `https://keyVaultName.vault.azure.net/keys/keyName/create?api-version=${apiVersion}`
+        `https://keyVaultName.vault.azure.net/keys/keyName/create?api-version=${serviceVersion}`
       );
     }
   });

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -107,7 +107,7 @@ export class SecretClient {
 
 // @public
 export interface SecretClientOptions extends coreHttp.PipelineOptions {
-    apiVersion?: "7.0" | "7.1";
+    serviceVersion?: "7.0" | "7.1";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -183,7 +183,7 @@ export class SecretClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.apiVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
   }
 
   /**

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -45,7 +45,7 @@ export interface SecretClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  apiVersion?: "7.0" | "7.1";
+  serviceVersion?: "7.0" | "7.1";
 }
 
 /**

--- a/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/serviceVersionParameter.spec.ts
@@ -9,7 +9,7 @@ import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from 
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
 
-describe("The Secrets client should set the apiVersion", () => {
+describe("The Secrets client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
 
   const mockHttpClient: HttpClient = {
@@ -62,14 +62,14 @@ describe("The Secrets client should set the apiVersion", () => {
 
   it("it should allow us to specify an API version from a specific set of versions", async function() {
     const versions: ApIVersions[] = ["7.0", "7.1"];
-    for (const apiVersion in versions) {
+    for (const serviceVersion in versions) {
       const credential = await new ClientSecretCredential(
         env.AZURE_TENANT_ID!,
         env.AZURE_CLIENT_ID!,
         env.AZURE_CLIENT_SECRET!
       );
       const client = new SecretClient(keyVaultUrl, credential, {
-        apiVersion: apiVersion as ApIVersions,
+        serviceVersion: serviceVersion as ApIVersions,
         httpClient: mockHttpClient
       });
       await client.setSecret("secretName", "value");
@@ -78,7 +78,7 @@ describe("The Secrets client should set the apiVersion", () => {
       const lastCall = calls[calls.length - 1];
       assert.equal(
         lastCall.args[0].url,
-        `https://keyVaultName.vault.azure.net/secrets/secretName?api-version=${apiVersion}`
+        `https://keyVaultName.vault.azure.net/secrets/secretName?api-version=${serviceVersion}`
       );
     }
   });


### PR DESCRIPTION
This PR is to align with other languages and packages on using `serviceVersion` instead of `apiVersion` to refer to the parameter that specifies the version of the service.

The `apiVersion` parameter has only been introduced in the preview version of the Key Vault packages, so I believe this should be fine.

Please let me know if I'm missing something.