### PR TITLE
[Tables] Tables serialization fixes

### DIFF
--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -200,6 +200,7 @@ export type ListTableEntitiesOptions = OperationOptions & {
 
 // @public
 export type ListTableItemsOptions = OperationOptions & {
+    queryOptions?: TableQueryOptions;
     requestId?: string;
     nextTableName?: string;
 };

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -447,13 +447,12 @@ export class TableClient {
         throw new Error("partitionKey and rowKey must be defined");
       }
 
-      const { queryOptions, etag = "*", ...upsertOptions } = updatedOptions || {};
+      const { queryOptions, ...upsertOptions } = updatedOptions || {};
       if (mode === "Merge") {
         return this.table.mergeEntity(this.tableName, entity.partitionKey, entity.rowKey, {
           tableEntityProperties: serialize(entity),
           queryOptions: this.convertQueryOptions(queryOptions || {}),
-          ...upsertOptions,
-          ifMatch: etag
+          ...upsertOptions
         });
       }
 
@@ -462,7 +461,6 @@ export class TableClient {
           tableEntityProperties: serialize(entity),
           queryOptions: this.convertQueryOptions(queryOptions || {}),
           ...upsertOptions,
-          ifMatch: etag
         });
       }
       throw new Error(`Unexpected value for update mode: ${mode}`);

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -215,6 +215,10 @@ export interface TableEntityQueryOptions {
  */
 export type ListTableItemsOptions = OperationOptions & {
   /**
+   * Query options group
+   */
+  queryOptions?: TableQueryOptions;
+  /**
    * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
    */
   requestId?: string;

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -28,7 +28,13 @@ type serializedType = {
 
 function serializePrimitive(value: any): serializedType {
   const serializedValue: serializedType = { value };
-  if (typeof value === "boolean" || typeof value === "string" || typeof value === "number") {
+  if (
+    value === undefined ||
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string" ||
+    typeof value === "number"
+  ) {
     serializedValue.value = value;
   } else if (value instanceof Date) {
     serializedValue.value = value;
@@ -67,7 +73,7 @@ function serializeObject(obj: { value: any; type: EdmTypes }): serializedType {
 }
 
 function getSerializedValue(value: any): serializedType {
-  if (typeof value === "object" && value.value && value.type) {
+  if (typeof value === "object" && value?.value && value?.type) {
     return serializeObject(value);
   } else {
     return serializePrimitive(value);

--- a/sdk/tables/data-tables/test/unit/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/unit/serialization.spec.ts
@@ -21,6 +21,8 @@ interface Entity {
   guidObjProp?: Edm<"Guid">;
   binProp?: Uint8Array;
   binObjProp?: Edm<"Binary">;
+  nullProp?: null;
+  undefinedProp?: undefined;
 }
 
 describe("Serializer", () => {
@@ -33,6 +35,15 @@ describe("Serializer", () => {
     assert.strictEqual(serialized.boolProp, boolValue);
     assert.strictEqual(serialized.boolObjProp, boolValue);
     assert.strictEqual(serialized["boolObjProp@odata.type"], "Edm.Boolean");
+  });
+
+  it("should serialize null and undefined values", () => {
+    const serialized: any = serialize({
+      nullProp: null,
+      undefinedProp: undefined
+    });
+    assert.strictEqual(serialized.nullProp, null);
+    assert.strictEqual(serialized.undefinedProp, undefined);
   });
 
   it("should serialize a String value", () => {
@@ -111,6 +122,15 @@ describe("Serializer", () => {
 });
 
 describe("Deserializer", () => {
+  it("should deserialize a null and undefined values", () => {
+    const deserialized: Entity = deserialize<Entity>({
+      nullProp: null,
+      undefinedProp: undefined
+    });
+    assert.strictEqual(deserialized.nullProp, null);
+    assert.strictEqual(deserialized.undefinedProp, undefined);
+  });
+
   it("should deserialize a Boolean value", () => {
     const boolValue = true;
     const deserialized: Entity = deserialize<Entity>({


### PR DESCRIPTION
Serializartion didn't play nice when trying to send entities with `null` or `undefined` properties.

This PR includes: 
- Fix so that serialization works with null and undefined properties.
- Adda missing `queryOptions` property for the `listTables` operation
- Remove ifMatch for upsert operation