### PR TITLE
[Identity] Sovereign Clouds don't support the VSCode credential

### DIFF
--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -29,6 +29,14 @@ const unsupportedTenantIds: Record<string, string> = {
   adfs: "The VisualStudioCodeCredential is not supported against ADFS tenant / authorities."
 };
 
+function checkUnsupportedTenant(tenantId: string): void {
+  // If the Tenant ID isn't supported, we throw.
+  const unsupportedTenantError = unsupportedTenantIds[tenantId];
+  if (unsupportedTenantError) {
+    throw new CredentialUnavailable(unsupportedTenantError);
+  }
+}
+
 /**
  * Attempts to load the tenant from the VSCode configurations of the current OS.
  * If it fails at any point, returns undefined.
@@ -93,12 +101,7 @@ export class VisualStudioCodeCredential implements TokenCredential {
     } else {
       this.tenantId = CommonTenantId;
     }
-
-    // If the Tenant ID isn't supported, we throw.
-    const unsupportedTenantError = unsupportedTenantIds[this.tenantId];
-    if (unsupportedTenantError) {
-      throw new CredentialUnavailable(unsupportedTenantError);
-    }
+    checkUnsupportedTenant(this.tenantId);
   }
 
   /**
@@ -110,6 +113,7 @@ export class VisualStudioCodeCredential implements TokenCredential {
     if (settingsTenant) {
       this.tenantId = settingsTenant;
     }
+    checkUnsupportedTenant(this.tenantId);
   }
 
   /**

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -26,7 +26,7 @@ const logger = credentialLogger("VisualStudioCodeCredential");
 
 // Map of unsupported Tenant IDs and the errors we will be throwing.
 const unsupportedTenantIds: Record<string, string> = {
-  adfs: "The VisualStudioCodeCredential is not supported against ADFS tenant / authorities."
+  adfs: "The VisualStudioCodeCredential does not support authentication with ADFS tenants."
 };
 
 function checkUnsupportedTenant(tenantId: string): void {

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -24,6 +24,11 @@ const AzureAccountClientId = "aebc6443-996d-45c2-90f0-388ff96faa56"; // VSC: 'ae
 const VSCodeUserName = "VS Code Azure";
 const logger = credentialLogger("VisualStudioCodeCredential");
 
+// Map of unsupported Tenant IDs and the errors we will be throwing.
+const unsupportedTenantIds: Record<string, string> = {
+  adfs: "The VisualStudioCodeCredential is not supported against ADFS tenant / authorities."
+};
+
 /**
  * Attempts to load the tenant from the VSCode configurations of the current OS.
  * If it fails at any point, returns undefined.
@@ -88,8 +93,11 @@ export class VisualStudioCodeCredential implements TokenCredential {
     } else {
       this.tenantId = CommonTenantId;
     }
-    if (this.tenantId === "adfs") {
-      throw new CredentialUnavailable("The VisualStudioCodeCredential is not supported in Sovereign Clouds")
+
+    // If the Tenant ID isn't supported, we throw.
+    const unsupportedTenantError = unsupportedTenantIds[this.tenantId];
+    if (unsupportedTenantError) {
+      throw new CredentialUnavailable(unsupportedTenantError);
     }
   }
 

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -88,6 +88,9 @@ export class VisualStudioCodeCredential implements TokenCredential {
     } else {
       this.tenantId = CommonTenantId;
     }
+    if (this.tenantId === "adfs") {
+      throw new CredentialUnavailable("The VisualStudioCodeCredential is not supported in Sovereign Clouds")
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #10922

Throws if the TenantID is `adfs` both as an input parameter, or after reading the VSCode configuration.