### PR TITLE
[Service Bus] Use subQueue for deadLetterReceiver

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -77,11 +77,13 @@ export interface CreateQueueOptions extends OperationOptions {
 // @public
 export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
     receiveMode?: ReceiveModeT;
+    subQueue?: SubQueue;
 }
 
 // @public
-export interface CreateSessionReceiverOptions<ReceiveModeT extends ReceiveMode> extends CreateReceiverOptions<ReceiveModeT>, OperationOptionsBase {
+export interface CreateSessionReceiverOptions<ReceiveModeT extends ReceiveMode> extends OperationOptionsBase {
     maxAutoRenewLockDurationInMs?: number;
+    receiveMode?: ReceiveModeT;
     sessionId?: string;
 }
 
@@ -285,10 +287,6 @@ export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
     constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: ServiceBusClientOptions);
     close(): Promise<void>;
-    createDeadLetterReceiver(queueName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver<ReceivedMessageWithLock>;
-    createDeadLetterReceiver(queueName: string, options: CreateReceiverOptions<"receiveAndDelete">): ServiceBusReceiver<ReceivedMessage>;
-    createDeadLetterReceiver(topicName: string, subscriptionName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver<ReceivedMessageWithLock>;
-    createDeadLetterReceiver(topicName: string, subscriptionName: string, options: CreateReceiverOptions<"receiveAndDelete">): ServiceBusReceiver<ReceivedMessage>;
     createReceiver(queueName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver<ReceivedMessageWithLock>;
     createReceiver(queueName: string, options: CreateReceiverOptions<"receiveAndDelete">): ServiceBusReceiver<ReceivedMessage>;
     createReceiver(topicName: string, subscriptionName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver<ReceivedMessageWithLock>;
@@ -436,6 +434,9 @@ export interface SqlRuleFilter {
     sqlExpression?: string;
     sqlParameters?: SqlParameter[];
 }
+
+// @public
+export type SubQueue = "deadLetter" | "transferDeadLetter";
 
 // @public
 export interface SubscribeOptions extends OperationOptionsBase, MessageHandlerOptions {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
@@ -32,8 +32,8 @@ async function main() {
 }
 
 async function processDeadletterMessageQueue() {
-  // If connecting to a subscription's dead letter queue you can use the createDeadLetterReceiver(topic, subscription) overload
-  const receiver = sbClient.createDeadLetterReceiver(queueName);
+  // If connecting to a subscription's dead letter queue you can use the createReceiver(topic, subscription) overload
+  const receiver = sbClient.createReceiver(queueName, { subQueue: "deadLetter" });
 
   const messages = await receiver.receiveMessages(1);
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
@@ -34,8 +34,8 @@ export async function main() {
 }
 
 async function processDeadletterMessageQueue() {
-  // If connecting to a subscription's dead letter queue you can use the createDeadLetterReceiver(topic, subscription) overload
-  const receiver = sbClient.createDeadLetterReceiver(queueName);
+  // If connecting to a subscription's dead letter queue you can use the createReceiver(topic, subscription) overload
+  const receiver = sbClient.createReceiver(queueName, { subQueue: "deadLetter" });
 
   const messages = await receiver.receiveMessages(1);
 

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -28,6 +28,7 @@ export {
   ReceiveMessagesOptions,
   ReceiveMode,
   SessionSubscribeOptions,
+  SubQueue,
   SubscribeOptions
 } from "./models";
 export { OperationOptionsBase } from "./modelsToBeSharedWithEventHubs";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -41,6 +41,11 @@ export interface InternalMessageHandlers<ReceivedMessageT>
 export type ReceiveMode = "peekLock" | "receiveAndDelete";
 
 /**
+ * Represents the sub queue that is applicable for any queue or subscription.
+ */
+export type SubQueue = "deadLetter" | "transferDeadLetter";
+
+/**
  *
  *
  * @interface CreateReceiverOptions
@@ -67,6 +72,10 @@ export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
    *
    */
   receiveMode?: ReceiveModeT;
+  /**
+   * Represents the sub queue that is applicable for any queue or subscription.
+   */
+  subQueue?: SubQueue;
 }
 
 /**
@@ -157,13 +166,31 @@ export interface MessageHandlerOptions extends MessageHandlerOptionsBase {
  *
  * @export
  * @interface CreateSessionReceiverOptions
- * @extends {CreateReceiverOptions<ReceiveModeT>}
  * @extends {OperationOptionsBase}
  * @template ReceiveModeT
  */
 export interface CreateSessionReceiverOptions<ReceiveModeT extends ReceiveMode>
-  extends CreateReceiverOptions<ReceiveModeT>,
-    OperationOptionsBase {
+  extends OperationOptionsBase {
+  /**
+   * Represents the receive mode for the receiver.
+   *
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
+   *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue/subscription.
+   *
+   * Messages that are not settled within the lock duration will be redelivered as many times as
+   * the max delivery count set on the queue/subscription, after which they get sent to a separate
+   * dead letter queue.
+   *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
+   *
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+   *
+   */
+  receiveMode?: ReceiveModeT;
   /**
    * @property The id of the session from which messages need to be received. If null or undefined is
    * provided, Service Bus chooses a random session from available sessions.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -42,6 +42,8 @@ export type ReceiveMode = "peekLock" | "receiveAndDelete";
 
 /**
  * Represents the sub queue that is applicable for any queue or subscription.
+ * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
+ * see https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
  */
 export type SubQueue = "deadLetter" | "transferDeadLetter";
 
@@ -74,6 +76,8 @@ export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
   receiveMode?: ReceiveModeT;
   /**
    * Represents the sub queue that is applicable for any queue or subscription.
+   * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
+   * see https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    */
   subQueue?: SubQueue;
 }

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -97,8 +97,12 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in peekLock mode. No connection is made
    * to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    *
+   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
+   * `subQueue` in the options. To learn more about dead letter queues, see
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
+   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    *
@@ -123,8 +127,12 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode. No connection is made
    * to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    *
+   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
+   * `subQueue` in the options. To learn more about dead letter queues, see
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
+   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param queueName The name of the queue to receive from.
@@ -138,8 +146,12 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode. No connection is made
    * to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    *
+   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
+   * `subQueue` in the options. To learn more about dead letter queues, see
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
+   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * subscription.
    *
@@ -166,8 +178,13 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode. No connection is made
    * to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    *
+   *
+   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
+   * `subQueue` in the options. To learn more about dead letter queues, see
+   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
+   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
@@ -190,23 +207,39 @@ export class ServiceBusClient {
   ): ServiceBusReceiver<ReceivedMessage> | ServiceBusReceiver<ReceivedMessageWithLock> {
     // NOTE: we don't currently have any options for this kind of receiver but
     // when we do make sure you pass them in and extract them.
-    const { entityPath, receiveMode } = extractReceiverArguments(
+    const { entityPath, receiveMode, options } = extractReceiverArguments(
       queueOrTopicName1,
       optionsOrSubscriptionName2,
       options3
     );
 
+    let entityPathWithSubQueue = entityPath;
+    if (options?.subQueue) {
+      switch (options?.subQueue) {
+        case "deadLetter":
+          entityPathWithSubQueue += "/$DeadLetterQueue";
+          break;
+        case "transferDeadLetter":
+          entityPathWithSubQueue += "/$Transfer/$DeadLetterQueue";
+          break;
+        default:
+          throw new Error(
+            `Invalid subQueue '${options?.subQueue}' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`
+          );
+      }
+    }
+
     if (receiveMode === "peekLock") {
       return new ServiceBusReceiverImpl<ReceivedMessageWithLock>(
         this._connectionContext,
-        entityPath,
+        entityPathWithSubQueue,
         receiveMode,
         this._clientOptions.retryOptions
       );
     } else {
       return new ServiceBusReceiverImpl<ReceivedMessage>(
         this._connectionContext,
-        entityPath,
+        entityPathWithSubQueue,
         receiveMode,
         this._clientOptions.retryOptions
       );
@@ -340,123 +373,6 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue's dead letter queue in peekLock mode.
-   * No connection is made to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue.
-   *
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue. Messages that are not settled within the lock duration will be redelivered.
-   *
-   * You can settle a message by calling complete(), abandon() or defer() methods on
-   * the message.
-   *
-   * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
-   *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
-   */
-  createDeadLetterReceiver(
-    queueName: string,
-    options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver<ReceivedMessageWithLock>;
-  /**
-   * Creates a receiver for an Azure Service Bus queue's dead letter queue in receiveAndDelete mode.
-   * No connection is made to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
-   */
-  createDeadLetterReceiver(
-    queueName: string,
-    options: CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver<ReceivedMessage>;
-  /**
-   * Creates a receiver for an Azure Service Bus subscription's dead letter queue in peekLock mode.
-   * No connection is made to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * subscription. Messages that are not settled within the lock duration will be redelivered.
-   *
-   * You can settle a message by calling complete(), abandon() or defer() methods on
-   * the message.
-   *
-   * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * More information about how peekLock and message settlement works here:
-   * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
-   *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
-   */
-  createDeadLetterReceiver(
-    topicName: string,
-    subscriptionName: string,
-    options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver<ReceivedMessageWithLock>;
-  /**
-   * Creates a receiver for an Azure Service Bus subscription's dead letter queue in receiveAndDelete mode.
-   * No connection is made to the service until one of the methods on the receiver is called.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * See here for more information about dead letter queues:
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
-   */
-  createDeadLetterReceiver(
-    topicName: string,
-    subscriptionName: string,
-    options: CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver<ReceivedMessage>;
-  createDeadLetterReceiver(
-    queueOrTopicName1: string,
-    optionsOrSubscriptionName2?:
-      | CreateReceiverOptions<"peekLock">
-      | CreateReceiverOptions<"receiveAndDelete">
-      | string,
-    options3?: CreateReceiverOptions<"peekLock"> | CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver<ReceivedMessage> | ServiceBusReceiver<ReceivedMessageWithLock> {
-    // NOTE: we don't currently have any options for this kind of receiver but
-    // when we do make sure you pass them in and extract them.
-    const { entityPath, receiveMode } = extractReceiverArguments(
-      queueOrTopicName1,
-      optionsOrSubscriptionName2,
-      options3
-    );
-
-    const deadLetterEntityPath = `${entityPath}/$DeadLetterQueue`;
-    if (receiveMode === "receiveAndDelete") {
-      return this.createReceiver(deadLetterEntityPath, { receiveMode: "receiveAndDelete" });
-    } else {
-      return this.createReceiver(deadLetterEntityPath, { receiveMode: "peekLock" });
-    }
-  }
-
-  /**
    * Closes the underlying AMQP connection.
    * NOTE: this will also disconnect any Receiver or Sender instances created from this
    * instance.
@@ -485,33 +401,31 @@ export function extractReceiverArguments<OptionsT extends { receiveMode?: Receiv
   receiveMode: ReceiveMode;
   options?: Omit<OptionsT, "receiveMode">;
 } {
-  try {
-    let entityPath: string;
-    let options: OptionsT | undefined;
-    if (typeof optionsOrSubscriptionName2 === "string") {
-      const topic = queueOrTopicName1;
-      const subscription = optionsOrSubscriptionName2;
-      entityPath = `${topic}/Subscriptions/${subscription}`;
-      options = definitelyOptions3;
-    } else {
-      entityPath = queueOrTopicName1;
-      options = optionsOrSubscriptionName2;
-    }
-    let receiveMode: ReceiveMode;
-    if (options?.receiveMode == undefined || options.receiveMode === "peekLock") {
-      receiveMode = "peekLock";
-    } else if (options.receiveMode === "receiveAndDelete") {
-      receiveMode = "receiveAndDelete";
-    } else {
-      throw new TypeError("Invalid receiveMode provided");
-    }
-    delete options?.receiveMode;
-    return {
-      entityPath,
-      receiveMode,
-      options
-    };
-  } catch (error) {
-    throw new TypeError("Unable to parse the arguments\n" + error);
+  let entityPath: string;
+  let options: OptionsT | undefined;
+  if (typeof optionsOrSubscriptionName2 === "string") {
+    const topic = queueOrTopicName1;
+    const subscription = optionsOrSubscriptionName2;
+    entityPath = `${topic}/Subscriptions/${subscription}`;
+    options = definitelyOptions3;
+  } else {
+    entityPath = queueOrTopicName1;
+    options = optionsOrSubscriptionName2;
   }
+  let receiveMode: ReceiveMode;
+  if (options?.receiveMode == undefined || options.receiveMode === "peekLock") {
+    receiveMode = "peekLock";
+  } else if (options.receiveMode === "receiveAndDelete") {
+    receiveMode = "receiveAndDelete";
+  } else {
+    throw new TypeError(
+      `Invalid receiveMode '${options?.receiveMode}' provided. Valid values are 'peekLock' and 'receiveAndDelete'`
+    );
+  }
+  delete options?.receiveMode;
+  return {
+    entityPath,
+    receiveMode,
+    options
+  };
 }

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -80,13 +80,14 @@ describe("serviceBusClient unit tests", () => {
     });
 
     it("failures", () => {
+      const badReceiveMode = "WOW THIS ISN'T A RECEIVE MODE";
       assert.throws(
         () =>
           extractReceiverArguments("topic", "subscription", {
             ...sessionReceiverOptions,
-            receiveMode: "WOW THIS ISN'T A RECEIVE MODE" as "peekLock"
+            receiveMode: badReceiveMode as "peekLock"
           }),
-        /Invalid receiveMode provided/
+        `Invalid receiveMode '${badReceiveMode}' provided. Valid values are 'peekLock' and 'receiveAndDelete'`
       );
     });
   });

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -67,7 +67,7 @@ describe("invalid parameters", () => {
       }
       should.equal(
         errorCaught,
-        "Unable to parse the arguments\nTypeError: Invalid receiveMode provided",
+        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
         "Did not throw error if created a client with invalid receiveMode."
       );
     });
@@ -224,8 +224,23 @@ describe("invalid parameters", () => {
       }
       should.equal(
         errorCaught,
-        "Unable to parse the arguments\nTypeError: Invalid receiveMode provided",
+        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
         "Did not throw error if created a client with invalid receiveMode."
+      );
+    });
+
+    it("Receiver: Invalid SubQueue", async function(): Promise<void> {
+      let errorCaught: string = "";
+      try {
+        // @ts-expect-error
+        sbClient.createReceiver("dummyQueue", { subQueue: 123 });
+      } catch (error) {
+        errorCaught = error.message;
+      }
+      should.equal(
+        errorCaught,
+        `Invalid subQueue '123' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`,
+        "Did not throw error if created a client with invalid subQueue."
       );
     });
 

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -41,8 +41,9 @@ describe("dead lettering", () => {
 
     deadLetterReceiver = serviceBusClient.test.addToCleanup(
       // receiveAndDelete since I don't care about further settlement after it's been dead lettered!
-      serviceBusClient.createDeadLetterReceiver(entityNames.queue, {
-        receiveMode: "receiveAndDelete"
+      serviceBusClient.createReceiver(entityNames.queue, {
+        receiveMode: "receiveAndDelete",
+        subQueue: "deadLetter"
       })
     );
 

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -719,7 +719,7 @@ describe("entityPath on sender and receiver", async () => {
 
   it("Entity Path on Queue deadletter Receiver", () => {
     const dummyQueueName = "dummy";
-    const receiver = sbClient.createDeadLetterReceiver(dummyQueueName);
+    const receiver = sbClient.createReceiver(dummyQueueName, { subQueue: "deadLetter" });
     should.equal(
       receiver.entityPath,
       `${dummyQueueName}/$DeadLetterQueue`,
@@ -741,7 +741,9 @@ describe("entityPath on sender and receiver", async () => {
   it("Entity Path on Subscription deadletter Receiver", () => {
     const dummyTopicName = "dummyTopicName";
     const dummySubscriptionName = "dummySubscriptionName";
-    const receiver = sbClient.createDeadLetterReceiver(dummyTopicName, dummySubscriptionName);
+    const receiver = sbClient.createReceiver(dummyTopicName, dummySubscriptionName, {
+      subQueue: "deadLetter"
+    });
     should.equal(
       receiver.entityPath,
       `${dummyTopicName}/Subscriptions/${dummySubscriptionName}/$DeadLetterQueue`,

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -423,11 +423,10 @@ export class ServiceBusTestHelpers {
   ): ServiceBusReceiver<ReceivedMessageWithLock> {
     return this.addToCleanup(
       entityNames.queue
-        ? this._serviceBusClient.createDeadLetterReceiver(entityNames.queue)
-        : this._serviceBusClient.createDeadLetterReceiver(
-            entityNames.topic!,
-            entityNames.subscription!
-          )
+        ? this._serviceBusClient.createReceiver(entityNames.queue, { subQueue: "deadLetter" })
+        : this._serviceBusClient.createReceiver(entityNames.topic!, entityNames.subscription!, {
+            subQueue: "deadLetter"
+          })
     );
   }
 
@@ -456,17 +455,18 @@ async function purgeForTestClientType(
 
   if (entityPaths.queue) {
     receiver = serviceBusClient.createReceiver(entityPaths.queue, "receiveAndDelete");
-    deadLetterReceiver = serviceBusClient.createDeadLetterReceiver(entityPaths.queue, {
-      receiveMode: "receiveAndDelete"
+    deadLetterReceiver = serviceBusClient.createReceiver(entityPaths.queue, {
+      receiveMode: "receiveAndDelete",
+      subQueue: "deadLetter"
     });
   } else if (entityPaths.topic && entityPaths.subscription) {
     receiver = serviceBusClient.createReceiver(entityPaths.topic, entityPaths.subscription, {
       receiveMode: "receiveAndDelete"
     });
-    deadLetterReceiver = serviceBusClient.createDeadLetterReceiver(
+    deadLetterReceiver = serviceBusClient.createReceiver(
       entityPaths.topic,
       entityPaths.subscription,
-      { receiveMode: "receiveAndDelete" }
+      { receiveMode: "receiveAndDelete", subQueue: "deadLetter" }
     );
   } else {
     throw new Error(`Unsupported TestClientType for purge: ${testClientType}`);


### PR DESCRIPTION
This PR shows an alternative to having a dedicated method to create dead letter receivers. 

As explained in https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues, we have another kind of dead letter queue called the "transfer dead letter queue". 

This PR introduces the concept of "sub queues" as described in Proposal 3 in https://gist.github.com/richardpark-msft/628f65c667dd44c5b748523655fe49fa

Other unrelated changes in this PR:
- Tweaked the error message for invalid receiveMode to list out valid values to match the pattern used for invalid subQueue
- Removed the try/catch `extractReceiverArguments` as I could not see a need for it. The only potential error from this method is the one for invalid receiveMode which should bubble up as is. 