### PR TITLE
[Monitor] add eslint-plugin-azure-sdk

### DIFF
--- a/sdk/monitor/opentelemetry-exporter/.eslintrc.json
+++ b/sdk/monitor/opentelemetry-exporter/.eslintrc.json
@@ -4,7 +4,9 @@
       "tryExtensions": [".ts"]
     }
   },
+  "plugins": ["@azure/azure-sdk"],
   "extends": [
+    "plugin:@azure/azure-sdk/azure-sdk-base",
     "plugin:node/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "prettier/@typescript-eslint"

--- a/sdk/monitor/opentelemetry-exporter/package.json
+++ b/sdk/monitor/opentelemetry-exporter/package.json
@@ -45,7 +45,9 @@
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/opentelemetry-exporter"
   },
+"prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "devDependencies": {
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^10.0.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -56,6 +58,9 @@
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-no-null": "^1.0.2",
+    "eslint-plugin-no-only-tests": "^2.3.0",
+    "eslint-plugin-promise": "^4.1.1",
     "mocha": "^7.1.1",
     "nock": "^12.0.3",
     "prettier": "^1.16.4",

--- a/sdk/monitor/opentelemetry-exporter/src/config.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { Logger } from "@opentelemetry/api";
 import { DEFAULT_BREEZE_ENDPOINT } from "./Declarations/Constants";
 

--- a/sdk/monitor/opentelemetry-exporter/src/export/exporter.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/export/exporter.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { Logger } from "@opentelemetry/api";
 import { ConsoleLogger, LogLevel, ExportResult } from "@opentelemetry/core";
 import { Envelope } from "../Declarations/Contracts";
@@ -105,7 +108,7 @@ export abstract class AzureMonitorBaseExporter implements BaseExporter {
     } catch (senderErr) {
       // Request failed -- always retry
       this._logger.error(senderErr.message);
-      return await this._persist(envelopes);
+      return this._persist(envelopes);
     }
   }
 
@@ -113,11 +116,11 @@ export abstract class AzureMonitorBaseExporter implements BaseExporter {
     this._telemetryProcessors.push(processor);
   }
 
-  clearTelemetryProcessors() {
+  clearTelemetryProcessors(): void {
     this._telemetryProcessors = [];
   }
 
-  shutdown() {
+  shutdown(): void {
     this._sender.shutdown();
   }
 
@@ -141,7 +144,7 @@ export abstract class AzureMonitorBaseExporter implements BaseExporter {
     return filteredEnvelopes;
   }
 
-  private async _sendFirstPersistedFile() {
+  private async _sendFirstPersistedFile(): Promise<void> {
     try {
       const envelopes = (await this._persister.shift()) as Envelope[];
       this._sender.send(envelopes);

--- a/sdk/monitor/opentelemetry-exporter/src/export/trace.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/export/trace.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { ExportResult } from "@opentelemetry/core";
 import { ReadableSpan, SpanExporter } from "@opentelemetry/tracing";
 import { readableSpanToEnvelope } from "../utils/spanUtils";

--- a/sdk/monitor/opentelemetry-exporter/src/index.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/index.ts
@@ -1,1 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export * from "./export/trace";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/index.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // Use the node platform by default. The "browser" field of package.json is used
 // to override this file to use `./browser/index.ts` when packaged with
 // webpack, Rollup, etc.

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/constants.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export const SDK_INFO = {
   NAME: "opentelemetry",
   RUNTIME: "node",

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/context/context.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/context/context.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
@@ -47,17 +50,17 @@ export class Context {
      * relative to `Context.ROOT_PATH`
      * @default `../../`
      */
-    private _appPrefix = "../../../",
+    private _appPrefix = "../../../"
   ) {
     this.keys = new Contracts.ContextTagKeys();
-    this.tags = <{ [key: string]: string }>{};
+    this.tags = {} as { [key: string]: string };
 
     this._loadApplicationContext();
     this._loadDeviceContext();
     this._loadInternalContext();
   }
 
-  private _loadApplicationContext() {
+  private _loadApplicationContext(): void {
     if (Object.keys(Context.appVersion).length === 0) {
       // note: this should return the host package.json
       let packageJson: PackageJson | null = null;
@@ -66,13 +69,13 @@ export class Context {
         Context.JS_NODE_PREFIX,
         this._appPrefix,
         Context.ROOT_PATH,
-        "./package.json",
+        "./package.json"
       );
       const packageJsonPathTsNode = path.resolve(
         __dirname,
         this._appPrefix,
         Context.ROOT_PATH,
-        "./package.json",
+        "./package.json"
       );
 
       Context.appVersion[packageJsonPath] = "unknown";
@@ -95,7 +98,7 @@ export class Context {
     }
   }
 
-  private _loadDeviceContext() {
+  private _loadDeviceContext(): void {
     this.tags[this.keys.deviceId] = "";
     this.tags[this.keys.cloudRoleInstance] = os && os.hostname();
     this.tags[this.keys.deviceOSVersion] = os && `${os.type()} ${os.release()}`;
@@ -106,7 +109,7 @@ export class Context {
     this.tags["ai.device.osPlatform"] = os && os.platform();
   }
 
-  private _loadInternalContext() {
+  private _loadInternalContext(): void {
     if (!Context.sdkVersion) {
       let packageJson: { version: string } | null = null;
       const { node } = process.versions;
@@ -118,13 +121,13 @@ export class Context {
         Context.JS_NODE_PREFIX,
         this._exporterPrefix,
         Context.ROOT_PATH,
-        "./package.json",
+        "./package.json"
       );
       const packageJsonPathTsNode = path.resolve(
         __dirname,
         this._exporterPrefix,
         Context.ROOT_PATH,
-        "./package.json",
+        "./package.json"
       );
 
       Context.sdkVersion = "unknown";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/context/index.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/context/index.ts
@@ -1,1 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export * from "./context";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/httpSender.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/httpSender.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as zlib from "zlib";
 import { Logger } from "@opentelemetry/api";
 import { ConsoleLogger, LogLevel } from "@opentelemetry/core";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/index.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Node.js specific platform utils
  */

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/fileSystemHelpers.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/fileSystemHelpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as fs from "fs";
 import * as path from "path";
 import { promisify } from "util";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -37,7 +40,7 @@ export class FileSystemPersist implements PersistentStorage {
 
   async push(value: unknown[]): Promise<boolean> {
     this._logger.debug("Pushing value to persistent storage", value.toString());
-    return await this._storeToDisk(JSON.stringify(value));
+    return this._storeToDisk(JSON.stringify(value));
   }
 
   async shift(): Promise<unknown> {

--- a/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/index.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/nodejs/persist/index.ts
@@ -1,1 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export * from "./fileSystemPersist";

--- a/sdk/monitor/opentelemetry-exporter/src/platform/types.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/platform/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as http from "http";
 import * as https from "https";
 import { DEFAULT_EXPORTER_CONFIG, AzureExporterConfig } from "../config";

--- a/sdk/monitor/opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { ExportResult } from "@opentelemetry/core";
 import { Envelope } from "./Declarations/Contracts";
 
@@ -15,7 +18,7 @@ export type SenderResult = { statusCode: number; result: string };
 export interface BaseExporter {
   addTelemetryProcessor(processor: TelemetryProcessor): void;
   clearTelemetryProcessors(): void;
-  exportEnvelopes(envelopes: Envelope[], resultCallback: (result: ExportResult) => void): void;
+  exportEnvelopes(envelopes: Envelope[]): Promise<ExportResult>;
 }
 
 export interface Sender {

--- a/sdk/monitor/opentelemetry-exporter/src/utils/breezeUtils.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/breezeUtils.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export interface BreezeError {
   index: number;
   statusCode: number;

--- a/sdk/monitor/opentelemetry-exporter/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/connectionStringParser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import type { Logger } from "@opentelemetry/api";
 import { NoopLogger } from "@opentelemetry/core";
 import type { ConnectionString, ConnectionStringKey } from "../Declarations/Contracts";

--- a/sdk/monitor/opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export const AI_OPERATION_ID = "ai.operation.id";
 export const AI_OPERATION_PARENT_ID = "ai.operation.parentId";
 export const AI_OPERATION_NAME = "ai.operation.name";

--- a/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/azAttributes.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/azAttributes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export const AzNamespace = "az.namespace";
 export const MicrosoftEventHub = "Microsoft.EventHub";
 export const MessageBusDestination = "message_bus.destination";

--- a/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/dbAttributes.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/dbAttributes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as conventions from "@opentelemetry/semantic-conventions";
 
 export const { DB_TYPE } = conventions.DatabaseAttribute;

--- a/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/grpcAttributes.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/grpcAttributes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as conventions from "@opentelemetry/semantic-conventions";
 
 export const { GRPC_KIND } = conventions.RpcAttribute;

--- a/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/httpAttributes.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/constants/span/httpAttributes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as conventions from "@opentelemetry/semantic-conventions";
 
 export const { HTTP_METHOD } = conventions.HttpAttribute;

--- a/sdk/monitor/opentelemetry-exporter/src/utils/eventhub.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/eventhub.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { SpanKind } from "@opentelemetry/api";
 import { hrTimeToMilliseconds } from "@opentelemetry/core";
 import { GeneralAttribute } from "@opentelemetry/semantic-conventions";

--- a/sdk/monitor/opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/opentelemetry-exporter/src/utils/spanUtils.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { URL } from "url";
 import { ReadableSpan } from "@opentelemetry/tracing";
 import { hrTimeToMilliseconds } from "@opentelemetry/core";

--- a/sdk/monitor/opentelemetry-exporter/test/breezeTestUtils.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/breezeTestUtils.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { BreezeResponse } from "../src/utils/breezeUtils";
 
 export function successfulBreezeResponse(count: number): BreezeResponse {

--- a/sdk/monitor/opentelemetry-exporter/test/export/export.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/export/export.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /* eslint-disable no-param-reassign */
 /* eslint-disable dot-notation */
 import * as assert from "assert";

--- a/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as assert from "assert";
 import { HttpSender } from "../../../src/platform/nodejs/httpSender";
 import { Envelope } from "../../../src/Declarations/Contracts";

--- a/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/persist/fileSystemPersist.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/platform/nodejs/persist/fileSystemPersist.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as assert from "assert";
 import * as fs from "fs";
 import * as os from "os";
@@ -14,7 +17,7 @@ const unlinkAsync = promisify(fs.unlink);
 const instrumentationKey = "abc";
 const tempDir = path.join(os.tmpdir(), `${FileSystemPersist.TEMPDIR_PREFIX}${instrumentationKey}`);
 
-const deleteFolderRecursive = (dirPath: string) => {
+const deleteFolderRecursive = (dirPath: string): void => {
   if (fs.existsSync(dirPath)) {
     fs.readdirSync(dirPath).forEach((file) => {
       const curPath = `${dirPath}/${file}`;
@@ -30,7 +33,7 @@ const deleteFolderRecursive = (dirPath: string) => {
   }
 };
 
-const assertFirstFile = async (tempDir: string, expectation: unknown) => {
+const assertFirstFile = async (tempDir: string, expectation: unknown) : Promise<void>=> {
   // Assert that tempDir is a directory
   const stats = await statAsync(tempDir);
   assert.strictEqual(stats.isDirectory(), true);
@@ -87,7 +90,9 @@ describe("FileSystemPersist", () => {
   describe("#shift()", () => {
     it("should not crash if folder does not exist", () => {
       const persister = new FileSystemPersist({ instrumentationKey });
-      assert.doesNotThrow(async () => await persister.shift());
+      assert.doesNotThrow(async () => {
+        await persister.shift();
+      });
     });
 
     it("should not crash if file does not exist", () => {

--- a/sdk/monitor/opentelemetry-exporter/test/utils/connectionStringParser.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/utils/connectionStringParser.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as assert from "assert";
 import * as Constants from "../../src/Declarations/Constants";
 import { ConnectionStringParser } from "../../src/utils/connectionStringParser";
@@ -44,9 +47,9 @@ describe("ConnectionStringParser", () => {
       const result = ConnectionStringParser.parse(options.connectionString);
 
       if (options.expectedAuthorization)
-        assert.deepEqual(result.authorization, options.expectedAuthorization);
+        {assert.deepEqual(result.authorization, options.expectedAuthorization);}
       if (options.expectedInstrumentationKey)
-        assert.deepEqual(result.instrumentationkey, options.expectedInstrumentationKey);
+        {assert.deepEqual(result.instrumentationkey, options.expectedInstrumentationKey);}
       assert.deepEqual(result.ingestionendpoint, options.expectedBreezeEndpoint);
       assert.deepEqual(result.liveendpoint, options.expectedLiveMetricsEndpoint);
     };

--- a/sdk/monitor/opentelemetry-exporter/test/utils/eventhub.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/utils/eventhub.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { Attributes, HrTime, SpanContext, SpanKind } from "@opentelemetry/api";
 import { NoopLogger, timeInputToHrTime } from "@opentelemetry/core";
 import { BasicTracerProvider, Span } from "@opentelemetry/tracing";

--- a/sdk/monitor/opentelemetry-exporter/test/utils/spanUtils.test.ts
+++ b/sdk/monitor/opentelemetry-exporter/test/utils/spanUtils.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { Span, BasicTracerProvider } from "@opentelemetry/tracing";
 import { SpanKind, CanonicalCode } from "@opentelemetry/api";
 import * as assert from "assert";


### PR DESCRIPTION
- `monitor/opentelemetry-exporter`: Adds `@azure/eslint-plugin-azure-sdk` to list of linting rules and fixes all problems introduced by the new checks.