### PR TITLE
[Service Bus] Values for props on the message only supports some types

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -355,7 +355,7 @@ export interface ServiceBusMessage {
     messageId?: string | number | Buffer;
     partitionKey?: string;
     properties?: {
-        [key: string]: any;
+        [key: string]: number | boolean | string | Date;
     };
     replyTo?: string;
     replyToSessionId?: string;

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -222,7 +222,7 @@ export interface ServiceBusMessage {
    * @property The application specific properties which can be
    * used for custom message metadata.
    */
-  properties?: { [key: string]: any };
+  properties?: { [key: string]: "number" | "boolean" | "string" | Date };
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -222,7 +222,7 @@ export interface ServiceBusMessage {
    * @property The application specific properties which can be
    * used for custom message metadata.
    */
-  properties?: { [key: string]: "number" | "boolean" | "string" | Date };
+  properties?: { [key: string]: number | boolean | string | Date };
 }
 
 /**

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -25,7 +25,8 @@ export class TestMessage {
       properties: {
         propOne: 1,
         propTwo: "two",
-        propThree: true
+        propThree: true,
+        propFour: Date()
       }
     };
   }


### PR DESCRIPTION
As part of the investigation at https://github.com/Azure/azure-sdk-for-js/issues/9850#issuecomment-670773548, it seems "number", "boolean", "string", and Date are the only types allowed for values in the properties on the message.

