### PR TITLE
[Key Vault] Build fixes

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0 (2020-08-12)
 
+4.1.0 had changes both relative to the last GA release, `4.0.4`, and the last preview release, `4.1.0-preview.1`.
+
 ### Changes since 4.0.2
 
 - Added the optional `serviceVersion` property to the `CertificateClient` optional parameters to control the version of the Key Vault service being used by the client. 

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -18,9 +18,21 @@ describe("Certificates client's user agent (only in Node, because of fs)", () =>
       this.skip();
       return;
     }
-    const { version } = JSON.parse(
-      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
-    );
+    let version: string;
+    try {
+      // The unit-test script has this test file at: test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    } catch {
+      // The integration-test script has this test file in a considerably different place,
+      // Along the lines of: dist-esm/keyvault-keys/test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    }
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0 (2020-08-12)
 
+4.1.0 had changes both relative to the last GA release, `4.0.4`, and the last preview release, `4.1.0-preview.1`.
+
 ### Changes since 4.0.4
 
 - Added the optional `serviceVersion` property to the `KeyClient` and `CryptographyClient` optional parameters to control the version of the Key Vault service being used by the clients.

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -13,7 +13,7 @@ describe("Keys client's user agent (only in Node, because of fs)", () => {
     assert.equal(SDK_VERSION, packageVersion);
   });
 
-  it.only("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
+  it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
     if (!isNode) {
       this.skip();
       return;

--- a/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/userAgent.spec.ts
@@ -13,14 +13,26 @@ describe("Keys client's user agent (only in Node, because of fs)", () => {
     assert.equal(SDK_VERSION, packageVersion);
   });
 
-  it("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
+  it.only("the version should also match with the one available in the package.json  (only in Node, because of fs)", async function() {
     if (!isNode) {
       this.skip();
       return;
     }
-    const { version } = JSON.parse(
-      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
-    );
+    let version: string;
+    try {
+      // The unit-test script has this test file at: test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    } catch {
+      // The integration-test script has this test file in a considerably different place,
+      // Along the lines of: dist-esm/keyvault-keys/test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    }
     assert.equal(version, packageVersion);
   });
 });

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0 (2020-08-12)
 
+4.1.0 had changes both relative to the last GA release, `4.0.4`, and the last preview release, `4.1.0-preview.1`.
+
 ### Changes since 4.0.4
 
 - Added the optional `serviceVersion` property to the `SecretClient` optional parameters to control the version of the Key Vault service being used by the client.

--- a/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/userAgent.spec.ts
@@ -18,9 +18,21 @@ describe("Secrets client's user agent (only in Node, because of fs)", () => {
       this.skip();
       return;
     }
-    const { version } = JSON.parse(
-      fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
-    );
+    let version: string;
+    try {
+      // The unit-test script has this test file at: test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    } catch {
+      // The integration-test script has this test file in a considerably different place,
+      // Along the lines of: dist-esm/keyvault-keys/test/internal/userAgent.spec.ts
+      const fileContents = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
+      );
+      version = fileContents.version;
+    }
     assert.equal(version, packageVersion);
   });
 });


### PR DESCRIPTION
When I tried to release these packages, the build failed with the following:

```
/usr/bin/pwsh -NoLogo -NoProfile -NonInteractive -Command . '/home/vsts/work/_temp/2e50d22d-8ff5-4439-b7fb-95f92dfe83e4.ps1'
Found the following change log entry for version '4.1.0' in [/home/vsts/work/1/s/sdk/keyvault/keyvault-secrets/CHANGELOG.md].
-----
## 4.1.0 (2020-08-12)

-----
Confirm-ChangeLogEntry: /home/vsts/work/1/s/eng/common/scripts/Verify-ChangeLog.ps1:40
Line |
  40 |  … ChangeLog = Confirm-ChangeLogEntry -ChangeLogLocation $PackageProp.pk …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Entry has no content. Please ensure to provide some content of
     | what changed in this version.


##[error]PowerShell exited with code '1'.
```

Here's my attempt to fix this.

Also, nightly builds were reporting some issues with the recent test changes. I'll run the live tests as part of this PR with the fixes I'm making.