### PR TITLE
[Key Vault] Fixing bad dist-esm folders on the resulting artifacts

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -109,7 +109,6 @@
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
-    "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/keyvault/keyvault-certificates/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-certificates/rollup.base.config.js
@@ -8,7 +8,6 @@ import replace from "@rollup/plugin-replace";
 import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
-import json from "@rollup/plugin-json";
 
 /**
  * @type {import('rollup').RollupFileOptions}
@@ -59,8 +58,7 @@ export function nodeConfig(test = false) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
 
     // different output file
@@ -133,8 +131,7 @@ export function browserConfig(test = false) {
     baseConfig.external.push("os");
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
     baseConfig.output.file = "dist-test/index.browser.js";
     baseConfig.context = "null";

--- a/sdk/keyvault/keyvault-certificates/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-certificates/rollup.base.config.js
@@ -57,9 +57,7 @@ export function nodeConfig(test = false) {
   if (test) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";
@@ -130,9 +128,7 @@ export function browserConfig(test = false) {
   if (test) {
     baseConfig.external.push("os");
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "dist-test/index.browser.js";
     baseConfig.context = "null";
 

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -471,7 +471,10 @@ export class CertificateClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(
+      pipelineOptions.serviceVersion || LATEST_API_VERSION,
+      pipeline
+    );
   }
 
   private async *listPropertiesOfCertificatesPage(

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -2,12 +2,17 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { version } from "../../package.json";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import { isNode } from '@azure/core-http';
+import * as fs from "fs";
 
-describe("Certificates client's user agent", () => {
-  // The tests follow
+describe("Certificates client's user agent (only in Node, because of fs)", () => {
+  if (!isNode) {
+    return;
+  }
+
+  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
 
   it("the version at constants should be as expected", async function() {
     assert.equal(version, SDK_VERSION);

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -5,6 +5,7 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from "@azure/core-http";
+import path from "path";
 import fs from "fs";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
@@ -18,7 +19,7 @@ describe("Certificates client's user agent (only in Node, because of fs)", () =>
       return;
     }
     const { version } = JSON.parse(
-      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
     );
     assert.equal(version, packageVersion);
   });

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -5,20 +5,19 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from '@azure/core-http';
-import * as fs from "fs";
+import fs from "fs";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
-  if (!isNode) {
-    return;
-  }
-
-  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
-
-  it("the version at constants should be as expected", async function() {
-    assert.equal(version, SDK_VERSION);
+  it("SDK_VERSION and packageVersion should match", async function() {
+    assert.equal(SDK_VERSION, packageVersion);
   });
 
-  it("the version at KeyVaultClientContext should be as expected", async function() {
+  it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
+    if (!isNode) {
+      this.skip();
+      return;
+    }
+    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from '@azure/core-http';
+import { isNode } from "@azure/core-http";
 import fs from "fs";
 
 describe("Certificates client's user agent (only in Node, because of fs)", () => {
@@ -17,7 +17,9 @@ describe("Certificates client's user agent (only in Node, because of fs)", () =>
       this.skip();
       return;
     }
-    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
+    const { version } = JSON.parse(
+      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+    );
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -99,7 +99,6 @@
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
-    "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/keyvault/keyvault-keys/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.base.config.js
@@ -57,9 +57,7 @@ export function nodeConfig(test = false) {
   if (test) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";
@@ -127,9 +125,7 @@ export function browserConfig(test = false) {
   baseConfig.external = ["fs-extra", "path", "crypto", "constants"];
   if (test) {
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "dist-test/index.browser.js";
     // mark fs-extra as external
     baseConfig.context = "null";

--- a/sdk/keyvault/keyvault-keys/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.base.config.js
@@ -8,7 +8,6 @@ import replace from "@rollup/plugin-replace";
 import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
-import json from "@rollup/plugin-json";
 
 /**
  * @type {import('rollup').RollupFileOptions}
@@ -59,8 +58,7 @@ export function nodeConfig(test = false) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
 
     // different output file
@@ -130,8 +128,7 @@ export function browserConfig(test = false) {
   if (test) {
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
     baseConfig.output.file = "dist-test/index.browser.js";
     // mark fs-extra as external

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -709,7 +709,10 @@ export class CryptographyClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(
+      pipelineOptions.serviceVersion || LATEST_API_VERSION,
+      pipeline
+    );
 
     let parsed;
     if (typeof key === "string") {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -239,7 +239,10 @@ export class KeyClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(
+      pipelineOptions.serviceVersion || LATEST_API_VERSION,
+      pipeline
+    );
   }
 
   /**

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -5,20 +5,19 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from '@azure/core-http';
-import * as fs from "fs";
+import fs from "fs";
 
 describe("Keys client's user agent (only in Node, because of fs)", () => {
-  if (!isNode) {
-    return;
-  }
-
-  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
-
-  it("the version at constants should be as expected", async function() {
-    assert.equal(version, SDK_VERSION);
+  it("SDK_VERSION and packageVersion should match", async function() {
+    assert.equal(SDK_VERSION, packageVersion);
   });
 
-  it("the version at KeyVaultClientContext should be as expected", async function() {
+  it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
+    if (!isNode) {
+      this.skip();
+      return;
+    }
+    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -5,6 +5,7 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from "@azure/core-http";
+import path from "path";
 import fs from "fs";
 
 describe("Keys client's user agent (only in Node, because of fs)", () => {
@@ -18,7 +19,7 @@ describe("Keys client's user agent (only in Node, because of fs)", () => {
       return;
     }
     const { version } = JSON.parse(
-      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
     );
     assert.equal(version, packageVersion);
   });

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from '@azure/core-http';
+import { isNode } from "@azure/core-http";
 import fs from "fs";
 
 describe("Keys client's user agent (only in Node, because of fs)", () => {
@@ -17,7 +17,9 @@ describe("Keys client's user agent (only in Node, because of fs)", () => {
       this.skip();
       return;
     }
-    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
+    const { version } = JSON.parse(
+      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+    );
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -2,12 +2,17 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { version } from "../../package.json";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import { isNode } from '@azure/core-http';
+import * as fs from "fs";
 
-describe("Keys client's user agent", () => {
-  // The tests follow
+describe("Keys client's user agent (only in Node, because of fs)", () => {
+  if (!isNode) {
+    return;
+  }
+
+  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
 
   it("the version at constants should be as expected", async function() {
     assert.equal(version, SDK_VERSION);

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -107,7 +107,6 @@
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
-    "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",

--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -57,9 +57,7 @@ export function nodeConfig(test = false) {
   if (test) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";
@@ -126,9 +124,7 @@ export function browserConfig(test = false) {
 
   if (test) {
     baseConfig.input = ["dist-esm/**/*.spec.js"];
-    baseConfig.plugins.unshift(
-      multiEntry({ exports: false })
-    );
+    baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "dist-test/index.browser.js";
     // mark fs-extra as external
     baseConfig.external = ["fs-extra", "path"];

--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -8,7 +8,6 @@ import replace from "@rollup/plugin-replace";
 import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
-import json from "@rollup/plugin-json";
 
 /**
  * @type {import('rollup').RollupFileOptions}
@@ -59,8 +58,7 @@ export function nodeConfig(test = false) {
     // entry point is every test file
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
 
     // different output file
@@ -129,8 +127,7 @@ export function browserConfig(test = false) {
   if (test) {
     baseConfig.input = ["dist-esm/**/*.spec.js"];
     baseConfig.plugins.unshift(
-      multiEntry({ exports: false }),
-      json() // This allows us to import/require the package.json file, to get the version and test it against the user agent.
+      multiEntry({ exports: false })
     );
     baseConfig.output.file = "dist-test/index.browser.js";
     // mark fs-extra as external

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -183,7 +183,10 @@ export class SecretClient {
     };
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
-    this.client = new KeyVaultClient(pipelineOptions.serviceVersion || LATEST_API_VERSION, pipeline);
+    this.client = new KeyVaultClient(
+      pipelineOptions.serviceVersion || LATEST_API_VERSION,
+      pipeline
+    );
   }
 
   /**

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -5,20 +5,19 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from '@azure/core-http';
-import * as fs from "fs";
+import fs from "fs";
 
 describe("Secrets client's user agent (only in Node, because of fs)", () => {
-  if (!isNode) {
-    return;
-  }
-
-  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
-
-  it("the version at constants should be as expected", async function() {
-    assert.equal(version, SDK_VERSION);
+  it("SDK_VERSION and packageVersion should match", async function() {
+    assert.equal(SDK_VERSION, packageVersion);
   });
 
-  it("the version at KeyVaultClientContext should be as expected", async function() {
+  it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
+    if (!isNode) {
+      this.skip();
+      return;
+    }
+    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
-import { isNode } from '@azure/core-http';
+import { isNode } from "@azure/core-http";
 import fs from "fs";
 
 describe("Secrets client's user agent (only in Node, because of fs)", () => {
@@ -17,7 +17,9 @@ describe("Secrets client's user agent (only in Node, because of fs)", () => {
       this.skip();
       return;
     }
-    const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
+    const { version } = JSON.parse(
+      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+    );
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -2,12 +2,17 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { version } from "../../package.json";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
+import { isNode } from '@azure/core-http';
+import * as fs from "fs";
 
-describe("Secrets client's user agent", () => {
-  // The tests follow
+describe("Secrets client's user agent (only in Node, because of fs)", () => {
+  if (!isNode) {
+    return;
+  }
+
+  const { version } = JSON.parse(fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" }))
 
   it("the version at constants should be as expected", async function() {
     assert.equal(version, SDK_VERSION);

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -5,6 +5,7 @@ import * as assert from "assert";
 import { SDK_VERSION } from "../../src/generated/utils/constants";
 import { packageVersion } from "../../src/generated/keyVaultClientContext";
 import { isNode } from "@azure/core-http";
+import path from "path";
 import fs from "fs";
 
 describe("Secrets client's user agent (only in Node, because of fs)", () => {
@@ -18,7 +19,7 @@ describe("Secrets client's user agent (only in Node, because of fs)", () => {
       return;
     }
     const { version } = JSON.parse(
-      fs.readFileSync(__dirname + "/../package.json", { encoding: "utf-8" })
+      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
     );
     assert.equal(version, packageVersion);
   });


### PR DESCRIPTION
By loading the package.json in the test files, the dist-esm folder was including a copy of the package.json, breaking the whole folder (thus also source maps, etc).