### PR TITLE
[core-http] Treat '=' in query parameter values as valid

### DIFF
--- a/sdk/core/core-http/src/url.ts
+++ b/sdk/core/core-http/src/url.ts
@@ -3,7 +3,7 @@
 
 import { replaceAll } from "./util/utils";
 
-type URLQueryParseState = "ParameterName" | "ParameterValue" | "Invalid";
+type URLQueryParseState = "ParameterName" | "ParameterValue";
 
 /**
  * A class that handles the query portion of a URLBuilder.
@@ -109,12 +109,6 @@ export class URLQuery {
 
           case "ParameterValue":
             switch (currentCharacter) {
-              case "=":
-                parameterName = "";
-                parameterValue = "";
-                currentState = "Invalid";
-                break;
-
               case "&":
                 result.set(parameterName, parameterValue);
                 parameterName = "";
@@ -125,12 +119,6 @@ export class URLQuery {
               default:
                 parameterValue += currentCharacter;
                 break;
-            }
-            break;
-
-          case "Invalid":
-            if (currentCharacter === "&") {
-              currentState = "ParameterName";
             }
             break;
 

--- a/sdk/core/core-http/test/urlTests.ts
+++ b/sdk/core/core-http/test/urlTests.ts
@@ -97,7 +97,15 @@ describe("URLQuery", () => {
     });
 
     it(`with "A=="`, () => {
-      assert.strictEqual(URLQuery.parse("A==").toString(), "");
+      assert.strictEqual(URLQuery.parse("A==").toString(), "A==");
+    });
+
+    it(`with "A=B&C=123=="`, () => {
+      assert.strictEqual(URLQuery.parse("A=B&C=123==").toString(), "A=B&C=123==");
+    });
+
+    it(`with "A===&C=123"`, () => {
+      assert.strictEqual(URLQuery.parse("A===&C=123").toString(), "A===&C=123");
     });
 
     it(`with "A=&B=C"`, () => {


### PR DESCRIPTION
The '=' character is valid in query parameter values. There are
scenarios where a query parameter value is base64 encoded (e.g., a
continuation token that is opaque to users) and '=' is very common in
base64 encoded strings. Currently we treat query parameter values
containing '=' as invalid and any parameter name/value pair with '='
in value is ignored thus we lose those key-value pairs after parsing
URLs.

I have verified that both NodeJS and browsers' URL types allow '=' in
their `searchParameter` values.

This change remove the invalidation of this case in `URLQuery.parse()`
so that our parsing behavior is consistent with NodeJS and browsers'
URL types.

Fixes #11014