### PR TITLE
[Anomaly Detector] Fix missing types in package

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/api-extractor.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/template.d.ts"
+    "publicTrimmedFilePath": "./types/ai-anomaly-detector.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -15,7 +15,7 @@
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples prep && cd dist-samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "npm run lint && tsc -p . && rollup -c 2>&1 && api-extractor run --local",
+    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-* test-dist temp types *.tgz *.log",
     "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -15,7 +15,7 @@
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples prep && cd dist-samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
+    "build": "npm run lint && tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-* test-dist temp types *.tgz *.log",
     "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",
@@ -25,7 +25,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o anomalydetector-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -43,11 +43,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/anomalydetector/ai-anomaly-detector"
+  "engines": {
+    "node": ">=8.0.0"
   },
+  "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",
     "cloud",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/javascript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/javascript/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "azure-template-samples-js",
+  "name": "azure-ai-anomaly-detector-samples-js",
   "private": true,
   "version": "0.1.0",
-  "description": "Azure template client library samples for JavaScript",
+  "description": "Azure ai-anomaly-detector client library samples for JavaScript",
   "engine": {
     "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/template/template"
+    "directory": "sdk/anomalydetector/ai-anomaly-detector/"
   },
   "keywords": [
     "Azure",
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/anomalydetector/ai-anomaly-detector",
   "sideEffects": false,
   "dependencies": {
     "@azure/ai-anomaly-detector": "../..",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "azure-template-samples-ts",
+  "name": "azure-ai-anomaly-detector-samples-ts",
   "private": true,
   "version": "0.1.0",
-  "description": "Azure template client library samples for TypeScript",
+  "description": "Azure ai-anomaly-detector client library samples for TypeScript",
   "engine": {
     "node": ">=8.0.0"
   },
@@ -13,7 +13,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/template/template"
+    "directory": "sdk/anomalydetector/ai-anomaly-detector"
   },
   "keywords": [
     "Azure",
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/anomalydetector/ai-anomaly-detector",
   "sideEffects": false,
   "dependencies": {
     "@azure/ai-anomaly-detector": "../..",

--- a/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
@@ -64,6 +64,7 @@ export class AnomalyDetectorClient {
   constructor(
     endpointUrl: string,
     credential: TokenCredential | KeyCredential,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: AnomalyDetectorClientOptions
   ) {
     this.endpointUrl = endpointUrl;
@@ -109,6 +110,7 @@ export class AnomalyDetectorClient {
    */
   public detectEntireSeries(
     body: DetectRequest,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: OperationOptions
   ): Promise<AnomalyDetectorClientDetectEntireResponse> {
     const realOptions = options || {};
@@ -140,6 +142,7 @@ export class AnomalyDetectorClient {
    */
   public detectLastPoint(
     body: DetectRequest,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: OperationOptions
   ): Promise<AnomalyDetectorClientDetectLastPointResponse> {
     const realOptions = options || {};
@@ -169,6 +172,7 @@ export class AnomalyDetectorClient {
    */
   detectChangePoint(
     body: DetectChangePointRequest,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: OperationOptions
   ): Promise<AnomalyDetectorClientDetectChangePointResponse> {
     const realOptions = options || {};

--- a/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
@@ -64,7 +64,6 @@ export class AnomalyDetectorClient {
   constructor(
     endpointUrl: string,
     credential: TokenCredential | KeyCredential,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: AnomalyDetectorClientOptions
   ) {
     this.endpointUrl = endpointUrl;

--- a/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
@@ -64,6 +64,7 @@ export class AnomalyDetectorClient {
   constructor(
     endpointUrl: string,
     credential: TokenCredential | KeyCredential,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: AnomalyDetectorClientOptions
   ) {
     this.endpointUrl = endpointUrl;

--- a/sdk/anomalydetector/ai-anomaly-detector/test/anomalydetector.spec.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/test/anomalydetector.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
 import { AnomalyDetectorClient } from "../src/AnomalyDetectorClient";
@@ -17,6 +20,7 @@ describe("AnomalyDetectorClient", () => {
   const apiKey = new AzureKeyCredential(testEnv.ANOMALY_DETECTOR_API_KEY);
 
   beforeEach(function() {
+    // eslint-disable-next-line no-invalid-this
     ({ recorder, client } = createRecordedAnomalyDetectorClient(this, apiKey));
   });
 

--- a/sdk/anomalydetector/ai-anomaly-detector/test/testData.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/test/testData.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import {
   TimeGranularity,
   DetectRequest,


### PR DESCRIPTION
Types file was generated with an incorrect name `template.d.ts` so it was not included in the package. Renaming it to `ai-anomaly-detector.d.ts` will match the entry in package.files and will include it in the package.

Also: 
* Fixing some leftover `template` strings in the samples package
* Enable linter when building
* Fix linting errors
