### PR TITLE
[Service Bus] Add @ignore tag for a const that showed up in the docs generated with typedoc

### DIFF
--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -58,6 +58,7 @@ export const streaming = debugModule("azure:service-bus:receiverstreaming");
 export const connectionCtxt = debugModule("azure:service-bus:connectionContext");
 /**
  * @internal
+ * @ignore
  * log statements for namespace
  */
 export const ns = debugModule("azure:service-bus:namespace");


### PR DESCRIPTION
Found this while testing out docs for #10491 