### PR TITLE
[Tables] Change prerelease tag

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0-preview.1 (Unreleased)
+## 1.0.0-beta.1 (Unreleased)

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/data-tables",
-  "version": "1.0.0-preview.1",
+  "version": "1.0.0-beta.1",
   "description": "An isomorphic client library for the Azure Tables service.",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
We have decided to use `beta` instead of `preview` going forward. (ref: https://github.com/Azure/azure-sdk/blob/d8c70b795c0c364d29d3c66bfb0e9d3ce163acef/docs/policies/releases.md#package-versioning)

I think since we have not released any previous previews of this package, we can adopt the new term now, which looks like what is being done for some other new packages we are releasing this sprint.