### PR TITLE
[core-http] The previous core-http change had a bug

### DIFF
--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -112,6 +112,7 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
       // Waiting for the next refresh only if the cache is unable to retrieve the access token,
       // which means that it has expired, or it has never been set.
       accessToken = await this.tokenRefresher.refresh(options);
+      this.tokenCache.setCachedToken(accessToken);
     } else {
       // If we still have a cached access token,
       // And any other time related conditionals have been reached based on the tokenRefresher class,

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -59,18 +59,18 @@ describe("BearerTokenAuthenticationPolicy", function() {
     const refreshCred2 = new MockRefreshAzureCredential(now + TokenRefreshBufferMs);
     const notRefreshCred1 = new MockRefreshAzureCredential(now + TokenRefreshBufferMs + 5000);
 
-    const credentialsToTest: [MockRefreshAzureCredential, number][] = [
-      [refreshCred1, 2],
-      [refreshCred2, 2],
-      [notRefreshCred1, 2]
+    const credentialsToTest: [MockRefreshAzureCredential, number, string][] = [
+      [refreshCred1, 2, "Refresh credential 1"],
+      [refreshCred2, 2, "Refresh credential 2"],
+      [notRefreshCred1, 1, "Not refresh credential 1"]
     ];
 
     const request = createRequest();
-    for (const [credentialToTest, expectedCalls] of credentialsToTest) {
+    for (const [credentialToTest, expectedCalls, message] of credentialsToTest) {
       const policy = createBearerTokenPolicy("testscope", credentialToTest);
       await policy.sendRequest(request);
       await policy.sendRequest(request);
-      assert.strictEqual(credentialToTest.authCount, expectedCalls);
+      assert.strictEqual(credentialToTest.authCount, expectedCalls, `${message} failed`);
     }
   });
 

--- a/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_pdf_file_stream.js
+++ b/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_pdf_file_stream.js
@@ -11,6 +11,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -22,19 +24,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '8da62935-5786-447c-ad31-9b61a6e12e00',
+  'ced75abb-f86d-43f1-be12-20970c3a0a00',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=Ai96nY6B1DJCg8V7V7w4uhD0CyfMAQAAAAwZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:36 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ah8FCp8SFv1OvshPPoezQJ_0CyfMAQAAAKhgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:09 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:35 GMT',
-  'Content-Length',
-  '1417'
+  'Tue, 18 Aug 2020 23:52:08 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
@@ -43,17 +43,17 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Operation-Location',
-  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/189b1000-8c41-41d9-9122-394189041b99',
+  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/e7de431a-1892-4270-b496-8cf2d55200ac',
   'x-envoy-upstream-service-time',
-  '65',
+  '62',
   'apim-request-id',
-  '189b1000-8c41-41d9-9122-394189041b99',
+  'e7de431a-1892-4270-b496-8cf2d55200ac',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:36 GMT'
+  'Tue, 18 Aug 2020 23:52:08 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -63,6 +63,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -74,128 +76,41 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '571f7927-a880-4fc7-8aa0-a043438f3d00',
+  '4969bdf2-5fe5-4391-81e2-35dbb9d40c00',
   'x-ms-ests-server',
-  '2.1.10963.11 - WUS2 ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=Ai96nY6B1DJCg8V7V7w4uhD0CyfMAgAAAAwZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:37 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ah8FCp8SFv1OvshPPoezQJ_0CyfMAgAAAKhgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:09 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:36 GMT',
-  'Content-Length',
-  '1417'
+  'Tue, 18 Aug 2020 23:52:09 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/189b1000-8c41-41d9-9122-394189041b99')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:37Z","lastUpdatedDateTime":"2020-08-18T18:46:37Z"}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/e7de431a-1892-4270-b496-8cf2d55200ac')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-18T23:52:09Z","lastUpdatedDateTime":"2020-08-18T23:52:09Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '13',
+  '15',
   'apim-request-id',
-  'b064ca00-666b-43fd-8248-44ec1fba89f9',
+  '75bd2900-8b6b-45c8-bd02-d4a101660849',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:36 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '0d7e002a-c74f-4cac-a2ec-dcf8348e3c00',
-  'x-ms-ests-server',
-  '2.1.10963.11 - WUS2 ProdSlices',
-  'Set-Cookie',
-  'fpc=Ai96nY6B1DJCg8V7V7w4uhD0CyfMAwAAAAwZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:37 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:36 GMT',
-  'Content-Length',
-  '1417'
+  'Tue, 18 Aug 2020 23:52:09 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/189b1000-8c41-41d9-9122-394189041b99')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:37Z","lastUpdatedDateTime":"2020-08-18T18:46:37Z"}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '9',
-  'apim-request-id',
-  '732b144c-5a21-48ac-91a8-3c803f234f95',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:36 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  'b344a53e-331f-4b44-aa09-78b337465700',
-  'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
-  'Set-Cookie',
-  'fpc=Ai96nY6B1DJCg8V7V7w4uhD0CyfMBAAAAAwZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:42 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:41 GMT',
-  'Content-Length',
-  '1417'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/189b1000-8c41-41d9-9122-394189041b99')
-  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T18:46:37Z","lastUpdatedDateTime":"2020-08-18T18:46:42Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/e7de431a-1892-4270-b496-8cf2d55200ac')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-18T23:52:09Z","lastUpdatedDateTime":"2020-08-18T23:52:09Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -203,11 +118,63 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'x-envoy-upstream-service-time',
   '18',
   'apim-request-id',
-  'c177a661-fe11-45c1-959f-28a3a31c3f06',
+  '2dd7470f-7857-47b4-9b85-a8bd531a0cb9',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Tue, 18 Aug 2020 23:52:09 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '776aa5f1-72ee-4f90-adae-bf164cf40800',
+  'x-ms-ests-server',
+  '2.1.10963.12 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=Ah8FCp8SFv1OvshPPoezQJ_0CyfMAwAAAKhgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:09 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/layout/analyzeResults/e7de431a-1892-4270-b496-8cf2d55200ac')
+  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T23:52:09Z","lastUpdatedDateTime":"2020-08-18T23:52:14Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '22',
+  'apim-request-id',
+  '80b02516-5563-4d2d-bd40-279c9061b69c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:14 GMT'
 ]);

--- a/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_url.js
+++ b/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_url.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "e79ab4b1399e6e2a46da28039cc6697f";
+module.exports.hash = "d89a24557e0a7c441da6c0d6f5bc26d7";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -11,8 +11,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -24,17 +22,19 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'ad11e2b3-b36e-473c-bc32-6d5222fb4d00',
+  '1450b819-f6df-440e-aa6b-c1f68c304101',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AjKejJ1nmPRLv9hPDlP_Iy_0CyfMAQAAABEZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:42 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAQAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:53 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:53 GMT',
+  'Content-Length',
+  '1417'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
@@ -43,17 +43,17 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Operation-Location',
-  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/33139562-f54f-47bb-a548-69953f72a95a',
+  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90',
   'x-envoy-upstream-service-time',
-  '432',
+  '422',
   'apim-request-id',
-  '33139562-f54f-47bb-a548-69953f72a95a',
+  '2249c664-b329-4e06-996f-690f08355a90',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:54 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -76,22 +76,22 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7017c93a-184a-4229-a89e-a4e9a8844d00',
+  'fafdf7aa-8a83-427b-9c6e-a0ab71ae4801',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AjKejJ1nmPRLv9hPDlP_Iy_0CyfMAgAAABEZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:43 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAgAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:54 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:54 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/33139562-f54f-47bb-a548-69953f72a95a')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:43Z","lastUpdatedDateTime":"2020-08-18T18:46:43Z"}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:54Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -99,13 +99,13 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'x-envoy-upstream-service-time',
   '10',
   'apim-request-id',
-  'fca34233-2891-417d-a1ce-6354dfe8d489',
+  'ef810506-7932-4e68-85ce-3fa2977520f0',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:54 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -115,8 +115,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -128,36 +126,38 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '2ee1cf50-0d0a-408c-856c-ab3e9c485700',
+  '3d553101-1dc4-4fd3-affc-43c501665401',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AjKejJ1nmPRLv9hPDlP_Iy_0CyfMAwAAABEZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:43 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAwAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:54 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:54 GMT',
+  'Content-Length',
+  '1417'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/33139562-f54f-47bb-a548-69953f72a95a')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:43Z","lastUpdatedDateTime":"2020-08-18T18:46:43Z"}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:54Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '99',
+  '10',
   'apim-request-id',
-  '4bd8358e-046b-420f-8b09-bca461a8f38b',
+  '4845b795-f154-4e22-83cc-0c9b5dbafe9c',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:42 GMT'
+  'Thu, 13 Aug 2020 21:55:54 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -167,8 +167,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -180,34 +178,36 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'd78e47ad-aacb-4f82-84f8-825660a43900',
+  'ed63f0d1-07f1-426a-9c89-b2549d190601',
   'x-ms-ests-server',
-  '2.1.10963.11 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AjKejJ1nmPRLv9hPDlP_Iy_0CyfMBAAAABEZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMBAAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:59 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:47 GMT'
+  'Thu, 13 Aug 2020 21:55:59 GMT',
+  'Content-Length',
+  '1417'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/33139562-f54f-47bb-a548-69953f72a95a')
-  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T18:46:43Z","lastUpdatedDateTime":"2020-08-18T18:46:48Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
+  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:59Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '108',
+  '21',
   'apim-request-id',
-  'ee8b1401-bd08-4b2a-85b0-b5f644595efd',
+  'fbbf365d-9d96-4226-95b2-e294c3d221f1',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:47 GMT'
+  'Thu, 13 Aug 2020 21:55:59 GMT'
 ]);

--- a/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_url.js
+++ b/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_content_from_a_url.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "d89a24557e0a7c441da6c0d6f5bc26d7";
+module.exports.hash = "e79ab4b1399e6e2a46da28039cc6697f";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -22,17 +22,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '1450b819-f6df-440e-aa6b-c1f68c304101',
+  '68fbbd02-38b8-4582-a781-0d6093a90700',
   'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAQAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:53 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ArPO22vZGfZIlxO77_Z7ecP0CyfMAQAAAK5gztYOAAAA; expires=Thu, 17-Sep-2020 23:52:14 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 13 Aug 2020 21:55:53 GMT',
+  'Tue, 18 Aug 2020 23:52:13 GMT',
   'Content-Length',
   '1417'
 ]);
@@ -43,69 +43,55 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Operation-Location',
-  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90',
+  'https://endpoint/formrecognizer/v2.0/layout/analyzeResults/868583d8-30ff-4bda-941b-42b6227532cc',
   'x-envoy-upstream-service-time',
-  '422',
+  '414',
   'apim-request-id',
-  '2249c664-b329-4e06-996f-690f08355a90',
+  '868583d8-30ff-4bda-941b-42b6227532cc',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Thu, 13 Aug 2020 21:55:54 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '1417',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  'fafdf7aa-8a83-427b-9c6e-a0ab71ae4801',
-  'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
-  'Set-Cookie',
-  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAgAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:54 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Thu, 13 Aug 2020 21:55:54 GMT'
+  'Tue, 18 Aug 2020 23:52:14 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:54Z"}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/868583d8-30ff-4bda-941b-42b6227532cc')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-18T23:52:15Z","lastUpdatedDateTime":"2020-08-18T23:52:15Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '10',
+  '9',
   'apim-request-id',
-  'ef810506-7932-4e68-85ce-3fa2977520f0',
+  '375ca350-55f9-4d39-93fa-ee627fc28ba2',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Thu, 13 Aug 2020 21:55:54 GMT'
+  'Tue, 18 Aug 2020 23:52:14 GMT'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/layout/analyzeResults/868583d8-30ff-4bda-941b-42b6227532cc')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-18T23:52:15Z","lastUpdatedDateTime":"2020-08-18T23:52:15Z"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '9',
+  'apim-request-id',
+  'b77970da-3c34-404e-92af-4e6e8c0b03b2',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:14 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -126,88 +112,69 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '3d553101-1dc4-4fd3-affc-43c501665401',
+  '0274ca5e-42ab-4234-a537-514064660700',
   'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMAwAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:54 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ArPO22vZGfZIlxO77_Z7ecP0CyfMAgAAAK5gztYOAAAA; expires=Thu, 17-Sep-2020 23:52:15 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 13 Aug 2020 21:55:54 GMT',
+  'Tue, 18 Aug 2020 23:52:14 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '3f0accef-334c-4ba6-a7d5-bde4c2200800',
+  'x-ms-ests-server',
+  '2.1.10963.12 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=ArPO22vZGfZIlxO77_Z7ecP0CyfMAgAAAK5gztYOAAAA; expires=Thu, 17-Sep-2020 23:52:15 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:14 GMT',
   'Content-Length',
   '1417'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:54Z"}, [
+  .get('/formrecognizer/v2.0/layout/analyzeResults/868583d8-30ff-4bda-941b-42b6227532cc')
+  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T23:52:15Z","lastUpdatedDateTime":"2020-08-18T23:52:19Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '10',
+  '19',
   'apim-request-id',
-  '4845b795-f154-4e22-83cc-0c9b5dbafe9c',
+  '88e71893-6216-4277-8e66-46a5adc0caa2',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Thu, 13 Aug 2020 21:55:54 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  'ed63f0d1-07f1-426a-9c89-b2549d190601',
-  'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
-  'Set-Cookie',
-  'fpc=Apk3kR8kBL1Iq36P2RNQV-v0CyfMBAAAAOmtx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:59 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Thu, 13 Aug 2020 21:55:59 GMT',
-  'Content-Length',
-  '1417'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/layout/analyzeResults/2249c664-b329-4e06-996f-690f08355a90')
-  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-13T21:55:54Z","lastUpdatedDateTime":"2020-08-13T21:55:59Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"language":"en","angle":0,"width":8.5,"height":11,"unit":"inch","lines":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","words":[{"boundingBox":[0.5384,1.1583,1.4466,1.1583,1.4466,1.3534,0.5384,1.3534],"text":"Contoso","confidence":1}]},{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","words":[{"boundingBox":[0.7994,1.5143,1.3836,1.5143,1.3836,1.6154,0.7994,1.6154],"text":"Address:","confidence":1}]},{"boundingBox":[4.4033,1.5114,5.8155,1.5114,5.8155,1.6155,4.4033,1.6155],"text":"Invoice For: Microsoft","words":[{"boundingBox":[4.4033,1.5143,4.8234,1.5143,4.8234,1.6155,4.4033,1.6155],"text":"Invoice","confidence":1},{"boundingBox":[4.8793,1.5143,5.1013,1.5143,5.1013,1.6154,4.8793,1.6154],"text":"For:","confidence":1},{"boundingBox":[5.2045,1.5114,5.8155,1.5114,5.8155,1.6151,5.2045,1.6151],"text":"Microsoft","confidence":1}]},{"boundingBox":[0.8106,1.7033,2.1445,1.7033,2.1445,1.8342,0.8106,1.8342],"text":"1 Redmond way Suite","words":[{"boundingBox":[0.8106,1.708,0.8463,1.708,0.8463,1.8053,0.8106,1.8053],"text":"1","confidence":1},{"boundingBox":[0.923,1.7047,1.5018,1.7047,1.5018,1.8068,0.923,1.8068],"text":"Redmond","confidence":1},{"boundingBox":[1.5506,1.7309,1.7949,1.7309,1.7949,1.8342,1.5506,1.8342],"text":"way","confidence":1},{"boundingBox":[1.8415,1.7033,2.1445,1.7033,2.1445,1.8078,1.8415,1.8078],"text":"Suite","confidence":1}]},{"boundingBox":[5.2036,1.716,6.5436,1.716,6.5436,1.8459,5.2036,1.8459],"text":"1020 Enterprise Way","words":[{"boundingBox":[5.2036,1.716,5.4935,1.716,5.4935,1.8185,5.2036,1.8185],"text":"1020","confidence":1},{"boundingBox":[5.5488,1.7164,6.2178,1.7164,6.2178,1.8441,5.5488,1.8441],"text":"Enterprise","confidence":1},{"boundingBox":[6.2618,1.7164,6.5436,1.7164,6.5436,1.8459,6.2618,1.8459],"text":"Way","confidence":1}]},{"boundingBox":[0.8019,1.896,2.0384,1.896,2.0384,2.0171,0.8019,2.0171],"text":"6000 Redmond, WA","words":[{"boundingBox":[0.8019,1.896,1.0991,1.896,1.0991,1.9994,0.8019,1.9994],"text":"6000","confidence":1},{"boundingBox":[1.1537,1.8964,1.7689,1.8964,1.7689,2.0171,1.1537,2.0171],"text":"Redmond,","confidence":1},{"boundingBox":[1.8196,1.8976,2.0384,1.8976,2.0384,1.9969,1.8196,1.9969],"text":"WA","confidence":1}]},{"boundingBox":[5.196,1.9047,6.6526,1.9047,6.6526,2.0359,5.196,2.0359],"text":"Sunnayvale, CA 87659","words":[{"boundingBox":[5.196,1.9047,5.9894,1.9047,5.9894,2.0359,5.196,2.0359],"text":"Sunnayvale,","confidence":1},{"boundingBox":[6.0427,1.9047,6.2354,1.9047,6.2354,2.0085,6.0427,2.0085],"text":"CA","confidence":1},{"boundingBox":[6.2801,1.906,6.6526,1.906,6.6526,2.0086,6.2801,2.0086],"text":"87659","confidence":1}]},{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","words":[{"boundingBox":[0.8025,2.0876,1.175,2.0876,1.175,2.1911,0.8025,2.1911],"text":"99243","confidence":1}]},{"boundingBox":[0.5439,2.8733,1.5729,2.8733,1.5729,2.9754,0.5439,2.9754],"text":"Invoice Number","words":[{"boundingBox":[0.5439,2.8733,1.0098,2.8733,1.0098,2.9754,0.5439,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[1.0611,2.8743,1.5729,2.8743,1.5729,2.9754,1.0611,2.9754],"text":"Number","confidence":1}]},{"boundingBox":[1.9491,2.8733,2.7527,2.8733,2.7527,2.9754,1.9491,2.9754],"text":"Invoice Date","words":[{"boundingBox":[1.9491,2.8733,2.415,2.8733,2.415,2.9754,1.9491,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[2.4673,2.8743,2.7527,2.8743,2.7527,2.9754,2.4673,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[3.3495,2.8733,4.4547,2.8733,4.4547,2.9754,3.3495,2.9754],"text":"Invoice Due Date","words":[{"boundingBox":[3.3495,2.8733,3.8155,2.8733,3.8155,2.9754,3.3495,2.9754],"text":"Invoice","confidence":1},{"boundingBox":[3.8677,2.8743,4.1149,2.8743,4.1149,2.9754,3.8677,2.9754],"text":"Due","confidence":1},{"boundingBox":[4.1678,2.8743,4.4547,2.8743,4.4547,2.9754,4.1678,2.9754],"text":"Date","confidence":1}]},{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","words":[{"boundingBox":[4.7468,2.8717,5.289,2.8717,5.289,3.0035,4.7468,3.0035],"text":"Charges","confidence":1}]},{"boundingBox":[6.141,2.873,6.5875,2.873,6.5875,2.9736,6.141,2.9736],"text":"VAT ID","words":[{"boundingBox":[6.141,2.873,6.4147,2.873,6.4147,2.9736,6.141,2.9736],"text":"VAT","confidence":1},{"boundingBox":[6.4655,2.873,6.5875,2.873,6.5875,2.9736,6.4655,2.9736],"text":"ID","confidence":1}]},{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","words":[{"boundingBox":[0.5397,3.411,1.1457,3.411,1.1457,3.5144,0.5397,3.5144],"text":"34278587","confidence":1}]},{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","words":[{"boundingBox":[1.9455,3.41,2.551,3.41,2.551,3.5144,1.9455,3.5144],"text":"6/18/2017","confidence":1}]},{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","words":[{"boundingBox":[3.346,3.41,3.9514,3.41,3.9514,3.5144,3.346,3.5144],"text":"6/24/2017","confidence":1}]},{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","words":[{"boundingBox":[5.3871,3.4047,6.0702,3.4047,6.0702,3.5321,5.3871,3.5321],"text":"$56,651.49","confidence":1}]},{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","words":[{"boundingBox":[6.2285,3.4114,6.3919,3.4114,6.3919,3.5119,6.2285,3.5119],"text":"PT","confidence":1}]}]}],"pageResults":[{"page":1,"tables":[{"rows":2,"columns":6,"cells":[{"rowIndex":0,"columnIndex":0,"text":"Invoice Number","boundingBox":[0.5075,2.8088,1.9061,2.8088,1.9061,3.3219,0.5075,3.3219],"elements":["#/readResults/0/lines/8/words/0","#/readResults/0/lines/8/words/1"]},{"rowIndex":0,"columnIndex":1,"text":"Invoice Date","boundingBox":[1.9061,2.8088,3.3074,2.8088,3.3074,3.3219,1.9061,3.3219],"elements":["#/readResults/0/lines/9/words/0","#/readResults/0/lines/9/words/1"]},{"rowIndex":0,"columnIndex":2,"text":"Invoice Due Date","boundingBox":[3.3074,2.8088,4.7074,2.8088,4.7074,3.3219,3.3074,3.3219],"elements":["#/readResults/0/lines/10/words/0","#/readResults/0/lines/10/words/1","#/readResults/0/lines/10/words/2"]},{"rowIndex":0,"columnIndex":3,"text":"Charges","boundingBox":[4.7074,2.8088,5.386,2.8088,5.386,3.3219,4.7074,3.3219],"elements":["#/readResults/0/lines/11/words/0"]},{"rowIndex":0,"columnIndex":5,"text":"VAT ID","boundingBox":[6.1051,2.8088,7.5038,2.8088,7.5038,3.3219,6.1051,3.3219],"elements":["#/readResults/0/lines/12/words/0","#/readResults/0/lines/12/words/1"]},{"rowIndex":1,"columnIndex":0,"text":"34278587","boundingBox":[0.5075,3.3219,1.9061,3.3219,1.9061,3.859,0.5075,3.859],"elements":["#/readResults/0/lines/13/words/0"]},{"rowIndex":1,"columnIndex":1,"text":"6/18/2017","boundingBox":[1.9061,3.3219,3.3074,3.3219,3.3074,3.859,1.9061,3.859],"elements":["#/readResults/0/lines/14/words/0"]},{"rowIndex":1,"columnIndex":2,"text":"6/24/2017","boundingBox":[3.3074,3.3219,4.7074,3.3219,4.7074,3.859,3.3074,3.859],"elements":["#/readResults/0/lines/15/words/0"]},{"rowIndex":1,"columnIndex":3,"columnSpan":2,"text":"$56,651.49","boundingBox":[4.7074,3.3219,6.1051,3.3219,6.1051,3.859,4.7074,3.859],"elements":["#/readResults/0/lines/16/words/0"]},{"rowIndex":1,"columnIndex":5,"text":"PT","boundingBox":[6.1051,3.3219,7.5038,3.3219,7.5038,3.859,6.1051,3.859],"elements":["#/readResults/0/lines/17/words/0"]}]}]}]}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '21',
-  'apim-request-id',
-  'fbbf365d-9d96-4226-95b2-e294c3d221f1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Thu, 13 Aug 2020 21:55:59 GMT'
+  'Tue, 18 Aug 2020 23:52:20 GMT'
 ]);

--- a/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_receipt_from_a_url.js
+++ b/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_receipt_from_a_url.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "57b28a018f274c6109d1f508b3be0340";
+module.exports.hash = "6b7cf7537e6e19edf19302088fee6787";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -11,6 +11,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -22,19 +24,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'e41addcf-f852-4f85-ab42-c83ad79e3000',
+  '3cb431e7-31ab-437a-a7df-e21da3734001',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AgCAGtYKWkpCph-f7eFyGlr0CyfMAQAAABgZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAQAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:59 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:48 GMT',
-  'Content-Length',
-  '1417'
+  'Thu, 13 Aug 2020 21:55:59 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
@@ -43,121 +43,17 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Operation-Location',
-  'https://endpoint/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/fbd72940-ed6c-44f8-98eb-0ce80e1bcc46',
+  'https://endpoint/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81',
   'x-envoy-upstream-service-time',
-  '474',
+  '886',
   'apim-request-id',
-  'fbd72940-ed6c-44f8-98eb-0ce80e1bcc46',
+  'd254705d-a6e6-4dc0-a818-3d777499dd81',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:49 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '636d9e09-d493-4368-9f70-31d0dec35400',
-  'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
-  'Set-Cookie',
-  'fpc=AgCAGtYKWkpCph-f7eFyGlr0CyfMAgAAABgZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:49 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:49 GMT',
-  'Content-Length',
-  '1417'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/fbd72940-ed6c-44f8-98eb-0ce80e1bcc46')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:49Z","lastUpdatedDateTime":"2020-08-18T18:46:49Z"}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '76',
-  'apim-request-id',
-  '4e7723e6-47d9-4a82-921b-5a540266352d',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:49 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  'c05d1f30-79f6-4b90-8e8d-b9da22222d00',
-  'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
-  'Set-Cookie',
-  'fpc=AgCAGtYKWkpCph-f7eFyGlr0CyfMAwAAABgZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:49 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:49 GMT',
-  'Content-Length',
-  '1417'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/fbd72940-ed6c-44f8-98eb-0ce80e1bcc46')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-18T18:46:49Z","lastUpdatedDateTime":"2020-08-18T18:46:49Z"}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '148',
-  'apim-request-id',
-  '3b854ca0-b776-4e79-aec7-bbec74f7d106',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 18 Aug 2020 18:46:49 GMT'
+  'Thu, 13 Aug 2020 21:56:00 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -180,34 +76,138 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'a2563ff8-ea31-41d2-a115-ecc36e963000',
+  '662fd98c-66d6-439d-9d72-82df3f894601',
   'x-ms-ests-server',
-  '2.1.10946.17 - WUS2 ProdSlices',
+  '2.1.10922.14 - SAN ProdSlices',
   'Set-Cookie',
-  'fpc=AgCAGtYKWkpCph-f7eFyGlr0CyfMBAAAABgZztYOAAAA; expires=Thu, 17-Sep-2020 18:46:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAgAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:01 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 18 Aug 2020 18:46:54 GMT'
+  'Thu, 13 Aug 2020 21:56:01 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/fbd72940-ed6c-44f8-98eb-0ce80e1bcc46')
-  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T18:46:49Z","lastUpdatedDateTime":"2020-08-18T18:46:51Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"angle":0.6893,"width":1688,"height":3000,"unit":"pixel","language":"en"}],"documentResults":[{"docType":"prebuilt:receipt","pageRange":[1,1],"fields":{"ReceiptType":{"type":"string","valueString":"Itemized","confidence":0.692},"MerchantName":{"type":"string","valueString":"Contoso Contoso","text":"Contoso Contoso","boundingBox":[378.2,292.4,1117.7,468.3,1035.7,812.7,296.3,636.8],"page":1,"confidence":0.613},"MerchantAddress":{"type":"string","valueString":"123 Main Street Redmond, WA 98052","text":"123 Main Street Redmond, WA 98052","boundingBox":[302,675.8,848.1,793.7,809.9,970.4,263.9,852.5],"page":1,"confidence":0.99},"MerchantPhoneNumber":{"type":"phoneNumber","valuePhoneNumber":"+19876543210","text":"987-654-3210","boundingBox":[278,1004,656.3,1054.7,646.8,1125.3,268.5,1074.7],"page":1,"confidence":0.99},"TransactionDate":{"type":"date","valueDate":"2019-06-10","text":"6/10/2019","boundingBox":[265.1,1228.4,525,1247,518.9,1332.1,259,1313.5],"page":1,"confidence":0.99},"TransactionTime":{"type":"time","valueTime":"13:59:00","text":"13:59","boundingBox":[541,1248,677.3,1261.5,668.9,1346.5,532.6,1333],"page":1,"confidence":0.977},"Items":{"type":"array","valueArray":[{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[245.1,1581.5,300.9,1585.1,295,1676,239.2,1672.4],"page":1,"confidence":0.92},"Name":{"type":"string","valueString":"Cappuccino","text":"Cappuccino","boundingBox":[322,1586,654.2,1601.1,650,1693,317.8,1678],"page":1,"confidence":0.923},"TotalPrice":{"type":"number","valueNumber":2.2,"text":"$2.20","boundingBox":[1107.7,1584,1263,1574,1268.3,1656,1113,1666],"page":1,"confidence":0.918}}},{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[232,1834,286.6,1835,285,1921,230.4,1920],"page":1,"confidence":0.858},"Name":{"type":"string","valueString":"BACON & EGGS","text":"BACON & EGGS","boundingBox":[308,1836,746,1841.4,745,1925.4,307,1920],"page":1,"confidence":0.916},"TotalPrice":{"type":"number","text":"$9.5","boundingBox":[1133.9,1955,1257,1952,1259.1,2036,1136,2039],"page":1,"confidence":0.916}}}]},"Subtotal":{"type":"number","valueNumber":11.7,"text":"11.70","boundingBox":[1146,2221,1297.3,2223,1296,2319,1144.7,2317],"page":1,"confidence":0.955},"Tax":{"type":"number","valueNumber":1.17,"text":"1.17","boundingBox":[1190,2359,1304,2359,1304,2456,1190,2456],"page":1,"confidence":0.979},"Tip":{"type":"number","valueNumber":1.63,"text":"1.63","boundingBox":[1094,2479,1267.7,2485,1264,2591,1090.3,2585],"page":1,"confidence":0.941},"Total":{"type":"number","valueNumber":14.5,"text":"$14.50","boundingBox":[1034.2,2617,1387.5,2638.2,1380,2763,1026.7,2741.8],"page":1,"confidence":0.985}}}]}}, [
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:01Z"}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '215',
+  '66',
   'apim-request-id',
-  '12c861ca-0ed1-49ae-81fb-6db604ec608f',
+  '35cf59b3-7d71-45ac-9589-3bbb29039dcc',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 18 Aug 2020 18:46:55 GMT'
+  'Thu, 13 Aug 2020 21:56:00 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1417',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '1693dbd3-d5f9-4eb2-aef4-894020535301',
+  'x-ms-ests-server',
+  '2.1.10922.14 - SAN ProdSlices',
+  'Set-Cookie',
+  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAwAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:01 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 13 Aug 2020 21:56:01 GMT'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:01Z"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '131',
+  'apim-request-id',
+  '937ac6e9-e131-4ac0-85ca-12f3e56601b2',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 13 Aug 2020 21:56:00 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1417',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '662fd98c-66d6-439d-9d72-82df6e8a4601',
+  'x-ms-ests-server',
+  '2.1.10922.14 - SAN ProdSlices',
+  'Set-Cookie',
+  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMBAAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:06 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 13 Aug 2020 21:56:06 GMT'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
+  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:02Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"angle":0.6893,"width":1688,"height":3000,"unit":"pixel","language":"en"}],"documentResults":[{"docType":"prebuilt:receipt","pageRange":[1,1],"fields":{"ReceiptType":{"type":"string","valueString":"Itemized","confidence":0.692},"MerchantName":{"type":"string","valueString":"Contoso Contoso","text":"Contoso Contoso","boundingBox":[378.2,292.4,1117.7,468.3,1035.7,812.7,296.3,636.8],"page":1,"confidence":0.613},"MerchantAddress":{"type":"string","valueString":"123 Main Street Redmond, WA 98052","text":"123 Main Street Redmond, WA 98052","boundingBox":[302,675.8,848.1,793.7,809.9,970.4,263.9,852.5],"page":1,"confidence":0.99},"MerchantPhoneNumber":{"type":"phoneNumber","valuePhoneNumber":"+19876543210","text":"987-654-3210","boundingBox":[278,1004,656.3,1054.7,646.8,1125.3,268.5,1074.7],"page":1,"confidence":0.99},"TransactionDate":{"type":"date","valueDate":"2019-06-10","text":"6/10/2019","boundingBox":[265.1,1228.4,525,1247,518.9,1332.1,259,1313.5],"page":1,"confidence":0.99},"TransactionTime":{"type":"time","valueTime":"13:59:00","text":"13:59","boundingBox":[541,1248,677.3,1261.5,668.9,1346.5,532.6,1333],"page":1,"confidence":0.977},"Items":{"type":"array","valueArray":[{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[245.1,1581.5,300.9,1585.1,295,1676,239.2,1672.4],"page":1,"confidence":0.92},"Name":{"type":"string","valueString":"Cappuccino","text":"Cappuccino","boundingBox":[322,1586,654.2,1601.1,650,1693,317.8,1678],"page":1,"confidence":0.923},"TotalPrice":{"type":"number","valueNumber":2.2,"text":"$2.20","boundingBox":[1107.7,1584,1263,1574,1268.3,1656,1113,1666],"page":1,"confidence":0.918}}},{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[232,1834,286.6,1835,285,1921,230.4,1920],"page":1,"confidence":0.858},"Name":{"type":"string","valueString":"BACON & EGGS","text":"BACON & EGGS","boundingBox":[308,1836,746,1841.4,745,1925.4,307,1920],"page":1,"confidence":0.916},"TotalPrice":{"type":"number","text":"$9.5","boundingBox":[1133.9,1955,1257,1952,1259.1,2036,1136,2039],"page":1,"confidence":0.916}}}]},"Subtotal":{"type":"number","valueNumber":11.7,"text":"11.70","boundingBox":[1146,2221,1297.3,2223,1296,2319,1144.7,2317],"page":1,"confidence":0.955},"Tax":{"type":"number","valueNumber":1.17,"text":"1.17","boundingBox":[1190,2359,1304,2359,1304,2456,1190,2456],"page":1,"confidence":0.979},"Tip":{"type":"number","valueNumber":1.63,"text":"1.63","boundingBox":[1094,2479,1267.7,2485,1264,2591,1090.3,2585],"page":1,"confidence":0.941},"Total":{"type":"number","valueNumber":14.5,"text":"$14.50","boundingBox":[1034.2,2617,1387.5,2638.2,1380,2763,1026.7,2741.8],"page":1,"confidence":0.985}}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '61',
+  'apim-request-id',
+  '07def35d-b5bd-4f28-b891-a9d627c7e2b5',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 13 Aug 2020 21:56:05 GMT'
 ]);

--- a/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_receipt_from_a_url.js
+++ b/sdk/formrecognizer/ai-form-recognizer/recordings/node/aad_formrecognizerclient_nodejs_only/recording_recognizes_receipt_from_a_url.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "6b7cf7537e6e19edf19302088fee6787";
+module.exports.hash = "57b28a018f274c6109d1f508b3be0340";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -11,8 +11,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1417',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -24,17 +22,19 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '3cb431e7-31ab-437a-a7df-e21da3734001',
+  '2cceb49b-c177-403d-ba4f-bbd70c5c0700',
   'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAQAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:55:59 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AnDnCOvzGh5NlT5UX8t6Hbr0CyfMAQAAALNgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:20 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 13 Aug 2020 21:55:59 GMT'
+  'Tue, 18 Aug 2020 23:52:20 GMT',
+  'Content-Length',
+  '1417'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
@@ -43,17 +43,121 @@ nock('https://endpoint:443', {"encodedQueryParams":true})
   'Content-Length',
   '0',
   'Operation-Location',
-  'https://endpoint/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81',
+  'https://endpoint/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/687d533d-3fde-4459-8567-da4144e3d7a7',
   'x-envoy-upstream-service-time',
-  '886',
+  '427',
   'apim-request-id',
-  'd254705d-a6e6-4dc0-a818-3d777499dd81',
+  '687d533d-3fde-4459-8567-da4144e3d7a7',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Thu, 13 Aug 2020 21:56:00 GMT'
+  'Tue, 18 Aug 2020 23:52:20 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2ed83807-708c-4ebc-80ef-c989708a0700',
+  'x-ms-ests-server',
+  '2.1.10963.12 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=AnDnCOvzGh5NlT5UX8t6Hbr0CyfMAgAAALNgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:21 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:20 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/687d533d-3fde-4459-8567-da4144e3d7a7')
+  .reply(200, {"status":"notStarted","createdDateTime":"2020-08-18T23:52:20Z","lastUpdatedDateTime":"2020-08-18T23:52:20Z"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '33',
+  'apim-request-id',
+  '5df2b87a-8316-4200-a6b8-82c02379364f',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:20 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '10217e96-7169-402f-8402-101b7b5f0a00',
+  'x-ms-ests-server',
+  '2.1.10963.12 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=AnDnCOvzGh5NlT5UX8t6Hbr0CyfMAwAAALNgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:21 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:20 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/687d533d-3fde-4459-8567-da4144e3d7a7')
+  .reply(200, {"status":"running","createdDateTime":"2020-08-18T23:52:20Z","lastUpdatedDateTime":"2020-08-18T23:52:21Z"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '108',
+  'apim-request-id',
+  '9d90d8fa-341d-4891-9087-8e5fedf71628',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 18 Aug 2020 23:52:20 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -76,138 +180,34 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '662fd98c-66d6-439d-9d72-82df3f894601',
+  'd4f9f478-d1c0-4329-a235-30e0def20d00',
   'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
+  '2.1.10963.12 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAgAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:01 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AnDnCOvzGh5NlT5UX8t6Hbr0CyfMBAAAALNgztYOAAAA; expires=Thu, 17-Sep-2020 23:52:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 13 Aug 2020 21:56:01 GMT'
+  'Tue, 18 Aug 2020 23:52:25 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:01Z"}, [
+  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/687d533d-3fde-4459-8567-da4144e3d7a7')
+  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-18T23:52:20Z","lastUpdatedDateTime":"2020-08-18T23:52:22Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"angle":0.6893,"width":1688,"height":3000,"unit":"pixel","language":"en"}],"documentResults":[{"docType":"prebuilt:receipt","pageRange":[1,1],"fields":{"ReceiptType":{"type":"string","valueString":"Itemized","confidence":0.692},"MerchantName":{"type":"string","valueString":"Contoso Contoso","text":"Contoso Contoso","boundingBox":[378.2,292.4,1117.7,468.3,1035.7,812.7,296.3,636.8],"page":1,"confidence":0.613},"MerchantAddress":{"type":"string","valueString":"123 Main Street Redmond, WA 98052","text":"123 Main Street Redmond, WA 98052","boundingBox":[302,675.8,848.1,793.7,809.9,970.4,263.9,852.5],"page":1,"confidence":0.99},"MerchantPhoneNumber":{"type":"phoneNumber","valuePhoneNumber":"+19876543210","text":"987-654-3210","boundingBox":[278,1004,656.3,1054.7,646.8,1125.3,268.5,1074.7],"page":1,"confidence":0.99},"TransactionDate":{"type":"date","valueDate":"2019-06-10","text":"6/10/2019","boundingBox":[265.1,1228.4,525,1247,518.9,1332.1,259,1313.5],"page":1,"confidence":0.99},"TransactionTime":{"type":"time","valueTime":"13:59:00","text":"13:59","boundingBox":[541,1248,677.3,1261.5,668.9,1346.5,532.6,1333],"page":1,"confidence":0.977},"Items":{"type":"array","valueArray":[{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[245.1,1581.5,300.9,1585.1,295,1676,239.2,1672.4],"page":1,"confidence":0.92},"Name":{"type":"string","valueString":"Cappuccino","text":"Cappuccino","boundingBox":[322,1586,654.2,1601.1,650,1693,317.8,1678],"page":1,"confidence":0.923},"TotalPrice":{"type":"number","valueNumber":2.2,"text":"$2.20","boundingBox":[1107.7,1584,1263,1574,1268.3,1656,1113,1666],"page":1,"confidence":0.918}}},{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[232,1834,286.6,1835,285,1921,230.4,1920],"page":1,"confidence":0.858},"Name":{"type":"string","valueString":"BACON & EGGS","text":"BACON & EGGS","boundingBox":[308,1836,746,1841.4,745,1925.4,307,1920],"page":1,"confidence":0.916},"TotalPrice":{"type":"number","text":"$9.5","boundingBox":[1133.9,1955,1257,1952,1259.1,2036,1136,2039],"page":1,"confidence":0.916}}}]},"Subtotal":{"type":"number","valueNumber":11.7,"text":"11.70","boundingBox":[1146,2221,1297.3,2223,1296,2319,1144.7,2317],"page":1,"confidence":0.955},"Tax":{"type":"number","valueNumber":1.17,"text":"1.17","boundingBox":[1190,2359,1304,2359,1304,2456,1190,2456],"page":1,"confidence":0.979},"Tip":{"type":"number","valueNumber":1.63,"text":"1.63","boundingBox":[1094,2479,1267.7,2485,1264,2591,1090.3,2585],"page":1,"confidence":0.941},"Total":{"type":"number","valueNumber":14.5,"text":"$14.50","boundingBox":[1034.2,2617,1387.5,2638.2,1380,2763,1026.7,2741.8],"page":1,"confidence":0.985}}}]}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '66',
+  '62',
   'apim-request-id',
-  '35cf59b3-7d71-45ac-9589-3bbb29039dcc',
+  '843c78e2-4c15-489c-99c7-508303edf6cc',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Thu, 13 Aug 2020 21:56:00 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '1417',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '1693dbd3-d5f9-4eb2-aef4-894020535301',
-  'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
-  'Set-Cookie',
-  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMAwAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:01 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Thu, 13 Aug 2020 21:56:01 GMT'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
-  .reply(200, {"status":"running","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:01Z"}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '131',
-  'apim-request-id',
-  '937ac6e9-e131-4ac0-85ca-12f3e56601b2',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Thu, 13 Aug 2020 21:56:00 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '1417',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '662fd98c-66d6-439d-9d72-82df6e8a4601',
-  'x-ms-ests-server',
-  '2.1.10922.14 - SAN ProdSlices',
-  'Set-Cookie',
-  'fpc=AoPJ8EoLo1xEg2FbIpX38_P0CyfMBAAAAO-tx9YOAAAA; expires=Sat, 12-Sep-2020 21:56:06 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=ests; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Thu, 13 Aug 2020 21:56:06 GMT'
-]);
-
-nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/formrecognizer/v2.0/prebuilt/receipt/analyzeResults/d254705d-a6e6-4dc0-a818-3d777499dd81')
-  .reply(200, {"status":"succeeded","createdDateTime":"2020-08-13T21:56:00Z","lastUpdatedDateTime":"2020-08-13T21:56:02Z","analyzeResult":{"version":"2.0.0","readResults":[{"page":1,"angle":0.6893,"width":1688,"height":3000,"unit":"pixel","language":"en"}],"documentResults":[{"docType":"prebuilt:receipt","pageRange":[1,1],"fields":{"ReceiptType":{"type":"string","valueString":"Itemized","confidence":0.692},"MerchantName":{"type":"string","valueString":"Contoso Contoso","text":"Contoso Contoso","boundingBox":[378.2,292.4,1117.7,468.3,1035.7,812.7,296.3,636.8],"page":1,"confidence":0.613},"MerchantAddress":{"type":"string","valueString":"123 Main Street Redmond, WA 98052","text":"123 Main Street Redmond, WA 98052","boundingBox":[302,675.8,848.1,793.7,809.9,970.4,263.9,852.5],"page":1,"confidence":0.99},"MerchantPhoneNumber":{"type":"phoneNumber","valuePhoneNumber":"+19876543210","text":"987-654-3210","boundingBox":[278,1004,656.3,1054.7,646.8,1125.3,268.5,1074.7],"page":1,"confidence":0.99},"TransactionDate":{"type":"date","valueDate":"2019-06-10","text":"6/10/2019","boundingBox":[265.1,1228.4,525,1247,518.9,1332.1,259,1313.5],"page":1,"confidence":0.99},"TransactionTime":{"type":"time","valueTime":"13:59:00","text":"13:59","boundingBox":[541,1248,677.3,1261.5,668.9,1346.5,532.6,1333],"page":1,"confidence":0.977},"Items":{"type":"array","valueArray":[{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[245.1,1581.5,300.9,1585.1,295,1676,239.2,1672.4],"page":1,"confidence":0.92},"Name":{"type":"string","valueString":"Cappuccino","text":"Cappuccino","boundingBox":[322,1586,654.2,1601.1,650,1693,317.8,1678],"page":1,"confidence":0.923},"TotalPrice":{"type":"number","valueNumber":2.2,"text":"$2.20","boundingBox":[1107.7,1584,1263,1574,1268.3,1656,1113,1666],"page":1,"confidence":0.918}}},{"type":"object","valueObject":{"Quantity":{"type":"number","text":"1","boundingBox":[232,1834,286.6,1835,285,1921,230.4,1920],"page":1,"confidence":0.858},"Name":{"type":"string","valueString":"BACON & EGGS","text":"BACON & EGGS","boundingBox":[308,1836,746,1841.4,745,1925.4,307,1920],"page":1,"confidence":0.916},"TotalPrice":{"type":"number","text":"$9.5","boundingBox":[1133.9,1955,1257,1952,1259.1,2036,1136,2039],"page":1,"confidence":0.916}}}]},"Subtotal":{"type":"number","valueNumber":11.7,"text":"11.70","boundingBox":[1146,2221,1297.3,2223,1296,2319,1144.7,2317],"page":1,"confidence":0.955},"Tax":{"type":"number","valueNumber":1.17,"text":"1.17","boundingBox":[1190,2359,1304,2359,1304,2456,1190,2456],"page":1,"confidence":0.979},"Tip":{"type":"number","valueNumber":1.63,"text":"1.63","boundingBox":[1094,2479,1267.7,2485,1264,2591,1090.3,2585],"page":1,"confidence":0.941},"Total":{"type":"number","valueNumber":14.5,"text":"$14.50","boundingBox":[1034.2,2617,1387.5,2638.2,1380,2763,1026.7,2741.8],"page":1,"confidence":0.985}}}]}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '61',
-  'apim-request-id',
-  '07def35d-b5bd-4f28-b891-a9d627c7e2b5',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Thu, 13 Aug 2020 21:56:05 GMT'
+  'Tue, 18 Aug 2020 23:52:25 GMT'
 ]);


### PR DESCRIPTION
PR https://github.com/Azure/azure-sdk-for-js/pull/10085 had a bug that prevented any caching from happening. The recordings in that PR should have helped us see the issue, but I didn't go through why we needed the recording changes. @HarshaNalluru had a similar issue with other recordings after this PR was merged, and from there we were able to spot the bug.

I'm really glad this wasn't released 😁

~The recording changes of this PR undo the recording changes in: https://github.com/Azure/azure-sdk-for-js/pull/10085/files 
I did so by checking out these files to the commit hash present on master before this PR was merged. The commit hash being: e76133f41d075451bc29bdac32027120ebc1de0b~ I couldn't use the older recordings because form recognizer was recently updated.

We also spotted that now the Recorder is unable to match the delayed requests, showing an error log even though the tests passed. This doesn't mean the tests are bad, but that the recorder wasn't considering this scenario. I made an issue: https://github.com/Azure/azure-sdk-for-js/issues/10694