### PR TITLE
[Cosmos] Adds BulkOperationType enum and autogens ID for create ops

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 3.9.1 (Unreleased)
+
+- FEATURE: Bulk requests with `Create` operations will now autogenerate IDs if they are not present.
+- FEATURE: The `BulkOperationType` enum now exists and can be used when making bulk requests.
+
 ## 3.9.0 (2020-08-13)
 
 - FEATURE: Adds support for autoscale parameters on container and database create methods

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -21,6 +21,20 @@ export interface Agent {
 // @public (undocumented)
 export type AggregateType = "Average" | "Count" | "Max" | "Min" | "Sum";
 
+// @public (undocumented)
+export enum BulkOperationType {
+    // (undocumented)
+    Create = "Create",
+    // (undocumented)
+    Delete = "Delete",
+    // (undocumented)
+    Read = "Read",
+    // (undocumented)
+    Replace = "Replace",
+    // (undocumented)
+    Upsert = "Upsert"
+}
+
 // @public
 export class ChangeFeedIterator<T> {
     fetchNext(): Promise<ChangeFeedResponse<Array<T & Resource>>>;
@@ -1782,10 +1796,6 @@ export class Users {
     upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
 }
 
-
-// Warnings were encountered during analysis:
-//
-// src/utils/batch.ts:62:3 - (ae-forgotten-export) The symbol "BulkOperationType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -512,7 +512,7 @@ export interface CosmosHeaders {
 
 // @public (undocumented)
 export type CreateOperation = OperationWithItem & {
-    operationType: OperationType_2.Create;
+    operationType: typeof BulkOperationType.Create;
 };
 
 // @public
@@ -609,7 +609,7 @@ export const DEFAULT_PARTITION_KEY_PATH: "/_partitionKey";
 
 // @public (undocumented)
 export type DeleteOperation = OperationBase & {
-    operationType: OperationType_2.Delete;
+    operationType: typeof BulkOperationType.Delete;
     id: string;
 };
 
@@ -1238,13 +1238,13 @@ export interface QueryRange {
 
 // @public (undocumented)
 export type ReadOperation = OperationBase & {
-    operationType: OperationType_2.Read;
+    operationType: typeof BulkOperationType.Read;
     id: string;
 };
 
 // @public (undocumented)
 export type ReplaceOperation = OperationWithItem & {
-    operationType: OperationType_2.Replace;
+    operationType: typeof BulkOperationType.Replace;
     id: string;
 };
 
@@ -1708,7 +1708,7 @@ export interface UniqueKeyPolicy {
 
 // @public (undocumented)
 export type UpsertOperation = OperationWithItem & {
-    operationType: OperationType_2.Upsert;
+    operationType: typeof BulkOperationType.Upsert;
 };
 
 // @public
@@ -1791,10 +1791,6 @@ export class Users {
     upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
 }
 
-
-// Warnings were encountered during analysis:
-//
-// src/utils/batch.ts:70:3 - (ae-forgotten-export) The symbol "OperationType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -22,18 +22,13 @@ export interface Agent {
 export type AggregateType = "Average" | "Count" | "Max" | "Min" | "Sum";
 
 // @public (undocumented)
-export enum BulkOperationType {
-    // (undocumented)
-    Create = "Create",
-    // (undocumented)
-    Delete = "Delete",
-    // (undocumented)
-    Read = "Read",
-    // (undocumented)
-    Replace = "Replace",
-    // (undocumented)
-    Upsert = "Upsert"
-}
+export const BulkOperationType: {
+    Create: string;
+    Upsert: string;
+    Read: string;
+    Delete: string;
+    Replace: string;
+};
 
 // @public
 export class ChangeFeedIterator<T> {
@@ -517,7 +512,7 @@ export interface CosmosHeaders {
 
 // @public (undocumented)
 export type CreateOperation = OperationWithItem & {
-    operationType: BulkOperationType.Create;
+    operationType: keyof typeof BulkOperationType.Create;
 };
 
 // @public
@@ -614,7 +609,7 @@ export const DEFAULT_PARTITION_KEY_PATH: "/_partitionKey";
 
 // @public (undocumented)
 export type DeleteOperation = OperationBase & {
-    operationType: BulkOperationType.Delete;
+    operationType: 'Delete';
     id: string;
 };
 
@@ -939,7 +934,7 @@ export interface OperationInput {
     // (undocumented)
     ifNoneMatch?: string;
     // (undocumented)
-    operationType: BulkOperationType;
+    operationType: string;
     // (undocumented)
     partitionKey?: string | number | null | {} | undefined;
     // (undocumented)
@@ -1243,13 +1238,13 @@ export interface QueryRange {
 
 // @public (undocumented)
 export type ReadOperation = OperationBase & {
-    operationType: BulkOperationType.Read;
+    operationType: 'Read';
     id: string;
 };
 
 // @public (undocumented)
 export type ReplaceOperation = OperationWithItem & {
-    operationType: BulkOperationType.Replace;
+    operationType: 'Replace';
     id: string;
 };
 
@@ -1713,7 +1708,7 @@ export interface UniqueKeyPolicy {
 
 // @public (undocumented)
 export type UpsertOperation = OperationWithItem & {
-    operationType: BulkOperationType.Upsert;
+    operationType: 'Create';
 };
 
 // @public

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -503,7 +503,7 @@ export interface CosmosHeaders {
 
 // @public (undocumented)
 export type CreateOperation = OperationWithItem & {
-    operationType: "Create";
+    operationType: BulkOperationType.Create;
 };
 
 // @public
@@ -600,7 +600,7 @@ export const DEFAULT_PARTITION_KEY_PATH: "/_partitionKey";
 
 // @public (undocumented)
 export type DeleteOperation = OperationBase & {
-    operationType: "Delete";
+    operationType: BulkOperationType.Delete;
     id: string;
 };
 
@@ -925,6 +925,8 @@ export interface OperationInput {
     // (undocumented)
     ifNoneMatch?: string;
     // (undocumented)
+    operationType: BulkOperationType;
+    // (undocumented)
     partitionKey?: string | number | null | {} | undefined;
     // (undocumented)
     resourceBody?: JSONObject;
@@ -1227,13 +1229,13 @@ export interface QueryRange {
 
 // @public (undocumented)
 export type ReadOperation = OperationBase & {
-    operationType: "Read";
+    operationType: BulkOperationType.Read;
     id: string;
 };
 
 // @public (undocumented)
 export type ReplaceOperation = OperationWithItem & {
-    operationType: "Replace";
+    operationType: BulkOperationType.Replace;
     id: string;
 };
 
@@ -1697,7 +1699,7 @@ export interface UniqueKeyPolicy {
 
 // @public (undocumented)
 export type UpsertOperation = OperationWithItem & {
-    operationType: "Upsert";
+    operationType: BulkOperationType.Upsert;
 };
 
 // @public
@@ -1780,6 +1782,10 @@ export class Users {
     upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
 }
 
+
+// Warnings were encountered during analysis:
+//
+// src/utils/batch.ts:62:3 - (ae-forgotten-export) The symbol "BulkOperationType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -23,11 +23,11 @@ export type AggregateType = "Average" | "Count" | "Max" | "Min" | "Sum";
 
 // @public (undocumented)
 export const BulkOperationType: {
-    Create: string;
-    Upsert: string;
-    Read: string;
-    Delete: string;
-    Replace: string;
+    readonly Create: "Create";
+    readonly Upsert: "Upsert";
+    readonly Read: "Read";
+    readonly Delete: "Delete";
+    readonly Replace: "Replace";
 };
 
 // @public
@@ -512,7 +512,7 @@ export interface CosmosHeaders {
 
 // @public (undocumented)
 export type CreateOperation = OperationWithItem & {
-    operationType: keyof typeof BulkOperationType.Create;
+    operationType: OperationType_2.Create;
 };
 
 // @public
@@ -609,7 +609,7 @@ export const DEFAULT_PARTITION_KEY_PATH: "/_partitionKey";
 
 // @public (undocumented)
 export type DeleteOperation = OperationBase & {
-    operationType: 'Delete';
+    operationType: OperationType_2.Delete;
     id: string;
 };
 
@@ -934,7 +934,7 @@ export interface OperationInput {
     // (undocumented)
     ifNoneMatch?: string;
     // (undocumented)
-    operationType: string;
+    operationType: keyof typeof BulkOperationType;
     // (undocumented)
     partitionKey?: string | number | null | {} | undefined;
     // (undocumented)
@@ -1238,13 +1238,13 @@ export interface QueryRange {
 
 // @public (undocumented)
 export type ReadOperation = OperationBase & {
-    operationType: 'Read';
+    operationType: OperationType_2.Read;
     id: string;
 };
 
 // @public (undocumented)
 export type ReplaceOperation = OperationWithItem & {
-    operationType: 'Replace';
+    operationType: OperationType_2.Replace;
     id: string;
 };
 
@@ -1708,7 +1708,7 @@ export interface UniqueKeyPolicy {
 
 // @public (undocumented)
 export type UpsertOperation = OperationWithItem & {
-    operationType: 'Create';
+    operationType: OperationType_2.Upsert;
 };
 
 // @public
@@ -1791,6 +1791,10 @@ export class Users {
     upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse>;
 }
 
+
+// Warnings were encountered during analysis:
+//
+// src/utils/batch.ts:70:3 - (ae-forgotten-export) The symbol "OperationType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -18,7 +18,7 @@ import {
   isKeyInRange,
   Operation,
   getPartitionKeyToHash,
-  addPKToOperation,
+  decorateOperation,
   OperationResponse,
   OperationInput
 } from "../../utils/batch";
@@ -429,7 +429,7 @@ export class Items {
       };
     });
     operations
-      .map((operation) => addPKToOperation(operation, definition))
+      .map((operation) => decorateOperation(operation, definition))
       .forEach((operation: Operation, index: number) => {
         const partitionProp = definition.paths[0].replace("/", "");
         const isV2 = definition.version && definition.version === 2;
@@ -472,6 +472,7 @@ export class Items {
                 "Partition key error. Either the partitions have split or an operation has an unsupported partitionKey type"
               );
             }
+            throw new Error(`Bulk request errored with: ${err.message}`)
           }
         })
     );

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -472,7 +472,7 @@ export class Items {
                 "Partition key error. Either the partitions have split or an operation has an unsupported partitionKey type"
               );
             }
-            throw new Error(`Bulk request errored with: ${err.message}`)
+            throw new Error(`Bulk request errored with: ${err.message}`);
           }
         })
     );

--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -14,7 +14,8 @@ export {
   ReadOperation,
   OperationBase,
   OperationWithItem,
-  OperationInput
+  OperationInput,
+  BulkOperationType,
 } from "./utils/batch";
 export {
   ConnectionMode,

--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -15,7 +15,7 @@ export {
   OperationBase,
   OperationWithItem,
   OperationInput,
-  BulkOperationType,
+  BulkOperationType
 } from "./utils/batch";
 export {
   ConnectionMode,

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -13,7 +13,7 @@ import {
   getInitialHeader,
   mergeHeaders,
   PipelinedQueryExecutionContext,
-  SqlQuerySpec,
+  SqlQuerySpec
 } from "./queryExecutionContext";
 import { Response } from "./request";
 import { ErrorResponse, PartitionedQueryExecutionInfo } from "./request/ErrorResponse";

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -46,14 +46,6 @@ export const BulkOperationType = {
   Replace: "Replace"
 } as const;
 
-enum OperationType {
-  Create = "Create",
-  Upsert = "Upsert",
-  Read = "Read",
-  Delete = "Delete",
-  Replace = "Replace"
-}
-
 export interface OperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
@@ -67,25 +59,25 @@ export type OperationWithItem = OperationBase & {
 };
 
 export type CreateOperation = OperationWithItem & {
-  operationType: OperationType.Create;
+  operationType: typeof BulkOperationType.Create;
 };
 
 export type UpsertOperation = OperationWithItem & {
-  operationType: OperationType.Upsert;
+  operationType: typeof BulkOperationType.Upsert;
 };
 
 export type ReadOperation = OperationBase & {
-  operationType: OperationType.Read;
+  operationType: typeof BulkOperationType.Read;
   id: string;
 };
 
 export type DeleteOperation = OperationBase & {
-  operationType: OperationType.Delete;
+  operationType: typeof BulkOperationType.Delete;
   id: string;
 };
 
 export type ReplaceOperation = OperationWithItem & {
-  operationType: OperationType.Replace;
+  operationType: typeof BulkOperationType.Replace;
   id: string;
 };
 

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -1,6 +1,8 @@
 import { JSONObject } from "../queryExecutionContext";
 import { extractPartitionKey } from "../extractPartitionKey";
 import { PartitionKeyDefinition } from "../documents";
+import { RequestOptions } from '..';
+import { v4 as uuid } from "uuid";
 
 export type Operation =
   | CreateOperation
@@ -36,10 +38,19 @@ export interface OperationBase {
   ifNoneMatch?: string;
 }
 
+export enum BulkOperationType {
+  Create = 'Create',
+  Upsert = 'Upsert',
+  Read = 'Read',
+  Delete = 'Delete',
+  Replace = 'Replace'
+}
+
 export interface OperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
   ifNoneMatch?: string;
+  operationType: BulkOperationType;
   resourceBody?: JSONObject;
 }
 
@@ -48,25 +59,25 @@ export type OperationWithItem = OperationBase & {
 };
 
 export type CreateOperation = OperationWithItem & {
-  operationType: "Create";
+  operationType: BulkOperationType.Create;
 };
 
 export type UpsertOperation = OperationWithItem & {
-  operationType: "Upsert";
+  operationType: BulkOperationType.Upsert;
 };
 
 export type ReadOperation = OperationBase & {
-  operationType: "Read";
+  operationType: BulkOperationType.Read;
   id: string;
 };
 
 export type DeleteOperation = OperationBase & {
-  operationType: "Delete";
+  operationType: BulkOperationType.Delete;
   id: string;
 };
 
 export type ReplaceOperation = OperationWithItem & {
-  operationType: "Replace";
+  operationType: BulkOperationType.Replace;
   id: string;
 };
 
@@ -88,7 +99,12 @@ export function getPartitionKeyToHash(operation: Operation, partitionProperty: s
   return toHashKey;
 }
 
-export function addPKToOperation(operation: OperationInput, definition: PartitionKeyDefinition) {
+export function decorateOperation(operation: OperationInput, definition: PartitionKeyDefinition, options: RequestOptions = {}) {
+  if (operation.operationType === BulkOperationType.Create) {
+    if ((operation.resourceBody.id === undefined || operation.resourceBody.id === "") && !options.disableAutomaticIdGeneration) {
+      operation.resourceBody.id = uuid();
+    }
+  }
   if (operation.partitionKey) {
     const extracted = extractPartitionKey(operation, { paths: ["/partitionKey"] });
     return { ...operation, partitionKey: JSON.stringify(extracted) };

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/murmurHash.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/murmurHash.ts
@@ -422,11 +422,11 @@ function x64Hash128(bytes: Buffer, seed?: number) {
   for (let i = 0; i < blocks; i = i + 16) {
     k1 = [
       bytes[i + 4] | (bytes[i + 5] << 8) | (bytes[i + 6] << 16) | (bytes[i + 7] << 24),
-      bytes[i] | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24),
+      bytes[i] | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24)
     ];
     k2 = [
       bytes[i + 12] | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24),
-      bytes[i + 8] | (bytes[i + 9] << 8) | (bytes[i + 10] << 16) | (bytes[i + 11] << 24),
+      bytes[i + 8] | (bytes[i + 9] << 8) | (bytes[i + 10] << 16) | (bytes[i + 11] << 24)
     ];
 
     k1 = _x64Multiply(k1, c1);
@@ -550,10 +550,10 @@ export default {
   version: "3.0.0",
   x86: {
     hash32: x86Hash32,
-    hash128: x86Hash128,
+    hash128: x86Hash128
   },
   x64: {
-    hash128: x64Hash128,
+    hash128: x64Hash128
   },
-  inputValidation: true,
+  inputValidation: true
 };

--- a/sdk/cosmosdb/cosmos/test/functional/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/client.spec.ts
@@ -49,7 +49,7 @@ describe("NodeJS CRUD Tests", function() {
     it("throws on a bad connection string", function() {
       assert.throws(() => new CosmosClient(`bad;Connection=string;`));
     });
-    it("throws on a bad endpoint", function () {
+    it("throws on a bad endpoint", function() {
       assert.throws(() => new CosmosClient({ endpoint: "asda=asda;asada;" }));
     });
   });

--- a/sdk/cosmosdb/cosmos/test/functional/database.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/database.spec.ts
@@ -131,7 +131,7 @@ describe("NodeJS CRUD Tests", function() {
     });
 
     it("nativeAPI should fail on contains '#'", async function() {
-      // Id shoudn't contain "#".
+      // Id shouldn't contain "#".
       try {
         await client.databases.create({ id: "id_with_illegal#_char" });
         assert.fail("Must throw if id contains illegal characters");

--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -16,7 +16,7 @@ import {
   addEntropy,
   getTestContainer
 } from "../common/TestHelpers";
-import { BulkOperationType } from '../../src/utils/batch';
+import { BulkOperationType } from "../../src/utils/batch";
 
 /**
  * @ignore
@@ -420,7 +420,7 @@ describe("bulk item operations", function() {
         }
       ];
       const response = await v2Container.items.bulk(operations);
-      assert.equal(response[1].statusCode, 424)
+      assert.equal(response[1].statusCode, 424);
     });
     it("autogenerates IDs for Create operations", async function() {
       const operations = [
@@ -433,7 +433,7 @@ describe("bulk item operations", function() {
         }
       ];
       const response = await v2Container.items.bulk(operations);
-      assert.equal(response[0].statusCode, 201)
+      assert.equal(response[0].statusCode, 201);
     });
   });
 });

--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -16,6 +16,7 @@ import {
   addEntropy,
   getTestContainer
 } from "../common/TestHelpers";
+import { BulkOperationType } from '../../src/utils/batch';
 
 /**
  * @ignore
@@ -258,26 +259,26 @@ describe("bulk item operations", function() {
     it("handles create, upsert, replace, delete", async function() {
       const operations = [
         {
-          operationType: "Create",
+          operationType: BulkOperationType.Create,
           resourceBody: { id: addEntropy("doc1"), name: "sample", key: "A" }
         },
         {
-          operationType: "Upsert",
+          operationType: BulkOperationType.Upsert,
           partitionKey: "A",
           resourceBody: { id: addEntropy("doc2"), name: "other", key: "A" }
         },
         {
-          operationType: "Read",
+          operationType: BulkOperationType.Read,
           id: readItemId,
           partitionKey: "A"
         },
         {
-          operationType: "Delete",
+          operationType: BulkOperationType.Delete,
           id: deleteItemId,
           partitionKey: "A"
         },
         {
-          operationType: "Replace",
+          operationType: BulkOperationType.Replace,
           partitionKey: 5,
           id: replaceItemId,
           resourceBody: { id: replaceItemId, name: "nice", key: 5 }
@@ -335,27 +336,27 @@ describe("bulk item operations", function() {
     it("handles create, upsert, replace, delete", async function() {
       const operations = [
         {
-          operationType: "Create",
+          operationType: BulkOperationType.Create,
           partitionKey: "A",
           resourceBody: { id: addEntropy("doc1"), name: "sample", key: "A" }
         },
         {
-          operationType: "Upsert",
+          operationType: BulkOperationType.Upsert,
           partitionKey: "U",
           resourceBody: { id: addEntropy("doc2"), name: "other", key: "U" }
         },
         {
-          operationType: "Read",
+          operationType: BulkOperationType.Read,
           id: readItemId,
           partitionKey: true
         },
         {
-          operationType: "Delete",
+          operationType: BulkOperationType.Delete,
           id: deleteItemId,
           partitionKey: {}
         },
         {
-          operationType: "Replace",
+          operationType: BulkOperationType.Replace,
           partitionKey: 5,
           id: replaceItemId,
           resourceBody: { id: replaceItemId, name: "nice", key: 5 }
@@ -386,12 +387,12 @@ describe("bulk item operations", function() {
       });
       const operations = [
         {
-          operationType: "Delete",
+          operationType: BulkOperationType.Delete,
           id: readItemId,
           partitionKey: "A"
         },
         {
-          operationType: "Read",
+          operationType: BulkOperationType.Read,
           id: readItemId,
           partitionKey: "A"
         }
@@ -400,6 +401,39 @@ describe("bulk item operations", function() {
       assert.equal(response[0].statusCode, 204);
       // Delete occurs first, so the read returns a 404
       assert.equal(response[1].statusCode, 404);
+    });
+    it("424 errors for operations after an error", async function() {
+      const operations = [
+        {
+          operationType: BulkOperationType.Create,
+          resourceBody: {
+            ttl: -10
+          }
+        },
+        {
+          operationType: BulkOperationType.Create,
+          resourceBody: {
+            key: "A",
+            licenseType: "B",
+            id: "o239uroihndsf"
+          }
+        }
+      ];
+      const response = await v2Container.items.bulk(operations);
+      assert.equal(response[1].statusCode, 424)
+    });
+    it("autogenerates IDs for Create operations", async function() {
+      const operations = [
+        {
+          operationType: BulkOperationType.Create,
+          resourceBody: {
+            key: "A",
+            licenseType: "C"
+          }
+        }
+      ];
+      const response = await v2Container.items.bulk(operations);
+      assert.equal(response[0].statusCode, 201)
     });
   });
 });

--- a/sdk/cosmosdb/cosmos/test/unit/hashing/v1.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/unit/hashing/v1.spec.ts
@@ -1,66 +1,66 @@
 import assert from "assert";
 import { hashV1PartitionKey } from "../../../src/utils/hashing/v1";
 
-describe("effectivePartitionKey", function () {
-  describe("computes v1 key", function () {
+describe("effectivePartitionKey", function() {
+  describe("computes v1 key", function() {
     const toMatch = [
       {
         key: "partitionKey",
-        output: "05C1E1B3D9CD2608716273756A756A706F4C667A00",
+        output: "05C1E1B3D9CD2608716273756A756A706F4C667A00"
       },
       {
         key: "redmond",
-        output: "05C1EFE313830C087366656E706F6500",
+        output: "05C1EFE313830C087366656E706F6500"
       },
       {
         key:
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         output:
-          "05C1EB5921F706086262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626200",
+          "05C1EB5921F706086262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626262626200"
       },
       {
         key: "",
-        output: "05C1CF33970FF80800",
+        output: "05C1CF33970FF80800"
       },
       {
         key: "aa",
-        output: "05C1C7B7270FE008626200",
+        output: "05C1C7B7270FE008626200"
       },
       {
         key: null,
-        output: "05C1ED45D7475601",
+        output: "05C1ED45D7475601"
       },
       {
         key: true,
-        output: "05C1D7C5A903D803",
+        output: "05C1D7C5A903D803"
       },
       {
         key: false,
-        output: "05C1DB857D857C02",
+        output: "05C1DB857D857C02"
       },
       {
         key: {},
-        output: "05C1D529E345DC00",
+        output: "05C1D529E345DC00"
       },
       {
         key: 5,
-        output: "05C1D9C1C5517C05C014",
+        output: "05C1D9C1C5517C05C014"
       },
       {
         key: 5.5,
-        output: "05C1D7A771716C05C016",
+        output: "05C1D7A771716C05C016"
       },
       {
         key: 12313.1221,
-        output: "05C1ED154D592E05C0C90723F50FC925D8",
+        output: "05C1ED154D592E05C0C90723F50FC925D8"
       },
       {
         key: 123456789,
-        output: "05C1D9E1A5311C05C19DB7CD8B40",
-      },
+        output: "05C1D9E1A5311C05C19DB7CD8B40"
+      }
     ];
     toMatch.forEach(({ key, output }) => {
-      it("matches expected hash output", function () {
+      it("matches expected hash output", function() {
         const hashed = hashV1PartitionKey(key);
         assert.equal(hashed, output);
       });

--- a/sdk/cosmosdb/cosmos/test/unit/hashing/v2.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/unit/hashing/v2.spec.ts
@@ -1,61 +1,61 @@
 import assert from "assert";
 import { hashV2PartitionKey } from "../../../src/utils/hashing/v2";
 
-describe("effectivePartitionKey", function () {
-  describe("computes v2 key", function () {
+describe("effectivePartitionKey", function() {
+  describe("computes v2 key", function() {
     const toMatch = [
       {
         key: "redmond",
-        output: "22E342F38A486A088463DFF7838A5963",
+        output: "22E342F38A486A088463DFF7838A5963"
       },
       {
         key:
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        output: "0BA3E9CA8EE4C14538828D1612A4B652",
+        output: "0BA3E9CA8EE4C14538828D1612A4B652"
       },
       {
         key: "",
-        output: "32E9366E637A71B4E710384B2F4970A0",
+        output: "32E9366E637A71B4E710384B2F4970A0"
       },
       {
         key: "aa",
-        output: "05033626483AE80D00E44FBD35362B19",
+        output: "05033626483AE80D00E44FBD35362B19"
       },
       {
         key: null,
-        output: "378867E4430E67857ACE5C908374FE16",
+        output: "378867E4430E67857ACE5C908374FE16"
       },
       {
         key: true,
-        output: "0E711127C5B5A8E4726AC6DD306A3E59",
+        output: "0E711127C5B5A8E4726AC6DD306A3E59"
       },
       {
         key: false,
-        output: "2FE1BE91E90A3439635E0E9E37361EF2",
+        output: "2FE1BE91E90A3439635E0E9E37361EF2"
       },
       {
         key: {},
-        output: "11622DAA78F835834610ABE56EFF5CB5",
+        output: "11622DAA78F835834610ABE56EFF5CB5"
       },
       {
         key: 5,
-        output: "19C08621B135968252FB34B4CF66F811",
+        output: "19C08621B135968252FB34B4CF66F811"
       },
       {
         key: 5.5,
-        output: "0E2EE47829D1AF775EEFB6540FD1D0ED",
+        output: "0E2EE47829D1AF775EEFB6540FD1D0ED"
       },
       {
         key: 12313.1221,
-        output: "27E7ECA8F2EE3E53424DE8D5220631C6",
+        output: "27E7ECA8F2EE3E53424DE8D5220631C6"
       },
       {
         key: 123456789,
-        output: "1F56D2538088EBA82CCF988F36E16760",
-      },
+        output: "1F56D2538088EBA82CCF988F36E16760"
+      }
     ];
     toMatch.forEach(({ key, output }) => {
-      it("matches expected hash output", function () {
+      it("matches expected hash output", function() {
         const hashed = hashV2PartitionKey(key);
         assert.equal(hashed, output);
       });


### PR DESCRIPTION
Closes #10721 by adding a BulkOperationType usable when building an operation list to use when invoking `items.bulk`

Closing #10706 for the functional pieces, but still need to supplement bulk with docs detailing that errors will not necessarily be raised and may instead be contained in the response array of operation results.
