### PR TITLE
Fixed iterator marker key in JavaScript sample

### DIFF
--- a/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
@@ -110,7 +110,7 @@ async function main() {
   }
   // Gets next marker
   console.log("\tContinuation");
-  let marker = response.value.continuationToken || response.value.nextMarker;
+  let marker = response.value.continuationToken;
   // Passing next marker as continuationToken
   iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
   response = await iterator.next();

--- a/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
@@ -110,7 +110,7 @@ async function main() {
   }
   // Gets next marker
   console.log("\tContinuation");
-  let marker = response.value.nextMarker;
+  let marker = response.value.continuationToken || response.value.nextMarker;
   // Passing next marker as continuationToken
   iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
   response = await iterator.next();

--- a/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
@@ -103,7 +103,7 @@ async function main() {
   }
   // Gets next marker
   console.log("\tContinuation");
-  let marker = response.value.nextMarker;
+  let marker = response.value.continuationToken;
   // Passing next marker as continuationToken
   iterator = blobServiceClient
     .listContainers()


### PR DESCRIPTION
Response returns "continuationToken" as opposed to "nextMarker"