### PR TITLE
[Identity] Remove linting from build

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -26,7 +26,7 @@
     "build:test:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c rollup.test.config.js 2>&1",
     "build:test:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js 2>&1",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "npm run extract-api && tsc -p . && rollup -c 2>&1 && npm run lint",
+    "build": "npm run extract-api && tsc -p . && rollup -c 2>&1",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-browser test-dist test-browser typings *.tgz *.log",
     "execute:samples": "echo skipped",


### PR DESCRIPTION
Linting has non trivial overhead and can substantially increase the runtime for `rush build` for no good reason, so we are taking it off from the `build` script and will rely on CI lint step in analyze to fail in case of linting errors.

@sadasant ^