### PR TITLE
[Service Bus] @internal @ignore tags for the methods/interfaces that aren't exported

### DIFF
--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -16,6 +16,7 @@ import { MessageSession } from "./session/messageSession";
  * Provides contextual information like the underlying amqp connection, cbs session,
  * management session, tokenCredential, senders, receivers, etc. about the ServiceBus client.
  * @internal
+ * @ignore
  */
 export interface ClientEntityContextBase {
   /**
@@ -75,6 +76,7 @@ export interface ClientEntityContextBase {
 
 /**
  * @internal
+ * @ignore
  */
 export interface ClientEntityContext extends ClientEntityContextBase {
   onDetached(error?: AmqpError | Error): Promise<void>;
@@ -84,6 +86,7 @@ export interface ClientEntityContext extends ClientEntityContextBase {
 
 /**
  * @internal
+ * @ignore
  */
 export interface ClientEntityContextOptions {
   managementClientAddress?: string;
@@ -93,6 +96,7 @@ export interface ClientEntityContextOptions {
 
 /**
  * @internal
+ * @ignore
  */
 export namespace ClientEntityContext {
   /**

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -20,6 +20,7 @@ import { getRuntimeInfo } from "./util/runtimeInfo";
 
 /**
  * @internal
+ * @ignore
  * Provides contextual information like the underlying amqp connection, cbs session, management session,
  * tokenCredential, senders, receivers, etc. about the ServiceBus client.
  */
@@ -89,6 +90,7 @@ type ConnectionContextMethods = Omit<
 
 /**
  * @internal
+ * @ignore
  */
 export namespace ConnectionContext {
   export function create(

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -28,6 +28,7 @@ import { checkAndRegisterWithAbortSignal } from "../util/utils";
  * Describes the batching receiver where the user can receive a specified number of messages for
  * a predefined time.
  * @internal
+ * @ignore
  * @class BatchingReceiver
  * @extends MessageReceiver
  */

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -15,6 +15,7 @@ import { getUniqueName } from "../util/utils";
 
 /**
  * @internal
+ * @ignore
  * Options passed to the constructor of LinkEntity
  */
 export interface LinkEntityOptions {
@@ -30,6 +31,7 @@ export interface LinkEntityOptions {
 
 /**
  * @internal
+ * @ignore
  * Describes the base class for entities like MessageSender, MessageReceiver and Management client.
  * @class ClientEntity
  */

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -161,6 +161,7 @@ export interface DispositionStatusOptions extends OperationOptionsBase {
 
 /**
  * @internal
+ * @ignore
  * Options passed to the constructor of ManagementClient
  */
 export interface ManagementClientOptions {
@@ -170,8 +171,9 @@ export interface ManagementClientOptions {
 
 /**
  * @internal
+ * @ignore
  * @class ManagementClient
- * Descibes the ServiceBus Management Client that talks
+ * Describes the ServiceBus Management Client that talks
  * to the $management endpoint over AMQP connection.
  */
 export class ManagementClient extends LinkEntity {

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -31,6 +31,7 @@ export type ReceiverHandlers = Pick<
 
 /**
  * @internal
+ * @ignore
  */
 export interface OnAmqpEventAsPromise extends OnAmqpEvent {
   (context: EventContext): Promise<void>;
@@ -47,6 +48,7 @@ export enum ReceiverType {
 
 /**
  * @internal
+ * @ignore
  */
 export interface ReceiveOptions extends MessageHandlerOptions {
   /**
@@ -87,6 +89,7 @@ export interface OnError {
 
 /**
  * @internal
+ * @ignore
  * Describes the MessageReceiver that will receive messages from ServiceBus.
  * @class MessageReceiver
  */

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -41,6 +41,7 @@ import { AbortError, AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * @internal
+ * @ignore
  * Describes the MessageSender that will send messages to ServiceBus.
  * @class MessageSender
  */

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -34,6 +34,7 @@ import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * @internal
+ * @ignore
  * Describes the streaming receiver where the user can receive the message
  * by providing handler functions.
  * @class StreamingReceiver

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -4,91 +4,109 @@
 import debugModule from "debug";
 /**
  * @internal
+ * @ignore
  * log statements for linkEntity
  */
 export const link = debugModule("azure:service-bus:linkEntity");
 /**
  * @internal
+ * @ignore
  * log statements for error
  */
 export const error = debugModule("azure:service-bus:error");
 /**
  * @internal
+ * @ignore
  * log statements for warning
  */
 export const warning = debugModule("azure:service-bus:warning");
 /**
  * @internal
+ * @ignore
  * log statements for management
  */
 export const mgmt = debugModule("azure:service-bus:management");
 /**
  * @internal
+ * @ignore
  * log statements for sender
  */
 export const sender = debugModule("azure:service-bus:sender");
 /**
  * @internal
+ * @ignore
  * log statements for receiver
  */
 export const receiver = debugModule("azure:service-bus:receiver");
 /**
  * @internal
+ * @ignore
  * log statements for receiverbatching
  */
 export const batching = debugModule("azure:service-bus:receiverbatching");
 /**
  * @internal
+ * @ignore
  * log statements for receiverstreaming
  */
 export const streaming = debugModule("azure:service-bus:receiverstreaming");
 /**
  * @internal
+ * @ignore
  * log statements for connectionContext
  */
 export const connectionCtxt = debugModule("azure:service-bus:connectionContext");
 /**
  * @internal
+ * @ignore
  * log statements for clientEntityContext
  */
 export const entityCtxt = debugModule("azure:service-bus:clientEntityContext");
 /**
  * @internal
+ * @ignore
  * log statements for namespace
  */
 export const ns = debugModule("azure:service-bus:namespace");
 /**
  * @internal
+ * @ignore
  * log statements for servicebusMessage
  */
 export const message = debugModule("azure:service-bus:servicebusMessage");
 /**
  * @internal
+ * @ignore
  * log statements for map
  */
 export const map = debugModule("azure:service-bus:concurrentMap");
 /**
  * @internal
+ * @ignore
  * log statements for utils
  */
 export const utils = debugModule("azure:service-bus:utils");
 /**
  * @internal
+ * @ignore
  * log statements for messageSession
  */
 export const messageSession = debugModule("azure:service-bus:messageSession");
 /**
  * @internal
+ * @ignore
  * log statements for semaphore
  */
 export const semaphore = debugModule("azure:service-bus:semaphore");
 /**
  * @internal
+ * @ignore
  * log statements for sessionManager
  */
 export const sessionManager = debugModule("azure:service-bus:sessionManager");
 /**
  * @internal
+ * @ignore
  * log statements for Atom XML management API over HTTP
  */
 export const httpAtomXml = debugModule("azure:service-bus:atom-xml");

--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -7,10 +7,10 @@ import { Span, SpanContext } from "@opentelemetry/api";
 import { OperationOptions } from "@azure/core-http";
 
 /**
+ * NOTE: This type is intended to mirror the relevant fields and structure from @azure/core-http OperationOptions
+ *
  * Options for configuring tracing and the abortSignal.
  */
-// NOTE: This type is intended to mirror the relevant fields and structure from
-// @azure/core-http OperationOptions
 export type OperationOptionsBase = Pick<OperationOptions, "abortSignal" | "tracingOptions">;
 
 /**

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -301,7 +301,6 @@ type RawKeyValuePair = {
 /**
  * @internal
  * @ignore
- * @interface InternalRawKeyValuePairs
  */
 interface InternalRawKeyValuePairs {
   KeyValueOfstringanyType: RawKeyValuePair[];

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -298,6 +298,11 @@ type RawKeyValuePair = {
   Value: any;
 };
 
+/**
+ * @internal
+ * @ignore
+ * @interface InternalRawKeyValuePairs
+ */
 interface InternalRawKeyValuePairs {
   KeyValueOfstringanyType: RawKeyValuePair[];
 }

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -416,7 +416,8 @@ export interface TopicRuntimeProperties {
 
 /**
  * @internal
- * @ignore TopicResourceSerializer for serializing / deserializing Topic entities
+ * @ignore 
+ * TopicResourceSerializer for serializing / deserializing Topic entities
  */
 export class TopicResourceSerializer implements AtomXmlSerializer {
   serialize(resource: InternalTopicOptions): object {

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -34,6 +34,7 @@ export enum InternalReceiveMode {
 
 /**
  * @internal
+ * @ignore
  */
 export enum DispositionType {
   complete = "complete",
@@ -44,6 +45,7 @@ export enum DispositionType {
 
 /**
  * @internal
+ * @ignore
  * Describes the delivery annotations for Service Bus.
  */
 export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
@@ -71,6 +73,7 @@ export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
 
 /**
  * @internal
+ * @ignore
  * Describes the message annotations for Service Bus.
  */
 export interface ServiceBusMessageAnnotations extends MessageAnnotations {
@@ -224,6 +227,7 @@ export interface ServiceBusMessage {
 
 /**
  * @internal
+ * @ignore
  * Gets the error message for when a property on given message is not of expected type
  */
 export function getMessagePropertyTypeMismatchError(msg: ServiceBusMessage): Error | undefined {
@@ -281,6 +285,7 @@ export function getMessagePropertyTypeMismatchError(msg: ServiceBusMessage): Err
 
 /**
  * @internal
+ * @ignore
  * Converts given ServiceBusMessage to AmqpMessage
  */
 export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
@@ -566,6 +571,7 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
 }
 
 /**
+ * @internal
  * @ignore
  * Converts given AmqpMessage to ReceivedMessage
  */

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -27,6 +27,7 @@ import { ReceiverHelper } from "../core/receiverHelper";
 /**
  * Describes the options that need to be provided while creating a message session receiver link.
  * @internal
+ * @ignore
  */
 export interface CreateMessageSessionReceiverLinkOptions {
   onClose: OnAmqpEventAsPromise;
@@ -79,6 +80,7 @@ export interface SessionMessageHandlerOptions {
 
 /**
  * @internal
+ * @ignore
  * Describes all the options that can be set while instantiating a MessageSession object.
  */
 export type MessageSessionOptions = SessionReceiverOptions & {
@@ -87,6 +89,7 @@ export type MessageSessionOptions = SessionReceiverOptions & {
 
 /**
  * @internal
+ * @ignore
  * Describes the receiver for a Message Session.
  */
 export class MessageSession extends LinkEntity {

--- a/sdk/servicebus/service-bus/src/util/concurrentExpiringMap.ts
+++ b/sdk/servicebus/service-bus/src/util/concurrentExpiringMap.ts
@@ -8,6 +8,7 @@ import * as log from "../log";
 /**
  * Describes a map that ensures, deleting a an entry from the map is concurrency safe.
  * @internal
+ * @ignore
  * @class ConcurrentExpiringMap<TKey>
  */
 export class ConcurrentExpiringMap<TKey> {

--- a/sdk/servicebus/service-bus/src/util/crypto.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.ts
@@ -9,8 +9,6 @@ import crypto from "crypto";
 /**
  * @internal
  * @ignore
- * @param {string} secret
- * @param {string} stringToSign
  */
 export async function generateKey(secret: string, stringToSign: string) {
   const result = encodeURIComponent(

--- a/sdk/servicebus/service-bus/src/util/crypto.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.ts
@@ -6,6 +6,12 @@
 
 import crypto from "crypto";
 
+/**
+ * @internal
+ * @ignore
+ * @param {string} secret
+ * @param {string} stringToSign
+ */
 export async function generateKey(secret: string, stringToSign: string) {
   const result = encodeURIComponent(
     crypto

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -7,6 +7,7 @@ import { ConnectionContext } from "../connectionContext";
 
 /**
  * @internal
+ * @ignore
  * Logs and throws Error if the current AMQP connection is closed.
  * @param context The ConnectionContext associated with the current AMQP connection.
  */
@@ -21,6 +22,7 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
 
 /**
  * @internal
+ * @ignore
  * Gets the error message when a sender is used when its already closed
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  */
@@ -33,6 +35,7 @@ export function getSenderClosedErrorMsg(entityPath: string): string {
 
 /**
  * @internal
+ * @ignore
  * Gets the error message when a receiver is used when its already closed
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  * @param sessionId If using session receiver, then the id of the session
@@ -52,6 +55,7 @@ export function getReceiverClosedErrorMsg(entityPath: string, sessionId?: string
 
 /**
  * @internal
+ * @ignore
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  * @param sessionId If using session receiver, then the id of the session
  */
@@ -64,6 +68,7 @@ export function getAlreadyReceivingErrorMsg(entityPath: string, sessionId?: stri
 
 /**
  * @internal
+ * @ignore
  * Logs and Throws TypeError if given parameter is undefined or null
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to check
@@ -83,6 +88,7 @@ export function throwTypeErrorIfParameterMissing(
 
 /**
  * @internal
+ * @ignore
  * Logs and Throws TypeError if given parameter is not of expected type
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -106,6 +112,7 @@ export function throwTypeErrorIfParameterTypeMismatch(
 
 /**
  * @internal
+ * @ignore
  * Logs and Throws TypeError if given parameter is not of type `Long` or an array of type `Long`
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -129,6 +136,7 @@ export function throwTypeErrorIfParameterNotLong(
 
 /**
  * @internal
+ * @ignore
  * Logs and Throws TypeError if given parameter is not an array of type `Long`
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -149,6 +157,7 @@ export function throwTypeErrorIfParameterNotLongArray(
 
 /**
  * @internal
+ * @ignore
  * Logs and Throws TypeError if given parameter is an empty string
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -169,6 +178,7 @@ export function throwTypeErrorIfParameterIsEmptyString(
 
 /**
  * @internal
+ * @ignore
  * Gets error message for when an operation is not supported in ReceiveAndDelete mode
  * @param failedToDo A string to add to the placeholder in the error message. Denotes the action
  * that is not supported in ReceiveAndDelete mode

--- a/sdk/servicebus/service-bus/src/util/runtimeInfo.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/runtimeInfo.browser.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @internal
+ * @ignore
+ */
 interface NavigatorEx extends Navigator {
   // oscpu is not yet standards-compliant, but can not be undefined in TypeScript 3.6.2
   readonly oscpu: string;

--- a/sdk/servicebus/service-bus/src/util/semaphore.ts
+++ b/sdk/servicebus/service-bus/src/util/semaphore.ts
@@ -3,6 +3,7 @@
 
 /**
  * @internal
+ * @ignore
  * A simple Semaphore
  * @class Semaphore
  */

--- a/sdk/servicebus/service-bus/src/util/tracing.ts
+++ b/sdk/servicebus/service-bus/src/util/tracing.ts
@@ -6,6 +6,8 @@ import { getTracer } from "@azure/core-tracing";
 import { CanonicalCode, Span, SpanKind, SpanOptions as OTSpanOptions } from "@opentelemetry/api";
 
 /**
+ * @internal
+ * @ignore
  * Creates a span using the global tracer.
  * @param name The name of the operation being performed.
  * @param operationOptions The options for the underlying http request.
@@ -44,6 +46,10 @@ export function createSpan(
   };
 }
 
+/**
+ * @internal
+ * @ignore
+ */
 export function getCanonicalCode(err: Error) {
   if (err instanceof RestError) {
     switch (err.statusCode) {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -598,7 +598,6 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
  * @ignore
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
- * @export
  * @param {string} [prefix]
  * @returns {string}
  */

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -586,12 +586,16 @@ export function checkAndRegisterWithAbortSignal(
 }
 
 /**
+ * @internal
+ * @ignore
  * @property {string} libInfo The user agent prefix string for the ServiceBus client.
  * See guideline at https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
  */
 export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJsonInfo.version}`;
 
 /**
+ * @internal
+ * @ignore
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
  * @export


### PR DESCRIPTION
Many un-exported interfaces/functions/classes are ending up in the generated docs since they don't have the `@internal`/`@ignore` tags on them. This PR attempts to clean the ref docs by fixing the issue.