### PR TITLE
[ai-form-recognizer] Final docs changes pre-GA

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -136,11 +136,11 @@ to illustrate using long-running operations [below](#examples).
 ## Examples
 The following section provides several JavaScript code snippets illustrating common patterns used in the Form Recognizer client libraries.
 
-* [Recognize receipts](#recognize-receipts)
-* [Recognize content](#recognize-content)
-* [Train model](#train-model)
-* [Recognize forms using a custom model](#recognize-forms-using-a-custom-model)
-* [Listing all models](#listing-all-models)
+* [Recognize Forms Using a Custom Model](#recognize-forms-using-a-custom-model)
+* [Recognize Content](#recognize-content)
+* [Recognize Receipts](#recognize-receipts)
+* [Train a Model](#train-a-model)
+* [Listing All Models](#listing-all-models)
 
 ### Recognize Forms Using a Custom Model
 

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -149,6 +149,8 @@ Recognize name/value pairs and table data from forms. These models are trained w
 ```javascript
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
 
+const fs = require("fs");
+
 async function main() {
   const endpoint = "<cognitive services endpoint>";
   const apiKey = "<api key>";
@@ -202,6 +204,7 @@ Recognize text and table structures, along with their bounding box, from documen
 
 ```javascript
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
 
 async function main() {
@@ -242,6 +245,7 @@ Recognize data from USA sales receipts using the pre-built model. A list of rece
 
 ```javascript
 const { FormRecognizerClient, AzureKeyCredential } = require("@azure/ai-form-recognizer");
+
 const fs = require("fs");
 
 async function main() {

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -125,6 +125,8 @@ const client = new FormRecognizerClient("<endpoint>", new DefaultAzureCredential
 
 Please note that models can also be trained using a graphical user interface such as the [Form Recognizer Labeling Tool][fr-labeling-tool].
 
+Sample code snippets that illustrate the use of `FormTrainingClient` can be found [below](#train-a-model).
+
 ### Long-Running Operations
 Long-running operations are operations which consist of an initial request sent to the service to start an operation,followed by polling the service at intervals to determine whether the operation has completed or failed, and if it has succeeded, to get the result.
 
@@ -194,7 +196,7 @@ main().catch((err) => {
 Alternatively, a form URL can be used to recognize custom forms using the `beginRecognizeCustomFormsFromUrl` method. Methods
 with a `FromUrl` suffix that use URLs instead of streams exist for all of the recognition methods.
 
-### Recognize content
+### Recognize Content
 
 Recognize text and table structures, along with their bounding box, from documents
 
@@ -234,7 +236,7 @@ main().catch((err) => {
 });
 ```
 
-### Recognize receipts
+### Recognize Receipts
 
 Recognize data from USA sales receipts using the pre-built model. A list of receipt fields recognized by the service can be found [here](https://aka.ms/azsdk/formrecognizer/receiptfields).
 
@@ -296,7 +298,7 @@ main().catch((err) => {
 });
 ```
 
-### Train model
+### Train a Model
 
 Train a machine-learned model on your own form type. The resulting model will be able to recognize values from the types of forms it was trained on. Provide a container SAS url to your Azure Storage Blob container where you're storing the training documents. See details on setting this up in the [service quickstart documentation][quickstart_training]. This sample creates and trains a custom model without using labels.
 
@@ -352,7 +354,7 @@ main().catch((err) => {
 
 For information on creating a labeled training data set, see the documentation for the [using the sample labeling tool][quickstart_labeling] and the [labeled model training sample][labeled_sample].
 
-### Listing all models
+### Listing All Models
 
 Listing custom models in the current cognitive service account. This sample shows several ways to iterate through the result.
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -300,7 +300,7 @@ export class FormRecognizerClient {
    * const pages = await poller.pollUntilDone();
    * ```
    * @summary Recognizes content/layout information from a url to a form document
-   * @param {string} formUrl Url to an accessible form document. Supported document types include PDF, JPEG, PNG, and TIFF.
+   * @param {string} formUrl Url to a form document that is accessible from the service. Must be a valid, encoded URL to one of the following supported document types: PDF, JPEG, PNG, and TIFF.
    * @param {BeginRecognizeContentOptions} [options] Options to start content recognition operation
    */
   public async beginRecognizeContentFromUrl(
@@ -428,7 +428,7 @@ export class FormRecognizerClient {
    * ```
    * @summary Recognizes form information from a url to a form document using a custom form model.
    * @param {string} modelId Id of the custom form model to use
-   * @param {string} formUrl Url to an accessible form document. Supported document types include PDF, JPEG, PNG, and TIFF.
+   * @param {string} formUrl Url to a form document that is accessible from the service. Must be a valid, encoded URL to one of the following supported document types: PDF, JPEG, PNG, and TIFF.
    * @param {BeginRecognizeFormsOptions} [options] Options to start the form recognition operation
    */
   public async beginRecognizeCustomFormsFromUrl(
@@ -635,7 +635,7 @@ export class FormRecognizerClient {
    * }
    * ```
    * @summary Recognizes receipt information from a given accessible url to input document
-   * @param {string} receiptUrl Url to an accesssible receipt document. Supported document types include PDF, JPEG, PNG, and TIFF.
+   * @param {string} receiptUrl Url to a receipt document that is accessible from the service. Must be a valid, encoded URL to one of the following supported document types: PDF, JPEG, PNG, and TIFF.
    * @param {BeginRecognizeFormsOptions} [options] Options to start receipt recognition operation
    */
   public async beginRecognizeReceiptsFromUrl(

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -521,7 +521,7 @@ export class FormTrainingClient {
    * model will be copied to) credentials, and the output can be passed as the `target` parameter to the
    * `beginCopyModel` method of a source client.
    *
-   * The required `resourceId` and `resourceRegion` of an Azure Form Recognizer resource can be found in the Azure Portal, under the "Properties" section of your Cognitive Services resource (under the "Resource Management" header).
+   * The required `resourceId` and `resourceRegion` are properties of an Azure Form Recognizer resource and their values can be found in the Azure Portal.
    *
    * @param {string} resourceId Id of the Azure Form Recognizer resource where a custom model will be copied to
    * @param {string} resourceRegion Location of the Azure Form Recognizer resource, must be a valid region name supported by Azure Cognitive Services. See https://aka.ms/azsdk/cognitiveservices/regionalavailability for information about the regional availability of Azure Cognitive Services.

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -515,10 +515,16 @@ export class FormTrainingClient {
   }
 
   /**
-   * Generates authorization for copying a custom model into this Azure Form Recognizer resource.
+   * Generate an authorization for copying a custom model into this Azure Form Recognizer resource.
+   *
+   * This method should be called on a client that is authenticated using the target resource (where the
+   * model will be copied to) credentials, and the output can be passed as the `target` parameter to the
+   * `beginCopyModel` method of a source client.
+   *
+   * The required `resourceId` and `resourceRegion` of an Azure Form Recognizer resource can be found in the Azure Portal, under the "Properties" section of your Cognitive Services resource (under the "Resource Management" header).
    *
    * @param {string} resourceId Id of the Azure Form Recognizer resource where a custom model will be copied to
-   * @param {string} resourceRegion Location of the Azure Form Recognizer resource
+   * @param {string} resourceRegion Location of the Azure Form Recognizer resource, must be a valid region name supported by Azure Cognitive Services. See https://aka.ms/azsdk/cognitiveservices/regionalavailability for information about the regional availability of Azure Cognitive Services.
    * @param {GetCopyAuthorizationOptions} [options={}] Options to get copy authorization operation
    * @returns {Promise<CopyAuthorization>} The authorization to copy a custom model
    */


### PR DESCRIPTION
These are the last changes to docs that I'm making before GA, closing the final docs issues in this milestone for FR.

- documented requirement to do URL-encoding of paramters given to FromUrl method variants
- Added some blurbs to readme about the function of the samples, reordered the sections to be like Python's README
- documented where to find `resourceId` and `resourceRegion` in Azure portal
- Fixed a sample in the README not having `fs` imported
- Added a pointer to the snippets from the key concepts section

closes #9641 
closes #8942