### PR TITLE
[Event Hubs] Add examples in jsdocs

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -410,6 +410,17 @@ export class EventHubConsumerClient {
    * partitions such that the load is balanced amongst them.
    *
    * Call close() on the returned object to stop receiving events.
+   * 
+   * Example usage:
+   * ```ts
+   * const client = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName);
+   * const subscription = client.subscribe(
+   *  {
+   *    processEvents: (events, context) => { console.log("Received event count: ", events.length) },
+   *    processError: (err, context) => { console.log("Error: ", err) }
+   *  },
+   *  { startPosition: earliestEventPosition }
+   * ```
    *
    * @param handlers Handlers for the lifecycle of the subscription - subscription initialization
    *                 per partition, receiving events, handling errors and the closing
@@ -423,6 +434,18 @@ export class EventHubConsumerClient {
   /**
    * Subscribe to events from a single partition.
    * Call close() on the returned object to stop receiving events.
+   * 
+   * Example usage:
+   * ```ts
+   * const client = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName);
+   * const subscription = client.subscribe(
+   *  partitionId, 
+   *  {
+   *    processEvents: (events, context) => { console.log("Received event count: ", events.length) },
+   *    processError: (err, context) => { console.log("Error: ", err) }
+   *  },
+   *  { startPosition: earliestEventPosition }
+   * ```
    *
    * @param partitionId The id of the partition to subscribe to.
    * @param handlers Handlers for the lifecycle of the subscription - subscription initialization

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -420,6 +420,7 @@ export class EventHubConsumerClient {
    *    processError: (err, context) => { console.log("Error: ", err) }
    *  },
    *  { startPosition: earliestEventPosition }
+   * );
    * ```
    *
    * @param handlers Handlers for the lifecycle of the subscription - subscription initialization
@@ -445,6 +446,7 @@ export class EventHubConsumerClient {
    *    processError: (err, context) => { console.log("Error: ", err) }
    *  },
    *  { startPosition: earliestEventPosition }
+   * );
    * ```
    *
    * @param partitionId The id of the partition to subscribe to.

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -410,7 +410,7 @@ export class EventHubConsumerClient {
    * partitions such that the load is balanced amongst them.
    *
    * Call close() on the returned object to stop receiving events.
-   * 
+   *
    * Example usage:
    * ```ts
    * const client = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName);
@@ -434,12 +434,12 @@ export class EventHubConsumerClient {
   /**
    * Subscribe to events from a single partition.
    * Call close() on the returned object to stop receiving events.
-   * 
+   *
    * Example usage:
    * ```ts
    * const client = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName);
    * const subscription = client.subscribe(
-   *  partitionId, 
+   *  partitionId,
    *  {
    *    processEvents: (events, context) => { console.log("Received event count: ", events.length) },
    *    processError: (err, context) => { console.log("Error: ", err) }

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -144,7 +144,7 @@ export class EventHubProducerClient {
   /**
    * Creates an instance of `EventDataBatch` to which one can add events until the maximum supported size is reached.
    * The batch can be passed to the {@link sendBatch} method of the `EventHubProducerClient` to be sent to Azure Event Hubs.
-   * 
+   *
    * Example usage:
    * ```ts
    * const client = new EventHubProducerClient(connectionString);
@@ -161,7 +161,7 @@ export class EventHubProducerClient {
    *  }
    * }
    * ```
-   * 
+   *
    * @param options  Configures the behavior of the batch.
    * - `partitionKey`  : A value that is hashed and used by the Azure Event Hubs service to determine the partition to which
    * the events need to be sent.
@@ -218,7 +218,7 @@ export class EventHubProducerClient {
    * const client = new EventHubProducerClient(connectionString);
    * await client.sendBatch(messages);
    * ```
-   * 
+   *
    * @param batch An array of {@link EventData}.
    * @param options A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.
@@ -234,7 +234,7 @@ export class EventHubProducerClient {
   async sendBatch(batch: EventData[], options?: SendBatchOptions): Promise<void>;
   /**
    * Sends a batch of events to the associated Event Hub.
-   * 
+   *
    * Example usage:
    * ```ts
    * const client = new EventHubProducerClient(connectionString);

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -156,9 +156,9 @@ export class EventHubProducerClient {
    *    if (!batch.tryAdd(messages[i])) {
    *      throw new Error("Message too big to fit")
    *    }
-   *  if (i === messages.length - 1) {
-   *    await client.sendBatch(batch);
-   *  }
+   *    if (i === messages.length - 1) {
+   *      await client.sendBatch(batch);
+   *    }
    * }
    * }
    * ```

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -156,7 +156,7 @@ export class EventHubProducerClient {
    *    if (!batch.tryAdd(messages[i])) {
    *      throw new Error("Message too big to fit")
    *    }
-   *  if (i === messages.length) {
+   *  if (i === messages.length - 1) {
    *    await client.sendBatch(batch);
    *  }
    * }
@@ -246,7 +246,7 @@ export class EventHubProducerClient {
    *    if (!batch.tryAdd(messages[i])) {
    *      throw new Error("Message too big to fit")
    *    }
-   *  if (i === messages.length) {
+   *  if (i === messages.length - 1) {
    *    await client.sendBatch(batch);
    *  }
    * }

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -159,7 +159,7 @@ export class EventHubProducerClient {
    *    if (i === messages.length - 1) {
    *      await client.sendBatch(batch);
    *    }
-   * }
+   *   }
    * }
    * ```
    *
@@ -250,7 +250,7 @@ export class EventHubProducerClient {
    *    if (i === messages.length - 1) {
    *      await client.sendBatch(batch);
    *    }
-   * }
+   *   }
    * }
    * ```
    * @param batch A batch of events that you can create using the {@link createBatch} method.

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -160,6 +160,7 @@ export class EventHubProducerClient {
    *    await client.sendBatch(batch);
    *  }
    * }
+   * }
    * ```
    *
    * @param options  Configures the behavior of the batch.
@@ -250,7 +251,8 @@ export class EventHubProducerClient {
    *    await client.sendBatch(batch);
    *  }
    * }
-   *
+   * }
+   * ```
    * @param batch A batch of events that you can create using the {@link createBatch} method.
    * @param options A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -144,6 +144,24 @@ export class EventHubProducerClient {
   /**
    * Creates an instance of `EventDataBatch` to which one can add events until the maximum supported size is reached.
    * The batch can be passed to the {@link sendBatch} method of the `EventHubProducerClient` to be sent to Azure Event Hubs.
+   * 
+   * Example usage:
+   * ```ts
+   * const client = new EventHubProducerClient(connectionString);
+   * let batch = await client.createBatch();
+   * for (let i = 0; i < messages.length; i++) {
+   *  if (!batch.tryAdd(messages[i])) {
+   *    await client.sendBatch(batch);
+   *    batch = await client.createBatch();
+   *    if (!batch.tryAdd(messages[i])) {
+   *      throw new Error("Message too big to fit")
+   *    }
+   *  if (i === messages.length) {
+   *    await client.sendBatch(batch);
+   *  }
+   * }
+   * ```
+   * 
    * @param options  Configures the behavior of the batch.
    * - `partitionKey`  : A value that is hashed and used by the Azure Event Hubs service to determine the partition to which
    * the events need to be sent.
@@ -195,6 +213,12 @@ export class EventHubProducerClient {
   /**
    * Sends an array of events to the associated Event Hub.
    *
+   * Example usage:
+   * ```ts
+   * const client = new EventHubProducerClient(connectionString);
+   * await client.sendBatch(messages);
+   * ```
+   * 
    * @param batch An array of {@link EventData}.
    * @param options A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.
@@ -210,6 +234,22 @@ export class EventHubProducerClient {
   async sendBatch(batch: EventData[], options?: SendBatchOptions): Promise<void>;
   /**
    * Sends a batch of events to the associated Event Hub.
+   * 
+   * Example usage:
+   * ```ts
+   * const client = new EventHubProducerClient(connectionString);
+   * let batch = await client.createBatch();
+   * for (let i = 0; i < messages.length; i++) {
+   *  if (!batch.tryAdd(messages[i])) {
+   *    await client.sendBatch(batch);
+   *    batch = await client.createBatch();
+   *    if (!batch.tryAdd(messages[i])) {
+   *      throw new Error("Message too big to fit")
+   *    }
+   *  if (i === messages.length) {
+   *    await client.sendBatch(batch);
+   *  }
+   * }
    *
    * @param batch A batch of events that you can create using the {@link createBatch} method.
    * @param options A set of options that can be specified to influence the way in which

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -247,9 +247,9 @@ export class EventHubProducerClient {
    *    if (!batch.tryAdd(messages[i])) {
    *      throw new Error("Message too big to fit")
    *    }
-   *  if (i === messages.length - 1) {
-   *    await client.sendBatch(batch);
-   *  }
+   *    if (i === messages.length - 1) {
+   *      await client.sendBatch(batch);
+   *    }
    * }
    * }
    * ```


### PR DESCRIPTION
This PR adds example code in jsdocs for the key methods in the producer and consumer client
Related to #4868

