### PR TITLE
[Pre-commit hook] Fix the hook

### DIFF
--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -10,7 +10,7 @@ echo Starting Git hook: pre-commit
 
 MERGE=$(git rev-parse -q --verify MERGE_HEAD)
 
-if [[ $MERGE ]]; then
+if [ ! -z ${MERGE} ]; then
     echo "This is a merge.... Skipping prettying"
     exit
 fi


### PR DESCRIPTION
The hook is a shell script but was using bash features. This replaces the bash expression with a shell one.