### PR TITLE
[Service Bus] Add LinkEntity.close()

### DIFF
--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -82,7 +82,7 @@ export class BatchingReceiver extends MessageReceiver {
    * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(connectionError?: AmqpError | Error): Promise<void> {
-    await this.closeLink("linkonly");
+    await this.closeLink();
 
     if (connectionError == null) {
       connectionError = new Error(

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -157,7 +157,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   private _logger: typeof log.error;
 
   /**
-   * Indicates that _closeLink("permanently") has been called on this link and
+   * Indicates that close() has been called on this link and
    * that it should not be allowed to reopen.
    */
   private _wasClosedPermanently: boolean = false;
@@ -262,11 +262,57 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
       this._logger(`${this._logPrefix} Link has been created.`);
     } catch (err) {
-      await this.closeLink("linkonly");
+      await this.closeLink();
       throw err;
     } finally {
       this._isConnecting = false;
     }
+  }
+
+  /**
+   * Clears token remewal for current link, removes current LinkEntity instance from cache,
+   * and closes the underlying AMQP link.
+   * Once closed, this instance of LinkEntity is not meant to be re-used.
+   */
+  async close(): Promise<void> {
+    // Set the flag to indicate that this instance of LinkEntity is not meant to be re-used.
+    this._wasClosedPermanently = true;
+
+    log.error(
+      "[%s] Closing the %s for entity '%s'.",
+      this._context.connectionId,
+      this._type,
+      this.address
+    );
+
+    // Remove the underlying AMQP link from the cache
+    switch (this._linkType) {
+      case "s": {
+        delete this._context.senders[this.name];
+        break;
+      }
+      case "br": {
+        delete this._context.batchingReceivers[this.name];
+        break;
+      }
+      case "sr": {
+        delete this._context.streamingReceivers[this.name];
+        break;
+      }
+      case "ms": {
+        delete this._context.messageSessions[this.name];
+        break;
+      }
+    }
+
+    log.error(
+      "[%s] Deleted the %s '%s' from the client cache.",
+      this._context.connectionId,
+      this._type,
+      this.name
+    );
+
+    await this.closeLink();
   }
 
   /**
@@ -280,18 +326,9 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   /**
    * Closes the internally held rhea link, stops the token renewal timer and sets
    * the this._link field to undefined.
-   *
-   * @param mode Indicates the original caller.
-   * - "permanently" closes the link permanently, setting _wasClosed to true which
-   * prevents it from being reinitializing.
-   * - "linkonly" closes the link but does not permanently close the LinkEntity. It can be reinitialized.
    */
-  protected async closeLink(mode: "permanently" | "linkonly"): Promise<void> {
-    if (mode === "permanently") {
-      this._wasClosedPermanently = true;
-    }
-
-    this._logger(`${this._logPrefix} closeLink(${mode}) called`);
+  protected async closeLink(): Promise<void> {
+    this._logger(`${this._logPrefix} closeLink() called`);
 
     clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
     this._tokenRenewalTimer = undefined;
@@ -305,7 +342,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
         // remove them from the internal map.
         await link.close();
 
-        this._logger(`${this._logPrefix} closed: ${mode}.`);
+        this._logger(`${this._logPrefix} closed.`);
       } catch (err) {
         log.error(`${this._logPrefix} An error occurred while closing the link.: %O`, err);
       }

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -376,7 +376,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       // NOTE: management link currently doesn't have a separate concept of "detaching" like
       // the other links do. When we add handling of this (via the onDetached call, like other links)
       // we can change this back to closeLink("permanent").
-      await this.closeLink("linkonly");
+      await this.closeLink();
       log.mgmt("Successfully closed the management session.");
     } catch (err) {
       log.error(

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -266,33 +266,14 @@ export class MessageReceiver extends LinkEntity<Receiver> {
     return this._context.connection.createReceiver(options);
   }
 
-  protected _deleteFromCache(): void {
-    if (this.receiverType === "sr") {
-      delete this._context.streamingReceivers[this.name];
-    } else if (this.receiverType === "br") {
-      delete this._context.batchingReceivers[this.name];
-    }
-    log.error(
-      "[%s] Deleted the receiver '%s' from the client cache.",
-      this._context.connectionId,
-      this.name
-    );
-  }
-
   /**
-   * Closes the underlying AMQP receiver.
+   * Clears lock renewal timers on all active messages, clears token remewal for current receiver,
+   * removes current MessageReceiver instance from cache, and closes the underlying AMQP receiver.
    * @return {Promise<void>} Promise<void>.
    */
   async close(): Promise<void> {
-    log.receiver(
-      "[%s] Closing the [%s]Receiver for entity '%s'.",
-      this._context.connectionId,
-      this.receiverType,
-      this._entityPath
-    );
     this._clearAllMessageLockRenewTimers();
-    this._deleteFromCache();
-    await this.closeLink("permanently");
+    await super.close();
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -201,16 +201,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
     };
   }
 
-  private _deleteFromCache(): void {
-    delete this._context.senders[this.name];
-    log.error(
-      "[%s] Deleted the sender '%s' with address '%s' from the client cache.",
-      this._context.connectionId,
-      this.name,
-      this.address
-    );
-  }
-
   private _createSenderOptions(timeoutInMs: number, newName?: boolean): AwaitableSenderOptions {
     if (newName) this.name = getUniqueName(this._entityPath);
     const srOptions: AwaitableSenderOptions = {
@@ -425,7 +415,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
     try {
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
-      await this.closeLink("linkonly");
+      await this.closeLink();
 
       // We should attempt to reopen only when the sender(sdk) did not initiate the close
       let shouldReopen = false;
@@ -501,20 +491,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
         err
       );
     }
-  }
-
-  /**
-   * Deletes the sender from the context. Clears the token renewal timer. Closes the sender link.
-   * @return {Promise<void>} Promise<void>
-   */
-  async close(): Promise<void> {
-    log.sender(
-      "[%s] Closing the Sender for the entity '%s'.",
-      this._context.connectionId,
-      this._entityPath
-    );
-    this._deleteFromCache();
-    await this.closeLink("permanently");
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -574,7 +574,7 @@ export class StreamingReceiver extends MessageReceiver {
     try {
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
-      await this.closeLink("linkonly");
+      await this.closeLink();
 
       const translatedError = receiverError ? translate(receiverError) : receiverError;
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -241,19 +241,6 @@ export class MessageSession extends LinkEntity<Receiver> {
     }
   }
 
-  /**
-   * Deletes the MessageSession from the internal cache.
-   */
-  private _deleteFromCache(): void {
-    delete this._context.messageSessions[this.name];
-    log.error(
-      "[%s] Deleted the receiver '%s' with sessionId '%s' from the client cache.",
-      this._context.connectionId,
-      this.name,
-      this.sessionId
-    );
-  }
-
   protected createRheaLink(
     options: ReceiverOptions,
     _abortSignal?: AbortSignalLike
@@ -570,13 +557,6 @@ export class MessageSession extends LinkEntity<Receiver> {
    */
   async close(): Promise<void> {
     try {
-      log.messageSession(
-        "[%s] Closing the MessageSession '%s' for queue '%s'.",
-        this._context.connectionId,
-        this.sessionId,
-        this.name
-      );
-
       this._isReceivingMessagesForSubscriber = false;
       if (this._sessionLockRenewalTimer) clearTimeout(this._sessionLockRenewalTimer);
       log.messageSession(
@@ -585,10 +565,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         this._context.connectionId
       );
 
-      if (this.link) {
-        this._deleteFromCache();
-        await this.closeLink("permanently");
-      }
+      await super.close();
 
       await this._batchingReceiverLite.close();
     } catch (err) {

--- a/sdk/servicebus/service-bus/test/internal/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/linkentity.unittest.spec.ts
@@ -27,7 +27,7 @@ describe("LinkEntity unit tests", () => {
   });
 
   afterEach(async () => {
-    await linkEntity["closeLink"]("permanently");
+    await linkEntity.close();
   });
 
   it("initLink - basic case", async () => {
@@ -40,13 +40,13 @@ describe("LinkEntity unit tests", () => {
 
     // when we close with 'linkonly' it closes the link but the
     // link can be reopened.
-    await linkEntity["closeLink"]("linkonly");
+    await linkEntity["closeLink"]();
     assertLinkEntityClosedTemporarily();
 
     await linkEntity.initLink({});
     assertLinkEntityOpen();
 
-    await linkEntity["closeLink"]("permanently");
+    await linkEntity.close();
     assertLinkEntityClosedPermanently();
 
     linkEntity.initLink({});
@@ -98,7 +98,7 @@ describe("LinkEntity unit tests", () => {
       ++negotiateClaimCalled;
     };
 
-    await linkEntity["closeLink"]("permanently");
+    await linkEntity.close();
     assertLinkEntityClosedPermanently();
 
     await linkEntity.initLink({});
@@ -196,7 +196,7 @@ describe("LinkEntity unit tests", () => {
 
   it("initLink - user closes link while it's initializing", async () => {
     linkEntity["createRheaLink"] = async () => {
-      await linkEntity["closeLink"]("permanently");
+      await linkEntity.close();
       return createRheaReceiverForTests();
     };
 
@@ -216,11 +216,11 @@ describe("LinkEntity unit tests", () => {
   it("initLink - multiple closes don't cause errors", async () => {
     // TODO: there is a possibility of a race condition here. We can address this
     // when we properly lock around init operations that are in progress.
-    await linkEntity["closeLink"]("linkonly");
-    await linkEntity["closeLink"]("linkonly");
+    await linkEntity["closeLink"]();
+    await linkEntity["closeLink"]();
 
-    await linkEntity["closeLink"]("permanently");
-    await linkEntity["closeLink"]("permanently");
+    await linkEntity.close();
+    await linkEntity.close();
   });
 
   it("initLink - get logger", async () => {


### PR DESCRIPTION
This PR is a follow up to the refactoring done in #10578 where the concept of closing "linkOnly" vs "permanently" was introduced on the `LinkEntity`. This PR covers the below
- Add a close() to the `LinkEntity` class that would denote the close "permanently" scenario. This is when we do not expect to re-use the `LinkEntity` instance
- Move the code to delete sender/receiver from cache into the above new method