### PR TITLE
[search-documents] Fix ISO8601 date regex

### DIFF
--- a/sdk/search/search-documents/src/serialization.ts
+++ b/sdk/search/search-documents/src/serialization.ts
@@ -3,7 +3,7 @@
 
 import GeographyPoint from "./geographyPoint";
 
-const ISO8601DateRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z/i;
+const ISO8601DateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/i;
 const GeoJSONPointTypeName = "Point";
 const WorldGeodeticSystem1984 = "EPSG:4326"; // See https://epsg.io/4326
 

--- a/sdk/search/search-documents/test/serialization.spec.ts
+++ b/sdk/search/search-documents/test/serialization.spec.ts
@@ -72,6 +72,24 @@ describe("serialization.deserialize", () => {
     assert.deepEqual(result, { a: new Date(Date.UTC(1975, 3, 4)) });
   });
 
+  it("doesn't deserialize as Date if text before", () => {
+    const value = "before 1975-04-04T00:00:00.000Z";
+    const result = deserialize({ a: value });
+    assert.deepEqual(result, { a: value });
+  });
+
+  it("doesn't deserialize as Date if text after", () => {
+    const value = "1975-04-04T00:00:00.000Z after";
+    const result = deserialize({ a: value });
+    assert.deepEqual(result, { a: value });
+  });
+
+  it("doesn't deserialize as Date if text before and after", () => {
+    const value = "before 1975-04-04T00:00:00.000Z after";
+    const result = deserialize({ a: value });
+    assert.deepEqual(result, { a: value });
+  });
+
   it("GeographyPoint", () => {
     const result: { location: GeographyPoint } = deserialize({
       location: {


### PR DESCRIPTION
I've updated the regex to match the entire string, not just a part of the string, meaning that fields that contain ISO8601 dates within them aren't treated as dates themselves.

See #10486 for more info.

Edit:

With this patch, the output of the replication steps provided in #10486 are:

```
$ node .
true
{ id: '1', name: 'Example 2019-09-18T01:08:36.393Z' }
```