### PR TITLE
[Service Bus] Avoid using dotnet links for status codes

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -304,8 +304,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async createQueue(queueName: string, options?: CreateQueueOptions): Promise<QueueResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -349,8 +348,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getQueue(queueName: string, operationOptions?: OperationOptions): Promise<QueueResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -389,8 +387,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getQueueRuntimeProperties(
     queueName: string,
@@ -433,8 +430,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getQueues(
     options?: ListRequestOptions & OperationOptions
@@ -541,8 +537,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getQueuesRuntimeProperties(
     options?: ListRequestOptions & OperationOptions
@@ -662,8 +657,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async updateQueue(
     queue: QueueProperties,
@@ -720,8 +714,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async deleteQueue(queueName: string, operationOptions?: OperationOptions): Promise<Response> {
     const { span, updatedOperationOptions } = createSpan(
@@ -794,8 +787,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async createTopic(topicName: string, options?: CreateTopicOptions): Promise<TopicResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -839,8 +831,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getTopic(topicName: string, operationOptions?: OperationOptions): Promise<TopicResponse> {
     const { span, updatedOperationOptions } = createSpan(
@@ -879,8 +870,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getTopicRuntimeProperties(
     topicName: string,
@@ -923,8 +913,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getTopics(
     options?: ListRequestOptions & OperationOptions
@@ -1032,8 +1021,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getTopicsRuntimeProperties(
     options?: ListRequestOptions & OperationOptions
@@ -1154,8 +1142,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async updateTopic(
     topic: TopicProperties,
@@ -1212,8 +1199,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async deleteTopic(topicName: string, operationOptions?: OperationOptions): Promise<Response> {
     const { span, updatedOperationOptions } = createSpan(
@@ -1287,8 +1273,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async createSubscription(
     topicName: string,
@@ -1338,8 +1323,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getSubscription(
     topicName: string,
@@ -1386,8 +1370,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getSubscriptionRuntimeProperties(
     topicName: string,
@@ -1433,8 +1416,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getSubscriptions(
     topicName: string,
@@ -1554,8 +1536,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getSubscriptionsRuntimeProperties(
     topicName: string,
@@ -1687,8 +1668,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async updateSubscription(
     subscription: SubscriptionProperties,
@@ -1753,8 +1733,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async deleteSubscription(
     topicName: string,
@@ -1843,8 +1822,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   createRule(
     topicName: string,
@@ -1870,8 +1848,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   createRule(
     topicName: string,
@@ -1944,8 +1921,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async getRule(
     topicName: string,
@@ -1990,8 +1966,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   private async getRules(
     topicName: string,
@@ -2116,8 +2091,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async updateRule(
     topicName: string,
@@ -2179,8 +2153,7 @@ export class ServiceBusManagementClient extends ServiceClient {
    * @throws `RestError` with code `ServerBusyError` when the request fails due to server being busy,
    * @throws `RestError` with code `ServiceError` when receiving unrecognized HTTP status or for a scenarios such as
    * bad requests or requests resulting in conflicting operation on the server,
-   * @throws `RestError` with code that is a value from the standard set of HTTP status codes as documented at
-   * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
+   * @throws `RestError` with code and statusCode representing the standard set of REST API errors.
    */
   async deleteRule(
     topicName: string,


### PR DESCRIPTION
This PR replaces reference to http status codes information in https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8 with a generic statement on REST API errors. 

This is a follow up from the discussion in https://github.com/Azure/azure-sdk-for-js/pull/10646#discussion_r471147023

I don't feel strongly about this either way, but if we were to remove this link then the change in this PR is what I would recommend

