### PR TITLE
[Cosmos] fix dates in changelog to be 2 digits

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.8.0 (2020-8-10)
+## 3.8.0 (2020-08-10)
 
 - FEATURE: Throws when initializing ClientContext with an invalid endpoint
 - FEATURE: Changes JSONArray type internal from Array to ArrayLike to avoid requiring type coercion for immutable data
@@ -27,24 +27,24 @@ const operations: OperationInput[] = [
 await database.container.items.bulk(operations);
 ```
 
-## 3.7.4 (2020-6-30)
+## 3.7.4 (2020-06-30)
 
 - BUGFIX: Properly escape ASCII "DEL" character in partition key header
 
-## 3.7.3 (2020-6-29)
+## 3.7.3 (2020-06-29)
 
 - BUGFIX: Cannot create item with automatic id generation and a container partitioned on ID (#9734)
 
-## 3.7.2 (2020-6-16)
+## 3.7.2 (2020-06-16)
 
 - BUGFIX: Internal abort signal incorrectly triggered when user passes a custom abort signal. See #9510 for details.
 
-## 3.7.1 (2020-6-12)
+## 3.7.1 (2020-06-12)
 
 - BUGFIX: Typo in globalCrypto.js causing errors in IE browser
 - BUGFIX: Resource tokens not matching for item delete operations (#9110)
 
-## 3.7.0 (2020-6-08)
+## 3.7.0 (2020-06-08)
 
 - BUGFIX: Support crypto functions in Internet Explorer browser
 - BUGFIX: Incorrect key casing in object returned by `setAuthorizationHeader`
@@ -73,7 +73,7 @@ const containerDefinition = {
 database.container.create(containerDefinition);
 ```
 
-## 3.6.3 (2020-4-08)
+## 3.6.3 (2020-04-08)
 
 - FEATURE: Add `partitionKey` to `FeedOptions` for scoping a query to a single partition key value
 
@@ -94,24 +94,24 @@ container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').fetchA
 
 Based on customer feedback, we identified scenarios where it still makes sense to support passing the partition key via `FeedOptions` and have decided to restore the behavior.
 
-## 3.6.2 (2020-2-20)
+## 3.6.2 (2020-02-20)
 
 - BUG FIX: Support signing in web workers where this === self
 
-## 3.6.1 (2020-2-11)
+## 3.6.1 (2020-02-11)
 
 - BUG FIX: Normalize location names when selecting endpoint. Allows passing of normalized endpoint names
 
-## 3.6.0 (2020-2-10)
+## 3.6.0 (2020-02-10)
 
 - FEATURE: Add support for spatial indexing, bounding boxes, and geospatial configuration
 - BUG FIX: Fix bug when passing forceQueryPlan to QueryIterator for non-item resources (#7333)
 
-## 3.5.4 (2020-1-28)
+## 3.5.4 (2020-01-28)
 
 - BUG FIX: Return parsed number instead of string for request charge
 
-## 3.5.3 (2020-1-06)
+## 3.5.3 (2020-01-06)
 
 - BUG FIX: maxDegreeOfParallelism was defaulting to 1 and should default to the number of partitions of the collection
 - BUG FIX: maxItemCount was defaulting to 10 and should default to undefined


### PR DESCRIPTION
Looks like changelog dates now fail with single digits, e.g., 2020-8-10 should be 2020-08-10