### PR TITLE
[Service Bus] Fix MaxListenersExceededWarning by avoiding adding too many listeners

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -325,7 +325,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     );
 
     try {
-      await this._init(sendRequestOptions?.abortSignal);
+      if (!this.isOpen()) {
+        await this._init(sendRequestOptions?.abortSignal);
+      }
     } finally {
       clearTimeout(waitTimer);
     }


### PR DESCRIPTION
### Issue #11154 

### Cause
The listeners for sender_error, receiver_error were added when the management link is initialized.
`managementClient._init` is being called for each of the management requests irrespective of the link being active/inactive.
As a result, listeners are being added for each request without cleaning up the older ones and hence blowing up the max limit (10).

### Fix
The fix in this PR is to call the _init only if the link is not open. This prevents from adding too many listeners.
(This I feel is the missing part from the refactoring at https://github.com/Azure/azure-sdk-for-js/pull/10807)