### PR TITLE
[Cosmos] Delete databases after bulk tests

### DIFF
--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -255,6 +255,7 @@ describe("bulk item operations", function() {
         class: "2010"
       });
     });
+    after(async () => { await container.database.delete() })
     it("handles create, upsert, replace, delete", async function() {
       const operations = [
         {
@@ -332,6 +333,7 @@ describe("bulk item operations", function() {
         class: "2012"
       });
     });
+    after(async () => { await v2Container.database.delete() })
     it("handles create, upsert, replace, delete", async function() {
       const operations = [
         {


### PR DESCRIPTION
This was leftover cleanup from the Bulk PR. Bulk tests create expensive containers so we want to make sure to delete those databases when the tests are done.