### PR TITLE
[Cosmos] Adds single partition delete spec and makes OperationInput more rigid

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 3.9.1 (Unreleased)
+## 3.9.1 (2020-08-26)
 
+- BUGFIX: Fixes `OperationInput` type to be more accurate based on `OperationType`.
 - FEATURE: Bulk requests with `Create` operations will now autogenerate IDs if they are not present.
 - FEATURE: The `BulkOperationType` enum now exists and can be used when making bulk requests.
 

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for SQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -515,6 +515,20 @@ export type CreateOperation = OperationWithItem & {
     operationType: typeof BulkOperationType.Create;
 };
 
+// @public (undocumented)
+export interface CreateOperationInput {
+    // (undocumented)
+    ifMatch?: string;
+    // (undocumented)
+    ifNoneMatch?: string;
+    // (undocumented)
+    operationType: typeof BulkOperationType.Create;
+    // (undocumented)
+    partitionKey?: string | number | null | {} | undefined;
+    // (undocumented)
+    resourceBody: JSONObject;
+}
+
 // @public
 export class Database {
     constructor(client: CosmosClient, id: string, clientContext: ClientContext);
@@ -612,6 +626,16 @@ export type DeleteOperation = OperationBase & {
     operationType: typeof BulkOperationType.Delete;
     id: string;
 };
+
+// @public (undocumented)
+export interface DeleteOperationInput {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    operationType: typeof BulkOperationType.Delete;
+    // (undocumented)
+    partitionKey?: string | number | null | {} | undefined;
+}
 
 // @public (undocumented)
 export interface ErrorBody {
@@ -928,18 +952,7 @@ export interface OperationBase {
 }
 
 // @public (undocumented)
-export interface OperationInput {
-    // (undocumented)
-    ifMatch?: string;
-    // (undocumented)
-    ifNoneMatch?: string;
-    // (undocumented)
-    operationType: keyof typeof BulkOperationType;
-    // (undocumented)
-    partitionKey?: string | number | null | {} | undefined;
-    // (undocumented)
-    resourceBody?: JSONObject;
-}
+export type OperationInput = CreateOperationInput | UpsertOperationInput | ReadOperationInput | DeleteOperationInput | ReplaceOperationInput;
 
 // @public (undocumented)
 export interface OperationResponse {
@@ -1243,10 +1256,34 @@ export type ReadOperation = OperationBase & {
 };
 
 // @public (undocumented)
+export interface ReadOperationInput {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    operationType: typeof BulkOperationType.Read;
+    // (undocumented)
+    partitionKey?: string | number | null | {} | undefined;
+}
+
+// @public (undocumented)
 export type ReplaceOperation = OperationWithItem & {
     operationType: typeof BulkOperationType.Replace;
     id: string;
 };
+
+// @public (undocumented)
+export interface ReplaceOperationInput {
+    // (undocumented)
+    ifMatch?: string;
+    // (undocumented)
+    ifNoneMatch?: string;
+    // (undocumented)
+    operationType: typeof BulkOperationType.Replace;
+    // (undocumented)
+    partitionKey?: string | number | null | {} | undefined;
+    // (undocumented)
+    resourceBody: JSONObject;
+}
 
 // @public (undocumented)
 export interface RequestContext {
@@ -1710,6 +1747,20 @@ export interface UniqueKeyPolicy {
 export type UpsertOperation = OperationWithItem & {
     operationType: typeof BulkOperationType.Upsert;
 };
+
+// @public (undocumented)
+export interface UpsertOperationInput {
+    // (undocumented)
+    ifMatch?: string;
+    // (undocumented)
+    ifNoneMatch?: string;
+    // (undocumented)
+    operationType: typeof BulkOperationType.Upsert;
+    // (undocumented)
+    partitionKey?: string | number | null | {} | undefined;
+    // (undocumented)
+    resourceBody: JSONObject;
+}
 
 // @public
 export class User {

--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -15,7 +15,12 @@ export {
   OperationBase,
   OperationWithItem,
   OperationInput,
-  BulkOperationType
+  BulkOperationType,
+  CreateOperationInput,
+  UpsertOperationInput,
+  ReplaceOperationInput,
+  ReadOperationInput,
+  DeleteOperationInput
 } from "./utils/batch";
 export {
   ConnectionMode,

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -46,12 +46,48 @@ export const BulkOperationType = {
   Replace: "Replace"
 } as const;
 
-export interface OperationInput {
+// TODO Make operationInput CreateOperationInput | ...
+export type OperationInput =
+  | CreateOperationInput
+  | UpsertOperationInput
+  | ReadOperationInput
+  | DeleteOperationInput
+  | ReplaceOperationInput;
+
+interface CreateOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
   ifNoneMatch?: string;
-  operationType: keyof typeof BulkOperationType;
-  resourceBody?: JSONObject;
+  operationType: typeof BulkOperationType.Create;
+  resourceBody: JSONObject;
+}
+
+interface UpsertOperationInput {
+  partitionKey?: string | number | null | {} | undefined;
+  ifMatch?: string;
+  ifNoneMatch?: string;
+  operationType: typeof BulkOperationType.Upsert;
+  resourceBody: JSONObject;
+}
+
+interface ReadOperationInput {
+  partitionKey?: string | number | null | {} | undefined;
+  operationType: typeof BulkOperationType.Read;
+  id: string;
+}
+
+interface DeleteOperationInput {
+  partitionKey?: string | number | null | {} | undefined;
+  operationType: typeof BulkOperationType.Delete;
+  id: string;
+}
+
+interface ReplaceOperationInput {
+  partitionKey?: string | number | null | {} | undefined;
+  ifMatch?: string;
+  ifNoneMatch?: string;
+  operationType: typeof BulkOperationType.Replace;
+  resourceBody: JSONObject;
 }
 
 export type OperationWithItem = OperationBase & {
@@ -103,7 +139,7 @@ export function decorateOperation(
   operation: OperationInput,
   definition: PartitionKeyDefinition,
   options: RequestOptions = {}
-) {
+): Operation {
   if (operation.operationType === BulkOperationType.Create) {
     if (
       (operation.resourceBody.id === undefined || operation.resourceBody.id === "") &&
@@ -114,10 +150,14 @@ export function decorateOperation(
   }
   if (operation.partitionKey) {
     const extracted = extractPartitionKey(operation, { paths: ["/partitionKey"] });
-    return { ...operation, partitionKey: JSON.stringify(extracted) };
-  } else if (operation.resourceBody) {
+    return { ...operation, partitionKey: JSON.stringify(extracted) } as Operation;
+  } else if (
+    operation.operationType === BulkOperationType.Create ||
+    operation.operationType === BulkOperationType.Replace ||
+    operation.operationType === BulkOperationType.Upsert
+  ) {
     const pk = extractPartitionKey(operation.resourceBody, definition);
-    return { ...operation, partitionKey: JSON.stringify(pk) };
+    return { ...operation, partitionKey: JSON.stringify(pk) } as Operation;
   }
-  return operation;
+  return operation as Operation;
 }

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -54,7 +54,7 @@ export type OperationInput =
   | DeleteOperationInput
   | ReplaceOperationInput;
 
-interface CreateOperationInput {
+export interface CreateOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
   ifNoneMatch?: string;
@@ -62,7 +62,7 @@ interface CreateOperationInput {
   resourceBody: JSONObject;
 }
 
-interface UpsertOperationInput {
+export interface UpsertOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
   ifNoneMatch?: string;
@@ -70,19 +70,19 @@ interface UpsertOperationInput {
   resourceBody: JSONObject;
 }
 
-interface ReadOperationInput {
+export interface ReadOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   operationType: typeof BulkOperationType.Read;
   id: string;
 }
 
-interface DeleteOperationInput {
+export interface DeleteOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   operationType: typeof BulkOperationType.Delete;
   id: string;
 }
 
-interface ReplaceOperationInput {
+export interface ReplaceOperationInput {
   partitionKey?: string | number | null | {} | undefined;
   ifMatch?: string;
   ifNoneMatch?: string;

--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -16,7 +16,7 @@ import {
   addEntropy,
   getTestContainer
 } from "../common/TestHelpers";
-import { BulkOperationType } from "../../src/utils/batch";
+import { BulkOperationType, OperationInput } from "../../src/utils/batch";
 
 /**
  * @ignore
@@ -434,6 +434,29 @@ describe("bulk item operations", function() {
       ];
       const response = await v2Container.items.bulk(operations);
       assert.equal(response[0].statusCode, 201);
+    });
+  });
+  describe("v2 single partition container", async function() {
+    let container: Container;
+    let deleteItemId: string;
+    before(async function() {
+      container = await getTestContainer("bulk container");
+      deleteItemId = addEntropy("item2");
+      await container.items.create({
+        id: deleteItemId,
+        key: "A",
+        class: "2010"
+      });
+    });
+    it("deletes an item with default partition", async function() {
+      const operation: OperationInput = {
+        operationType: BulkOperationType.Delete,
+        partitionKey: {},
+        id: deleteItemId
+      };
+
+      const deleteResponse = await container.items.bulk([operation]);
+      assert.equal(deleteResponse[0].statusCode, 204)
     });
   });
 });


### PR DESCRIPTION
Addresses a customer reported issue that a `deleteOperation` wasn't working or reporting an error. We fixed the issue around errors not being reported in a previous PR but they were still able to pass an object with invalid keys, `delete` requires `id` but the type accepted `resourceBody`. This makes the operatoin input more rigid again.