### PR TITLE
[Identity] managedIdentityClientId optional parameter on the DAC options

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-preview.6 (Unreleased)
 
 - Renamed the `VSCodeCredential` to `VisualStudioCodeCredential`, and its options parameter from `VSCodeCredentialOptions` to `VisualStudioCodeCredentialOptions`.
+- Added `managedIdentityClientId` to optionally pass in a user assigned client ID for the `ManagedIdentityCredential`.
 
 ## 1.1.0-preview.5 (2020-07-22)
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -85,6 +85,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
 // @public
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
+    managedIdentityClientId?: string;
     tenantId?: string;
 }
 

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -16,6 +16,10 @@ export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
    * Optionally pass in a Tenant ID to be used as part of the credential
    */
   tenantId?: string;
+  /**
+   * Optionally pass in a user assigned client ID for the ManagedIdentityCredential
+   */
+  managedIdentityClientId?: string;
 }
 
 /**
@@ -41,7 +45,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
     if (process.env.AZURE_CLIENT_ID) {
       credentials.push(
-        new ManagedIdentityCredential(process.env.AZURE_CLIENT_ID, tokenCredentialOptions)
+        new ManagedIdentityCredential(tokenCredentialOptions?.managedIdentityClientId || process.env.AZURE_CLIENT_ID, tokenCredentialOptions)
       );
     }
     credentials.push(new AzureCliCredential());


### PR DESCRIPTION
This PR is to align with .Net,
but this comes mainly from the feedback I got from Scott on the Identity README PR: https://github.com/Azure/azure-sdk-for-js/pull/10506/files#r467472978
Feedback appreciated 🌻