### PR TITLE
[Monitor] refactor httpSender.ts to use async/await

### DIFF
--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/httpSender.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/httpSender.ts
@@ -1,7 +1,7 @@
 import * as zlib from "zlib";
 import { Logger } from "@opentelemetry/api";
 import { ConsoleLogger, LogLevel } from "@opentelemetry/core";
-import { Sender, SenderCallback } from "../../types";
+import { Sender, SenderResult } from "../../types";
 import { Envelope } from "../../Declarations/Contracts";
 import { DEFAULT_SENDER_OPTIONS, NodejsPlatformConfig } from "../types";
 import { promisify } from "util";
@@ -19,7 +19,7 @@ export class HttpSender implements Sender {
     this._httpClient = new DefaultHttpClient();
   }
 
-  async send(envelopes: Envelope[], callback: SenderCallback = () => {}): Promise<void> {
+  async send(envelopes: Envelope[]): Promise<SenderResult> {
     const endpointUrl = `${this._options.endpointUrl}/v2/track`;
     const payload = Buffer.from(JSON.stringify(envelopes));
 
@@ -44,12 +44,8 @@ export class HttpSender implements Sender {
       undefined,
       false // withCredentials: false
     );
-    try {
-      const res = await this._httpClient.sendRequest(options);
-      callback(null, res.status, res.bodyAsText || "");
-    } catch (err) {
-      callback(err);
-    }
+    const res = await this._httpClient.sendRequest(options);
+    return { statusCode: res.status, result: res.bodyAsText || "" };
   }
 
   shutdown(): void {

--- a/sdk/monitor/opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/types.ts
@@ -10,7 +10,7 @@ export interface MSLink {
 }
 export type Measurements = { [key: string]: number };
 export type TelemetryProcessor = (envelope: Envelope) => boolean | void;
-export type SenderCallback = (err: Error | null, statusCode?: number, result?: string) => void;
+export type SenderResult = { statusCode: number; result: string };
 
 export interface BaseExporter {
   addTelemetryProcessor(processor: TelemetryProcessor): void;
@@ -19,7 +19,7 @@ export interface BaseExporter {
 }
 
 export interface Sender {
-  send(payload: unknown[], callback?: SenderCallback): void;
+  send(payload: unknown[]): Promise<SenderResult>;
   shutdown(): void;
 }
 

--- a/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
@@ -27,37 +27,28 @@ describe("HttpSender", () => {
 
   describe("#send()", () => {
     const envelope = new Envelope();
-    it("should send a valid envelope", (done) => {
+    it("should send a valid envelope", async () => {
       const sender = new HttpSender();
       scope.reply(200, JSON.stringify(successfulBreezeResponse(1)));
-      sender.send([envelope], (err, statusCode, result) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(statusCode, 200);
-        assert.deepStrictEqual(JSON.parse(result!), successfulBreezeResponse(1));
-        done();
-      });
+      const { result, statusCode } = await sender.send([envelope]);
+      assert.strictEqual(statusCode, 200);
+      assert.deepStrictEqual(JSON.parse(result), successfulBreezeResponse(1));
     });
 
-    it("should send an invalid non-retriable envelope", (done) => {
+    it("should send an invalid non-retriable envelope", async () => {
       const sender = new HttpSender();
       scope.reply(403, JSON.stringify(failedBreezeResponse(2, 403)));
-      sender.send([envelope, envelope], (err, statusCode, result) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(statusCode, 403);
-        assert.deepStrictEqual(JSON.parse(result!), failedBreezeResponse(2, 403));
-        done();
-      });
+      const { result, statusCode } = await sender.send([envelope, envelope]);
+      assert.strictEqual(statusCode, 403);
+      assert.deepStrictEqual(JSON.parse(result), failedBreezeResponse(2, 403));
     });
 
-    it("should send a partially retriable envelope", (done) => {
+    it("should send a partially retriable envelope", async () => {
       const sender = new HttpSender();
       scope.reply(206, JSON.stringify(partialBreezeResponse([200, 408, 408])));
-      sender.send([envelope, envelope], (err, statusCode, result) => {
-        assert.strictEqual(err, null);
-        assert.strictEqual(statusCode, 206);
-        assert.deepStrictEqual(JSON.parse(result!), partialBreezeResponse([200, 408, 408]));
-        done();
-      });
+      const { result, statusCode } = await sender.send([envelope, envelope]);
+      assert.strictEqual(statusCode, 206);
+      assert.deepStrictEqual(JSON.parse(result!), partialBreezeResponse([200, 408, 408]));
     });
   });
 });


### PR DESCRIPTION
Convert `httpSender.ts` to use async/await instead of callback pattern