### PR TITLE
Fix readme for form recognizer

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -160,7 +160,8 @@ async function main() {
   const readStream = fs.createReadStream(path);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeCustomForms(modelId, readStream, "application/pdf", {
+  const poller = await client.beginRecognizeCustomForms(modelId, readStream, {
+    contentType: "application/pdf",
     onProgress: (state) => { console.log(`status: ${state.status}`); }
   });
   const forms = await poller.pollUntilDone();
@@ -256,7 +257,8 @@ async function main() {
   const readStream = fs.createReadStream(path);
 
   const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-  const poller = await client.beginRecognizeReceipts(readStream, "image/jpeg", {
+  const poller = await client.beginRecognizeReceipts(readStream, {
+    contentType: "image/jpeg",
     onProgress: (state) => { console.log(`status: ${state.status}`); }
   });
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -516,7 +516,8 @@ export class FormRecognizerClient {
    * const readStream = fs.createReadStream(path);
    *
    * const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
-   * const poller = await client.beginRecognizeReceipts(readStream, "image/jpeg", {
+   * const poller = await client.beginRecognizeReceipts(readStream, {
+   *   contentType: "image/jpeg",
    *   onProgress: (state) => { console.log(`status: ${state.status}`); }
    * });
    *


### PR DESCRIPTION
The contentType parameter was moved to `BeginRecognizeReceiptsOptions` 

Resolves: #10742

The second mentioned issue in #10742 (about `doc.documentName` -> `doc.name`) is already solved in PR #10685.