### PR TITLE
Enable master link replacement feature for js

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -146,6 +146,11 @@ stages:
                         displayName: Set Documentation File Name
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml
                         parameters:
+                          SourceFolder: ${{parameters.ArtifactName}}
+                          TargetFolder: ${{artifact.safeName}}
+                          PackageName: ${{artifact.name}}-*.tgz
+                      - template: /eng/pipelines/templates/steps/stage-artifacts.yml
+                        parameters:
                           SourceFolder: ${{parameters.DocArtifact}}
                           TargetFolder: ${{artifact.safeName}}/${{parameters.DocArtifact}}
                           PackageName: $(Documentation.Zip).zip
@@ -159,6 +164,7 @@ stages:
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'javascript'
+                          ArtifactLocation: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
                           ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
 


### PR DESCRIPTION
This is a follow up step of master link replacement work.

Tested in template: 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=530882&view=logs&j=ef505d45-100b-5890-ec9f-7c3786c71051&t=8bcf9df7-7eb7-51ec-7060-817ed374a684

Retrieved release tag successfully:
![image](https://user-images.githubusercontent.com/48036328/92666573-75115680-f2be-11ea-9eb7-201516d416f9.png)
