### PR TITLE
[Service Bus] Add ServiceBus prefix to ReceivedMessage

### DIFF
--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -11,7 +11,7 @@
 import {
   ServiceBusClient,
   delay,
-  ReceivedMessageWithLock,
+  ServiceBusReceivedMessageWithLock,
   ServiceBusSessionReceiver,
   MessagingError
 } from "@azure/service-bus";
@@ -42,7 +42,7 @@ async function sessionAccepted(sessionId: string) {
 
 // Called by the ServiceBusSessionReceiver when a message is received.
 // This is passed as part of the handlers when calling `ServiceBusSessionReceiver.subscribe()`.
-async function processMessage(msg: ReceivedMessageWithLock) {
+async function processMessage(msg: ServiceBusReceivedMessageWithLock) {
   console.log(`[${msg.sessionId}] received message with body ${msg.body}`);
 }
 
@@ -80,7 +80,7 @@ function createRefreshableTimer(timeoutMs: number, resolve: Function): () => voi
 
 // Queries Service Bus for the next available session and processes it.
 async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promise<void> {
-  let sessionReceiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+  let sessionReceiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
 
   try {
     sessionReceiver = await serviceBusClient.createSessionReceiver(queueName, {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -25,7 +25,7 @@ import {
 import { ConnectionContext } from "../connectionContext";
 import {
   DispositionType,
-  ReceivedMessage,
+  ServiceBusReceivedMessage,
   ServiceBusMessage,
   ServiceBusMessageImpl,
   getMessagePropertyTypeMismatchError,
@@ -375,7 +375,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   async peek(
     messageCount?: number,
     options?: OperationOptionsBase & SendManagementRequestOptions
-  ): Promise<ReceivedMessage[]> {
+  ): Promise<ServiceBusReceivedMessage[]> {
     throwErrorIfConnectionClosed(this._context);
     return this.peekBySequenceNumber(
       this._lastPeekedSequenceNumber.add(1),
@@ -402,7 +402,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     sessionId: string,
     messageCount?: number,
     options?: OperationOptionsBase & SendManagementRequestOptions
-  ): Promise<ReceivedMessage[]> {
+  ): Promise<ServiceBusReceivedMessage[]> {
     throwErrorIfConnectionClosed(this._context);
     return this.peekBySequenceNumber(
       this._lastPeekedSequenceNumber.add(1),
@@ -425,7 +425,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     maxMessageCount?: number,
     sessionId?: string,
     options?: OperationOptionsBase & SendManagementRequestOptions
-  ): Promise<ReceivedMessage[]> {
+  ): Promise<ServiceBusReceivedMessage[]> {
     throwErrorIfConnectionClosed(this._context);
     const connId = this._context.connectionId;
 
@@ -443,7 +443,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       maxMessageCount = 1;
     }
 
-    const messageList: ReceivedMessage[] = [];
+    const messageList: ServiceBusReceivedMessage[] = [];
     try {
       const messageBody: any = {};
       messageBody[Constants.fromSequenceNumber] = types.wrap_long(

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -71,8 +71,8 @@ export {
   AmqpMessageHeader,
   AmqpMessageProperties,
   DeadLetterOptions,
-  ReceivedMessage,
-  ReceivedMessageWithLock,
+  ServiceBusReceivedMessage,
+  ServiceBusReceivedMessageWithLock,
   ServiceBusMessage
 } from "./serviceBusMessage";
 export { ServiceBusMessageBatch } from "./serviceBusMessageBatch";

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ConnectionContext } from "../connectionContext";
-import { MessageHandlers, ReceiveMessagesOptions, ReceivedMessage } from "..";
+import { MessageHandlers, ReceiveMessagesOptions, ServiceBusReceivedMessage } from "..";
 import {
   PeekMessagesOptions,
   CreateSessionReceiverOptions,
@@ -24,7 +24,7 @@ import { assertValidMessageHandlers, getMessageIterator, wrapProcessErrorHandler
 import { convertToInternalReceiveMode } from "../constructorHelpers";
 import { defaultMaxTimeAfterFirstMessageForBatchingMs, ServiceBusReceiver } from "./receiver";
 import Long from "long";
-import { ReceivedMessageWithLock, ServiceBusMessageImpl } from "../serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock, ServiceBusMessageImpl } from "../serviceBusMessage";
 import {
   Constants,
   RetryConfig,
@@ -42,7 +42,7 @@ import { AmqpError } from "rhea-promise";
  *A receiver that handles sessions, including renewing the session lock.
  */
 export interface ServiceBusSessionReceiver<
-  ReceivedMessageT extends ReceivedMessage | ReceivedMessageWithLock
+  ReceivedMessageT extends ServiceBusReceivedMessage | ServiceBusReceivedMessageWithLock
 > extends ServiceBusReceiver<ReceivedMessageT> {
   /**
    * The session ID.
@@ -111,7 +111,7 @@ export interface ServiceBusSessionReceiver<
  * @ignore
  */
 export class ServiceBusSessionReceiverImpl<
-  ReceivedMessageT extends ReceivedMessage | ReceivedMessageWithLock
+  ReceivedMessageT extends ServiceBusReceivedMessage | ServiceBusReceivedMessageWithLock
 > implements ServiceBusSessionReceiver<ReceivedMessageT> {
   public sessionId: string;
 
@@ -137,7 +137,7 @@ export class ServiceBusSessionReceiverImpl<
   }
 
   static async createInitializedSessionReceiver<
-    ReceivedMessageT extends ReceivedMessage | ReceivedMessageWithLock
+    ReceivedMessageT extends ServiceBusReceivedMessage | ServiceBusReceivedMessageWithLock
   >(
     context: ConnectionContext,
     entityPath: string,
@@ -319,7 +319,7 @@ export class ServiceBusSessionReceiverImpl<
   async peekMessages(
     maxMessageCount: number,
     options: PeekMessagesOptions = {}
-  ): Promise<ReceivedMessage[]> {
+  ): Promise<ServiceBusReceivedMessage[]> {
     this._throwIfReceiverOrConnectionClosed();
 
     if (maxMessageCount == undefined) {
@@ -349,14 +349,14 @@ export class ServiceBusSessionReceiverImpl<
       }
     };
 
-    const config: RetryConfig<ReceivedMessage[]> = {
+    const config: RetryConfig<ServiceBusReceivedMessage[]> = {
       operation: peekOperationPromise,
       connectionId: this._context.connectionId,
       operationType: RetryOperationType.management,
       retryOptions: this._retryOptions,
       abortSignal: options?.abortSignal
     };
-    return retry<ReceivedMessage[]>(config);
+    return retry<ServiceBusReceivedMessage[]>(config);
   }
 
   async receiveDeferredMessages(

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -14,7 +14,7 @@ import {
   ServiceBusSessionReceiver,
   ServiceBusSessionReceiverImpl
 } from "./receivers/sessionReceiver";
-import { ReceivedMessage, ReceivedMessageWithLock } from "./serviceBusMessage";
+import { ServiceBusReceivedMessage, ServiceBusReceivedMessageWithLock } from "./serviceBusMessage";
 import { ServiceBusSender, ServiceBusSenderImpl } from "./sender";
 
 /**
@@ -118,12 +118,12 @@ export class ServiceBusClient {
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessageWithLock`
    */
   createReceiver(
     queueName: string,
     options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver<ReceivedMessageWithLock>;
+  ): ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode. No connection is made
    * to the service until one of the methods on the receiver is called.
@@ -137,12 +137,12 @@ export class ServiceBusClient {
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
    */
   createReceiver(
     queueName: string,
     options: CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver<ReceivedMessage>;
+  ): ServiceBusReceiver<ServiceBusReceivedMessage>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode. No connection is made
    * to the service until one of the methods on the receiver is called.
@@ -168,13 +168,13 @@ export class ServiceBusClient {
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessageWithLock`
    */
   createReceiver(
     topicName: string,
     subscriptionName: string,
     options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver<ReceivedMessageWithLock>;
+  ): ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode. No connection is made
    * to the service until one of the methods on the receiver is called.
@@ -190,13 +190,13 @@ export class ServiceBusClient {
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
    */
   createReceiver(
     topicName: string,
     subscriptionName: string,
     options: CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver<ReceivedMessage>;
+  ): ServiceBusReceiver<ServiceBusReceivedMessage>;
   createReceiver(
     queueOrTopicName1: string,
     optionsOrSubscriptionName2?:
@@ -204,7 +204,9 @@ export class ServiceBusClient {
       | CreateReceiverOptions<"peekLock">
       | string,
     options3?: CreateReceiverOptions<"receiveAndDelete"> | CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver<ReceivedMessage> | ServiceBusReceiver<ReceivedMessageWithLock> {
+  ):
+    | ServiceBusReceiver<ServiceBusReceivedMessage>
+    | ServiceBusReceiver<ServiceBusReceivedMessageWithLock> {
     // NOTE: we don't currently have any options for this kind of receiver but
     // when we do make sure you pass them in and extract them.
     const { entityPath, receiveMode, options } = extractReceiverArguments(
@@ -230,14 +232,14 @@ export class ServiceBusClient {
     }
 
     if (receiveMode === "peekLock") {
-      return new ServiceBusReceiverImpl<ReceivedMessageWithLock>(
+      return new ServiceBusReceiverImpl<ServiceBusReceivedMessageWithLock>(
         this._connectionContext,
         entityPathWithSubQueue,
         receiveMode,
         this._clientOptions.retryOptions
       );
     } else {
-      return new ServiceBusReceiverImpl<ReceivedMessage>(
+      return new ServiceBusReceiverImpl<ServiceBusReceivedMessage>(
         this._connectionContext,
         entityPathWithSubQueue,
         receiveMode,
@@ -265,12 +267,12 @@ export class ServiceBusClient {
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessageWithLock`
    */
   createSessionReceiver(
     queueName: string,
     options?: CreateSessionReceiverOptions<"peekLock">
-  ): Promise<ServiceBusSessionReceiver<ReceivedMessageWithLock>>;
+  ): Promise<ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>>;
   /**
    * Creates a receiver for a session enabled Azure Service Bus queue in receiveAndDelete mode.
    * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
@@ -279,12 +281,12 @@ export class ServiceBusClient {
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
    */
   createSessionReceiver(
     queueName: string,
     options: CreateSessionReceiverOptions<"receiveAndDelete">
-  ): Promise<ServiceBusSessionReceiver<ReceivedMessage>>;
+  ): Promise<ServiceBusSessionReceiver<ServiceBusReceivedMessage>>;
   /**
    * Creates a receiver for a session enabled Azure Service Bus subscription in peekLock mode.
    * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
@@ -305,13 +307,13 @@ export class ServiceBusClient {
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessageWithLock`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessageWithLock`
    */
   createSessionReceiver(
     topicName: string,
     subscriptionName: string,
     options?: CreateSessionReceiverOptions<"peekLock">
-  ): Promise<ServiceBusSessionReceiver<ReceivedMessageWithLock>>;
+  ): Promise<ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>>;
   /**
    * Creates a receiver for a session enabled Azure Service Bus subscription in receiveAndDelete mode.
    * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
@@ -321,13 +323,13 @@ export class ServiceBusClient {
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ReceivedMessage`
+   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
    */
   createSessionReceiver(
     topicName: string,
     subscriptionName: string,
     options: CreateSessionReceiverOptions<"receiveAndDelete">
-  ): Promise<ServiceBusSessionReceiver<ReceivedMessage>>;
+  ): Promise<ServiceBusSessionReceiver<ServiceBusReceivedMessage>>;
   async createSessionReceiver(
     queueOrTopicName1: string,
     optionsOrSubscriptionName2?:
@@ -338,7 +340,8 @@ export class ServiceBusClient {
       | CreateSessionReceiverOptions<"peekLock">
       | CreateSessionReceiverOptions<"receiveAndDelete">
   ): Promise<
-    ServiceBusSessionReceiver<ReceivedMessage> | ServiceBusSessionReceiver<ReceivedMessageWithLock>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessage>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>
   > {
     const { entityPath, receiveMode, options } = extractReceiverArguments(
       queueOrTopicName1,

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -233,7 +233,7 @@ export interface ServiceBusMessage {
 }
 
 /**
- * Describes the AmqpAnnotatedMessage, part of the ReceivedMessage(as `amqpAnnotatedMessage` property).
+ * Describes the AmqpAnnotatedMessage, part of the ServiceBusReceivedMessage(as `amqpAnnotatedMessage` property).
  */
 export interface AmqpAnnotatedMessage {
   /**
@@ -498,9 +498,9 @@ export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
 
 /**
  * Describes the message received from Service Bus during peek operations and so cannot be settled.
- * @class ReceivedMessage
+ * @class ServiceBusReceivedMessage
  */
-export interface ReceivedMessage extends ServiceBusMessage {
+export interface ServiceBusReceivedMessage extends ServiceBusMessage {
   /**
    * @property The reason for deadlettering the message.
    * @readonly
@@ -586,7 +586,7 @@ export interface ReceivedMessage extends ServiceBusMessage {
  * A message that can be settled by completing it, abandoning it, deferring it, or sending
  * it to the dead letter queue.
  */
-export interface ReceivedMessageWithLock extends ReceivedMessage {
+export interface ServiceBusReceivedMessageWithLock extends ServiceBusReceivedMessage {
   /**
    * Removes the message from Service Bus.
    *
@@ -707,13 +707,13 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
 /**
  * @internal
  * @ignore
- * Converts given AmqpMessage to ReceivedMessage
+ * Converts given AmqpMessage to ServiceBusReceivedMessage
  */
 export function fromAmqpMessage(
   msg: AmqpMessage,
   delivery?: Delivery,
   shouldReorderLockToken?: boolean
-): ReceivedMessage {
+): ServiceBusReceivedMessage {
   if (!msg) {
     msg = {
       body: undefined
@@ -794,7 +794,7 @@ export function fromAmqpMessage(
     props.expiresAtUtc = new Date(props.enqueuedTimeUtc.getTime() + msg.ttl!);
   }
 
-  const rcvdsbmsg: ReceivedMessage = {
+  const rcvdsbmsg: ServiceBusReceivedMessage = {
     _amqpAnnotatedMessage: toAmqpAnnotatedMessage(msg),
     _delivery: delivery,
     deliveryCount: msg.delivery_count,
@@ -854,9 +854,9 @@ export function isServiceBusMessage(possible: any): possible is ServiceBusMessag
  * @internal
  * @ignore
  * @class ServiceBusMessageImpl
- * @implements {ReceivedMessageWithLock}
+ * @implements {ServiceBusReceivedMessageWithLock}
  */
-export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
+export class ServiceBusMessageImpl implements ServiceBusReceivedMessageWithLock {
   /**
    * @property The message body that needs to be sent or is received.
    */
@@ -1072,7 +1072,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   }
 
   /**
-   * See ReceivedMessageWithLock.complete().
+   * See ServiceBusReceivedMessageWithLock.complete().
    */
   async complete(): Promise<void> {
     log.message(
@@ -1084,7 +1084,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   }
 
   /**
-   * See ReceivedMessageWithLock.abandon().
+   * See ServiceBusReceivedMessageWithLock.abandon().
    */
   async abandon(propertiesToModify?: { [key: string]: any }): Promise<void> {
     // TODO: Figure out a mechanism to convert specified properties to message_annotations.
@@ -1099,7 +1099,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   }
 
   /**
-   * See ReceivedMessageWithLock.defer().
+   * See ServiceBusReceivedMessageWithLock.defer().
    */
   async defer(propertiesToModify?: { [key: string]: any }): Promise<void> {
     log.message(
@@ -1113,7 +1113,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   }
 
   /**
-   * See ReceivedMessageWithLock.deadLetter().
+   * See ServiceBusReceivedMessageWithLock.deadLetter().
    */
   async deadLetter(propertiesToModify?: DeadLetterOptions & { [key: string]: any }): Promise<void> {
     log.message(

--- a/sdk/servicebus/service-bus/test/auth.spec.ts
+++ b/sdk/servicebus/service-bus/test/auth.spec.ts
@@ -6,7 +6,7 @@ import chai from "chai";
 import { parseConnectionString } from "rhea-promise";
 import { ServiceBusReceiver } from "../src/receivers/receiver";
 import { ServiceBusClient } from "../src/serviceBusClient";
-import { ReceivedMessage } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessage } from "../src/serviceBusMessage";
 import { getEnvVars } from "./utils/envVarUtils";
 import { TestClientType } from "./utils/testUtils";
 import {
@@ -60,7 +60,7 @@ type UnpackReturnType<T extends (...args: any) => any> = ReturnType<T> extends P
 
         await sender.close();
 
-        let receiver: ServiceBusReceiver<ReceivedMessage>;
+        let receiver: ServiceBusReceiver<ServiceBusReceivedMessage>;
 
         if (entities.queue) {
           receiver = client.createReceiver(entities.queue!, {

--- a/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
+++ b/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
@@ -15,7 +15,7 @@ import {
   getRandomTestClientTypeWithSessions,
   getRandomTestClientTypeWithNoSessions
 } from "./utils/testutils2";
-import { DispositionType, ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -27,8 +27,8 @@ describe("Message settlement After Receiver is Closed - Through ManagementLink",
   let serviceBusClient: ServiceBusClientForTests;
 
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let deadLetterReceiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let deadLetterReceiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   let entityNames: EntityName;
 
   before(() => {
@@ -54,7 +54,9 @@ describe("Message settlement After Receiver is Closed - Through ManagementLink",
     await serviceBusClient.test.afterEach();
   });
 
-  async function sendReceiveMsg(testMessages: ServiceBusMessage): Promise<ReceivedMessageWithLock> {
+  async function sendReceiveMsg(
+    testMessages: ServiceBusMessage
+  ): Promise<ServiceBusReceivedMessageWithLock> {
     await sender.sendMessages(testMessages);
     const msgs = await receiver.receiveMessages(1);
 

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -16,13 +16,13 @@ import {
 } from "./utils/testutils2";
 import { ServiceBusReceiver } from "../src/receivers/receiver";
 import { ServiceBusSender } from "../src/sender";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 describe("Deferred Messages", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let deadLetterReceiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let deadLetterReceiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
 
   let entityNames: EntityName;
   const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
@@ -61,7 +61,7 @@ describe("Deferred Messages", () => {
   async function deferMessage(
     testMessage: ServiceBusMessage,
     passSequenceNumberInArray: boolean
-  ): Promise<ReceivedMessageWithLock> {
+  ): Promise<ServiceBusReceivedMessageWithLock> {
     await sender.sendMessages(testMessage);
     const receivedMsgs = await receiver.receiveMessages(1);
 

--- a/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
@@ -4,7 +4,7 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Receiver, ReceiverEvents, ReceiverOptions } from "rhea-promise";
-import { ReceivedMessage, ReceivedMessageWithLock } from "../../src";
+import { ServiceBusReceivedMessage, ServiceBusReceivedMessageWithLock } from "../../src";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
@@ -212,7 +212,7 @@ describe("Receiver unit tests", () => {
     });
 
     async function subscribeAndWaitForInitialize<
-      T extends ReceivedMessage | ReceivedMessageWithLock
+      T extends ServiceBusReceivedMessage | ServiceBusReceivedMessageWithLock
     >(receiver: ServiceBusReceiverImpl<T>): Promise<ReturnType<typeof receiver["subscribe"]>> {
       const sub = await new Promise<{
         close(): Promise<void>;

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -9,7 +9,7 @@ chai.use(chaiAsPromised);
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import { ServiceBusClient, ServiceBusSessionReceiver } from "../src";
 
 describe("invalid parameters", () => {
@@ -25,7 +25,7 @@ describe("invalid parameters", () => {
 
   describe("Invalid parameters in SessionReceiver", function(): void {
     let sender: ServiceBusSender;
-    let receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+    let receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
 
     // Since, the below tests never actually make use of any AMQP links, there is no need to create
     // new sender/receiver clients before each test. Doing it once for each describe block.

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -3,7 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ReceivedMessageWithLock, ServiceBusSender, ServiceBusReceiver } from "../src";
+import { ServiceBusReceivedMessageWithLock, ServiceBusSender, ServiceBusReceiver } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 chai.should();
@@ -12,7 +12,7 @@ chai.use(chaiAsPromised);
 describe("ManagementClient - disconnects", function(): void {
   let serviceBusClient: ServiceBusClientForTests;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
 
   async function beforeEachTest(entityType: TestClientType): Promise<void> {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -6,13 +6,17 @@ const should = chai.should();
 
 import { createServiceBusClientForTests } from "./utils/testutils2";
 import { TestClientType, TestMessage } from "./utils/testUtils";
-import { ReceivedMessage, ReceivedMessageWithLock, ServiceBusReceiver } from "../src";
+import {
+  ServiceBusReceivedMessage,
+  ServiceBusReceivedMessageWithLock,
+  ServiceBusReceiver
+} from "../src";
 
 describe("dead lettering", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
-  let deadLetterReceiver: ServiceBusReceiver<ReceivedMessage>;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let receivedMessage: ReceivedMessageWithLock;
+  let deadLetterReceiver: ServiceBusReceiver<ServiceBusReceivedMessage>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let receivedMessage: ServiceBusReceivedMessageWithLock;
 
   before(() => {
     serviceBusClient = createServiceBusClientForTests();
@@ -166,8 +170,8 @@ describe("dead lettering", () => {
 
 describe("abandoning", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let receivedMessage: ReceivedMessageWithLock;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let receivedMessage: ServiceBusReceivedMessageWithLock;
 
   before(() => {
     serviceBusClient = createServiceBusClientForTests();
@@ -276,7 +280,7 @@ describe("abandoning", () => {
   });
 
   async function checkAbandonedMessage(
-    abandonedMessage: ReceivedMessageWithLock,
+    abandonedMessage: ServiceBusReceivedMessageWithLock,
     expected: { customProperty?: string }
   ) {
     should.exist(abandonedMessage);
@@ -289,8 +293,8 @@ describe("abandoning", () => {
 
 describe("deferring", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let receivedMessage: ReceivedMessageWithLock;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let receivedMessage: ServiceBusReceivedMessageWithLock;
 
   before(() => {
     serviceBusClient = createServiceBusClientForTests();

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -6,7 +6,7 @@ const should = chai.should();
 const expect = chai.expect;
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ReceivedMessage, ServiceBusMessage, ServiceBusReceiver } from "../src";
+import { ServiceBusReceivedMessage, ServiceBusMessage, ServiceBusReceiver } from "../src";
 
 import { TestClientType, TestMessage, checkWithTimeout } from "./utils/testUtils";
 
@@ -20,7 +20,7 @@ import {
   getRandomTestClientTypeWithSessions,
   getRandomTestClientTypeWithNoSessions
 } from "./utils/testutils2";
-import { DispositionType, ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 let errorWasThrown: boolean;
 const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
@@ -28,7 +28,7 @@ const withSessionTestClientType = getRandomTestClientTypeWithSessions();
 
 describe("receive and delete", () => {
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessage>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessage>;
   let serviceBusClient: ServiceBusClientForTests;
   let entityName: EntityName;
 
@@ -123,11 +123,11 @@ describe("receive and delete", () => {
       await sender.sendMessages(testMessages);
 
       const errors: string[] = [];
-      const receivedMsgs: ReceivedMessage[] = [];
+      const receivedMsgs: ServiceBusReceivedMessage[] = [];
 
       receiver.subscribe(
         {
-          async processMessage(message: ReceivedMessage): Promise<void> {
+          async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
             receivedMsgs.push(message);
           },
           async processError(err: Error): Promise<void> {
@@ -212,7 +212,9 @@ describe("receive and delete", () => {
       await afterEachTest();
     });
 
-    async function sendReceiveMsg(testMessages: ServiceBusMessage): Promise<ReceivedMessage> {
+    async function sendReceiveMsg(
+      testMessages: ServiceBusMessage
+    ): Promise<ServiceBusReceivedMessage> {
       await sender.sendMessages(testMessages);
       const msgs = await receiver.receiveMessages(1);
 
@@ -241,7 +243,7 @@ describe("receive and delete", () => {
         : TestMessage.getSample();
       // we have to force this cast - the type system doesn't allow this if you've chosen receiveAndDelete
       // as your lock mode.
-      const msg = (await sendReceiveMsg(testMessages)) as ReceivedMessageWithLock;
+      const msg = (await sendReceiveMsg(testMessages)) as ServiceBusReceivedMessageWithLock;
 
       try {
         if (operation === DispositionType.complete) {
@@ -307,7 +309,7 @@ describe("receive and delete", () => {
       const msg = await sendReceiveMsg(TestMessage.getSample());
 
       // have to cast it - the type system doesn't allow us to call into this method otherwise.
-      await (msg as ReceivedMessageWithLock).renewLock().catch((err) => {
+      await (msg as ServiceBusReceivedMessageWithLock).renewLock().catch((err) => {
         should.equal(
           err.message,
           getErrorMessageNotSupportedInReceiveAndDeleteMode("renew the lock on the message"),
@@ -352,11 +354,13 @@ describe("receive and delete", () => {
       );
       should.equal(msgs[0].deliveryCount, 0, "DeliveryCount is different than expected");
 
-      await (msgs[0] as ReceivedMessageWithLock).defer();
+      await (msgs[0] as ServiceBusReceivedMessageWithLock).defer();
       return msgs[0].sequenceNumber!;
     }
 
-    async function testDeferredMessage(testClientType: TestClientType): Promise<ReceivedMessage> {
+    async function testDeferredMessage(
+      testClientType: TestClientType
+    ): Promise<ServiceBusReceivedMessage> {
       const sequenceNumber = await deferMessage(testClientType);
       await receiver.close();
       receiver = await serviceBusClient.test.getReceiveAndDeleteReceiver(entityNames);
@@ -414,7 +418,9 @@ describe("receive and delete", () => {
 
     let entityNames: EntityName;
 
-    async function testDeferredMessage(testClientType: TestClientType): Promise<ReceivedMessage> {
+    async function testDeferredMessage(
+      testClientType: TestClientType
+    ): Promise<ServiceBusReceivedMessage> {
       entityNames = await beforeEachTest(testClientType, "peekLock");
 
       // send message
@@ -425,7 +431,7 @@ describe("receive and delete", () => {
 
       // receive and defer the message
       const [msg] = await receiver.receiveMessages(1);
-      await (msg as ReceivedMessageWithLock).defer();
+      await (msg as ServiceBusReceivedMessageWithLock).defer();
       const sequenceNumber = msg.sequenceNumber!;
       await receiver.close();
 
@@ -452,7 +458,7 @@ describe("receive and delete", () => {
       const deferredMsg = await testDeferredMessage(testClienttype);
       // we have to force this cast - the type system doesn't allow this if you've chosen receiveAndDelete
       // as your lock mode.
-      const msg = deferredMsg as ReceivedMessageWithLock;
+      const msg = deferredMsg as ServiceBusReceivedMessageWithLock;
 
       try {
         if (operation === DispositionType.complete) {
@@ -510,7 +516,7 @@ describe("receive and delete", () => {
       // as your lock mode.
 
       // have to cast it - the type system doesn't allow us to call into this method otherwise.
-      await (deferredMsg as ReceivedMessageWithLock).renewLock().catch((err) => {
+      await (deferredMsg as ServiceBusReceivedMessageWithLock).renewLock().catch((err) => {
         should.equal(
           err.message,
           getErrorMessageNotSupportedInReceiveAndDeleteMode("renew the lock on the message"),

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -14,12 +14,12 @@ import {
 } from "./utils/testutils2";
 import { ServiceBusReceiver } from "../src/receivers/receiver";
 import { ServiceBusSender } from "../src/sender";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 describe("Message Lock Renewal", () => {
   let serviceBusClient: ServiceBusClientForTests;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
 
   const testClientType = getRandomTestClientTypeWithNoSessions();
 
@@ -124,7 +124,7 @@ describe("Message Lock Renewal", () => {
    */
   async function testBatchReceiverManualLockRenewalHappyCase(
     sender: ServiceBusSender,
-    receiver: ServiceBusReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     const testMessage = TestMessage.getSample();
     await sender.sendMessages(testMessage);
@@ -172,7 +172,7 @@ describe("Message Lock Renewal", () => {
    */
   async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
     sender: ServiceBusSender,
-    receiver: ServiceBusReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     const testMessage = TestMessage.getSample();
     await sender.sendMessages(testMessage);
@@ -205,13 +205,15 @@ describe("Message Lock Renewal", () => {
    */
   async function testStreamingReceiverManualLockRenewalHappyCase(
     sender: ServiceBusSender,
-    receiver: ServiceBusReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     let numOfMessagesReceived = 0;
     const testMessage = TestMessage.getSample();
     await sender.sendMessages(testMessage);
 
-    async function processMessage(brokeredMessage: ReceivedMessageWithLock): Promise<void> {
+    async function processMessage(
+      brokeredMessage: ServiceBusReceivedMessageWithLock
+    ): Promise<void> {
       if (numOfMessagesReceived < 1) {
         numOfMessagesReceived++;
 
@@ -281,14 +283,16 @@ describe("Message Lock Renewal", () => {
 
   async function testAutoLockRenewalConfigBehavior(
     sender: ServiceBusSender,
-    receiver: ServiceBusReceiver<ReceivedMessageWithLock>,
+    receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>,
     options: AutoLockRenewalTestOptions
   ): Promise<void> {
     let numOfMessagesReceived = 0;
     const testMessage = TestMessage.getSample();
     await sender.sendMessages(testMessage);
 
-    async function processMessage(brokeredMessage: ReceivedMessageWithLock): Promise<void> {
+    async function processMessage(
+      brokeredMessage: ServiceBusReceivedMessageWithLock
+    ): Promise<void> {
       if (numOfMessagesReceived < 1) {
         numOfMessagesReceived++;
 

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -14,11 +14,11 @@ import {
 } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
 import { ServiceBusSessionReceiver } from "../src/receivers/sessionReceiver";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 describe("Session Lock Renewal", () => {
   let sender: ServiceBusSender;
-  let receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
   let sessionId: string;
 
   let serviceBusClient: ServiceBusClientForTests;
@@ -134,7 +134,7 @@ describe("Session Lock Renewal", () => {
    */
   async function testBatchReceiverManualLockRenewalHappyCase(
     sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     const testMessage = getTestMessage();
     testMessage.body = `testBatchReceiverManualLockRenewalHappyCase-${Date.now().toString()}`;
@@ -182,7 +182,7 @@ describe("Session Lock Renewal", () => {
   async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
     entityType: TestClientType,
     sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     const testMessage = getTestMessage();
     testMessage.body = `testBatchReceiverManualLockRenewalErrorOnLockExpiry-${Date.now().toString()}`;
@@ -221,14 +221,14 @@ describe("Session Lock Renewal", () => {
    */
   async function testStreamingReceiverManualLockRenewalHappyCase(
     sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>
+    receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>
   ): Promise<void> {
     let numOfMessagesReceived = 0;
     const testMessage = getTestMessage();
     testMessage.body = `testStreamingReceiverManualLockRenewalHappyCase-${Date.now().toString()}`;
     await sender.sendMessages(testMessage);
 
-    async function processMessage(brokeredMessage: ReceivedMessageWithLock) {
+    async function processMessage(brokeredMessage: ServiceBusReceivedMessageWithLock) {
       if (numOfMessagesReceived < 1) {
         numOfMessagesReceived++;
 
@@ -297,7 +297,7 @@ describe("Session Lock Renewal", () => {
 
   async function testAutoLockRenewalConfigBehavior(
     sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>,
+    receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>,
     options: AutoLockRenewalTestOptions
   ): Promise<void> {
     let numOfMessagesReceived = 0;
@@ -306,9 +306,11 @@ describe("Session Lock Renewal", () => {
     await sender.sendMessages(testMessage);
 
     let sessionLockLostErrorThrown = false;
-    const messagesReceived: ReceivedMessageWithLock[] = [];
+    const messagesReceived: ServiceBusReceivedMessageWithLock[] = [];
 
-    async function processMessage(brokeredMessage: ReceivedMessageWithLock): Promise<void> {
+    async function processMessage(
+      brokeredMessage: ServiceBusReceivedMessageWithLock
+    ): Promise<void> {
       if (numOfMessagesReceived < 1) {
         numOfMessagesReceived++;
 

--- a/sdk/servicebus/service-bus/test/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/retries.spec.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const should = chai.should();
-import { ReceivedMessageWithLock } from "../src";
+import { ServiceBusReceivedMessageWithLock } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 import { ServiceBusSender, ServiceBusSenderImpl } from "../src/sender";
@@ -22,8 +22,8 @@ import { ServiceBusReceiver, ServiceBusReceiverImpl } from "../src/receivers/rec
 describe("Retries - ManagementClient", () => {
   let sender: ServiceBusSender;
   let receiver:
-    | ServiceBusReceiver<ReceivedMessageWithLock>
-    | ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+    | ServiceBusReceiver<ServiceBusReceivedMessageWithLock>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
   let serviceBusClient: ServiceBusClientForTests;
   const defaultMaxRetries = 2;
   let numberOfTimesManagementClientInvoked: number;
@@ -144,11 +144,11 @@ describe("Retries - ManagementClient", () => {
   });
 
   describe("Session Receiver Retries", () => {
-    let sessionReceiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+    let sessionReceiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
     beforeEach(async () => {
       numberOfTimesManagementClientInvoked = 0;
       await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
-      sessionReceiver = receiver as ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+      sessionReceiver = receiver as ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
     });
     afterEach(async () => {
       await afterEachTest();
@@ -309,7 +309,7 @@ describe("Retries - MessageSender", () => {
 });
 
 describe("Retries - Receive methods", () => {
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   let serviceBusClient: ServiceBusClientForTests;
   const defaultMaxRetries = 2;
   let numberOfTimesTried: number;
@@ -346,7 +346,7 @@ describe("Retries - Receive methods", () => {
 
     if (receiver instanceof ServiceBusSessionReceiverImpl) {
       // Mocking `_messageSession.receiveMessages()` to throw the error and fail
-      (receiver as ServiceBusSessionReceiverImpl<ReceivedMessageWithLock>)[
+      (receiver as ServiceBusSessionReceiverImpl<ServiceBusReceivedMessageWithLock>)[
         "_messageSession"
       ].receiveMessages = fakeFunction;
     } else {
@@ -357,7 +357,7 @@ describe("Retries - Receive methods", () => {
       );
       batchingReceiver.isOpen = () => true;
       batchingReceiver.receive = fakeFunction;
-      (receiver as ServiceBusReceiverImpl<ReceivedMessageWithLock>)[
+      (receiver as ServiceBusReceiverImpl<ServiceBusReceivedMessageWithLock>)[
         "_batchingReceiver"
       ] = batchingReceiver;
     }
@@ -416,8 +416,8 @@ describe("Retries - Receive methods", () => {
 describe("Retries - onDetached", () => {
   let sender: ServiceBusSender;
   let receiver:
-    | ServiceBusReceiver<ReceivedMessageWithLock>
-    | ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+    | ServiceBusReceiver<ServiceBusReceivedMessageWithLock>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
   let serviceBusClient: ServiceBusClientForTests;
   const defaultMaxRetries = 2;
   let numberOfTimesOnDetachedInvoked: number;

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -19,7 +19,7 @@ import {
   getRandomTestClientType
 } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import { AbortController } from "@azure/abort-controller";
 
 const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
@@ -28,7 +28,7 @@ const anyRandomTestClientType = getRandomTestClientType();
 
 describe("Sender Tests", () => {
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   let serviceBusClient: ServiceBusClientForTests;
   let entityName: EntityName;
 
@@ -330,7 +330,7 @@ describe("Sender Tests", () => {
   });
 
   async function testReceivedMsgsLength(
-    receiver: ServiceBusReceiver<ReceivedMessageWithLock>,
+    receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>,
     expectedReceivedMsgsLength: number
   ): Promise<void> {
     const receivedMsgs = await receiver.receiveMessages(expectedReceivedMsgsLength + 1, {

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -8,7 +8,7 @@ import * as dotenv from "dotenv";
 import Long from "long";
 import { MessagingError, ServiceBusClient, ServiceBusSessionReceiver } from "../src";
 import { ServiceBusSender } from "../src/sender";
-import { DispositionType, ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import { getReceiverClosedErrorMsg, getSenderClosedErrorMsg } from "../src/util/errors";
 import { EnvVarNames, getEnvVars, isNode } from "../test/utils/envVarUtils";
 import { checkWithTimeout, isMessagingError, TestClientType, TestMessage } from "./utils/testUtils";
@@ -359,8 +359,8 @@ describe("Test ServiceBusClient with TokenCredentials", function(): void {
 describe("Errors after close()", function(): void {
   let sbClient: ServiceBusClientForTests;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusReceiver<ReceivedMessageWithLock>;
-  let receivedMessage: ReceivedMessageWithLock;
+  let receiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
+  let receivedMessage: ServiceBusReceivedMessageWithLock;
   let entityName: EntityName;
 
   afterEach(async () => {
@@ -579,7 +579,9 @@ describe("Errors after close()", function(): void {
    */
   async function testSessionReceiver(expectedErrorMsg: string): Promise<void> {
     await testReceiver(expectedErrorMsg);
-    const sessionReceiver = receiver as ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+    const sessionReceiver = receiver as ServiceBusSessionReceiver<
+      ServiceBusReceivedMessageWithLock
+    >;
 
     let errorPeek: string = "";
     await sessionReceiver.peekMessages(1).catch((err) => {

--- a/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
@@ -11,7 +11,7 @@ import {
 import { ServiceBusSender } from "../src/sender";
 import { ServiceBusMessage, ServiceBusSessionReceiver } from "../src";
 import { TestMessage } from "./utils/testUtils";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 const should = chai.should();
 
 // NOTE: these tests should be reworked, if possible. Since they need to be deterministic
@@ -23,7 +23,7 @@ const should = chai.should();
 describe("sessions tests -  requires completely clean entity for each test", () => {
   let serviceBusClient: ServiceBusClientForTests;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
 
   let testClientType = getRandomTestClientTypeWithSessions();
 

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -6,7 +6,7 @@ import Long from "long";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ReceivedMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, delay } from "../src";
 
 import { TestClientType, TestMessage, checkWithTimeout, isMessagingError } from "./utils/testUtils";
 import { ServiceBusSender } from "../src/sender";
@@ -18,7 +18,7 @@ import {
   testPeekMsgsLength,
   getRandomTestClientTypeWithSessions
 } from "./utils/testutils2";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import { AbortController } from "@azure/abort-controller";
 
 let unexpectedError: Error | undefined;
@@ -32,7 +32,7 @@ async function processError(err: Error): Promise<void> {
 describe("session tests", () => {
   let serviceBusClient: ServiceBusClientForTests;
   let sender: ServiceBusSender;
-  let receiver: ServiceBusSessionReceiver<ReceivedMessageWithLock>;
+  let receiver: ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>;
   let testClientType = getRandomTestClientTypeWithSessions();
 
   async function beforeEachTest(sessionId?: string): Promise<void> {
@@ -161,9 +161,9 @@ describe("session tests", () => {
       const testMessage = TestMessage.getSessionSample();
       await sender.sendMessages(testMessage);
 
-      let receivedMsgs: ReceivedMessage[] = [];
+      let receivedMsgs: ServiceBusReceivedMessage[] = [];
       receiver.subscribe({
-        async processMessage(msg: ReceivedMessage) {
+        async processMessage(msg: ServiceBusReceivedMessage) {
           receivedMsgs.push(msg);
           return Promise.resolve();
         },
@@ -181,7 +181,7 @@ describe("session tests", () => {
       receivedMsgs = [];
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             should.equal(msg.body, testMessage.body, "MessageBody is different than expected");
             should.equal(
               msg.messageId,

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ReceivedMessage, ServiceBusReceiver, ServiceBusMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, ServiceBusReceiver, ServiceBusMessage, delay } from "../src";
 import { TestClientType } from "./utils/testUtils";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { getEntityNameFromConnectionString } from "../src/constructorHelpers";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
-import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
@@ -53,7 +53,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessageWithLock): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessageWithLock): Promise<void> {
           await message.complete();
           receivedBodies.push(message.body);
         },
@@ -126,7 +126,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessage): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
         async processError(err: Error): Promise<void> {
@@ -208,7 +208,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessageWithLock): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessageWithLock): Promise<void> {
           await message.complete();
           receivedBodies.push(message.body);
         },
@@ -233,7 +233,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessage): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
         async processError(err: Error): Promise<void> {
@@ -346,7 +346,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessage): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
         async processError(err: Error): Promise<void> {
@@ -383,7 +383,7 @@ describe("Sample scenarios for track 2", () => {
       const receivedBodies: string[] = [];
 
       receiver.subscribe({
-        async processMessage(message: ReceivedMessage): Promise<void> {
+        async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
         async processError(err: Error): Promise<void> {
@@ -475,7 +475,7 @@ async function waitAndValidate(
   expectedMessage: string,
   receivedBodies: string[],
   errors: string[],
-  receiver: ServiceBusReceiver<ReceivedMessage>
+  receiver: ServiceBusReceiver<ServiceBusReceivedMessage>
 ): Promise<void> {
   const maxChecks = 20;
   let numChecks = 0;

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -3,10 +3,10 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ReceivedMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, delay } from "../src";
 import { getAlreadyReceivingErrorMsg } from "../src/util/errors";
 import { TestClientType, TestMessage, checkWithTimeout } from "./utils/testUtils";
-import { DispositionType, ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import {
   ServiceBusSessionReceiver,
   ServiceBusSessionReceiverImpl
@@ -28,9 +28,9 @@ chai.use(chaiAsPromised);
 describe("Streaming with sessions", () => {
   let sender: ServiceBusSender;
   let receiver:
-    | ServiceBusSessionReceiver<ReceivedMessageWithLock>
-    | ServiceBusSessionReceiver<ReceivedMessage>;
-  let deadLetterReceiver: ServiceBusReceiver<ReceivedMessageWithLock>;
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessage>;
+  let deadLetterReceiver: ServiceBusReceiver<ServiceBusReceivedMessageWithLock>;
   let errorWasThrown: boolean;
   let unexpectedError: Error | undefined;
   let serviceBusClient: ServiceBusClientForTests;
@@ -167,9 +167,9 @@ describe("Streaming with sessions", () => {
       const testMessage = TestMessage.getSessionSample();
       await sender.sendMessages(testMessage);
 
-      const receivedMsgs: ReceivedMessage[] = [];
+      const receivedMsgs: ServiceBusReceivedMessage[] = [];
       receiver.subscribe({
-        async processMessage(msg: ReceivedMessage) {
+        async processMessage(msg: ServiceBusReceivedMessage) {
           receivedMsgs.push(msg);
           should.equal(msg.body, testMessage.body, "MessageBody is different than expected");
           should.equal(
@@ -204,10 +204,10 @@ describe("Streaming with sessions", () => {
     > {
       const testMessage = TestMessage.getSessionSample();
       await sender.sendMessages(testMessage);
-      const receivedMsgs: ReceivedMessageWithLock[] = [];
+      const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             receivedMsgs.push(msg);
             should.equal(msg.body, testMessage.body, "MessageBody is different than expected");
             should.equal(
@@ -248,10 +248,10 @@ describe("Streaming with sessions", () => {
       const testMessage = TestMessage.getSessionSample();
       await sender.sendMessages(testMessage);
 
-      const receivedMsgs: ReceivedMessageWithLock[] = [];
+      const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             should.equal(msg.body, testMessage.body, "MessageBody is different than expected");
             should.equal(
               msg.messageId,
@@ -303,11 +303,11 @@ describe("Streaming with sessions", () => {
 
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             return msg.abandon().then(() => {
               abandonFlag = 1;
               if (
-                (receiver as ServiceBusSessionReceiverImpl<ReceivedMessageWithLock>)[
+                (receiver as ServiceBusSessionReceiverImpl<ServiceBusReceivedMessageWithLock>)[
                   "_isReceivingMessages"
                 ]()
               ) {
@@ -325,7 +325,7 @@ describe("Streaming with sessions", () => {
       should.equal(msgAbandonCheck, true, "Abandoning the message results in a failure");
 
       if (
-        (receiver as ServiceBusSessionReceiverImpl<ReceivedMessageWithLock>)[
+        (receiver as ServiceBusSessionReceiverImpl<ServiceBusReceivedMessageWithLock>)[
           "_isReceivingMessages"
         ]()
       ) {
@@ -344,7 +344,7 @@ describe("Streaming with sessions", () => {
         "MessageId is different than expected"
       );
       should.equal(receivedMsgs[0].deliveryCount, 1, "DeliveryCount is different than expected");
-      await (receivedMsgs[0] as ReceivedMessageWithLock).complete();
+      await (receivedMsgs[0] as ServiceBusReceivedMessageWithLock).complete();
       await testPeekMsgsLength(receiver, 0);
     }
     it("abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
@@ -376,7 +376,7 @@ describe("Streaming with sessions", () => {
       let sequenceNum: any = 0;
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             await msg.defer();
             sequenceNum = msg.sequenceNumber;
           },
@@ -407,7 +407,7 @@ describe("Streaming with sessions", () => {
       );
       should.equal(deferredMsg.deliveryCount, 1, "DeliveryCount is different than expected");
 
-      await (deferredMsg as ReceivedMessageWithLock).complete();
+      await (deferredMsg as ServiceBusReceivedMessageWithLock).complete();
       await testPeekMsgsLength(receiver, 0);
     }
     it("defer() moves message to deferred queue(with sessions)", async function(): Promise<void> {
@@ -437,7 +437,7 @@ describe("Streaming with sessions", () => {
       let msgCount = 0;
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             await msg.deadLetter();
             msgCount++;
           },
@@ -491,7 +491,7 @@ describe("Streaming with sessions", () => {
         TestMessage.sessionId
       );
       receiver.subscribe({
-        async processMessage(msg: ReceivedMessageWithLock) {
+        async processMessage(msg: ServiceBusReceivedMessageWithLock) {
           return msg.complete();
         },
         processError
@@ -561,9 +561,9 @@ describe("Streaming with sessions", () => {
         const testMessage = TestMessage.getSessionSample();
         await sender.sendMessages(testMessage);
 
-        const receivedMsgs: ReceivedMessageWithLock[] = [];
+        const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
         receiver.subscribe({
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             receivedMsgs.push(msg);
             return Promise.resolve();
           },
@@ -639,9 +639,9 @@ describe("Streaming with sessions", () => {
       await sender.sendMessages(testMessage);
       const errorMessage = "Will we see this error message?";
 
-      const receivedMsgs: ReceivedMessageWithLock[] = [];
+      const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
       receiver.subscribe({
-        async processMessage(msg: ReceivedMessageWithLock) {
+        async processMessage(msg: ServiceBusReceivedMessageWithLock) {
           await msg.complete();
           receivedMsgs.push(msg);
           throw new Error(errorMessage);
@@ -697,12 +697,12 @@ describe("Streaming with sessions", () => {
       }
       await sender.sendMessages(batchMessageToSend);
 
-      const settledMsgs: ReceivedMessageWithLock[] = [];
-      const receivedMsgs: ReceivedMessageWithLock[] = [];
+      const settledMsgs: ServiceBusReceivedMessageWithLock[] = [];
+      const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
 
       receiver.subscribe(
         {
-          async processMessage(msg: ReceivedMessageWithLock) {
+          async processMessage(msg: ServiceBusReceivedMessageWithLock) {
             if (receivedMsgs.length === 1) {
               if ((!maxConcurrentCalls || maxConcurrentCalls === 1) && settledMsgs.length === 0) {
                 throw new Error(
@@ -775,11 +775,11 @@ describe("Streaming with sessions", () => {
       }
       await sender.sendMessages(batch);
 
-      const receivedMsgs: ReceivedMessageWithLock[] = [];
+      const receivedMsgs: ServiceBusReceivedMessageWithLock[] = [];
 
       receiver.subscribe(
         {
-          async processMessage(brokeredMessage: ReceivedMessageWithLock) {
+          async processMessage(brokeredMessage: ServiceBusReceivedMessageWithLock) {
             receivedMsgs.push(brokeredMessage);
             await brokeredMessage.complete();
           },

--- a/sdk/servicebus/service-bus/test/utils/misc.ts
+++ b/sdk/servicebus/service-bus/test/utils/misc.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import { defaultLock } from "@azure/core-amqp";
-import { Delivery, ReceivedMessage } from "../../src";
+import { Delivery, ServiceBusReceivedMessage } from "../../src";
 import { LinkEntity } from "../../src/core/linkEntity";
 import { ServiceBusMessageImpl } from "../../src/serviceBusMessage";
 
 // some functions useful as we transition between interfaces and classes.
 
-export function getDeliveryProperty(message: ReceivedMessage): Delivery {
+export function getDeliveryProperty(message: ServiceBusReceivedMessage): Delivery {
   if (
     message &&
     (message as ServiceBusMessageImpl).delivery &&

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import chai from "chai";
-import { MessagingError, ReceivedMessage, ServiceBusMessage, delay } from "../../src";
+import { MessagingError, ServiceBusReceivedMessage, ServiceBusMessage, delay } from "../../src";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -60,7 +60,7 @@ export class TestMessage {
    */
   static checkMessageContents(
     sent: ServiceBusMessage,
-    received: ReceivedMessage,
+    received: ServiceBusReceivedMessage,
     useSessions?: boolean,
     usePartitions?: boolean
   ): void {

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -22,8 +22,8 @@ import {
 import { ServiceBusClientOptions } from "../../src";
 import chai from "chai";
 import {
-  ReceivedMessage,
-  ReceivedMessageWithLock,
+  ServiceBusReceivedMessage,
+  ServiceBusReceivedMessageWithLock,
   ServiceBusMessage
 } from "../../src/serviceBusMessage";
 
@@ -213,8 +213,10 @@ export class ServiceBusTestHelpers {
     useSessions: boolean,
     sentMessages: ServiceBusMessage[]
   ): Promise<void> {
-    let receiver: ServiceBusReceiver<ReceivedMessage> | ServiceBusSessionReceiver<ReceivedMessage>;
-    let receivedMsgs: ReceivedMessage[];
+    let receiver:
+      | ServiceBusReceiver<ServiceBusReceivedMessage>
+      | ServiceBusSessionReceiver<ServiceBusReceivedMessage>;
+    let receivedMsgs: ServiceBusReceivedMessage[];
     if (!useSessions) {
       receiver = await this.getReceiveAndDeleteReceiver({
         queue: entityNames.queue,
@@ -327,7 +329,7 @@ export class ServiceBusTestHelpers {
    */
   async getPeekLockReceiver(
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned">
-  ): Promise<ServiceBusReceiver<ReceivedMessageWithLock>> {
+  ): Promise<ServiceBusReceiver<ServiceBusReceivedMessageWithLock>> {
     try {
       // if you're creating a receiver this way then you'll just use the default
       // session ID for your receiver.
@@ -352,7 +354,7 @@ export class ServiceBusTestHelpers {
   async getSessionPeekLockReceiver(
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned">,
     getSessionReceiverOptions?: CreateSessionReceiverOptions<"peekLock">
-  ): Promise<ServiceBusSessionReceiver<ReceivedMessageWithLock>> {
+  ): Promise<ServiceBusSessionReceiver<ServiceBusReceivedMessageWithLock>> {
     if (!entityNames.usesSessions) {
       throw new TypeError(
         "Not a session-full entity - can't create a session receiver type for it"
@@ -384,7 +386,7 @@ export class ServiceBusTestHelpers {
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned"> & {
       sessionId?: string | undefined;
     }
-  ): Promise<ServiceBusReceiver<ReceivedMessage>> {
+  ): Promise<ServiceBusReceiver<ServiceBusReceivedMessage>> {
     // TODO: we should generate a random ID here - there's no harm in
     // creating as many sessions as we wish. Some tests will need to change.
     const sessionId = entityNames.sessionId ?? TestMessage.sessionId;
@@ -420,7 +422,7 @@ export class ServiceBusTestHelpers {
 
   createDeadLetterReceiver(
     entityNames: ReturnType<typeof getEntityNames>
-  ): ServiceBusReceiver<ReceivedMessageWithLock> {
+  ): ServiceBusReceiver<ServiceBusReceivedMessageWithLock> {
     return this.addToCleanup(
       entityNames.queue
         ? this._serviceBusClient.createReceiver(entityNames.queue, { subQueue: "deadLetter" })
@@ -447,11 +449,11 @@ async function purgeForTestClientType(
   testClientType: TestClientType
 ): Promise<void> {
   let receiver:
-    | ServiceBusReceiver<ReceivedMessage>
-    | ServiceBusSessionReceiver<ReceivedMessage>
+    | ServiceBusReceiver<ServiceBusReceivedMessage>
+    | ServiceBusSessionReceiver<ServiceBusReceivedMessage>
     | undefined;
   const entityPaths = getEntityNames(testClientType);
-  let deadLetterReceiver: ServiceBusReceiver<ReceivedMessage>;
+  let deadLetterReceiver: ServiceBusReceiver<ServiceBusReceivedMessage>;
 
   if (entityPaths.queue) {
     receiver = serviceBusClient.createReceiver(entityPaths.queue, "receiveAndDelete");
@@ -517,7 +519,7 @@ function connectionString() {
 }
 
 export async function testPeekMsgsLength(
-  peekableReceiver: ServiceBusReceiver<ReceivedMessage>,
+  peekableReceiver: ServiceBusReceiver<ServiceBusReceivedMessage>,
   expectedPeekLength: number
 ): Promise<void> {
   const peekedMsgs = await peekableReceiver.peekMessages(expectedPeekLength + 1);


### PR DESCRIPTION
Based on the suggestion in https://github.com/Azure/azure-sdk-for-js/issues/10802#issuecomment-683996165, this PR adds the `ServiceBus` prefix to the `ReceivedMessage` and `ReceivedMessageWithLock` interfaces.

This does make the names way too long, so we can use this opportunity to discuss how we want to move forward