### PR TITLE
[arm-sql] Add accept header on sendRequest

### DIFF
--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-sql",
   "author": "Microsoft Corporation",
   "description": "SqlManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^2.0.1",
     "@azure/ms-rest-js": "^2.0.4",

--- a/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClientContext.ts
@@ -13,7 +13,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 
 const packageName = "@azure/arm-sql";
-const packageVersion = "7.0.1";
+const packageVersion = "7.0.2";
 
 export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
   credentials: msRest.ServiceClientCredentials;
@@ -63,22 +63,17 @@ export class SqlManagementClientContext extends msRestAzure.AzureServiceClient {
    * When this library is regenerated, this override needs to be brought back
    * This override adds the header "Accept: application/json" to every request
    */
-  sendOperationRequest(
-    operationArguments: msRest.OperationArguments,
-    operationSpec: msRest.OperationSpec,
-    callback?: msRest.ServiceCallback<any>
-  ): Promise<msRest.RestResponse> {
-    const options = {
-      ...operationArguments,
-      options: {
-        ...operationArguments.options,
-        customHeaders: {
-          ...operationArguments.options?.customHeaders,
-          accept: "application/json",
-        },
-      },
-    };
+  sendRequest(options: msRest.RequestPrepareOptions | msRest.WebResourceLike) {
+    if(!options.headers) {
+      options.headers = {accept: "application/json"};
+    } else {
+      if (options.headers.set) {
+        options.headers.set("accept", "application/json");
+      } else {
+        (options.headers as {[key: string]: any})["accept"] = "application/json"
+      }
+    }
 
-    return super.sendOperationRequest(options, operationSpec, callback);
+    return super.sendRequest(options);
   }
 }


### PR DESCRIPTION
We were setting by default the accept header on `sendOperationRequest` however LRO operations call directly `sendRequest` which resulted in LRO poll to get XML responses.

Moving the accept header injection lower in the stack to `sendRequest` fixes the problem since `sendOperationRequest` also calls it.

Fixes #10350

/cc: @qiaozha