### PR TITLE
[Form Recognizer] Remove linting from build

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -53,7 +53,7 @@
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples prep && cd dist-samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "tsc -p . && rollup -c 2>&1 && npm run lint && api-extractor run --local",
+    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-browser dist-test test-browser temp types *.tgz *.log",
     "execute:samples": "npm run build:samples && dev-tool samples run samples/javascript/ && dev-tool samples run dist-samples/typescript/dist/dist-samples/typescript/src/",


### PR DESCRIPTION
Linting has non trivial overhead and can substantially increase the runtime for `rush build` for no good reason, so we are taking it off from the `build` script and will rely on CI lint step in analyze to fail in case of linting errors.