### PR TITLE
Bump the template version for JS

### DIFF
--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release History
+## 1.0.9-beta.3 (Unreleased)
+
 
 ## 1.0.9-beta.2 (2020-09-04)
 - Testing release tag replacement

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
-## 1.0.9-beta.1 (2020-08-27)
+## 1.0.9-beta.2 (2020-09-04)
+- Testing release tag replacement
 
+## 1.0.9-beta.1 (2020-08-27)
 - Testing prerelease versioning changes
 
 ## 1.0.8 (Unreleased)

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.9-beta.1",
+  "version": "1.0.9-beta.2",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.9-beta.2",
+  "version": "1.0.9-beta.3",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Kick off the pipeline of template to test the release tag default setting. All passed, but release tag 1.0.9-beta.2 has been used. Bump to a new one to 1.0.9-beta.3.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=525026&view=results