### PR TITLE
Fix up New-TestResources.ps1 while eng/common changes are locked down

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -10,109 +10,107 @@
 
 [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param (
-  # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming.
-  [Parameter(Mandatory = $true, Position = 0)]
-  [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
-  [string] $BaseName,
+    # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming.
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
+    [string] $BaseName,
 
-  [ValidatePattern('^[-\w\._\(\)]+$')]
-  [string] $ResourceGroupName,
+    [ValidatePattern('^[-\w\._\(\)]+$')]
+    [string] $ResourceGroupName,
 
-  [Parameter(Mandatory = $true)]
-  [string] $ServiceDirectory,
+    [Parameter(Mandatory = $true)]
+    [string] $ServiceDirectory,
 
-  [Parameter(Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-  [string] $TestApplicationId,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $TestApplicationId,
 
-  [Parameter()]
-  [string] $TestApplicationSecret,
+    [Parameter()]
+    [string] $TestApplicationSecret,
 
-  [Parameter()]
-  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-  [string] $TestApplicationOid,
+    [Parameter()]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $TestApplicationOid,
 
-  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
-  [ValidateNotNullOrEmpty()]
-  [string] $TenantId,
+    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $TenantId,
 
-  [Parameter(ParameterSetName = 'Provisioner')]
-  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-  [string] $SubscriptionId,
+    [Parameter(ParameterSetName = 'Provisioner')]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $SubscriptionId,
 
-  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
-  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-  [string] $ProvisionerApplicationId,
+    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $ProvisionerApplicationId,
 
-  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
-  [string] $ProvisionerApplicationSecret,
+    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [string] $ProvisionerApplicationSecret,
 
-  [Parameter()]
-  [ValidateRange(0, [int]::MaxValue)]
-  [int] $DeleteAfterHours,
+    [Parameter()]
+    [ValidateRange(0, [int]::MaxValue)]
+    [int] $DeleteAfterHours,
 
-  [Parameter()]
-  [string] $Location = '',
+    [Parameter()]
+    [string] $Location = '',
 
-  [Parameter()]
-  [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureChinaCloud')]
-  [string] $Environment = 'AzureCloud',
+    [Parameter()]
+    [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureChinaCloud')]
+    [string] $Environment = 'AzureCloud',
 
-  [Parameter()]
-  [hashtable] $AdditionalParameters,
+    [Parameter()]
+    [hashtable] $AdditionalParameters,
 
-  [Parameter()]
-  [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
+    [Parameter()]
+    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
-  [Parameter()]
-  [switch] $Force,
+    [Parameter()]
+    [switch] $Force,
 
-  [Parameter()]
-  [switch] $OutFile
+    [Parameter()]
+    [switch] $OutFile
 )
 
 # By default stop for any error.
 if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
-  $ErrorActionPreference = 'Stop'
+    $ErrorActionPreference = 'Stop'
 }
 
 function Log($Message) {
-  Write-Host ('{0} - {1}' -f [DateTime]::Now.ToLongTimeString(), $Message)
+    Write-Host ('{0} - {1}' -f [DateTime]::Now.ToLongTimeString(), $Message)
 }
 
 function Retry([scriptblock] $Action, [int] $Attempts = 5) {
-  $attempt = 0
-  $sleep = 5
+    $attempt = 0
+    $sleep = 5
 
-  while ($attempt -lt $Attempts) {
-    try {
-      $attempt++
-      return $Action.Invoke()
-    }
-    catch {
-      if ($attempt -lt $Attempts) {
-        $sleep *= 2
+    while ($attempt -lt $Attempts) {
+        try {
+            $attempt++
+            return $Action.Invoke()
+        } catch {
+            if ($attempt -lt $Attempts) {
+                $sleep *= 2
 
-        Write-Warning "Attempt $attempt failed: $_. Trying again in $sleep seconds..."
-        Start-Sleep -Seconds $sleep
-      }
-      else {
-        Write-Error -ErrorRecord $_
-      }
+                Write-Warning "Attempt $attempt failed: $_. Trying again in $sleep seconds..."
+                Start-Sleep -Seconds $sleep
+            } else {
+                Write-Error -ErrorRecord $_
+            }
+        }
     }
-  }
 }
 
 # Support actions to invoke on exit.
-$exitActions = @( {
+$exitActions = @({
     if ($exitActions.Count -gt 1) {
-      Write-Verbose 'Running registered exit actions'
+        Write-Verbose 'Running registered exit actions'
     }
-  })
+})
 
 trap {
-  # Like using try..finally in PowerShell, but without keeping track of more braces or tabbing content.
-  $exitActions.Invoke()
+    # Like using try..finally in PowerShell, but without keeping track of more braces or tabbing content.
+    $exitActions.Invoke()
 }
 
 # Enumerate test resources to deploy. Fail if none found.
@@ -124,69 +122,69 @@ $environmentVariables = @{}
 
 Write-Verbose "Checking for '$templateFileName' files under '$root'"
 Get-ChildItem -Path $root -Filter $templateFileName -Recurse | ForEach-Object {
-  $templateFile = $_.FullName
+    $templateFile = $_.FullName
 
-  Write-Verbose "Found template '$templateFile'"
-  $templateFiles += $templateFile
+    Write-Verbose "Found template '$templateFile'"
+    $templateFiles += $templateFile
 }
 
 if (!$templateFiles) {
-  Write-Warning -Message "No template files found under '$root'"
-  exit
+    Write-Warning -Message "No template files found under '$root'"
+    exit
 }
 
 # If no location is specified use safe default locations for the given
 # environment. If no matching environment is found $Location remains an empty
 # string.
 if (!$Location) {
-  $Location = @{
-    'AzureCloud'        = 'westus2';
-    'AzureUSGovernment' = 'usgovvirginia';
-    'AzureChinaCloud'   = 'chinaeast2';
-  }[$Environment]
+    $Location = @{
+        'AzureCloud' = 'westus2';
+        'AzureUSGovernment' = 'usgovvirginia';
+        'AzureChinaCloud' = 'chinaeast2';
+    }[$Environment]
 
-  Write-Verbose "Location was not set. Using default location for environment: '$Location'"
+    Write-Verbose "Location was not set. Using default location for environment: '$Location'"
 }
 
 # Log in if requested; otherwise, the user is expected to already be authenticated via Connect-AzAccount.
 if ($ProvisionerApplicationId) {
-  $null = Disable-AzContextAutosave -Scope Process
+    $null = Disable-AzContextAutosave -Scope Process
 
-  Log "Logging into service principal '$ProvisionerApplicationId'"
-  $provisionerSecret = ConvertTo-SecureString -String $ProvisionerApplicationSecret -AsPlainText -Force
-  $provisionerCredential = [System.Management.Automation.PSCredential]::new($ProvisionerApplicationId, $provisionerSecret)
+    Log "Logging into service principal '$ProvisionerApplicationId'"
+    $provisionerSecret = ConvertTo-SecureString -String $ProvisionerApplicationSecret -AsPlainText -Force
+    $provisionerCredential = [System.Management.Automation.PSCredential]::new($ProvisionerApplicationId, $provisionerSecret)
 
-  # Use the given subscription ID if provided.
-  $subscriptionArgs = if ($SubscriptionId) {
-    @{SubscriptionId = $SubscriptionId }
-  }
-  else {
-    @{}
-  }
-
-  $provisionerAccount = Retry {
-    Connect-AzAccount -Force:$Force -Tenant $TenantId -Credential $provisionerCredential -ServicePrincipal -Environment $Environment @subscriptionArgs
-  }
-
-  $exitActions += {
-    Write-Verbose "Logging out of service principal '$($provisionerAccount.Context.Account)'"
-
-    # Only attempt to disconnect if the -WhatIf flag was not set.  Otherwise, this call is not necessary and will fail.
-    if ($PSCmdlet.ShouldProcess($ProvisionerApplicationId)) {
-      $null = Disconnect-AzAccount -AzureContext $provisionerAccount.Context
+    # Use the given subscription ID if provided.
+    $subscriptionArgs = if ($SubscriptionId) {
+        @{SubscriptionId = $SubscriptionId}
     }
-  }
+    else {
+        @{}
+    }
+
+    $provisionerAccount = Retry {
+        Connect-AzAccount -Force:$Force -Tenant $TenantId -Credential $provisionerCredential -ServicePrincipal -Environment $Environment @subscriptionArgs
+    }
+
+    $exitActions += {
+        Write-Verbose "Logging out of service principal '$($provisionerAccount.Context.Account)'"
+
+        # Only attempt to disconnect if the -WhatIf flag was not set.  Otherwise, this call is not necessary and will fail.
+        if ($PSCmdlet.ShouldProcess($ProvisionerApplicationId)) {
+            $null = Disconnect-AzAccount -AzureContext $provisionerAccount.Context
+        }
+    }
 }
 
 # Get test application OID from ID if not already provided.
 if ($TestApplicationId -and !$TestApplicationOid) {
-  $testServicePrincipal = Retry {
-    Get-AzADServicePrincipal -ApplicationId $TestApplicationId
-  }
+    $testServicePrincipal = Retry {
+        Get-AzADServicePrincipal -ApplicationId $TestApplicationId
+    }
 
-  if ($testServicePrincipal -and $testServicePrincipal.Id) {
-    $script:TestApplicationOid = $testServicePrincipal.Id
-  }
+    if ($testServicePrincipal -and $testServicePrincipal.Id) {
+        $script:TestApplicationOid = $testServicePrincipal.Id
+    }
 }
 
 # Determine the Azure context that the script is running in.
@@ -195,10 +193,9 @@ $context = Get-AzContext;
 # If the ServiceDirectory is an absolute path use the last directory name
 # (e.g. D:\foo\bar\ -> bar)
 $serviceName = if (Split-Path -IsAbsolute  $ServiceDirectory) {
-  Split-Path -Leaf $ServiceDirectory
-}
-else {
-  $ServiceDirectory
+    Split-Path -Leaf $ServiceDirectory
+} else {
+    $ServiceDirectory
 }
 
 if ($CI) { 
@@ -206,202 +203,201 @@ if ($CI) {
   Write-Verbose "Generated base name '$BaseName' for CI build"
 }
 
-$rgName = if ($ResourceGroupName -ne '') {
+$ResourceGroupName = if ($ResourceGroupName) {
   $ResourceGroupName
-}
-elseif ($CI) {
+} elseif ($CI) {
   # Format the resource group name based on resource group naming recommendations and limitations.
   "rg-{0}-$BaseName" -f ($serviceName -replace '[\\\/:]', '-').Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
-}
-else {
+} else {
   "rg-$BaseName"
 }
 
 # Tag the resource group to be deleted after a certain number of hours if specified.
 $tags = @{
-  Creator          = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-  ServiceDirectory = $ServiceDirectory
+    Creator = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+    ServiceDirectory = $ServiceDirectory
 }
 
 if ($PSBoundParameters.ContainsKey('DeleteAfterHours')) {
-  $deleteAfter = [DateTime]::UtcNow.AddHours($DeleteAfterHours)
-  $tags.Add('DeleteAfter', $deleteAfter.ToString('o'))
+    $deleteAfter = [DateTime]::UtcNow.AddHours($DeleteAfterHours)
+    $tags.Add('DeleteAfter', $deleteAfter.ToString('o'))
 }
 
 if ($CI) {
-  # Add tags for the current CI job.
-  $tags += @{
-    BuildId     = "${env:BUILD_BUILDID}"
-    BuildJob    = "${env:AGENT_JOBNAME}"
-    BuildNumber = "${env:BUILD_BUILDNUMBER}"
-    BuildReason = "${env:BUILD_REASON}"
-  }
+    # Add tags for the current CI job.
+    $tags += @{
+        BuildId = "${env:BUILD_BUILDID}"
+        BuildJob = "${env:AGENT_JOBNAME}"
+        BuildNumber = "${env:BUILD_BUILDNUMBER}"
+        BuildReason = "${env:BUILD_REASON}"
+    }
 
-  # Set the resource group name variable.
-  Write-Host "Setting variable 'AZURE_RESOURCEGROUP_NAME': $rgName"
-  Write-Host "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$rgName"
-  $environmentVariables['AZURE_RESOURCEGROUP_NAME'] = $rgName
+    # Set the resource group name variable.
+    Write-Host "Setting variable 'AZURE_RESOURCEGROUP_NAME': $ResourceGroupName"
+    Write-Host "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$ResourceGroupName"
+    $environmentVariables['AZURE_RESOURCEGROUP_NAME'] = $ResourceGroupName
 }
 
-Log "Creating resource group '$rgName' in location '$Location'"
+Log "Creating resource group '$ResourceGroupName' in location '$Location'"
 $resourceGroup = Retry {
-  New-AzResourceGroup -Name "$rgName" -Location $Location -Tag $tags -Force:$Force
+    New-AzResourceGroup -Name "$ResourceGroupName" -Location $Location -Tag $tags -Force:$Force
 }
 
 if ($resourceGroup.ProvisioningState -eq 'Succeeded') {
-  # New-AzResourceGroup would've written an error and stopped the pipeline by default anyway.
-  Write-Verbose "Successfully created resource group '$($resourceGroup.ResourceGroupName)'"
+    # New-AzResourceGroup would've written an error and stopped the pipeline by default anyway.
+    Write-Verbose "Successfully created resource group '$($resourceGroup.ResourceGroupName)'"
 }
 elseif (($resourceGroup -eq $null) -and (-not $PSCmdlet.ShouldProcess($resourceGroupName))) {
-  # If the -WhatIf flag was passed, there will be no resource group created.  Fake it.
-  $resourceGroup = [PSCustomObject]@{
-    ResourceGroupName = $resourceGroupName
-    Location          = $Location
-  }
+    # If the -WhatIf flag was passed, there will be no resource group created.  Fake it.
+    $resourceGroup = [PSCustomObject]@{
+        ResourceGroupName = $resourceGroupName
+        Location = $Location
+    }
 }
 
 # Populate the template parameters and merge any additional specified.
 $templateParameters = @{
-  baseName           = $BaseName
-  testApplicationId  = $TestApplicationId
-  testApplicationOid = "$TestApplicationOid"
+    baseName = $BaseName
+    testApplicationId = $TestApplicationId
+    testApplicationOid = "$TestApplicationOid"
 }
 
 if ($TenantId) {
-  $templateParameters.Add('tenantId', $TenantId)
+    $templateParameters.Add('tenantId', $TenantId)
 }
 if ($TestApplicationSecret) {
-  $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
+    $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
 }
 if ($AdditionalParameters) {
-  $templateParameters += $AdditionalParameters
+    $templateParameters += $AdditionalParameters
 }
 
 # Include environment-specific parameters only if not already provided as part of the "AdditionalParameters"
 if (($context.Environment.StorageEndpointSuffix) -and (-not ($templateParameters.ContainsKey('storageEndpointSuffix')))) {
-  $templateParameters.Add('storageEndpointSuffix', $context.Environment.StorageEndpointSuffix)
+    $templateParameters.Add('storageEndpointSuffix', $context.Environment.StorageEndpointSuffix)
 }
 
 # Try to detect the shell based on the parent process name (e.g. launch via shebang).
 $shell, $shellExportFormat = if (($parentProcessName = (Get-Process -Id $PID).Parent.ProcessName) -and $parentProcessName -eq 'cmd') {
-  'cmd', 'set {0}={1}'
-}
-elseif (@('bash', 'csh', 'tcsh', 'zsh') -contains $parentProcessName) {
-  'shell', 'export {0}={1}'
-}
-else {
-  'PowerShell', '$env:{0} = ''{1}'''
+    'cmd', 'set {0}={1}'
+} elseif (@('bash', 'csh', 'tcsh', 'zsh') -contains $parentProcessName) {
+    'shell', 'export {0}={1}'
+} else {
+    'PowerShell', '$env:{0} = ''{1}'''
 }
 
 # Deploy the templates
 foreach ($templateFile in $templateFiles) {
-  # Deployment fails if we pass in more parameters than are defined.
-  Write-Verbose "Removing unnecessary parameters from template '$templateFile'"
-  $templateJson = Get-Content -LiteralPath $templateFile | ConvertFrom-Json
-  $templateParameterNames = $templateJson.parameters.PSObject.Properties.Name
+    # Deployment fails if we pass in more parameters than are defined.
+    Write-Verbose "Removing unnecessary parameters from template '$templateFile'"
+    $templateJson = Get-Content -LiteralPath $templateFile | ConvertFrom-Json
+    $templateParameterNames = $templateJson.parameters.PSObject.Properties.Name
 
-  $templateFileParameters = $templateParameters.Clone()
-  foreach ($key in $templateParameters.Keys) {
-    if ($templateParameterNames -notcontains $key) {
-      Write-Verbose "Removing unnecessary parameter '$key'"
-      $templateFileParameters.Remove($key)
-    }
-  }
-
-  $preDeploymentScript = $templateFile | Split-Path | Join-Path -ChildPath 'test-resources-pre.ps1'
-  if (Test-Path $preDeploymentScript) {
-    Log "Invoking pre-deployment script '$preDeploymentScript'"
-    &$preDeploymentScript -ResourceGroupName $rgName @PSBoundParameters
-  }
-
-  Log "Deploying template '$templateFile' to resource group '$($resourceGroup.ResourceGroupName)'"
-  $deployment = Retry {
-    New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
-  }
-
-  if ($deployment.ProvisioningState -eq 'Succeeded') {
-    # New-AzResourceGroupDeployment would've written an error and stopped the pipeline by default anyway.
-    Write-Verbose "Successfully deployed template '$templateFile' to resource group '$($resourceGroup.ResourceGroupName)'"
-  }
-
-  $serviceDirectoryPrefix = $serviceName.ToUpperInvariant() + "_"
-
-  # Add default values
-  $deploymentOutputs = @{
-    "$($serviceDirectoryPrefix)CLIENT_ID"               = $TestApplicationId;
-    "$($serviceDirectoryPrefix)CLIENT_SECRET"           = $TestApplicationSecret;
-    "$($serviceDirectoryPrefix)TENANT_ID"               = $context.Tenant.Id;
-    "$($serviceDirectoryPrefix)SUBSCRIPTION_ID"         = $context.Subscription.Id;
-    "$($serviceDirectoryPrefix)RESOURCE_GROUP"          = $resourceGroup.ResourceGroupName;
-    "$($serviceDirectoryPrefix)LOCATION"                = $resourceGroup.Location;
-    "$($serviceDirectoryPrefix)ENVIRONMENT"             = $context.Environment.Name;
-    "$($serviceDirectoryPrefix)AZURE_AUTHORITY_HOST"    = $context.Environment.ActiveDirectoryAuthority;
-    "$($serviceDirectoryPrefix)RESOURCE_MANAGER_URL"    = $context.Environment.ResourceManagerUrl;
-    "$($serviceDirectoryPrefix)SERVICE_MANAGEMENT_URL"  = $context.Environment.ServiceManagementUrl;
-    "$($serviceDirectoryPrefix)STORAGE_ENDPOINT_SUFFIX" = $context.Environment.StorageEndpointSuffix;
-  }
-
-  foreach ($key in $deployment.Outputs.Keys) {
-    $variable = $deployment.Outputs[$key]
-
-    # Work around bug that makes the first few characters of environment variables be lowercase.
-    $key = $key.ToUpperInvariant()
-
-    if ($variable.Type -eq 'String' -or $variable.Type -eq 'SecureString') {
-      $deploymentOutputs[$key] = $variable.Value
-    }
-  }
-
-  if ($OutFile) {
-    if (!$IsWindows) {
-      Write-Host "File option is supported only on Windows"
+    $templateFileParameters = $templateParameters.Clone()
+    foreach ($key in $templateParameters.Keys) {
+        if ($templateParameterNames -notcontains $key) {
+            Write-Verbose "Removing unnecessary parameter '$key'"
+            $templateFileParameters.Remove($key)
+        }
     }
 
-    $outputFile = "$templateFile.env"
-
-    $environmentText = $deploymentOutputs | ConvertTo-Json;
-    $bytes = ([System.Text.Encoding]::UTF8).GetBytes($environmentText)
-    $protectedBytes = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
-
-    Set-Content $outputFile -Value $protectedBytes -AsByteStream -Force
-
-    Write-Host "Test environment settings`n $environmentText`nstored into encrypted $outputFile"
-  }
-  else {
-
-    if (!$CI) {
-      # Write an extra new line to isolate the environment variables for easy reading.
-      Log "Persist the following environment variables based on your detected shell ($shell):`n"
+    $preDeploymentScript = $templateFile | Split-Path | Join-Path -ChildPath 'test-resources-pre.ps1'
+    if (Test-Path $preDeploymentScript) {
+        Log "Invoking pre-deployment script '$preDeploymentScript'"
+        &$preDeploymentScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
     }
 
-    foreach ($key in $deploymentOutputs.Keys) {
-      $value = $deploymentOutputs[$key]
-      $environmentVariables[$key] = $value
-
-      if ($CI) {
-        # Treat all ARM template output variables as secrets since "SecureString" variables do not set values.
-        # In order to mask secrets but set environment variables for any given ARM template, we set variables twice as shown below.
-        Write-Host "Setting variable '$key': ***"
-        Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($value)"
-        Write-Host "##vso[task.setvariable variable=$key;]$($value)"
-      }
-      else {
-        Write-Host ($shellExportFormat -f $key, $value)
-      }
+    Log "Deploying template '$templateFile' to resource group '$($resourceGroup.ResourceGroupName)'"
+    $deployment = Retry {
+        New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
     }
 
-    if ($key) {
-      # Isolate the environment variables for easy reading.
-      Write-Host "`n"
-      $key = $null
+    if ($deployment.ProvisioningState -eq 'Succeeded') {
+        # New-AzResourceGroupDeployment would've written an error and stopped the pipeline by default anyway.
+        Write-Verbose "Successfully deployed template '$templateFile' to resource group '$($resourceGroup.ResourceGroupName)'"
     }
-  }
 
-  $postDeploymentScript = $templateFile | Split-Path | Join-Path -ChildPath 'test-resources-post.ps1'
-  if (Test-Path $postDeploymentScript) {
-    Log "Invoking post-deployment script '$postDeploymentScript'"
-    &$postDeploymentScript -ResourceGroupName $rgName -DeploymentOutputs $deploymentOutputs @PSBoundParameters
-  }
+    $serviceDirectoryPrefix = $serviceName.ToUpperInvariant() + "_"
+
+    # Add default values
+    $deploymentOutputs = @{
+        "$($serviceDirectoryPrefix)CLIENT_ID" = $TestApplicationId;
+        "$($serviceDirectoryPrefix)CLIENT_SECRET" = $TestApplicationSecret;
+        "$($serviceDirectoryPrefix)TENANT_ID" = $context.Tenant.Id;
+        "$($serviceDirectoryPrefix)SUBSCRIPTION_ID" =  $context.Subscription.Id;
+        "$($serviceDirectoryPrefix)RESOURCE_GROUP" = $resourceGroup.ResourceGroupName;
+        "$($serviceDirectoryPrefix)LOCATION" = $resourceGroup.Location;
+        "$($serviceDirectoryPrefix)ENVIRONMENT" = $context.Environment.Name;
+        "$($serviceDirectoryPrefix)AZURE_AUTHORITY_HOST" = $context.Environment.ActiveDirectoryAuthority;
+        "$($serviceDirectoryPrefix)RESOURCE_MANAGER_URL" = $context.Environment.ResourceManagerUrl;
+        "$($serviceDirectoryPrefix)SERVICE_MANAGEMENT_URL" = $context.Environment.ServiceManagementUrl;
+        "$($serviceDirectoryPrefix)STORAGE_ENDPOINT_SUFFIX" = $context.Environment.StorageEndpointSuffix;
+    }
+
+    foreach ($key in $deployment.Outputs.Keys) {
+        $variable = $deployment.Outputs[$key]
+
+        # Work around bug that makes the first few characters of environment variables be lowercase.
+        $key = $key.ToUpperInvariant()
+
+        if ($variable.Type -eq 'String' -or $variable.Type -eq 'SecureString') {
+            $deploymentOutputs[$key] = $variable.Value
+        }
+    }
+
+    if ($OutFile)
+    {
+        if (!$IsWindows)
+        {
+            Write-Host "File option is supported only on Windows"
+        }
+
+        $outputFile = "$templateFile.env"
+
+        $environmentText = $deploymentOutputs | ConvertTo-Json;
+        $bytes = ([System.Text.Encoding]::UTF8).GetBytes($environmentText)
+        $protectedBytes = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+
+        Set-Content $outputFile -Value $protectedBytes -AsByteStream -Force
+
+        Write-Host "Test environment settings`n $environmentText`nstored into encrypted $outputFile"
+    }
+    else
+    {
+
+        if (!$CI) {
+            # Write an extra new line to isolate the environment variables for easy reading.
+            Log "Persist the following environment variables based on your detected shell ($shell):`n"
+        }
+
+        foreach ($key in $deploymentOutputs.Keys)
+        {
+            $value = $deploymentOutputs[$key]
+            $environmentVariables[$key] = $value
+
+            if ($CI) {
+                # Treat all ARM template output variables as secrets since "SecureString" variables do not set values.
+                # In order to mask secrets but set environment variables for any given ARM template, we set variables twice as shown below.
+                Write-Host "Setting variable '$key': ***"
+                Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($value)"
+                Write-Host "##vso[task.setvariable variable=$key;]$($value)"
+            } else {
+                Write-Host ($shellExportFormat -f $key, $value)
+            }
+        }
+
+        if ($key) {
+            # Isolate the environment variables for easy reading.
+            Write-Host "`n"
+            $key = $null
+        }
+    }
+
+    $postDeploymentScript = $templateFile | Split-Path | Join-Path -ChildPath 'test-resources-post.ps1'
+    if (Test-Path $postDeploymentScript) {
+        Log "Invoking post-deployment script '$postDeploymentScript'"
+        &$postDeploymentScript -ResourceGroupName $ResourceGroupName -DeploymentOutputs $deploymentOutputs @PSBoundParameters
+    }
 }
 
 $exitActions.Invoke()

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -8,13 +8,11 @@ schema: 2.0.0
 # New-TestResources.ps1
 
 ## SYNOPSIS
-
 Deploys live test resources defined for a service directory to Azure.
 
 ## SYNTAX
 
 ### Default (Default)
-
 ```
 New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
  -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
@@ -23,7 +21,6 @@ New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -Servic
 ```
 
 ### Provisioner
-
 ```
 New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
  -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
@@ -34,11 +31,10 @@ New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -Servic
 ```
 
 ## DESCRIPTION
-
 Deploys live test resouces specified in test-resources.json files to a resource
 group.
 
-This script searches the directory specified in \$ServiceDirectory recursively
+This script searches the directory specified in $ServiceDirectory recursively
 for files named test-resources.json.
 All found test-resources.json files will be
 deployed to the test resource group.
@@ -57,7 +53,6 @@ specified in $ProvisionerApplicationId and $ProvisionerApplicationSecret.
 ## EXAMPLES
 
 ### EXAMPLE 1
-
 ```
 Connect-AzAccount -Subscription "REPLACE_WITH_SUBSCRIPTION_ID"
 $testAadApp = New-AzADServicePrincipal -Role Owner -DisplayName 'azure-sdk-live-test-app'
@@ -75,7 +70,6 @@ Requires PowerShell 7 to use ConvertFrom-SecureString -AsPlainText or convert
 the SecureString to plaintext by another means.
 
 ### EXAMPLE 2
-
 ```
 New-TestResources.ps1 `
     -BaseName 'Generated' `
@@ -99,14 +93,13 @@ log redaction).
 ## PARAMETERS
 
 ### -BaseName
-
 A name to use in the resource group and passed to the ARM template as 'baseName'.
-Limit \$BaseName to enough characters to be under limit plus prefixes specified in
+Limit $BaseName to enough characters to be under limit plus prefixes specified in
 the ARM template.
 See also https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
 
 Note: The value specified for this parameter will be overriden and generated
-by New-TestResources.ps1 if \$CI is specified.
+by New-TestResources.ps1 if $CI is specified.
 
 ```yaml
 Type: String
@@ -121,7 +114,6 @@ Accept wildcard characters: False
 ```
 
 ### -ResourceGroupName
-
 Set this value to deploy directly to a Resource Group that has already been
 created.
 
@@ -138,7 +130,6 @@ Accept wildcard characters: False
 ```
 
 ### -ServiceDirectory
-
 A directory under 'sdk' in the repository root - optionally with subdirectories
 specified - in which to discover ARM templates named 'test-resources.json'.
 This can also be an absolute path or specify parent directories.
@@ -156,7 +147,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationId
-
 The AAD Application ID to authenticate the test runner against deployed
 resources.
 Passed to the ARM template as 'testApplicationId'.
@@ -177,7 +167,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationSecret
-
 Optional service principal secret (password) to authenticate the test runner
 against deployed resources.
 Passed to the ARM template as
@@ -199,7 +188,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationOid
-
 Service Principal Object ID of the AAD Test application.
 This is used to assign
 permissions to the AAD application so it can access tested features on the live
@@ -224,7 +212,6 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
-
 The tenant ID of a service principal when a provisioner is specified.
 The same
 Tenant ID is used for Test Application and Provisioner Application.
@@ -244,7 +231,6 @@ Accept wildcard characters: False
 ```
 
 ### -SubscriptionId
-
 Optional subscription ID to use for new resources when logging in as a
 provisioner.
 You can also use Set-AzContext if not provisioning.
@@ -262,7 +248,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationId
-
 The AAD Application ID used to provision test resources when a provisioner is
 specified.
 
@@ -283,7 +268,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationSecret
-
 A service principal secret (password) used to provision test resources when a
 provisioner is specified.
 
@@ -304,7 +288,6 @@ Accept wildcard characters: False
 ```
 
 ### -DeleteAfterHours
-
 Optional.
 Positive integer number of hours from the current time to set the
 'DeleteAfter' tag on the created resource group.
@@ -332,14 +315,13 @@ Accept wildcard characters: False
 ```
 
 ### -Location
-
 Optional location where resources should be created.
 If left empty, the default
 is based on the cloud to which the template is being deployed:
 
-- AzureCloud -\> 'westus2'
-- AzureUSGovernment -\> 'usgovvirginia'
-- AzureChinaCloud -\> 'chinaeast2'
+* AzureCloud -\> 'westus2'
+* AzureUSGovernment -\> 'usgovvirginia'
+* AzureChinaCloud -\> 'chinaeast2'
 
 ```yaml
 Type: String
@@ -354,7 +336,6 @@ Accept wildcard characters: False
 ```
 
 ### -Environment
-
 Name of the cloud environment.
 The default is the Azure Public Cloud
 ('PublicCloud')
@@ -372,7 +353,6 @@ Accept wildcard characters: False
 ```
 
 ### -AdditionalParameters
-
 Optional key-value pairs of parameters to pass to the ARM template(s).
 
 ```yaml
@@ -388,7 +368,6 @@ Accept wildcard characters: False
 ```
 
 ### -CI
-
 Indicates the script is run as part of a Continuous Integration / Continuous
 Deployment (CI/CD) build (only Azure Pipelines is currently supported).
 
@@ -405,7 +384,6 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-
 Force creation of resources instead of being prompted.
 
 ```yaml
@@ -421,7 +399,6 @@ Accept wildcard characters: False
 ```
 
 ### -OutFile
-
 Save test environment settings into a test-resources.json.env file next to test-resources.json.
 File is protected via DPAPI.
 Supported only on windows.
@@ -440,7 +417,6 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -457,7 +433,6 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -473,7 +448,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -485,3 +459,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Remove-TestResources.ps1]()
+

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -8,32 +8,37 @@ schema: 2.0.0
 # New-TestResources.ps1
 
 ## SYNOPSIS
+
 Deploys live test resources defined for a service directory to Azure.
 
 ## SYNTAX
 
 ### Default (Default)
+
 ```
-New-TestResources.ps1 [-BaseName] <String> -ServiceDirectory <String> -TestApplicationId <String>
- [-TestApplicationSecret <String>] [-TestApplicationOid <String>] [-DeleteAfterHours <Int32>]
- [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>] [-CI] [-Force] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
+ -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
+ [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>]
+ [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
+
 ```
-New-TestResources.ps1 [-BaseName] <String> -ServiceDirectory <String> -TestApplicationId <String>
- [-TestApplicationSecret <String>] [-TestApplicationOid <String>] -TenantId <String> [-SubscriptionId <String>]
- -ProvisionerApplicationId <String> -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>]
- [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>] [-CI] [-Force] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
+ -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
+ -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
+ -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
+ [-Environment <String>] [-AdditionalParameters <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 Deploys live test resouces specified in test-resources.json files to a resource
 group.
 
-This script searches the directory specified in $ServiceDirectory recursively
+This script searches the directory specified in \$ServiceDirectory recursively
 for files named test-resources.json.
 All found test-resources.json files will be
 deployed to the test resource group.
@@ -52,6 +57,7 @@ specified in $ProvisionerApplicationId and $ProvisionerApplicationSecret.
 ## EXAMPLES
 
 ### EXAMPLE 1
+
 ```
 Connect-AzAccount -Subscription "REPLACE_WITH_SUBSCRIPTION_ID"
 $testAadApp = New-AzADServicePrincipal -Role Owner -DisplayName 'azure-sdk-live-test-app'
@@ -69,6 +75,7 @@ Requires PowerShell 7 to use ConvertFrom-SecureString -AsPlainText or convert
 the SecureString to plaintext by another means.
 
 ### EXAMPLE 2
+
 ```
 New-TestResources.ps1 `
     -BaseName 'Generated' `
@@ -92,13 +99,14 @@ log redaction).
 ## PARAMETERS
 
 ### -BaseName
+
 A name to use in the resource group and passed to the ARM template as 'baseName'.
-Limit $BaseName to enough characters to be under limit plus prefixes specified in
+Limit \$BaseName to enough characters to be under limit plus prefixes specified in
 the ARM template.
 See also https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
 
 Note: The value specified for this parameter will be overriden and generated
-by New-TestResources.ps1 if $CI is specified.
+by New-TestResources.ps1 if \$CI is specified.
 
 ```yaml
 Type: String
@@ -112,7 +120,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ResourceGroupName
+
+Set this value to deploy directly to a Resource Group that has already been
+created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServiceDirectory
+
 A directory under 'sdk' in the repository root - optionally with subdirectories
 specified - in which to discover ARM templates named 'test-resources.json'.
 This can also be an absolute path or specify parent directories.
@@ -130,6 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationId
+
 The AAD Application ID to authenticate the test runner against deployed
 resources.
 Passed to the ARM template as 'testApplicationId'.
@@ -150,6 +177,7 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationSecret
+
 Optional service principal secret (password) to authenticate the test runner
 against deployed resources.
 Passed to the ARM template as
@@ -171,6 +199,7 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationOid
+
 Service Principal Object ID of the AAD Test application.
 This is used to assign
 permissions to the AAD application so it can access tested features on the live
@@ -195,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
+
 The tenant ID of a service principal when a provisioner is specified.
 The same
 Tenant ID is used for Test Application and Provisioner Application.
@@ -214,6 +244,7 @@ Accept wildcard characters: False
 ```
 
 ### -SubscriptionId
+
 Optional subscription ID to use for new resources when logging in as a
 provisioner.
 You can also use Set-AzContext if not provisioning.
@@ -231,6 +262,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationId
+
 The AAD Application ID used to provision test resources when a provisioner is
 specified.
 
@@ -251,6 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationSecret
+
 A service principal secret (password) used to provision test resources when a
 provisioner is specified.
 
@@ -271,6 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### -DeleteAfterHours
+
 Optional.
 Positive integer number of hours from the current time to set the
 'DeleteAfter' tag on the created resource group.
@@ -298,13 +332,14 @@ Accept wildcard characters: False
 ```
 
 ### -Location
+
 Optional location where resources should be created.
 If left empty, the default
 is based on the cloud to which the template is being deployed:
 
-* AzureCloud -\> 'westus2'
-* AzureUSGovernment -\> 'usgovvirginia'
-* AzureChinaCloud -\> 'chinaeast2'
+- AzureCloud -\> 'westus2'
+- AzureUSGovernment -\> 'usgovvirginia'
+- AzureChinaCloud -\> 'chinaeast2'
 
 ```yaml
 Type: String
@@ -319,6 +354,7 @@ Accept wildcard characters: False
 ```
 
 ### -Environment
+
 Name of the cloud environment.
 The default is the Azure Public Cloud
 ('PublicCloud')
@@ -336,6 +372,7 @@ Accept wildcard characters: False
 ```
 
 ### -AdditionalParameters
+
 Optional key-value pairs of parameters to pass to the ARM template(s).
 
 ```yaml
@@ -351,6 +388,7 @@ Accept wildcard characters: False
 ```
 
 ### -CI
+
 Indicates the script is run as part of a Continuous Integration / Continuous
 Deployment (CI/CD) build (only Azure Pipelines is currently supported).
 
@@ -367,6 +405,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Force creation of resources instead of being prompted.
 
 ```yaml
@@ -381,7 +420,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutFile
+
+Save test environment settings into a test-resources.json.env file next to test-resources.json.
+File is protected via DPAPI.
+Supported only on windows.
+The environment file would be scoped to the current repository directory.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -398,6 +457,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -412,24 +472,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OutFile
-save test environment settings into a test-resources.json.env file next to test-resources.json. 
-The file is protected via DPAPI. The environment file would be scoped to the current repository directory.
-Note: Supported only on Windows.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -440,4 +484,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Remove-TestResources.ps1](./Remove-TestResources.ps1.md)
+[Remove-TestResources.ps1]()

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -27,7 +27,7 @@ steps:
 
       eng/common/TestResources/Remove-TestResources.ps1 `
         -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}" `
-        -ServiceDirectory ${{ parameters.ServiceDirectory }} `
+        -ServiceDirectory "${{ parameters.ServiceDirectory }}" `
         @subscriptionConfiguration `
         -Force `
         -Verbose


### PR DESCRIPTION
This change fixes smoke test provisioning while changes to `eng/common` are locked down. The long term fix is here: https://github.com/Azure/azure-sdk-tools/pull/850 

Warning: any merge that causes `eng/common` to sync will replace these changes. 