### PR TITLE
Gracefully exit the samples if env variables are not set

### DIFF
--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/createDataSourceConnection.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/createDataSourceConnection.js
@@ -13,6 +13,11 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 async function main() {
   console.log(`Running Create Datasource Connection Sample....`);
 
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
+  
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const dataSourceConnection = {
     name: "my-data-source-2",
@@ -27,4 +32,6 @@ async function main() {
   await client.createDataSourceConnection(dataSourceConnection);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/createOrUpdateDataSourceConnection.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/createOrUpdateDataSourceConnection.js
@@ -12,6 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running CreateOrUpdate Datasource Connection Sample....`);
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds = await client.getDataSourceConnection("my-data-source-2")
@@ -20,4 +24,6 @@ async function main() {
   await client.createOrUpdateDataSourceConnection(ds);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/deleteDataSourceConnectionByName.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/deleteDataSourceConnectionByName.js
@@ -12,10 +12,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Datasource Connection my-data-source-2`);
   await client.deleteDataSourceConnection("my-data-source-2")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/deleteDataSourceConnectionByObject.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/deleteDataSourceConnectionByObject.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds = await client.getDataSourceConnection("my-data-source-2");
@@ -20,4 +23,6 @@ async function main() {
   await client.deleteDataSourceConnection(ds);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/getDataSourceConnection.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/getDataSourceConnection.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds = await client.getDataSourceConnection("my-data-source-2")
@@ -28,4 +31,6 @@ async function main() {
   console.log();
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/listDataSourceConnectionNames.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/listDataSourceConnectionNames.js
@@ -5,6 +5,7 @@ const {
   SearchIndexerClient,
   AzureKeyCredential
 } = require("@azure/search-documents");
+
 require("dotenv").config();
 
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
@@ -12,15 +13,20 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Datasource Connection Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfDataSourceConnectionNames = await client.listDataSourceConnectionsNames();
 
   console.log(`Names of Data Source Connections`);
   console.log(`*******************************`);
-  for(let ds of listOfDataSourceConnectionNames) {
+  for(const ds of listOfDataSourceConnectionNames) {
     console.log(ds);
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/listDataSourceConnections.js
+++ b/sdk/search/search-documents/samples/javascript/src/dataSourceConnections/listDataSourceConnections.js
@@ -12,13 +12,16 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Datasource Connections Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfDataSourceConnections = await client.listDataSourceConnections();
 
   console.log(`List of Data Source Connections`);
   console.log(`*******************************`)
-  for(let ds of listOfDataSourceConnections) {
+  for(const ds of listOfDataSourceConnections) {
     console.log(`Name: ${ds.name}`);
     console.log(`Description: ${ds.description}`);
     console.log(`Connection String: ${ds.connectionString}`);
@@ -32,4 +35,6 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/createIndexer.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/createIndexer.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const indexer = {
     name: "my-azure-indexer-1",
@@ -22,4 +25,6 @@ async function main() {
   await client.createIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/createOrUpdateIndexer.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/createOrUpdateIndexer.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Or Update Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer = await client.getIndexer("my-azure-indexer-1");
@@ -18,4 +21,6 @@ async function main() {
   await client.createOrUpdateIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/deleteIndexerByName.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/deleteIndexerByName.js
@@ -12,10 +12,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Indexer my-azure-indexer-1`);
   await client.deleteIndexer("my-azure-indexer-1")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/deleteIndexerByObject.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/deleteIndexerByObject.js
@@ -13,7 +13,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer = await client.getIndexer("my-azure-indexer-1");
@@ -21,4 +24,6 @@ async function main() {
   await client.deleteIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/getIndexer.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/getIndexer.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer = await client.getIndexer("my-azure-indexer-1");
@@ -22,4 +25,6 @@ async function main() {
   console.log(`ETag: ${indexer.etag}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/getIndexerStatus.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/getIndexerStatus.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Indexer Status Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer Status of my-azure-indexer-1`);
   const indexerStatus = await client.getIndexerStatus("my-azure-indexer-1");
@@ -21,4 +24,6 @@ async function main() {
   console.log(`MaxRunTime: ${indexerStatus.limits.maxRunTime}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/listIndexerNames.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/listIndexerNames.js
@@ -9,15 +9,20 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Indexer Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfIndexerNames = await client.listIndexersNames();
 
   console.log(`\tNames of Indexers`);
   console.log(`\t*****************`);
-  for(let indexerName of listOfIndexerNames) {
+  for(const indexerName of listOfIndexerNames) {
     console.log(`${indexerName}`);
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/listIndexers.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/listIndexers.js
@@ -9,13 +9,16 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Indexers Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfIndexers = await client.listIndexers();
 
   console.log(`\tList of Indexers`);
   console.log(`\t****************`);
-  for(let indexer of listOfIndexers) {
+  for(const indexer of listOfIndexers) {
     console.log(`Name: ${indexer.name}`);
     console.log(`Description: ${indexer.description}`);
     console.log(`Data Source Name: ${indexer.dataSourceName}`);
@@ -27,4 +30,6 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/resetIndexer.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/resetIndexer.js
@@ -9,10 +9,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Reset Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Reset Indexer my-azure-indexer-1`);
   await client.resetIndexer("my-azure-indexer-1");
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexers/runIndexer.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexers/runIndexer.js
@@ -9,10 +9,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Run Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Run Indexer my-azure-indexer-1`);
   await client.runIndexer("my-azure-indexer-1");
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/analyzeText.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/analyzeText.js
@@ -15,6 +15,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Analyze Text Sample....`);
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const index = await client.getIndex("example-index");
 
@@ -31,4 +35,6 @@ async function main() {
 
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/createIndex.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/createIndex.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const index = {
     name: "example-index-2",
@@ -55,4 +58,6 @@ async function main() {
   await client.createIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/createOrUpdateIndex.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/createOrUpdateIndex.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Or Update Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index-2`);
   const index = await client.getIndex("example-index-2");
@@ -27,4 +30,6 @@ async function main() {
   await client.createOrUpdateIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/deleteIndexByName.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/deleteIndexByName.js
@@ -12,10 +12,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Index example-index-2`);
   await client.deleteIndex("example-index-2")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/deleteIndexByObject.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/deleteIndexByObject.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index-2`);
   const index = await client.getIndex("example-index-2");
@@ -20,4 +23,6 @@ async function main() {
   await client.deleteIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/getIndex.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/getIndex.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index`);
   const index = await client.getIndex("example-index");
@@ -20,4 +23,6 @@ async function main() {
   console.log(`Similarity Algorithm: ${index.similarity.odatatype}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/getIndexStatistics.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/getIndexStatistics.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Index Statistics Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index Statistics of example-index`);
   const statistics = await client.getIndexStatistics("example-index");
@@ -20,4 +23,6 @@ async function main() {
   console.log(`Storage Size: ${statistics.storageSize}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/getServiceStatistics.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/getServiceStatistics.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Service Statistics Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const {counters, limits} = await client.getServiceStatistics();
   console.log(`Counters`);
@@ -44,4 +47,6 @@ async function main() {
   console.log(`\tMax Complex Objects In Collections Per Document: ${limits.maxComplexObjectsInCollectionsPerDocument}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/listIndexNames.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/listIndexNames.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Indexes Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const result = await client.listIndexesNames();
   let listOfIndexNames = await result.next();
@@ -22,4 +25,6 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/indexes/listIndexes.js
+++ b/sdk/search/search-documents/samples/javascript/src/indexes/listIndexes.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Indexes Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const result = await client.listIndexes();
   let listOfIndexes = await result.next();
@@ -24,4 +27,6 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/createOrUpdateSkillset.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/createOrUpdateSkillset.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Or Update Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset = await client.getSkillset("my-azureblob-skillset");
@@ -28,4 +31,6 @@ async function main() {
   await client.createOrUpdateSkillset(skillset);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/createSkillset.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/createSkillset.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const skillset = {
     name: `my-azureblob-skillset`,
@@ -47,4 +50,6 @@ async function main() {
   await client.createSkillset(skillset);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/deleteSkillsetByName.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/deleteSkillsetByName.js
@@ -12,10 +12,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Indexer my-azureblob-skillset`);
   await client.deleteSkillset("my-azureblob-skillset")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/deleteSkillsetByObject.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/deleteSkillsetByObject.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset = await client.getSkillset("my-azureblob-skillset");
@@ -20,4 +23,6 @@ async function main() {
   await client.deleteSkillset(skillset)
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/getSkillset.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/getSkillset.js
@@ -9,7 +9,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset = await client.getSkillset("my-azureblob-skillset");
@@ -17,19 +20,21 @@ async function main() {
   console.log(`Description: ${skillset.description}`);
   console.log(`Skills`);
   console.log(`******`);
-  for(let skill of skillset.skills) {
+  for(const skill of skillset.skills) {
     console.log(`ODataType: ${skill.odatatype}`);
     console.log(`Inputs`);
-    for(let input of skill.inputs) {
+    for(const input of skill.inputs) {
       console.log(`\tName: ${input.name}`);
       console.log(`\tSource: ${input.source}`);
     }
     console.log(`Outputs`);
-    for(let output of skill.outputs) {
+    for(const output of skill.outputs) {
       console.log(`\tName: ${output.name}`);
       console.log(`\tTarget Name: ${output.targetName}`);
     }
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/listSkillsets.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/listSkillsets.js
@@ -12,26 +12,29 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Skillsets Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSkillsets = await client.listSkillsets();
 
   console.log(`\tList of Skillsets`);
   console.log(`\t******************`);
-  for(let skillset of listOfSkillsets) {
+  for(const skillset of listOfSkillsets) {
     console.log(`Name: ${skillset.name}`);
     console.log(`Description: ${skillset.description}`);
     console.log(`Skills`);
     console.log(`******`);
-    for(let skill of skillset.skills) {
+    for(const skill of skillset.skills) {
       console.log(`ODataType: ${skill.odatatype}`);
       console.log(`Inputs`);
-      for(let input of skill.inputs) {
+      for(const input of skill.inputs) {
         console.log(`\tName: ${input.name}`);
         console.log(`\tSource: ${input.source}`);
       }
       console.log(`Outputs`);
-      for(let output of skill.outputs) {
+      for(const output of skill.outputs) {
         console.log(`\tName: ${output.name}`);
         console.log(`\tTarget Name: ${output.targetName}`);
       }
@@ -39,4 +42,6 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/skillSets/listSkillsetsNames.js
+++ b/sdk/search/search-documents/samples/javascript/src/skillSets/listSkillsetsNames.js
@@ -9,15 +9,20 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List Skillsets Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSkillsetNames = await client.listSkillsetsNames();
 
   console.log(`\tNames of Skillsets`);
   console.log(`\t******************`);
-  for(let skName of listOfSkillsetNames) {
+  for(const skName of listOfSkillsetNames) {
     console.log(`${skName}`);
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/createOrUpdateSynonymMap.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/createOrUpdateSynonymMap.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create Or Update SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm = await client.getSynonymMap("my-synonymmap");
@@ -21,4 +24,6 @@ async function main() {
   await client.createOrUpdateSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/createSynonymMap.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/createSynonymMap.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Create SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const sm = {
     name: `my-synonymmap`,
@@ -21,4 +24,6 @@ async function main() {
   await client.createSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/deleteSynonymMapByName.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/deleteSynonymMapByName.js
@@ -12,10 +12,15 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting SynonymMap my-synonymmap`);
   await client.deleteSynonymMap("my-synonymmap")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/deleteSynonymMapByObject.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/deleteSynonymMapByObject.js
@@ -12,7 +12,10 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Delete SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm = await client.getSynonymMap("my-synonymmap");
@@ -20,4 +23,6 @@ async function main() {
   await client.deleteSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/getSynonymMap.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/getSynonymMap.js
@@ -12,15 +12,20 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running Get SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm = await client.getSynonymMap("my-synonymmap");
   console.log(`Name: ${sm.name}`);
   console.log(`Synonyms`);
-  for(let synonym of sm.synonyms) {
+  for(const synonym of sm.synonyms) {
     console.log(synonym);
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/listSynonymMapNames.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/listSynonymMapNames.js
@@ -9,15 +9,20 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List SynonymMap Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSynonymMapsNames = await client.listSynonymMapsNames();
 
   console.log(`List of SynonymMap Names`);
   console.log(`************************`);
-  for(let smName of listOfSynonymMapsNames) {
+  for(const smName of listOfSynonymMapsNames) {
     console.log(`${smName}`);
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/javascript/src/synonymMaps/listSynonymMaps.js
+++ b/sdk/search/search-documents/samples/javascript/src/synonymMaps/listSynonymMaps.js
@@ -9,19 +9,24 @@ const apiKey = process.env.SEARCH_API_KEY || "";
 
 async function main() {
   console.log(`Running List SynonymMaps Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSynonymMaps = await client.listSynonymMaps();
 
   console.log(`List of SynonymMaps`);
   console.log(`*******************`);
-  for(let sm of listOfSynonymMaps) {
+  for(const sm of listOfSynonymMaps) {
     console.log(`Name: ${sm.name}`);
     console.log(`Synonyms`);
-    for(let synonym of sm.synonyms) {
+    for(const synonym of sm.synonyms) {
       console.log(synonym);
     }
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/tsconfig.json
+++ b/sdk/search/search-documents/samples/tsconfig.json
@@ -5,6 +5,6 @@
     "outDir": "typescript/dist",
     "lib": ["DOM", "ES6"]
   },
-  "include": ["typescript/src/**.ts"],
+  "include": ["typescript/src/**.ts", "typescript/src/**/**.ts"],
   "exclude": ["typescript/*.json", "**/node_modules/", "../node_modules", "../typings"]
 }

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/createDataSourceConnection.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/createDataSourceConnection.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const dataSourceConnection: SearchIndexerDataSourceConnection = {
     name: "my-data-source-2",
@@ -29,4 +32,6 @@ async function main(): Promise<void> {
   await client.createDataSourceConnection(dataSourceConnection);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/createOrUpdateDataSourceConnection.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/createOrUpdateDataSourceConnection.ts
@@ -12,8 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running CreateOrUpdate Datasource Connection Sample....`);
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds:SearchIndexerDataSourceConnection = await client.getDataSourceConnection("my-data-source-2")
@@ -22,4 +26,6 @@ async function main(): Promise<void> {
   await client.createOrUpdateDataSourceConnection(ds);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/deleteDataSourceConnectionByName.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/deleteDataSourceConnectionByName.ts
@@ -11,12 +11,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Datasource Connection my-data-source-2`);
   await client.deleteDataSourceConnection("my-data-source-2")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/deleteDataSourceConnectionByObject.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/deleteDataSourceConnectionByObject.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds:SearchIndexerDataSourceConnection = await client.getDataSourceConnection("my-data-source-2");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   await client.deleteDataSourceConnection(ds);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/getDataSourceConnection.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/getDataSourceConnection.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Datasource Connection Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Datasource Connection my-data-source-2`);
   const ds:SearchIndexerDataSourceConnection = await client.getDataSourceConnection("my-data-source-2")
@@ -30,4 +33,6 @@ async function main(): Promise<void> {
   console.log();
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/listDataSourceConnectionNames.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/listDataSourceConnectionNames.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Datasource Connection Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfDataSourceConnectionNames: string[] = await client.listDataSourceConnectionsNames();
 
@@ -21,4 +24,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/listDataSourceConnections.ts
+++ b/sdk/search/search-documents/samples/typescript/src/dataSourceConnections/listDataSourceConnections.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Datasource Connections Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfDataSourceConnections: Array<SearchIndexerDataSourceConnection> = await client.listDataSourceConnections();
 
@@ -34,4 +37,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/createIndexer.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/createIndexer.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const indexer: SearchIndexer = {
     name: "my-azure-indexer-1",
@@ -23,4 +26,6 @@ async function main(): Promise<void> {
   await client.createIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/createOrUpdateIndexer.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/createOrUpdateIndexer.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Or Update Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer: SearchIndexer = await client.getIndexer("my-azure-indexer-1");
@@ -19,4 +22,6 @@ async function main(): Promise<void> {
   await client.createOrUpdateIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/deleteIndexerByName.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/deleteIndexerByName.ts
@@ -11,12 +11,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Indexer my-azure-indexer-1`);
   await client.deleteIndexer("my-azure-indexer-1")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/deleteIndexerByObject.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/deleteIndexerByObject.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer: SearchIndexer = await client.getIndexer("my-azure-indexer-1");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   await client.deleteIndexer(indexer);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/getIndexer.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/getIndexer.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer my-azure-indexer-1`);
   const indexer: SearchIndexer = await client.getIndexer("my-azure-indexer-1");
@@ -30,4 +33,6 @@ async function main(): Promise<void> {
   console.log(`\tMax Failed Items Per Batch: ${indexer.parameters?.maxFailedItemsPerBatch}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/getIndexerStatus.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/getIndexerStatus.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Indexer Status Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Indexer Status of my-azure-indexer-1`);
   const indexerStatus: SearchIndexerStatus = await client.getIndexerStatus("my-azure-indexer-1");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   console.log(`MaxRunTime: ${indexerStatus.limits.maxRunTime}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/listIndexerNames.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/listIndexerNames.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Indexer Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfIndexerNames: string[] = await client.listIndexersNames();
 
@@ -21,4 +24,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/listIndexers.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/listIndexers.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Indexers Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfIndexers: Array<SearchIndexer> = await client.listIndexers();
 
@@ -35,4 +38,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/resetIndexer.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/resetIndexer.ts
@@ -8,12 +8,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Reset Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Reset Indexer my-azure-indexer-1`);
   await client.resetIndexer("my-azure-indexer-1");
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexers/runIndexer.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexers/runIndexer.ts
@@ -8,12 +8,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Run Indexer Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Run Indexer my-azure-indexer-1`);
   await client.runIndexer("my-azure-indexer-1");
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/analyzeText.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/analyzeText.ts
@@ -15,8 +15,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Analyze Text Sample....`);
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const index:SearchIndex = await client.getIndex("example-index");
 
@@ -59,4 +63,6 @@ async function main(): Promise<void> {
 
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/createIndex.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/createIndex.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const index: SearchIndex = {
     name: "example-index-2",
@@ -57,4 +60,6 @@ async function main(): Promise<void> {
   await client.createIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/createOrUpdateIndex.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/createOrUpdateIndex.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Or Update Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index-2`);
   const index:SearchIndex = await client.getIndex("example-index-2");
@@ -29,4 +32,6 @@ async function main(): Promise<void> {
   await client.createOrUpdateIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/deleteIndexByName.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/deleteIndexByName.ts
@@ -11,12 +11,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Index example-index-2`);
   await client.deleteIndex("example-index-2")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/deleteIndexByObject.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/deleteIndexByObject.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index-2`);
   const index:SearchIndex = await client.getIndex("example-index-2");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   await client.deleteIndex(index);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/getIndex.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/getIndex.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Index Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index example-index`);
   const index:SearchIndex = await client.getIndex("example-index");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   console.log(`Similarity Algorithm: ${index.similarity?.odatatype}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/getIndexStatistics.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/getIndexStatistics.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Index Statistics Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Index Statistics of example-index`);
   const statistics:SearchIndexStatistics = await client.getIndexStatistics("example-index");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   console.log(`Storage Size: ${statistics.storageSize}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/getServiceStatistics.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/getServiceStatistics.ts
@@ -11,9 +11,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Service Statistics Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const {counters, limits} = await client.getServiceStatistics();
   console.log(`Counters`);
@@ -45,4 +48,6 @@ async function main(): Promise<void> {
   console.log(`\tMax Complex Objects In Collections Per Document: ${limits.maxComplexObjectsInCollectionsPerDocument}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/listIndexNames.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/listIndexNames.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Indexes Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const result = await client.listIndexesNames();
   let listOfIndexNames = await result.next();
@@ -23,4 +26,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/indexes/listIndexes.ts
+++ b/sdk/search/search-documents/samples/typescript/src/indexes/listIndexes.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Indexes Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const result = await client.listIndexes();
   let listOfIndexes = await result.next();
@@ -25,4 +28,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/createOrUpdateSkillset.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/createOrUpdateSkillset.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Or Update Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset: SearchIndexerSkillset = await client.getSkillset("my-azureblob-skillset");
@@ -29,4 +32,6 @@ async function main(): Promise<void> {
   await client.createOrUpdateSkillset(skillset);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/createSkillset.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/createSkillset.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const skillset: SearchIndexerSkillset = {
     name: `my-azureblob-skillset`,
@@ -48,4 +51,6 @@ async function main(): Promise<void> {
   await client.createSkillset(skillset);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/deleteSkillsetByName.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/deleteSkillsetByName.ts
@@ -11,12 +11,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting Indexer my-azureblob-skillset`);
   await client.deleteSkillset("my-azureblob-skillset")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/deleteSkillsetByObject.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/deleteSkillsetByObject.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset: SearchIndexerSkillset = await client.getSkillset("my-azureblob-skillset");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   await client.deleteSkillset(skillset)
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/getSkillset.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/getSkillset.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get Skillset Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Getting Skillset my-azureblob-skillset`);
   const skillset: SearchIndexerSkillset = await client.getSkillset("my-azureblob-skillset");
@@ -37,4 +40,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/listSkillsets.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/listSkillsets.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Skillsets Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSkillsets: Array<SearchIndexerSkillset> = await client.listSkillsets();
 
@@ -41,4 +44,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/skillSets/listSkillsetsNames.ts
+++ b/sdk/search/search-documents/samples/typescript/src/skillSets/listSkillsetsNames.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List Skillsets Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexerClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSkillsetNames: string[] = await client.listSkillsetsNames();
 
@@ -21,4 +24,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/createOrUpdateSynonymMap.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/createOrUpdateSynonymMap.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create Or Update SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm:SynonymMap = await client.getSynonymMap("my-synonymmap");
@@ -23,4 +26,6 @@ async function main(): Promise<void> {
   await client.createOrUpdateSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/createSynonymMap.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/createSynonymMap.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Create SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const sm: SynonymMap = {
     name: `my-synonymmap`,
@@ -23,4 +26,6 @@ async function main(): Promise<void> {
   await client.createSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/deleteSynonymMapByName.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/deleteSynonymMapByName.ts
@@ -11,12 +11,17 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Deleting SynonymMap my-synonymmap`);
   await client.deleteSynonymMap("my-synonymmap")
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/deleteSynonymMapByObject.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/deleteSynonymMapByObject.ts
@@ -12,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Delete SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm:SynonymMap = await client.getSynonymMap("my-synonymmap");
@@ -22,4 +25,6 @@ async function main(): Promise<void> {
   await client.deleteSynonymMap(sm);
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/getSynonymMap.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/getSynonymMap.ts
@@ -4,7 +4,6 @@
 import {
   SearchIndexClient,
   AzureKeyCredential,
-  SearchIndex,
   SynonymMap
 } from "@azure/search-documents";
 import * as dotenv from "dotenv";
@@ -13,9 +12,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running Get SynonymMap Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   console.log(`Get Synonym Map my-synonymmap`);
   const sm: SynonymMap = await client.getSynonymMap("my-synonymmap");
@@ -26,4 +28,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/listSynonymMapNames.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/listSynonymMapNames.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List SynonymMap Names Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSynonymMapsNames: string[] = await client.listSynonymMapsNames();
 
@@ -21,4 +24,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/search/search-documents/samples/typescript/src/synonymMaps/listSynonymMaps.ts
+++ b/sdk/search/search-documents/samples/typescript/src/synonymMaps/listSynonymMaps.ts
@@ -8,9 +8,12 @@ dotenv.config();
 const endpoint = process.env.SEARCH_API_ENDPOINT || "";
 const apiKey = process.env.SEARCH_API_KEY || "";
 
-async function main(): Promise<void> {
+export async function main() {
   console.log(`Running List SynonymMaps Sample....`);
-
+  if (!endpoint || !apiKey) {
+    console.log("Make sure to set valid values for endpoint and apiKey with proper authorization.");
+    return;
+  }
   const client = new SearchIndexClient(endpoint, new AzureKeyCredential(apiKey));
   const listOfSynonymMaps: Array<SynonymMap> = await client.listSynonymMaps();
 
@@ -25,4 +28,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});


### PR DESCRIPTION
This PR is to fix the issue https://github.com/Azure/azure-sdk-for-js/issues/9962 

**Issue**
The error happens when you execute ```rushx execute:samples```. Why? All of these samples need a valid subscription key, endpoint with search service setup and possible initial data setup. 

**Solution**
Before all the samples, we could setup a complete new subscription and service. I think this will be complicated for running a simple set of samples. 

Instead, more easier approach will be to gracefully exit the samples, if the environment variables are not set. Tested locally and confirmed everything works fine. 

@xirzec Please review and approve. 