### PR TITLE
[service-bus] Fixing service bus samples for track 1 and track 2

### DIFF
--- a/sdk/servicebus/service-bus/samples-v1/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/README.md
@@ -85,4 +85,4 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [azsvcbus]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-create-namespace-portal
 [freesub]: https://azure.microsoft.com/free/
 [package-next]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/README.md
-[package-latest]: https://github.com/Azure/azure-sdk-for-js/blob/hotfix/service-bus-1.1.7/sdk/servicebus/service-bus/README.md
+[package-latest]: https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.9/sdk/servicebus/service-bus/README.md

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionState.js
@@ -100,7 +100,7 @@ async function runScenario() {
 
 async function getSessionState(sessionId) {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
 
   const sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: sessionId
@@ -120,7 +120,7 @@ async function getSessionState(sessionId) {
 
 async function sendMessagesForSession(shoppingEvents, sessionId) {
   // If sending to a Topic, use `createTopicClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
   const sender = queueClient.createSender();
 
   for (let index = 0; index < shoppingEvents.length; index++) {
@@ -136,7 +136,7 @@ async function sendMessagesForSession(shoppingEvents, sessionId) {
 
 async function processMessageFromSession(sessionId) {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
 
   const sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: sessionId

--- a/sdk/servicebus/service-bus/samples-v1/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@azure/abort-controller": "latest",
     "@azure/ms-rest-nodeauth": "^3.0.0",
-    "@azure/service-bus": "^1.1.6",
+    "@azure/service-bus": "^1.1.9",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^5.0.0",
     "ws": "^7.0.0"

--- a/sdk/servicebus/service-bus/samples-v1/javascript/servicePrincipalLogin.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/servicePrincipalLogin.js
@@ -29,9 +29,9 @@ const serviceBusEndpoint =
   process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
-const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
+const tenantId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
 const clientSecret = process.env.AZURE_CLIENT_SECRET || "<azure client secret>";
-const tenantId = process.env.AZURE_CLIENT_ID || "<azure client id>";
+const clientId = process.env.AZURE_CLIENT_ID || "<azure client id>";
 
 async function main() {
   const tokenCreds = await loginWithServicePrincipalSecret(clientId, clientSecret, tenantId, {

--- a/sdk/servicebus/service-bus/samples-v1/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/README.md
@@ -97,5 +97,5 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [azsvcbus]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-create-namespace-portal
 [freesub]: https://azure.microsoft.com/free/
 [package-next]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/README.md
-[package-latest]: https://github.com/Azure/azure-sdk-for-js/blob/hotfix/service-bus-1.1.7/sdk/servicebus/service-bus/README.md
+[package-latest]: https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.9/sdk/servicebus/service-bus/README.md
 [typescript]: https://www.typescriptlang.org/docs/home.html

--- a/sdk/servicebus/service-bus/samples-v1/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@azure/abort-controller": "latest",
     "@azure/ms-rest-nodeauth": "^3.0.0",
-    "@azure/service-bus": "^1.1.6",
+    "@azure/service-bus": "^1.1.9",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^5.0.0",
     "ws": "^7.0.0"

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionState.ts
@@ -80,7 +80,7 @@ async function runScenario() {
 
 async function getSessionState(sessionId: string) {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
 
   const sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: sessionId
@@ -100,7 +100,7 @@ async function getSessionState(sessionId: string) {
 
 async function sendMessagesForSession(shoppingEvents: any[], sessionId: string) {
   // If sending to a Topic, use `createTopicClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
   const sender = queueClient.createSender();
 
   for (let index = 0; index < shoppingEvents.length; index++) {
@@ -116,7 +116,7 @@ async function sendMessagesForSession(shoppingEvents: any[], sessionId: string) 
 
 async function processMessageFromSession(sessionId: string) {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
-  const queueClient = sbClient.createQueueClient(userEventsQueueName);
+  const queueClient = sbClient.createQueueClient(queueName);
 
   const sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: sessionId

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/servicePrincipalLogin.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/servicePrincipalLogin.ts
@@ -30,9 +30,9 @@ const serviceBusEndpoint =
   process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
-const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
+const clientId = process.env.AZURE_CLIENT_ID || "<azure client id>";
 const clientSecret = process.env.AZURE_CLIENT_SECRET || "<azure client secret>";
-const tenantId = process.env.AZURE_CLIENT_ID || "<azure client id>";
+const tenantId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
 
 export async function main() {
   const tokenCreds = await loginWithServicePrincipalSecret(clientId, clientSecret, tenantId, {

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/useProxy.ts
@@ -8,7 +8,7 @@
 
 import { ServiceBusClient } from "@azure/service-bus";
 import WebSocket from "ws";
-import HttpsProxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";

--- a/sdk/servicebus/service-bus/samples-v1/typescript/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/tsconfig.json
@@ -3,12 +3,13 @@
     "module": "commonjs",
     "target": "ES2015",
     "moduleResolution": "node",
-
+    "lib": ["ESNext.AsyncIterable", "DOM"],
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
 
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
@@ -32,9 +32,9 @@ const serviceBusEndpoint =
   process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
-const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
+const tenantId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
 const clientSecret = process.env.AZURE_CLIENT_SECRET || "<azure client secret>";
-const tenantId = process.env.AZURE_CLIENT_ID || "<azure client id>";
+const clientId = process.env.AZURE_CLIENT_ID || "<azure client id>";
 async function main() {
   const tokenCreds = new DefaultAzureCredential();
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
@@ -34,9 +34,9 @@ const serviceBusEndpoint =
   process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
-const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
+const tenantId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
 const clientSecret = process.env.AZURE_CLIENT_SECRET || "<azure client secret>";
-const tenantId = process.env.AZURE_CLIENT_ID || "<azure client id>";
+const clientId = process.env.AZURE_CLIENT_ID || "<azure client id>";
 
 export async function main() {
   const tokenCreds = new DefaultAzureCredential();


### PR DESCRIPTION
There were several breakages:

- The track 1 samples weren't compiling properly (several issues) and the proxy sample was broken even after fixing compile errors
- We'd swapped the token and client id fields in the AAD samples in both track 1 and track 2.
- The sessionState samples were using a variable that didn't exist (looks like a partial rename that didn't get propagated)

Fixes #10733 