### PR TITLE
[ai-form-recognizer] Change version number for GA, minor README changes

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 3.0.0 (2020-08-20)
+
+- This release marks the general availability of the `@azure/ai-form-recognizer` package.
+
 ## 3.0.0-preview.1 (2020-08-11)
 
 - Changed the package version to 3.0.0-preview.1 to reduce confusion with older versions of the Azure Form Recognizer SDKs.

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -118,8 +118,8 @@ const client = new FormRecognizerClient("<endpoint>", new DefaultAzureCredential
 ### FormTrainingClient
 `FormTrainingClient` provides operations for:
 
-- Training custom models to recognize all fields and values found in your custom forms. A `CustomFormModel` is returned indicating the form types the model will recognize, and the fields it will extract for each form type. See the [service's documents][fr-train-without-labels] for a more detailed explanation.
-- Training custom models to recognize specific fields and values you specify by labeling your custom forms. A `CustomFormModel` is returned indicating the fields the model will extract, as well as the estimated accuracy for each field. See the [service's documents][fr-train-with-labels] for a more detailed explanation.
+- Training custom models to recognize all fields and values found in your custom forms. A `CustomFormModel` is returned indicating the form types the model will recognize, and the fields it will extract for each form type. See the [service's documentation on unlabeled model training][fr-train-without-labels] for a more detailed explanation of creating a training data set.
+- Training custom models to recognize specific fields and values you specify by labeling your custom forms. A `CustomFormModel` is returned indicating the fields the model will extract, as well as the estimated accuracy for each field. See the [service's documentation on labeled model training][fr-train-with-labels] for a more detailed explanation of applying labels to a training data set.
 - Managing models created in your account.
 - Copying a custom model from one Form Recognizer resource to another.
 
@@ -297,6 +297,8 @@ main().catch((err) => {
 });
 ```
 
+For information on creating a labeled training data set, see the documentation for the [using the sample labeling tool][quickstart_labeling] and the [labeled model training sample][labeled_sample].
+
 ### Recognize forms using a custom model
 
 ```javascript
@@ -424,6 +426,8 @@ If you'd like to contribute to this library, please read the [contributing guide
 [register_aad_app]: https://docs.microsoft.com/azure/cognitive-services/authentication#assign-a-role-to-a-service-principal
 [defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential
 [quickstart_training]: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/curl-train-extract#train-a-form-recognizer-model
+[quickstart_labeling]: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/label-tool
+[labeled_sample]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainLabeledModel.ts
 [multi_and_single_service]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account?tabs=multiservice%2Cwindows
 [azure_portal_create_FR_resource]: https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesFormRecognizer
 [azure_cli_create_FR_resource]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account-cli?tabs=windows

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Form Recognizer service.",
-  "version": "3.0.0-preview.1",
+  "version": "3.0.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "3.0.0-preview.1";
+export const SDK_VERSION: string = "3.0.0";
 
 export const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default";
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { GeneratedClientOptionalParams } from "./models";
 
 const packageName = "@azure/ai-form-recognizer";
-const packageVersion = "3.0.0-preview.1";
+const packageVersion = "3.0.0";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
- version number is now 3.0.0
- updated CHANGELOG to reflect GA status
- minor changes to wording in README
  - added a couple more links to service docs/samples for info on setting up data sets