### PR TITLE
[Tables] Helper functions for Query options

### DIFF
--- a/sdk/tables/azure-tables/review/tables.api.md
+++ b/sdk/tables/azure-tables/review/tables.api.md
@@ -46,7 +46,7 @@ export type CreateEntityResponse = TableInsertEntityHeaders & {
 
 // @public
 export interface CreateTableOptions extends coreHttp.OperationOptions {
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     responsePreference?: ResponseFormat;
 }
@@ -62,7 +62,7 @@ export type CreateTableResponse = TableCreateHeaders & TableResponse & {
 
 // @public
 export interface DeleteEntityOptions extends coreHttp.OperationOptions {
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     timeout?: number;
 }
@@ -128,7 +128,7 @@ export type GetAccessPolicyResponse = TableGetAccessPolicyHeaders & SignedIdenti
 
 // @public
 export interface GetEntityOptions extends coreHttp.OperationOptions {
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     timeout?: number;
 }
@@ -209,12 +209,9 @@ export interface Metrics {
 export type OdataMetadataFormat = "application/json;odata=nometadata" | "application/json;odata=minimalmetadata" | "application/json;odata=fullmetadata";
 
 // @public
-export interface QueryOptions {
-    filter?: string;
-    format?: OdataMetadataFormat;
-    select?: string;
-    top?: number;
-}
+export type QueryOptions = Omit<TableQueryOptions, "select"> & {
+    select?: string[];
+};
 
 // @public
 export type ResponseFormat = "return-no-content" | "return-content";
@@ -375,7 +372,7 @@ export interface TableInsertEntityHeaders {
 
 // @public
 export interface TableInsertEntityOptionalParams extends coreHttp.OperationOptions {
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     responsePreference?: ResponseFormat;
     tableEntityProperties?: {
@@ -396,7 +393,7 @@ export interface TableMergeEntityHeaders {
 // @public
 export interface TableMergeEntityOptionalParams extends coreHttp.OperationOptions {
     ifMatch?: string;
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     tableEntityProperties?: {
         [propertyName: string]: any;
@@ -418,7 +415,7 @@ export interface TableQueryEntitiesHeaders {
 export interface TableQueryEntitiesOptionalParams extends coreHttp.OperationOptions {
     nextPartitionKey?: string;
     nextRowKey?: string;
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     timeout?: number;
 }
@@ -468,8 +465,16 @@ export interface TableQueryHeaders {
 // @public
 export interface TableQueryOptionalParams extends coreHttp.OperationOptions {
     nextTableName?: string;
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
+}
+
+// @public
+export interface TableQueryOptions {
+    filter?: string;
+    format?: OdataMetadataFormat;
+    select?: string;
+    top?: number;
 }
 
 // @public
@@ -565,7 +570,7 @@ export interface TableUpdateEntityHeaders {
 // @public
 export interface TableUpdateEntityOptionalParams extends coreHttp.OperationOptions {
     ifMatch?: string;
-    queryOptions?: QueryOptions;
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     tableEntityProperties?: {
         [propertyName: string]: any;

--- a/sdk/tables/azure-tables/review/tables.api.md
+++ b/sdk/tables/azure-tables/review/tables.api.md
@@ -206,6 +206,9 @@ export interface Metrics {
 }
 
 // @public
+export function odata(strings: TemplateStringsArray, ...values: unknown[]): string;
+
+// @public
 export type OdataMetadataFormat = "application/json;odata=nometadata" | "application/json;odata=minimalmetadata" | "application/json;odata=fullmetadata";
 
 // @public

--- a/sdk/tables/azure-tables/src/TableClient.ts
+++ b/sdk/tables/azure-tables/src/TableClient.ts
@@ -4,6 +4,7 @@
 import { TableServiceClient } from "./TableServiceClient";
 import {
   Entity,
+  QueryOptions,
   ListEntitiesOptions,
   GetEntityResponse,
   ListEntitiesResponse,
@@ -17,7 +18,6 @@ import {
   TableServiceClientOptions as TableClientOptions,
   DeleteTableOptions,
   DeleteTableResponse,
-  QueryOptions,
   GetEntityOptions,
   CreateEntityResponse,
   DeleteEntityOptions,

--- a/sdk/tables/azure-tables/src/TableServiceClient.ts
+++ b/sdk/tables/azure-tables/src/TableServiceClient.ts
@@ -6,6 +6,7 @@ import { Service } from "./generated/operations";
 import { Table } from "./generated/operations";
 import {
   Entity,
+  QueryOptions,
   ListTablesOptions,
   ListEntitiesOptions,
   GetEntityResponse,
@@ -29,7 +30,7 @@ import {
   CreateTableResponse,
   DeleteTableOptions,
   DeleteTableResponse,
-  QueryOptions,
+  TableQueryOptions,
   ListTablesResponse,
   GetEntityOptions,
   CreateEntityResponse,
@@ -194,7 +195,7 @@ export class TableServiceClient {
     query?: QueryOptions,
     options?: ListTablesOptions
   ): Promise<ListTablesResponse> {
-    return this.table.query({ queryOptions: query, ...options });
+    return this.table.query({ queryOptions: this.convertQueryOptions(query), ...options });
   }
 
   /**
@@ -233,7 +234,7 @@ export class TableServiceClient {
     options?: ListEntitiesOptions
   ): Promise<ListEntitiesResponse<T>> {
     const response = (await this.table.queryEntities(tableName, {
-      queryOptions: query,
+      queryOptions: this.convertQueryOptions(query),
       ...options
     })) as ListEntitiesResponse<T>;
     response.value = deserializeObjectsArray<T>(response.value || []);
@@ -366,6 +367,14 @@ export class TableServiceClient {
     options?: SetAccessPolicyOptions
   ): Promise<SetAccessPolicyResponse> {
     return this.table.setAccessPolicy(tableName, { tableAcl: acl, ...options });
+  }
+
+  private convertQueryOptions(query: QueryOptions = {}): TableQueryOptions {
+    const mappedQuery: any = { ...query };
+    if (mappedQuery.select) {
+      mappedQuery.select = mappedQuery.select.join(",");
+    }
+    return mappedQuery;
   }
 
   /**

--- a/sdk/tables/azure-tables/src/generatedModels.ts
+++ b/sdk/tables/azure-tables/src/generatedModels.ts
@@ -15,7 +15,7 @@ export {
   TableDeleteOptionalParams as DeleteTableOptions,
   TableDeleteResponse as DeleteTableResponse,
   TableQueryOptionalParams,
-  QueryOptions,
+  QueryOptions as TableQueryOptions,
   TableQueryOperationResponse as ListTablesResponse,
   TableQueryEntitiesWithPartitionAndRowKeyOptionalParams as GetEntityOptions,
   TableQueryEntitiesWithPartitionAndRowKeyResponse,

--- a/sdk/tables/azure-tables/src/index.ts
+++ b/sdk/tables/azure-tables/src/index.ts
@@ -8,3 +8,4 @@ export { TableServiceClient } from "./TableServiceClient";
 export { TableClient } from "./TableClient";
 export { TablesSharedKeyCredential } from "./TablesSharedKeyCredential";
 export { TablesSharedKeyCredentialPolicy } from "./TablesSharedKeyCredentialPolicy";
+export { odata } from "./odata";

--- a/sdk/tables/azure-tables/src/models.ts
+++ b/sdk/tables/azure-tables/src/models.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  QueryOptions as TableQueryOptions,
   TableQueryOptionalParams,
   TableQueryEntitiesOptionalParams,
   TableQueryEntitiesWithPartitionAndRowKeyResponse,
@@ -30,6 +31,16 @@ export type GetEntityResponse<T> = TableQueryEntitiesWithPartitionAndRowKeyRespo
    * The table entity object.
    */
   value?: T;
+};
+
+/*
+ * OData Query options to limit the set of tables or entities returned.
+ */
+export type QueryOptions = Omit<TableQueryOptions, "select"> & {
+  /**
+   * A select expression limits the properties on each entity to just those requested.
+   */
+  select?: string[];
 };
 
 /**

--- a/sdk/tables/azure-tables/src/models.ts
+++ b/sdk/tables/azure-tables/src/models.ts
@@ -33,7 +33,7 @@ export type GetEntityResponse<T> = TableQueryEntitiesWithPartitionAndRowKeyRespo
   value?: T;
 };
 
-/*
+/**
  * OData Query options to limit the set of tables or entities returned.
  */
 export type QueryOptions = Omit<TableQueryOptions, "select"> & {

--- a/sdk/tables/azure-tables/src/odata.ts
+++ b/sdk/tables/azure-tables/src/odata.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+function escapeQuotesIfString(input: unknown, previous: string): string | unknown {
+  let result = input;
+
+  if (typeof input === "string") {
+    result = input.replace(/'/g, "''");
+    // check if we need to escape this literal
+    if (!previous.trim().endsWith("'")) {
+      result = `'${result}'`;
+    }
+  }
+  return result;
+}
+
+/**
+ * Escapes an odata filter expression to avoid errors with quoting string literals.
+ */
+export function odata(strings: TemplateStringsArray, ...values: unknown[]): string {
+  const results = [];
+  for (let i = 0; i < strings.length; i++) {
+    results.push(strings[i]);
+    if (i < values.length) {
+      results.push(escapeQuotesIfString(values[i], strings[i]));
+    }
+  }
+  return results.join("");
+}

--- a/sdk/tables/azure-tables/test/odata.spec.ts
+++ b/sdk/tables/azure-tables/test/odata.spec.ts
@@ -1,0 +1,38 @@
+import { odata } from "../src";
+import { assert } from "chai";
+
+describe("odata", () => {
+  it("should handle empty string", () => {
+    const testString = odata``;
+    assert.equal(testString, "");
+  });
+
+  it("should handle string without variables", () => {
+    const testString = odata`Foo`;
+    assert.equal(testString, "Foo");
+  });
+
+  it("should not quote number", () => {
+    const testValue = 4;
+    const testString = odata`test number ${testValue}`;
+    assert.equal(testString, "test number 4");
+  });
+
+  it("should not quote boolean", () => {
+    const testValue = true;
+    const testString = odata`test boolean ${testValue}`;
+    assert.equal(testString, "test boolean true");
+  });
+
+  it("should quote string", () => {
+    const testValue = "FooBar";
+    const testString = odata`test string ${testValue}`;
+    assert.equal(testString, "test string 'FooBar'");
+  });
+
+  it("should escape string with quotes", () => {
+    const testValue = '"FooBar"';
+    const testString = odata`test string ${testValue}`;
+    assert.equal(testString, "test string '\"FooBar\"'");
+  });
+});


### PR DESCRIPTION
This PR adds:

* Better interface to set a select filter in queries. Select now takes an array of strings instead of a comma-separated string.
* odata helper that enables users to use interpolated strings in query filter. This helper also takes care of adding quotes when needed