### PR TITLE
[Template] Allow CI Analyze when there are lint errors

### DIFF
--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -26,7 +26,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o template-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -43,10 +43,9 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/template/template"
+  "repository": "github:Azure/azure-sdk-for-js",
+  "engines": {
+    "node": ">=8.0.0"
   },
   "keywords": [
     "azure",


### PR DESCRIPTION
Make lint script actually fail if there were any Lint errors. This will allow Analyze to fail in CI with any lint errors.

Also fixing a couple of lint errors in this project