### PR TITLE
[Service Bus] Remove en-us from links

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -86,7 +86,7 @@
   - The "update" methods (`updateQueue`, `updateTopic`, and `updateSubscription`) now require all properties on the given queue/topic/subscription object to be set even though only a subset of them are updatable. Therefore, the suggested flow is to use the "get" methods to get the queue/topic/subscription object, update as needed and then pass it to the "update" methods.
     [PR 9751](https://github.com/Azure/azure-sdk-for-js/pull/9751)
 
-    See [update queue](https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue) and [update-topic](https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue) for list of updatable properties.
+    See [update queue](https://docs.microsoft.com/rest/api/servicebus/update-queue) and [update-topic](https://docs.microsoft.com/rest/api/servicebus/update-queue) for list of updatable properties.
 
 ## 7.0.0-preview.3 (2020-06-08)
 

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -1,6 +1,6 @@
 # Azure Service Bus client library for Javascript (Preview)
 
-[Azure Service Bus](https://azure.microsoft.com/en-us/services/service-bus/) is a highly-reliable cloud messaging service from Microsoft.
+[Azure Service Bus](https://azure.microsoft.com/services/service-bus/) is a highly-reliable cloud messaging service from Microsoft.
 
 Use the client library `@azure/service-bus` in your application to
 
@@ -12,7 +12,7 @@ Resources for the v7.0.0-preview.5 of `@azure/service-bus`:
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus) |
 [Package (npm)](https://www.npmjs.com/package/@azure/service-bus) |
 [API Reference Documentation][apiref] |
-[Product documentation](https://azure.microsoft.com/en-us/services/service-bus/) |
+[Product documentation](https://azure.microsoft.com/services/service-bus/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples)
 
 > **NOTE**: This document has instructions, links and code snippets for the **preview** of the next version of the `@azure/service-bus` package
@@ -20,7 +20,7 @@ Resources for the v7.0.0-preview.5 of `@azure/service-bus`:
 
 [Source code or Readme for v1.1.5](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.5/sdk/servicebus/service-bus) |
 [Package for v1.1.5 (npm)](https://www.npmjs.com/package/@azure/service-bus/v/1.1.5) |
-[API Reference Documentation for v1.1.5](https://docs.microsoft.com/en-us/javascript/api/%40azure/service-bus/?view=azure-node-latest) |
+[API Reference Documentation for v1.1.5](https://docs.microsoft.com/javascript/api/%40azure/service-bus/?view=azure-node-latest) |
 [Samples for v1.1.5](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.5/sdk/servicebus/service-bus/samples)
 
 We also provide a migration guide for users familiar with the stable package that would like to try the preview: [migration guide to move from Service Bus V1 to Service Bus V7 Preview][migrationguide]
@@ -36,7 +36,7 @@ Install the preview version for the Azure Service Bus client library using npm
 ### Prerequisites
 
 You must have an [Azure subscription](https://azure.microsoft.com/free/) and a
-[Service Bus Namespace](https://docs.microsoft.com/en-us/azure/service-bus-messaging/) to use this package.
+[Service Bus Namespace](https://docs.microsoft.com/azure/service-bus-messaging/) to use this package.
 If you are using this package in a Node.js application, then use Node.js 8.x or higher.
 
 ### Configure Typescript
@@ -184,7 +184,7 @@ for await (let message of receiver.getMessageIterator()) {
 Once you receive a message you can call `complete()`, `abandon()`, `defer()` or `deadletter()` on it
 based on how you want to settle the message.
 
-To learn more, please read [Settling Received Messages](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations)
+To learn more, please read [Settling Received Messages](https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations)
 
 ### Send messages using Sessions
 
@@ -331,7 +331,7 @@ export DEBUG=azure:service-bus:error,azure-core-amqp:error,rhea-promise:error,rh
 
 Please take a look at the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples)
 directory for detailed examples on how to use this library to send and receive messages to/from
-[Service Bus Queues, Topics and Subscriptions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview).
+[Service Bus Queues, Topics and Subscriptions](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview).
 
 ## Contributing
 
@@ -353,9 +353,9 @@ If you'd like to contribute to this library, please read the [contributing guide
 [receiver_getmessageiterator]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.5/interfaces/receiver.html#getmessageiterator
 [sessionreceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.5/interfaces/sessionreceiver.html
 [migrationguide]: https://github.com/Azure/azure-sdk-for-js/blob/%40azure/service-bus_7.0.0-preview.5/sdk/servicebus/service-bus/migrationguide.md
-[docsms_messagesessions]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions
-[docsms_messagesessions_fifo]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#first-in-first-out-fifo-pattern
-[queue_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#queues
-[topic_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#topics
-[subscription_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions
-[service_bus_overview]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview
+[docsms_messagesessions]: https://docs.microsoft.com/azure/service-bus-messaging/message-sessions
+[docsms_messagesessions_fifo]: https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#first-in-first-out-fifo-pattern
+[queue_concept]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview#queues
+[topic_concept]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview#topics
+[subscription_concept]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions
+[service_bus_overview]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview

--- a/sdk/servicebus/service-bus/samples-v1/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/README.md
@@ -11,12 +11,12 @@ There are three ways to work with the samples.
 ## Get connection string for Service Bus & names for Queues/Topics/Subscriptions
 
 - In the [Azure Portal](https://portal.azure.com), go to **Dashboard > Service Bus > _your-servicebus-namespace_**.
-- If you don't have a Service Bus resource, then here are the docs which can help you create a Service Bus resource in the portal : [Service Bus - Node.js docs](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-nodejs-how-to-use-queues).
+- If you don't have a Service Bus resource, then here are the docs which can help you create a Service Bus resource in the portal : [Service Bus - Node.js docs](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-nodejs-how-to-use-queues).
 - Note down the "Primary Connection String" of **RootManageSharedAccessKey** at **Shared access policies** under **Settings** tab.
 - To work with Queues, find the "Queues" tab right under "Entities" at **_your-servicebus-namespace_**, create a Queue and note down its name.
 - To work with Topics, find the "Topics" tab right under "Entities" at **_your-servicebus-namespace_**, create a Topic. Go to **_your-servicebus-namespace_ > _your-topic_**, create subscriptions for the topic. Note down the names of the topic and subscriptions.
 
-> _Note : **RootManageSharedAccessKey** is automatically created for the namespace and has permissions for the entire namespace. If you want to use restricted access, refer [Shared Access Signatures](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas), create the Access Keys exclusive to the specific created Queue/Topic._
+> _Note : **RootManageSharedAccessKey** is automatically created for the namespace and has permissions for the entire namespace. If you want to use restricted access, refer [Shared Access Signatures](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-sas), create the Access Keys exclusive to the specific created Queue/Topic._
 
 Before running any of the samples, update it with the connection string and the queue/topic/subscription names you have noted down above, or follow the instructions in the README files referring to the `sample.env` file.
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/deferral.js
@@ -7,7 +7,7 @@ This sample demonstrates how the defer() function can be used to defer a message
 In this sample, we have an application that gets cooking instructions out of order. It uses
 message deferral to defer the instruction that is out of order, and then processes it in order.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-deferral to learn about
+See https://docs.microsoft.com/azure/service-bus-messaging/message-deferral to learn about
 message deferral.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/movingMessagesToDLQ.js
@@ -4,7 +4,7 @@ Licensed under the MIT Licence.
 
 This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
 the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
 
 Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionState.js
@@ -15,7 +15,7 @@ The session state keeps track of the cart items accordingly.
 
 Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state
+See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state
 to learn about session state.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/topicFilters.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/topicFilters.js
@@ -10,7 +10,7 @@ and the rest of the messages to the third subscription.
 
 Setup: To run this sample, you would need a Topic with 3 subscriptions.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters to learn aboout
+See https://docs.microsoft.com/azure/service-bus-messaging/topic-filters to learn aboout
 Topic filters and actions.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/browseMessages.js
@@ -4,7 +4,7 @@ Licensed under the MIT Licence.
 
 This sample demonstrates how the peek() function can be used to browse a Service Bus message.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
+See https://docs.microsoft.com/azure/service-bus-messaging/message-browsing to learn
 about message browsing.
 
 Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic

--- a/sdk/servicebus/service-bus/samples-v1/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/scheduledMessages.js
@@ -5,7 +5,7 @@ Licensed under the MIT Licence.
 This sample demonstrates how the scheduleMessage() function can be used to schedule messages to
 appear on a Service Bus Queue/Subscription at a later time.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing#scheduled-messages
+See https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing#scheduled-messages
 to learn about scheduling messages.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/sendMessages.js
@@ -5,7 +5,7 @@ Licensed under the MIT Licence.
 This sample demonstrates how the send() function can be used to send messages to Service Bus
 Queue/Topic.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
+See https://docs.microsoft.com/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
 to learn about Queues, Topics and Subscriptions.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/servicePrincipalLogin.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/servicePrincipalLogin.js
@@ -10,7 +10,7 @@ Please ensure that your Azure Service Bus resource is in US East, US East 2, or 
 region. AAD Role Based Access Control is not supported in other regions yet.
 
 Register a new application in AAD and assign the "Azure Service Bus Data Owner" role to it
-- See https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+- See https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app
 to register a new application in the Azure Active Directory.
 - Note down the CLIENT_ID and TENANT_ID from the above step.
 - In the "Certificates & Secrets" tab, create a secret and note that down.

--- a/sdk/servicebus/service-bus/samples-v1/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/session.js
@@ -7,7 +7,7 @@ in Service Bus.
 
 Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions to learn about
+See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions to learn about
 sessions in Service Bus.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/deferral.ts
@@ -7,7 +7,7 @@
   In this sample, we have an application that gets cooking instructions out of order. It uses
   message deferral to defer the instruction that is out of order, and then processes it in order.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-deferral to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-deferral to learn about
   message deferral.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -4,7 +4,7 @@
 
   This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
   the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-  https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+  https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
 
   Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionState.ts
@@ -15,7 +15,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state
   to learn about session state.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/topicFilters.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/topicFilters.ts
@@ -10,7 +10,7 @@
 
   Setup: To run this sample, you would need a Topic with 3 subscriptions.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters to learn aboout
+  See https://docs.microsoft.com/azure/service-bus-messaging/topic-filters to learn aboout
   Topic filters and actions.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/browseMessages.ts
@@ -4,7 +4,7 @@
 
   This sample demonstrates how the peek() function can be used to browse a Service Bus message.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-browsing to learn
   about message browsing.
 
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/scheduledMessages.ts
@@ -5,7 +5,7 @@
   This sample demonstrates how the scheduleMessages() function can be used to schedule messages to
   appear on a Service Bus Queue/Subscription at a later time.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing#scheduled-messages
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing#scheduled-messages
   to learn about scheduling messages.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/sendMessages.ts
@@ -5,7 +5,7 @@
   This sample demonstrates how the send() function can be used to send messages to Service Bus
   Queue/Topic.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
+  See https://docs.microsoft.com/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
   to learn about Queues, Topics and Subscriptions.
 */
 

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/servicePrincipalLogin.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/servicePrincipalLogin.ts
@@ -10,7 +10,7 @@
     region. AAD Role Based Access Control is not supported in other regions yet.
 
     Register a new application in AAD and assign the "Azure Service Bus Data Owner" role to it
-     - See https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app 
+     - See https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app 
        to register a new application in the Azure Active Directory.
      - Note down the CLIENT_ID and TENANT_ID from the above step.
      - In the "Certificates & Secrets" tab, create a secret and note that down.

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/session.ts
@@ -7,7 +7,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions to learn about
   sessions in Service Bus.
 */
 

--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -13,12 +13,12 @@ There are three ways to work with the samples.
 ## Get connection string for Service Bus & names for Queues/Topics/Subscriptions
 
 - In the [Azure Portal](https://portal.azure.com), go to **Dashboard > Service Bus > _your-servicebus-namespace_**.
-- If you don't have a Service Bus resource, then here are the docs which can help you create a Service Bus resource in the portal : [Service Bus - Node.js docs](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-nodejs-how-to-use-queues).
+- If you don't have a Service Bus resource, then here are the docs which can help you create a Service Bus resource in the portal : [Service Bus - Node.js docs](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-nodejs-how-to-use-queues).
 - Note down the "Primary Connection String" of **RootManageSharedAccessKey** at **Shared access policies** under **Settings** tab.
 - To work with Queues, find the "Queues" tab right under "Entities" at **_your-servicebus-namespace_**, create a Queue and note down its name.
 - To work with Topics, find the "Topics" tab right under "Entities" at **_your-servicebus-namespace_**, create a Topic. Go to **_your-servicebus-namespace_ > _your-topic_**, create subscriptions for the topic. Note down the names of the topic and subscriptions.
 
-> _Note : **RootManageSharedAccessKey** is automatically created for the namespace and has permissions for the entire namespace. If you want to use restricted access, refer [Shared Access Signatures](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas), create the Access Keys exclusive to the specific created Queue/Topic._
+> _Note : **RootManageSharedAccessKey** is automatically created for the namespace and has permissions for the entire namespace. If you want to use restricted access, refer [Shared Access Signatures](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-sas), create the Access Keys exclusive to the specific created Queue/Topic._
 
 Before running any of the samples, update it with the connection string and the queue/topic/subscription names you have noted down above, or follow the instructions in the README files referring to the `sample.env` file.
 

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -10,7 +10,7 @@
   In this sample, we have an application that gets cooking instructions out of order. It uses
   message deferral to defer the instruction that is out of order, and then processes it in order.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-deferral to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-deferral to learn about
   message deferral.
 */
 

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/listingEntities.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/listingEntities.js
@@ -8,7 +8,7 @@
   
   This sample demonstrates how the ServiceBusManagementClient can be used to manage the resources of a service bus namespace.
 
-  See https://docs.microsoft.com/en-us/rest/api/servicebus/resource-provider-apis to learn more.
+  See https://docs.microsoft.com/rest/api/servicebus/resource-provider-apis to learn more.
 */
 
 const { ServiceBusManagementClient } = require("@azure/service-bus");

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/managementClient.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/managementClient.js
@@ -8,7 +8,7 @@
   
   This sample demonstrates how the ServiceBusManagementClient can be used to manage the resources of a service bus namespace.
 
-  See https://docs.microsoft.com/en-us/rest/api/servicebus/resource-provider-apis to learn more.
+  See https://docs.microsoft.com/rest/api/servicebus/resource-provider-apis to learn more.
 */
 
 const { ServiceBusManagementClient } = require("@azure/service-bus");

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -7,7 +7,7 @@
 
   This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
   the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-  https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+  https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
 
   Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
@@ -18,7 +18,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state
   to learn about session state.
 */
 const { ServiceBusClient } = require("@azure/service-bus");

--- a/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
@@ -7,7 +7,7 @@
   
   This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-browsing to learn
   about message browsing.
 
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -8,7 +8,7 @@
   This sample demonstrates how the scheduleMessage() function can be used to schedule messages to
   appear on a Service Bus Queue/Subscription at a later time.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing#scheduled-messages
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing#scheduled-messages
   to learn about scheduling messages.
 */
 

--- a/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
@@ -8,7 +8,7 @@
   This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus
   Queue/Topic.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
+  See https://docs.microsoft.com/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
   to learn about Queues, Topics and Subscriptions.
 */
 

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -10,7 +10,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions to learn about
   sessions in Service Bus.
 */
 const { ServiceBusClient, delay } = require("@azure/service-bus");

--- a/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
@@ -13,7 +13,7 @@
     region. AAD Role Based Access Control is not supported in other regions yet.
 
     Register a new application in AAD and assign the "Azure Service Bus Data Owner" role to it
-     - See https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+     - See https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app
        to register a new application in the Azure Active Directory.
      - Note down the CLIENT_ID and TENANT_ID from the above step.
      - In the "Certificates & Secrets" tab, create a secret and note that down.

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -11,7 +11,7 @@
   In this sample, we have an application that gets cooking instructions out of order. It uses
   message deferral to defer the instruction that is out of order, and then processes it in order.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-deferral to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-deferral to learn about
   message deferral.
 */
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/listingEntities.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/listingEntities.ts
@@ -8,7 +8,7 @@
   
   This sample demonstrates how the ServiceBusManagementClient can be used to list the entities of a service bus namespace.
 
-  See https://docs.microsoft.com/en-us/rest/api/servicebus/resource-provider-apis to learn more.
+  See https://docs.microsoft.com/rest/api/servicebus/resource-provider-apis to learn more.
 */
 
 import { ServiceBusManagementClient } from "@azure/service-bus";

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/managementClient.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/managementClient.ts
@@ -8,7 +8,7 @@
   
   This sample demonstrates how the ServiceBusManagementClient can be used to manage the resources of a service bus namespace.
 
-  See https://docs.microsoft.com/en-us/rest/api/servicebus/resource-provider-apis to learn more.
+  See https://docs.microsoft.com/rest/api/servicebus/resource-provider-apis to learn more.
 */
 
 import { ServiceBusManagementClient } from "@azure/service-bus";

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -8,7 +8,7 @@
   
   This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
   the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-  https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+  https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
 
   Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
@@ -19,7 +19,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state
   to learn about session state.
 */
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
@@ -8,7 +8,7 @@
   
   This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-browsing to learn
   about message browsing.
 
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -9,7 +9,7 @@
   This sample demonstrates how the scheduleMessages() function can be used to schedule messages to
   appear on a Service Bus Queue/Subscription at a later time.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing#scheduled-messages
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing#scheduled-messages
   to learn about scheduling messages.
 */
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
@@ -9,7 +9,7 @@
   This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus
   Queue/Topic.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
+  See https://docs.microsoft.com/azure/service-bus-messaging/service-bus-queues-topics-subscriptions
   to learn about Queues, Topics and Subscriptions.
 */
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -11,7 +11,7 @@
 
   Setup: To run this sample, you would need session enabled Queue/Subscription.
 
-  See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions to learn about
+  See https://docs.microsoft.com/azure/service-bus-messaging/message-sessions to learn about
   sessions in Service Bus.
 */
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
@@ -14,7 +14,7 @@
     region. AAD Role Based Access Control is not supported in other regions yet.
 
     Register a new application in AAD and assign the "Azure Service Bus Data Owner" role to it
-     - See https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app 
+     - See https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app 
        to register a new application in the Azure Active Directory.
      - Note down the CLIENT_ID and TENANT_ID from the above step.
      - In the "Certificates & Secrets" tab, create a secret and note that down.

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1152,7 +1152,7 @@ export class ManagementClient extends LinkEntity {
         return [];
       }
 
-      // Reference: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#response-11
+      // Reference: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-amqp-request-response#response-11
       const result: { "rule-description": Typed }[] = response.body.rules || [];
       const rules: RuleDescription[] = [];
       result.forEach((x) => {

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -63,7 +63,7 @@ export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
    * the message.
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    */
   receiveMode?: ReceiveModeT;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -84,7 +84,7 @@ export interface ServiceBusSessionReceiver<
 
   /**
    * Gets the state of the Session. For more on session states, see
-   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {Promise<any>} The state of that session
    * @throws Error if the underlying connection or receiver is closed.
@@ -94,7 +94,7 @@ export interface ServiceBusSessionReceiver<
 
   /**
    * Sets the state on the Session. For more on session states, see
-   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param state The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
@@ -256,7 +256,7 @@ export class ServiceBusSessionReceiverImpl<
 
   /**
    * Sets the state on the Session. For more on session states, see
-   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param state The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
@@ -288,7 +288,7 @@ export class ServiceBusSessionReceiverImpl<
 
   /**
    * Gets the state of the Session. For more on session states, see
-   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<any> The state of that session
    * @throws Error if the underlying connection or receiver is closed.

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -305,7 +305,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async createQueue(queueName: string, options?: CreateQueueOptions): Promise<QueueResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -350,7 +350,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getQueue(queueName: string, operationOptions?: OperationOptions): Promise<QueueResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -390,7 +390,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getQueueRuntimeProperties(
     queueName: string,
@@ -434,7 +434,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getQueues(
     options?: ListRequestOptions & OperationOptions
@@ -542,7 +542,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getQueuesRuntimeProperties(
     options?: ListRequestOptions & OperationOptions
@@ -649,7 +649,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * All queue properties must be set even though only a subset of them are actually updatable.
    * Therefore, the suggested flow is to use `getQueue()` to get the complete set of queue properties,
    * update as needed and then pass it to `updateQueue()`.
-   * See https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue for more details.
+   * See https://docs.microsoft.com/rest/api/servicebus/update-queue for more details.
    *
    * @param queue Object representing the properties of the queue.
    * `requiresSession`, `requiresDuplicateDetection`, `enablePartitioning`, and `name` can't be updated after creating the queue.
@@ -663,7 +663,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async updateQueue(
     queue: QueueProperties,
@@ -721,7 +721,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async deleteQueue(queueName: string, operationOptions?: OperationOptions): Promise<Response> {
     const { span, updatedOperationOptions } = createSpan(
@@ -795,7 +795,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async createTopic(topicName: string, options?: CreateTopicOptions): Promise<TopicResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -840,7 +840,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getTopic(topicName: string, operationOptions?: OperationOptions): Promise<TopicResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -880,7 +880,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getTopicRuntimeProperties(
     topicName: string,
@@ -924,7 +924,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getTopics(
     options?: ListRequestOptions & OperationOptions
@@ -1033,7 +1033,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getTopicsRuntimeProperties(
     options?: ListRequestOptions & OperationOptions
@@ -1141,7 +1141,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * All topic properties must be set even though only a subset of them are actually updatable.
    * Therefore, the suggested flow is to use `getTopic()` to get the complete set of topic properties,
    * update as needed and then pass it to `updateTopic()`.
-   * See https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic for more details.
+   * See https://docs.microsoft.com/rest/api/servicebus/update-topic for more details.
    *
    * @param topic Object representing the properties of the topic.
    * `requiresDuplicateDetection`, `enablePartitioning`, and `name` can't be updated after creating the topic.
@@ -1155,7 +1155,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async updateTopic(
     topic: TopicProperties,
@@ -1213,7 +1213,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async deleteTopic(topicName: string, operationOptions?: OperationOptions): Promise<Response> {
     const { span, updatedOperationOptions } = createSpan(
@@ -1288,7 +1288,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async createSubscription(
     topicName: string,
@@ -1339,7 +1339,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getSubscription(
     topicName: string,
@@ -1387,7 +1387,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getSubscriptionRuntimeProperties(
     topicName: string,
@@ -1434,7 +1434,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getSubscriptions(
     topicName: string,
@@ -1555,7 +1555,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getSubscriptionsRuntimeProperties(
     topicName: string,
@@ -1688,7 +1688,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async updateSubscription(
     subscription: SubscriptionProperties,
@@ -1754,7 +1754,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async deleteSubscription(
     topicName: string,
@@ -1844,7 +1844,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   createRule(
     topicName: string,
@@ -1871,7 +1871,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   createRule(
     topicName: string,
@@ -1945,7 +1945,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async getRule(
     topicName: string,
@@ -1991,7 +1991,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   private async getRules(
     topicName: string,
@@ -2117,7 +2117,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async updateRule(
     topicName: string,
@@ -2180,7 +2180,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
    * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
    */
   async deleteRule(
     topicName: string,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -110,7 +110,7 @@ export class ServiceBusClient {
    * the message.
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
@@ -151,7 +151,7 @@ export class ServiceBusClient {
    * the message.
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -228,7 +228,7 @@ export class ServiceBusClient {
    * the message.
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
@@ -267,7 +267,7 @@ export class ServiceBusClient {
    * the message.
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -353,10 +353,10 @@ export class ServiceBusClient {
    * the message.
    *
    * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
@@ -374,7 +374,7 @@ export class ServiceBusClient {
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
@@ -396,10 +396,10 @@ export class ServiceBusClient {
    * the message.
    *
    * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -419,7 +419,7 @@ export class ServiceBusClient {
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -365,7 +365,7 @@ export const ATOM_METADATA_MARKER = "_";
 
 /**
  * Known HTTP status codes as documented and referenced in ATOM based management API feature
- * https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+ * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
  * @internal
  * @ignore
  */

--- a/sdk/servicebus/service-bus/test/README.md
+++ b/sdk/servicebus/service-bus/test/README.md
@@ -8,7 +8,7 @@ The Azure Azure Service Bus client does not have any recorded tests and so, all 
 
 The Azure resource that is used by the tests in this project is:
 
-- A standard [Azure Service Bus namespace](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces) with listen, manage and send authorization rules.
+- A standard [Azure Service Bus namespace](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview#namespaces) with listen, manage and send authorization rules.
 - An Azure Active Directory application for the tests to use. See the [AAD based authentication](#AAD-based-authentication) for steps to register the application.
 
 To run the live tests, you will also need to set the below environment variables:
@@ -26,7 +26,7 @@ The following steps will help you setup the AAD credentials.
 
 ### Register a new application in AAD
 
-- Follow [Documentation to register a new application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory (in the Azure portal).
+- Follow [Documentation to register a new application](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory (in the Azure portal).
 - Note down the `CLIENT_ID` and `TENANT_ID`.
 - In the "Certificates & Secrets" tab, create a secret and note that down.
 
@@ -35,6 +35,6 @@ The following steps will help you setup the AAD credentials.
 - In the Azure portal, go to your Azure Service Bus namespace and assign the **Azure Service Bus Data Owner** role to the registered application.
 - This can be done from `Role assignment` section of `Access control (IAM)` tab (in the left-side-navbar of your Service Bus namespace in the azure-portal)<br>
   _Doing this would allow the registered application manage the namespace, i.e., entity creation, deletion, etc.,_<br>
-- For more information on Service Bus RBAC setup: [Learn more](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-role-based-access-control)
+- For more information on Service Bus RBAC setup: [Learn more](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-role-based-access-control)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fservicebus%2Fservice-bus%2Ftest%2FREADME.png)


### PR DESCRIPTION
This PR removes the locale `en-us` from all links in the Service Bus project so that the user preferred locale gets used by the browser when these links are clicked on

Fixes #10568