### PR TITLE
[Recorder] Followup of #10009 - Allow all successful status codes while decoding hex values into binary

### DIFF
--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -58,6 +58,7 @@ export const streaming = debugModule("azure:service-bus:receiverstreaming");
 export const connectionCtxt = debugModule("azure:service-bus:connectionContext");
 /**
  * @internal
+ * @ignore
  * log statements for namespace
  */
 export const ns = debugModule("azure:service-bus:namespace");

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2020-08-27
 
-- [Bug Fix] When the responses have binary content, "nock" library saves the fixture by converting them into hex values. [#10048](https://github.com/Azure/azure-sdk-for-js/pull/10048) fixed the issue if the status code in the response is 200. Now, allowing the rest of the "successful" status codes(200-206).
+- [Bug Fix] When the responses have binary content, "nock" library saves the fixture by converting them into hex values. [#10048](https://github.com/Azure/azure-sdk-for-js/pull/10048) fixed the issue if the status code in the response is 200. Now, allowing the rest of the "successful" status codes(200-299).
   [#10892](https://github.com/Azure/azure-sdk-for-js/pull/10892)
 
 ## 2020-08-21

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0 (Unreleased)
 
+## 2020-08-27
+
+- [Bug Fix] When the responses have binary content, "nock" library saves the fixture by converting them into hex values. [#10048](https://github.com/Azure/azure-sdk-for-js/pull/10048) fixed the issue if the status code in the response is 200. Now, allowing the rest of the "successful" status codes(200-206).
+
 ## 2020-08-21
 
 - [Bug Fix] When the responses have binary content, "nock" library saves the fixture by converting them into hex values. Fixtures are now overridden before being saved as recordings by decoding the hex values into the buffer as expected if the "Content-Type" is "avro/binary".

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2020-08-27
 
 - [Bug Fix] When the responses have binary content, "nock" library saves the fixture by converting them into hex values. [#10048](https://github.com/Azure/azure-sdk-for-js/pull/10048) fixed the issue if the status code in the response is 200. Now, allowing the rest of the "successful" status codes(200-206).
+  [#10892](https://github.com/Azure/azure-sdk-for-js/pull/10892)
 
 ## 2020-08-21
 

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -549,9 +549,13 @@ export function decodeHexEncodingIfExistsInNockFixture(fixture: string): string 
   // Replaces only if the content-type is binary(Currently, "avro/binary" is considered)
   if (!isBrowser() && isContentTypeInNockFixture(fixture, binaryContentTypes)) {
     // Matching with 200-206 status codes (Successful codes)
-    const matches = fixture.match(/\.reply\((200|201|202|303|204|205|206), "(.*)", .*/);
-    if (matches && isHex(matches[2])) {
-      fixture = fixture.replace(`"${matches[2]}"`, `Buffer.from("${matches[2]}", "hex")`);
+    const matches = fixture.match(/\.reply\((.*), "(.*)", .*/);
+    if (matches) {
+      const statusCode = Number(matches[1]);
+      // Success status codes >=200 & < 300
+      if (statusCode >= 200 && statusCode < 300 && isHex(matches[2])) {
+        fixture = fixture.replace(`"${matches[2]}"`, `Buffer.from("${matches[2]}", "hex")`);
+      }
     }
   }
   return fixture;

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -546,12 +546,12 @@ export function isContentTypeInNockFixture(
  * @param {string} fixture
  */
 export function decodeHexEncodingIfExistsInNockFixture(fixture: string): string {
-  // Matching with 200 status code since only they have the responses with hex encoding
   // Replaces only if the content-type is binary(Currently, "avro/binary" is considered)
   if (!isBrowser() && isContentTypeInNockFixture(fixture, binaryContentTypes)) {
-    const matches = fixture.match(/\.reply\(200, "(.*)", .*/);
-    if (matches && isHex(matches[1])) {
-      fixture = fixture.replace(`"${matches[1]}"`, `Buffer.from("${matches[1]}", "hex")`);
+    // Matching with 200-206 status codes (Successful codes)
+    const matches = fixture.match(/\.reply\((200|201|202|303|204|205|206), "(.*)", .*/);
+    if (matches && isHex(matches[2])) {
+      fixture = fixture.replace(`"${matches[2]}"`, `Buffer.from("${matches[2]}", "hex")`);
     }
   }
   return fixture;

--- a/sdk/test-utils/recorder/test/node/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/node/utils.spec.ts
@@ -296,6 +296,31 @@ describe("NodeJS utils", () => {
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
 ]);`
+      },
+      {
+        name: `Hex encoding is not decoded for non-successful status codes`,
+        input: `nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/path', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><QueryRequest><Expression>select * from BlobStorage</Expression></QueryRequest>")
+  .query(true)
+  .reply(400, "4f626a0131c2", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'avro/binary',
+  'Last-Modified',
+  'Thu, 20 Aug 2020 09:22:11 GMT',
+]);`,
+        output: `nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/path', "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><QueryRequest><Expression>select * from BlobStorage</Expression></QueryRequest>")
+  .query(true)
+  .reply(400, "4f626a0131c2", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'avro/binary',
+  'Last-Modified',
+  'Thu, 20 Aug 2020 09:22:11 GMT',
+]);`
       }
     ].forEach((test) => {
       it(test.name, () => {

--- a/sdk/test-utils/recorder/test/node/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/node/utils.spec.ts
@@ -271,6 +271,31 @@ describe("NodeJS utils", () => {
   'Last-Modified',
   'Thu, 20 Aug 2020 09:22:11 GMT',
 ]);`
+      },
+      {
+        name: `Hex encoding decodes for "avro/binary" content type even for partial success(status code 206)`,
+        input: `nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/path', "<?xml version=\"1.0\">")
+  .query(true)
+  .reply(206, "4f626a0131c2", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'avro/binary',
+  'Last-Modified',
+  'Thu, 20 Aug 2020 09:22:11 GMT',
+]);`,
+        output: `nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/path', "<?xml version=\"1.0\">")
+  .query(true)
+  .reply(206, Buffer.from("4f626a0131c2", "hex"), [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'avro/binary',
+  'Last-Modified',
+  'Thu, 20 Aug 2020 09:22:11 GMT',
+]);`
       }
     ].forEach((test) => {
       it(test.name, () => {


### PR DESCRIPTION
@ljian3377 came up with an issue where the response has Partial Content(Success code - 206), the hex value is not decoded for such responses.
This PR adds all the successful status codes to be allowed to filter to decode the binary responses.