### PR TITLE
[schema-registry] Hide _response and reduce interface count

### DIFF
--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { HttpOperationResponse } from '@azure/core-http';
 import { OperationOptions } from '@azure/core-http';
 import { PipelineOptions } from '@azure/core-http';
 import { TokenCredential } from '@azure/core-http';
@@ -22,21 +21,13 @@ export interface RegisterSchemaOptions extends OperationOptions {
 }
 
 // @public
-export interface Response {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface Schema extends SchemaDefinition, SchemaId {
-}
-
-// @public
-export interface SchemaDefinition {
+export interface Schema extends SchemaId {
     content: string;
 }
 
 // @public
-export interface SchemaDescription extends SchemaDefinition {
+export interface SchemaDescription {
+    content: string;
     group: string;
     name: string;
     serializationType: string;
@@ -51,24 +42,16 @@ export interface SchemaId {
 }
 
 // @public
-export interface SchemaIdResponse extends SchemaId, Response {
-}
-
-// @public
 export class SchemaRegistryClient {
     constructor(endpoint: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
     readonly endpoint: string;
-    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<SchemaResponse>;
-    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaIdResponse>;
-    registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaIdResponse>;
+    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema>;
+    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId>;
+    registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaId>;
 }
 
 // @public
 export interface SchemaRegistryClientOptions extends PipelineOptions {
-}
-
-// @public
-export interface SchemaResponse extends Schema, Response {
 }
 
 

--- a/sdk/schemaregistry/schema-registry/src/conversions.ts
+++ b/sdk/schemaregistry/schema-registry/src/conversions.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SchemaResponse, SchemaIdResponse } from "./models";
+import { SchemaId, Schema } from "./models";
 
 import {
   SchemaGetByIdResponse,
   SchemaRegisterResponse,
   SchemaQueryIdByContentResponse
 } from "./generated/models";
+import { HttpOperationResponse } from "@azure/core-http";
 
 /**
  * Union of generated client's responses that return schema content.
@@ -25,11 +26,16 @@ type GeneratedSchemaIdResponse = SchemaRegisterResponse | SchemaQueryIdByContent
 type GeneratedResponse = GeneratedSchemaResponse | GeneratedSchemaIdResponse;
 
 /**
+ * Underlying HTTP response.
+ */
+type Response = { _response: HttpOperationResponse };
+
+/**
  * Converts generated client's reponse to IdentifiedSchemaResponse.
  *
  * @internal
  */
-export function convertSchemaResponse(response: GeneratedSchemaResponse): SchemaResponse {
+export function convertSchemaResponse(response: GeneratedSchemaResponse): Schema & Response {
   return {
     ...convertResponse(response),
     content: response.body
@@ -41,7 +47,7 @@ export function convertSchemaResponse(response: GeneratedSchemaResponse): Schema
  *
  * @internal
  */
-export function convertSchemaIdResponse(response: GeneratedSchemaIdResponse): SchemaIdResponse {
+export function convertSchemaIdResponse(response: GeneratedSchemaIdResponse): SchemaId & Response {
   return {
     ...convertResponse(response),
     // `!` here because server is required to return this on success, but that
@@ -53,7 +59,7 @@ export function convertSchemaIdResponse(response: GeneratedSchemaIdResponse): Sc
 /**
  * Converts common portion of all generated client responses.
  */
-function convertResponse(response: GeneratedResponse): SchemaIdResponse {
+function convertResponse(response: GeneratedResponse): SchemaId & Response {
   return {
     _response: response._response,
     // `!`s here because server is required to return these on success, but that

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -1,15 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineOptions, OperationOptions, HttpOperationResponse } from "@azure/core-http";
-
-/**
- * Schema definition.
- */
-export interface SchemaDefinition {
-  /** String representation of schema. */
-  content: string;
-}
+import { PipelineOptions, OperationOptions } from "@azure/core-http";
 
 /**
  * Identifies a Schema by its unique ID, version, and location.
@@ -29,14 +21,9 @@ export interface SchemaId {
 }
 
 /**
- * Schema definition with its unique ID, version, and location.
- */
-export interface Schema extends SchemaDefinition, SchemaId {}
-
-/**
  * Schema definition with its group, name, and serialization type.
  */
-export interface SchemaDescription extends SchemaDefinition {
+export interface SchemaDescription {
   /** Schema group under which schema is or should be registered. */
   group: string;
 
@@ -48,25 +35,18 @@ export interface SchemaDescription extends SchemaDefinition {
    * Currently only 'avro' is supported, but this is subject to change.
    */
   serializationType: string;
+
+  /** String representation of schema. */
+  content: string;
 }
 
 /**
- * Provides access to underlying HTTP response.
+ * Schema definition with its unique ID, version, and location.
  */
-export interface Response {
-  /** The underlying HTTP reponse. */
-  _response: HttpOperationResponse;
+export interface Schema extends SchemaId {
+  /** String representation of schema. */
+  content: string;
 }
-
-/**
- * Schema with underlying HTTP response.
- */
-export interface SchemaResponse extends Schema, Response {}
-
-/**
- * SchemaId with underlying HTTP reponse.
- */
-export interface SchemaIdResponse extends SchemaId, Response {}
 
 /**
  * Options for SchemaRegistrationClient.

--- a/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
@@ -11,10 +11,10 @@ import {
   GetSchemaByIdOptions,
   GetSchemaIdOptions,
   SchemaDescription,
-  SchemaIdResponse,
-  SchemaResponse,
   SchemaRegistryClientOptions,
-  RegisterSchemaOptions
+  RegisterSchemaOptions,
+  SchemaId,
+  Schema
 } from "./models";
 
 /**
@@ -58,7 +58,7 @@ export class SchemaRegistryClient {
   async registerSchema(
     schema: SchemaDescription,
     options?: RegisterSchemaOptions
-  ): Promise<SchemaIdResponse> {
+  ): Promise<SchemaId> {
     const response = await this.client.schema.register(
       schema.group,
       schema.name,
@@ -79,10 +79,7 @@ export class SchemaRegistryClient {
    * @param schema Schema to match.
    * @return Matched schema's ID.
    */
-  async getSchemaId(
-    schema: SchemaDescription,
-    options?: GetSchemaIdOptions
-  ): Promise<SchemaIdResponse> {
+  async getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId> {
     const response = await this.client.schema.queryIdByContent(
       schema.group,
       schema.name,
@@ -102,7 +99,7 @@ export class SchemaRegistryClient {
    * @param id Unique schema ID.
    * @return Schema with given ID.
    */
-  async getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<SchemaResponse> {
+  async getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema> {
     const response = await this.client.schema.getById(id, options);
     return convertSchemaResponse(response);
   }

--- a/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
@@ -51,6 +51,11 @@ function assertIsValidSchemaId(schemaId: SchemaId) {
   assert.isNotNull(schemaId.version);
 }
 
+// `any` because _response is deliberately withheld from the typing
+function assertStatus(response: any, status: number) {
+  assert.equal(response._response.status, status);
+}
+
 describe("SchemaRegistryClient", function() {
   let recorder: Recorder;
   let client: SchemaRegistryClient;
@@ -95,7 +100,7 @@ describe("SchemaRegistryClient", function() {
     recorder.skip("node", "https://github.com/Azure/azure-sdk-for-js/issues/10659");
 
     const registered = await client.registerSchema(schema);
-    assert.equal(registered._response.status, 200);
+    assertStatus(registered, 200);
     assert.isNotNull(registered.id);
     assert.isNotNull(registered.version);
     assert.isNotNull(registered.location);
@@ -106,7 +111,7 @@ describe("SchemaRegistryClient", function() {
       ...schema,
       content: schema.content.replace("name", "fullName")
     });
-    assert.equal(changed._response.status, 200);
+    assertStatus(changed, 200);
     assert.notEqual(changed.version, registered.version);
     assert.notEqual(changed.id, registered.id);
     assert.notEqual(changed.location, registered.location);
@@ -129,11 +134,11 @@ describe("SchemaRegistryClient", function() {
     recorder.skip("node", "https://github.com/Azure/azure-sdk-for-js/issues/10659");
 
     const registered = await client.registerSchema(schema);
-    assert.equal(registered._response.status, 200);
+    assertStatus(registered, 200);
     assertIsValidSchemaId(registered);
 
     const found = await client.getSchemaId(schema);
-    assert.equal(found._response.status, 200);
+    assertStatus(found, 200);
     assertIsValidSchemaId(found);
 
     // NOTE: IDs may differ here as we could get a different version with same content.
@@ -151,11 +156,11 @@ describe("SchemaRegistryClient", function() {
     recorder.skip("node", "https://github.com/Azure/azure-sdk-for-js/issues/10659");
 
     const registered = await client.registerSchema(schema);
-    assert.equal(registered._response.status, 200);
+    assertStatus(registered, 200);
     assertIsValidSchemaId(registered);
 
     const found = await client.getSchemaById(registered.id);
-    assert.equal(found._response.status, 200);
+    assertStatus(found, 200);
     assertIsValidSchemaId(found);
 
     assert.equal(found.content, schema.content);


### PR DESCRIPTION
Reduced the number of interfaces in the schema-registry API in two ways:

1. Removed _response from typing, eliminating the Response interface and each of the XxxResponse types which are now just Xxx.

2. Inlined content property into SchemaDescription and Schema, eliminating SchemaDefinition. There is no customer use case for a type that holds only the content. More likely, they'd just pass 'string' around for that.

It's also possible to further collapse SchemaId and Schema, and that is being proposed for the Java API. The reason it is possible is that they differ only by `content` , but when we return a SchemaId, we are passed the content so we could hand that back. However, I haven't done this yet as I'm not yet convinced it's helpful. I think it would actually make the purpose each API less clear. That said, I'll do it if the group feels strongly about it after we discuss the Java proposal.
