### PR TITLE
[EventHub][DistributedTracing] propagate context downstream

### DIFF
--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -215,7 +215,7 @@ export function createProcessingSpan(
  */
 export async function trace(fn: () => Promise<void>, span: Span): Promise<void> {
   try {
-    await fn();
+    await getTracer().withSpan(span, fn);
     span.setStatus({ code: CanonicalCode.OK });
   } catch (err) {
     span.setStatus({


### PR DESCRIPTION
Fixes #9666 by calling wrapping `fn` provided to `trace(..,)` in `tracer.withSpan(span, fn)`