### PR TITLE
[Text Analytics] Remove linting from build

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -52,7 +52,7 @@
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples prep && cd dist-samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "tsc -p . && npm run lint && rollup -c 2>&1 && api-extractor run --local",
+    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "build:debug": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",


### PR DESCRIPTION
Linting has non trivial overhead and can substantially increase the runtime for `rush build` for no good reason, so we are taking it off from the `build` script and will rely on CI lint step in analyze to fail in case of linting errors.