### PR TITLE
[Core-http] Support xml namespaces

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -17,33 +17,19 @@ import { TransferProgressEvent } from '@azure/core-https';
 
 // @public (undocumented)
 export interface BaseMapper {
-    // (undocumented)
     constraints?: MapperConstraints;
-    // (undocumented)
     defaultValue?: any;
-    // (undocumented)
     isConstant?: boolean;
-    // (undocumented)
     nullable?: boolean;
-    // (undocumented)
     readOnly?: boolean;
-    // (undocumented)
     required?: boolean;
-    // (undocumented)
     serializedName?: string;
-    // (undocumented)
     type: MapperType;
-    // (undocumented)
     xmlElementName?: string;
-    // (undocumented)
     xmlIsAttribute?: boolean;
-    // (undocumented)
     xmlIsWrapped?: boolean;
-    // (undocumented)
     xmlName?: string;
-    // (undocumented)
     xmlNamespace?: string;
-    // (undocumented)
     xmlNamespacePrefix?: string;
 }
 

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -41,6 +41,10 @@ export interface BaseMapper {
     xmlIsWrapped?: boolean;
     // (undocumented)
     xmlName?: string;
+    // (undocumented)
+    xmlNamespace?: string;
+    // (undocumented)
+    xmlNamespacePrefix?: string;
 }
 
 // @public (undocumented)

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -375,17 +375,61 @@ export interface EnumMapperType {
 }
 
 export interface BaseMapper {
+  /**
+   * Name for the xml element
+   */
   xmlName?: string;
+  /**
+   * Xml element namespace
+   */
+  xmlNamespace?: string;
+  /**
+   * Xml element namespace prefix
+   */
+  xmlNamespacePrefix?: string;
+  /**
+   * Determines if the current property should be serialized as an attribute of the parent xml element
+   */
   xmlIsAttribute?: boolean;
+  /**
+   * Name for the xml elements when serializing an array
+   */
   xmlElementName?: string;
+  /**
+   * Whether or not the current propery should have a wrapping XML element
+   */
   xmlIsWrapped?: boolean;
+  /**
+   * Whether or not the current propery is readonly
+   */
   readOnly?: boolean;
+  /**
+   * Whether or not the current propery is a constant
+   */
   isConstant?: boolean;
+  /**
+   * Whether or not the current propery is required
+   */
   required?: boolean;
+  /**
+   * Whether or not the current propery allows mull as a value
+   */
   nullable?: boolean;
+  /**
+   * The name to use when serializing
+   */
   serializedName?: string;
+  /**
+   * Type of the mapper
+   */
   type: MapperType;
+  /**
+   * Default value when one is not explicitly provided
+   */
   defaultValue?: any;
+  /**
+   * Constraints to test the current value against
+   */
   constraints?: MapperConstraints;
 }
 

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -521,14 +521,12 @@ function serializeSequenceType(
         : "xmlns";
       if (elementType.type.name === "Composite") {
         tempArray[i] = { ...serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
-        continue;
       } else {
         tempArray[i] = { _: serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
-        continue;
       }
+    } else {
+      tempArray[i] = serializedValue;
     }
-
-    tempArray[i] = serializedValue;
   }
   return tempArray;
 }
@@ -561,16 +559,14 @@ function serializeDictionaryType(
       // If the value is an object the object's properties need to be siblings of the $ property
       if (valueType.type.name === "Composite") {
         tempDictionary[key] = { ...serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-        continue;
       } else {
         // When the value is not an object, it has to go under _
         tempDictionary[key] = { _: serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-        continue;
       }
+    } else {
+      // Add the serialized value when we are not serializing XML or it doesn't need a namespace
+      tempDictionary[key] = serializedValue;
     }
-
-    // Just add the value when we are not serializing XML or it doesn't need a namespace
-    tempDictionary[key] = serializedValue;
   }
 
   // Add the namespace to the root element if needed

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -153,11 +153,29 @@ class SerializerImpl implements Serializer {
       } else if (mapperType.match(/^Base64Url$/i) !== null) {
         payload = serializeBase64UrlType(objectName, object);
       } else if (mapperType.match(/^Sequence$/i) !== null) {
-        payload = serializeSequenceType(this, mapper as SequenceMapper, object, objectName);
+        payload = serializeSequenceType(
+          this,
+          mapper as SequenceMapper,
+          object,
+          objectName,
+          Boolean(this.isXML)
+        );
       } else if (mapperType.match(/^Dictionary$/i) !== null) {
-        payload = serializeDictionaryType(this, mapper as DictionaryMapper, object, objectName);
+        payload = serializeDictionaryType(
+          this,
+          mapper as DictionaryMapper,
+          object,
+          objectName,
+          Boolean(this.isXML)
+        );
       } else if (mapperType.match(/^Composite$/i) !== null) {
-        payload = serializeCompositeType(this, mapper as CompositeMapper, object, objectName);
+        payload = serializeCompositeType(
+          this,
+          mapper as CompositeMapper,
+          object,
+          objectName,
+          Boolean(this.isXML)
+        );
       }
     }
     return payload;
@@ -481,7 +499,8 @@ function serializeSequenceType(
   serializer: Serializer,
   mapper: SequenceMapper,
   object: any,
-  objectName: string
+  objectName: string,
+  isXml: boolean
 ): any {
   if (!Array.isArray(object)) {
     throw new Error(`${objectName} must be of type Array.`);
@@ -495,7 +514,21 @@ function serializeSequenceType(
   }
   const tempArray = [];
   for (let i = 0; i < object.length; i++) {
-    tempArray[i] = serializer.serialize(elementType, object[i], objectName);
+    const serializedValue = serializer.serialize(elementType, object[i], objectName);
+    if (isXml && elementType.xmlNamespace) {
+      const xmlnsKey = elementType.xmlNamespacePrefix
+        ? `xmlns:${elementType.xmlNamespacePrefix}`
+        : "xmlns";
+      if (elementType.type.name === "Composite") {
+        tempArray[i] = { ...serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
+        continue;
+      } else {
+        tempArray[i] = { _: serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
+        continue;
+      }
+    }
+
+    tempArray[i] = serializedValue;
   }
   return tempArray;
 }
@@ -504,7 +537,8 @@ function serializeDictionaryType(
   serializer: Serializer,
   mapper: DictionaryMapper,
   object: any,
-  objectName: string
+  objectName: string,
+  isXml: boolean
 ): any {
   if (typeof object !== "object") {
     throw new Error(`${objectName} must be of type object.`);
@@ -518,8 +552,34 @@ function serializeDictionaryType(
   }
   const tempDictionary: { [key: string]: any } = {};
   for (const key of Object.keys(object)) {
-    tempDictionary[key] = serializer.serialize(valueType, object[key], objectName + "." + key);
+    const serializedValue = serializer.serialize(valueType, object[key], objectName);
+    // If the element needs an XML namespace we need to add it within the $ property
+    if (isXml && valueType.xmlNamespace) {
+      const xmlnsKey = valueType.xmlNamespacePrefix
+        ? `xmlns:${valueType.xmlNamespacePrefix}`
+        : "xmlns";
+      // If the value is an object the object's properties need to be siblings of the $ property
+      if (valueType.type.name === "Composite") {
+        tempDictionary[key] = { ...serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
+        continue;
+      } else {
+        // When the value is not an object, it has to go under _
+        tempDictionary[key] = { _: serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
+        continue;
+      }
+    }
+
+    // Just add the value when we are not serializing XML or it doesn't need a namespace
+    tempDictionary[key] = serializedValue;
   }
+
+  // Add the namespace to the root element if needed
+  if (isXml && mapper.xmlNamespace) {
+    const xmlnsKey = mapper.xmlNamespacePrefix ? `xmlns:${mapper.xmlNamespacePrefix}` : "xmlns";
+
+    return { ...tempDictionary, $: { [xmlnsKey]: mapper.xmlNamespace } };
+  }
+
   return tempDictionary;
 }
 
@@ -568,7 +628,8 @@ function serializeCompositeType(
   serializer: Serializer,
   mapper: CompositeMapper,
   object: any,
-  objectName: string
+  objectName: string,
+  isXml: boolean
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, object, "clientName");
@@ -609,6 +670,12 @@ function serializeCompositeType(
       }
 
       if (parentObject !== undefined && parentObject !== null) {
+        if (isXml && mapper.xmlNamespace) {
+          const xmlnsKey = mapper.xmlNamespacePrefix
+            ? `xmlns:${mapper.xmlNamespacePrefix}`
+            : "xmlns";
+          parentObject.$ = { ...parentObject.$, [xmlnsKey]: mapper.xmlNamespace };
+        }
         const propertyObjectName =
           propertyMapper.serializedName !== ""
             ? objectName + "." + propertyMapper.serializedName
@@ -630,16 +697,17 @@ function serializeCompositeType(
           propertyObjectName
         );
         if (serializedValue !== undefined && propName !== undefined && propName !== null) {
-          if (propertyMapper.xmlIsAttribute) {
+          const value = getXmlObjectValue(propertyMapper, serializedValue, isXml);
+          if (isXml && propertyMapper.xmlIsAttribute) {
             // $ is the key attributes are kept under in xml2js.
             // This keeps things simple while preventing name collision
             // with names in user documents.
             parentObject.$ = parentObject.$ || {};
             parentObject.$[propName] = serializedValue;
-          } else if (propertyMapper.xmlIsWrapped) {
-            parentObject[propName] = { [propertyMapper.xmlElementName!]: serializedValue };
+          } else if (isXml && propertyMapper.xmlIsWrapped) {
+            parentObject[propName] = { [propertyMapper.xmlElementName!]: value };
           } else {
-            parentObject[propName] = serializedValue;
+            parentObject[propName] = value;
           }
         }
       }
@@ -663,6 +731,22 @@ function serializeCompositeType(
     return payload;
   }
   return object;
+}
+
+function getXmlObjectValue(propertyMapper: Mapper, serializedValue: any, isXml: boolean) {
+  if (!isXml || !propertyMapper.xmlNamespace) {
+    return serializedValue;
+  }
+
+  const xmlnsKey = propertyMapper.xmlNamespacePrefix
+    ? `xmlns:${propertyMapper.xmlNamespacePrefix}`
+    : "xmlns";
+  const xmlNamespace = { [xmlnsKey]: propertyMapper.xmlNamespace };
+
+  if (["Composite"].includes(propertyMapper.type.name)) {
+    return { $: xmlNamespace, ...serializedValue };
+  }
+  return { _: serializedValue, $: xmlNamespace };
 }
 
 function isSpecialXmlProperty(propertyName: string): boolean {

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -552,21 +552,7 @@ function serializeDictionaryType(
   for (const key of Object.keys(object)) {
     const serializedValue = serializer.serialize(valueType, object[key], objectName);
     // If the element needs an XML namespace we need to add it within the $ property
-    if (isXml && valueType.xmlNamespace) {
-      const xmlnsKey = valueType.xmlNamespacePrefix
-        ? `xmlns:${valueType.xmlNamespacePrefix}`
-        : "xmlns";
-      // If the value is an object the object's properties need to be siblings of the $ property
-      if (valueType.type.name === "Composite") {
-        tempDictionary[key] = { ...serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-      } else {
-        // When the value is not an object, it has to go under _
-        tempDictionary[key] = { _: serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-      }
-    } else {
-      // Add the serialized value when we are not serializing XML or it doesn't need a namespace
-      tempDictionary[key] = serializedValue;
-    }
+    tempDictionary[key] = getXmlObjectValue(valueType, serializedValue, isXml);
   }
 
   // Add the namespace to the root element if needed

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -247,6 +247,8 @@ describe("ServiceClient", function() {
             parameterPath: "bodyArg",
             mapper: {
               required: true,
+              xmlNamespace: "https://example.com",
+              xmlNamespacePrefix: "foo",
               serializedName: "bodyArg",
               type: {
                 name: "String"
@@ -505,6 +507,7 @@ describe("ServiceClient", function() {
             parameterPath: "bodyArg",
             mapper: {
               required: true,
+              xmlNamespace: "https://microsoft.com",
               serializedName: "bodyArg",
               type: {
                 name: MapperTypeNames.Stream

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -25,6 +25,7 @@ import { stringifyXML } from "@azure/core-xml";
 import { serializeRequestBody } from "../src/serviceClient";
 import { getOperationArgumentValueFromParameter } from "../src/operationHelpers";
 import { deserializationPolicy } from "../src/deserializationPolicy";
+import { Mappers } from "./testMappers";
 
 describe("ServiceClient", function() {
   it("should serialize headerCollectionPrefix", async function() {
@@ -189,7 +190,7 @@ describe("ServiceClient", function() {
           200: {
             bodyMapper: {
               type: {
-                name: "Sequence",
+                name: MapperTypeNames.Sequence,
                 element: {
                   type: {
                     name: "Number"
@@ -233,6 +234,32 @@ describe("ServiceClient", function() {
       assert.strictEqual(httpRequest.body, `"body value"`);
     });
 
+    it("should serialize a JSON String request body with namespace, ignoring namespace", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: "String"
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, `"body value"`);
+    });
+
     it("should serialize a JSON ByteArray request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(
@@ -259,6 +286,34 @@ describe("ServiceClient", function() {
       assert.strictEqual(httpRequest.body, `"SmF2YXNjcmlwdA=="`);
     });
 
+    it("should serialize a JSON ByteArray request body, ignoring xml properties", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: stringToByteArray("Javascript")
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              xmlNamespace: "https://microsoft.com",
+              xmlNamespacePrefix: "test",
+              serializedName: "bodyArg",
+              type: {
+                name: MapperTypeNames.ByteArray
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, `"SmF2YXNjcmlwdA=="`);
+    });
+
     it("should serialize a JSON Stream request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(
@@ -272,6 +327,35 @@ describe("ServiceClient", function() {
             parameterPath: "bodyArg",
             mapper: {
               required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperTypeNames.Stream
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        },
+        stringifyXML
+      );
+      assert.strictEqual(httpRequest.body, "body value");
+    });
+
+    it("should serialize a JSON Stream request body", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              xmlNamespace: "http://microsoft.com",
+              xmlNamespacePrefix: "test",
               serializedName: "bodyArg",
               type: {
                 name: MapperTypeNames.Stream
@@ -317,6 +401,38 @@ describe("ServiceClient", function() {
       );
     });
 
+    it("should serialize an XML String request body, with namespace", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              type: {
+                name: MapperTypeNames.String
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com">body value</bodyArg>`
+      );
+    });
+
     it("should serialize an XML ByteArray request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(
@@ -337,7 +453,7 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: createSerializer(),
+          serializer: createSerializer(undefined, true /** isXML */),
           isXML: true
         },
         stringifyXML
@@ -368,12 +484,425 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: createSerializer(),
+          serializer: createSerializer(undefined, true /** isXML */),
           isXML: true
         },
         stringifyXML
       );
       assert.strictEqual(httpRequest.body, "body value");
+    });
+
+    it("should serialize an XML Stream request body, with namespace", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperTypeNames.Stream
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(httpRequest.body, "body value");
+    });
+
+    it("should serialize an XML ByteArray request body with namespace and prefix", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: stringToByteArray("Javascript")
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              xmlNamespace: "https://microsoft.com",
+              xmlNamespacePrefix: "sample",
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperTypeNames.ByteArray
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns:sample="https://microsoft.com">SmF2YXNjcmlwdA==</bodyArg>`
+      );
+    });
+
+    it("should serialize an XML Composite request body", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          requestBody: {
+            updated: new Date("2020-08-12T23:36:18.308Z"),
+            content: { type: "application/xml", queueDescription: { maxDeliveryCount: 15 } }
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: Mappers.requestBody1,
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><entry xmlns="http://www.w3.org/2005/Atom"><updated xmlns="http://www.w3.org/2005/Atom">2020-08-12T23:36:18.308Z</updated><content xmlns="http://www.w3.org/2005/Atom" type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"><MaxDeliveryCount xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">15</MaxDeliveryCount></QueueDescription></content></entry>`
+      );
+    });
+
+    it("should serialize a JSON Composite request body, ignoring XML metadata", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          requestBody: {
+            updated: new Date("2020-08-12T23:36:18.308Z"),
+            content: { type: "application/xml", queueDescription: { maxDeliveryCount: 15 } }
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: Mappers.requestBody1,
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+
+      assert.deepEqual(
+        httpRequest.body,
+        '{"updated":"2020-08-12T23:36:18.308Z","content":{"type":"application/xml","queueDescription":{"maxDeliveryCount":15}}}'
+      );
+    });
+
+    it("should serialize an XML Array request body with namespace and prefix", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: ["Foo", "Bar"]
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              xmlElementName: "testItem",
+              type: {
+                name: MapperTypeNames.Sequence,
+                element: {
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: { name: "String" }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><testItem xmlns="https://microsoft.com/element">Foo</testItem><testItem xmlns="https://microsoft.com/element">Bar</testItem></bodyArg>`
+      );
+    });
+
+    it("should serialize a JSON Array request body, ignoring XML metadata", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: ["Foo", "Bar"]
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              xmlElementName: "testItem",
+              type: {
+                name: MapperTypeNames.Sequence,
+                element: {
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: { name: "String" }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+      assert.deepEqual(httpRequest.body, JSON.stringify(["Foo", "Bar"]));
+    });
+
+    it("should serialize an XML Array of composite elements, namespace and prefix", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: [
+            { foo: "Foo1", bar: "Bar1" },
+            { foo: "Foo2", bar: "Bar2" },
+            { foo: "Foo3", bar: "Bar3" }
+          ]
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              xmlElementName: "testItem",
+              type: {
+                name: MapperTypeNames.Sequence,
+                element: {
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: {
+                    name: "Composite",
+                    modelProperties: {
+                      foo: {
+                        serializedName: "foo",
+                        xmlNamespace: "https://microsoft.com/foo",
+                        xmlName: "Foo",
+                        type: {
+                          name: "String"
+                        }
+                      },
+                      bar: {
+                        xmlNamespacePrefix: "bar",
+                        xmlNamespace: "https://microsoft.com/bar",
+                        xmlName: "Bar",
+                        serializedName: "bar",
+                        type: {
+                          name: "String"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><testItem xmlns="https://microsoft.com/element"><Foo xmlns="https://microsoft.com/foo">Foo1</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar1</Bar></testItem><testItem xmlns="https://microsoft.com/element"><Foo xmlns="https://microsoft.com/foo">Foo2</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar2</Bar></testItem><testItem xmlns="https://microsoft.com/element"><Foo xmlns="https://microsoft.com/foo">Foo3</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar3</Bar></testItem></bodyArg>`
+      );
+    });
+
+    it("should serialize an XML Composite request body with namespace and prefix", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          bodyArg: { foo: "Foo", bar: "Bar" }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              type: {
+                name: MapperTypeNames.Composite,
+                modelProperties: {
+                  foo: {
+                    serializedName: "foo",
+                    xmlNamespace: "https://microsoft.com/foo",
+                    xmlName: "Foo",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  bar: {
+                    xmlNamespacePrefix: "bar",
+                    xmlNamespace: "https://microsoft.com/bar",
+                    xmlName: "Bar",
+                    serializedName: "bar",
+                    type: {
+                      name: "String"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><Foo xmlns="https://microsoft.com/foo">Foo</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar></bodyArg>`
+      );
+    });
+
+    it("should serialize an XML Dictionary request body", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata><alpha>hello</alpha><beta>world</beta></metadata>`
+      );
+    });
+
+    it("should serialize an XML Dictionary request body, with namespace and prefix", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              xmlNamespacePrefix: "sample",
+              xmlNamespace: "https://microsoft.com",
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  xmlNamespacePrefix: "el",
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer(undefined, true /** isXML */),
+          isXML: true
+        },
+        stringifyXML
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns:sample="https://microsoft.com"><alpha xmlns:el="https://microsoft.com/element">hello</alpha><beta xmlns:el="https://microsoft.com/element">world</beta></metadata>`
+      );
+    });
+
+    it("should serialize a JSON Dictionary request body, ignoring xml metadata", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              xmlNamespacePrefix: "sample",
+              xmlNamespace: "https://microsoft.com",
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  xmlNamespacePrefix: "el",
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        },
+        stringifyXML
+      );
+      assert.deepEqual(httpRequest.body, `{"alpha":"hello","beta":"world"}`);
     });
 
     it("should serialize a string send to a text/plain endpoint as just a string", () => {

--- a/sdk/core/core-client/test/testMappers.ts
+++ b/sdk/core/core-client/test/testMappers.ts
@@ -1,5 +1,268 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+import { CompositeMapper } from "../src/interfaces";
+
+const QueueDescription: CompositeMapper = {
+  serializedName: "QueueDescription",
+  xmlName: "QueueDescription",
+  xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+  type: {
+    name: "Composite",
+    className: "QueueDescription",
+    modelProperties: {
+      lockDuration: {
+        serializedName: "lockDuration",
+        xmlName: "LockDuration",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      maxSizeInMegabytes: {
+        serializedName: "maxSizeInMegabytes",
+        xmlName: "MaxSizeInMegabytes",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      requiresDuplicateDetection: {
+        serializedName: "requiresDuplicateDetection",
+        xmlName: "RequiresDuplicateDetection",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      requiresSession: {
+        serializedName: "requiresSession",
+        xmlName: "RequiresSession",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      defaultMessageTimeToLive: {
+        serializedName: "defaultMessageTimeToLive",
+        xmlName: "DefaultMessageTimeToLive",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      deadLetteringOnMessageExpiration: {
+        serializedName: "deadLetteringOnMessageExpiration",
+        xmlName: "DeadLetteringOnMessageExpiration",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      duplicateDetectionHistoryTimeWindow: {
+        serializedName: "duplicateDetectionHistoryTimeWindow",
+        xmlName: "DuplicateDetectionHistoryTimeWindow",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      maxDeliveryCount: {
+        serializedName: "maxDeliveryCount",
+        xmlName: "MaxDeliveryCount",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      enableBatchedOperations: {
+        serializedName: "enableBatchedOperations",
+        xmlName: "EnableBatchedOperations",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      sizeInBytes: {
+        serializedName: "sizeInBytes",
+        xmlName: "SizeInBytes",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      messageCount: {
+        serializedName: "messageCount",
+        xmlName: "MessageCount",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      isAnonymousAccessible: {
+        serializedName: "isAnonymousAccessible",
+        xmlName: "IsAnonymousAccessible",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      status: {
+        serializedName: "status",
+        xmlName: "Status",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      forwardTo: {
+        serializedName: "forwardTo",
+        xmlName: "ForwardTo",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      userMetadata: {
+        serializedName: "userMetadata",
+        xmlName: "UserMetadata",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      createdAt: {
+        serializedName: "createdAt",
+        xmlName: "CreatedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      updatedAt: {
+        serializedName: "updatedAt",
+        xmlName: "UpdatedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      accessedAt: {
+        serializedName: "accessedAt",
+        xmlName: "AccessedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      supportOrdering: {
+        serializedName: "supportOrdering",
+        xmlName: "SupportOrdering",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      autoDeleteOnIdle: {
+        serializedName: "autoDeleteOnIdle",
+        xmlName: "AutoDeleteOnIdle",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      enablePartitioning: {
+        serializedName: "enablePartitioning",
+        xmlName: "EnablePartitioning",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      entityAvailabilityStatus: {
+        serializedName: "entityAvailabilityStatus",
+        xmlName: "EntityAvailabilityStatus",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      enableExpress: {
+        serializedName: "enableExpress",
+        xmlName: "EnableExpress",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      forwardDeadLetteredMessagesTo: {
+        serializedName: "forwardDeadLetteredMessagesTo",
+        xmlName: "ForwardDeadLetteredMessagesTo",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+const CreateQueueBodyContent: CompositeMapper = {
+  serializedName: "CreateQueueBodyContent",
+  xmlNamespace: "http://www.w3.org/2005/Atom",
+  type: {
+    name: "Composite",
+    className: "CreateQueueBodyContent",
+    modelProperties: {
+      type: {
+        defaultValue: "application/xml",
+        serializedName: "type",
+        xmlName: "type",
+        xmlIsAttribute: true,
+        type: {
+          name: "String"
+        }
+      },
+      queueDescription: {
+        serializedName: "queueDescription",
+        xmlName: "QueueDescription",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          ...QueueDescription.type
+        }
+      }
+    }
+  }
+};
+
+const CreateQueueBody: CompositeMapper = {
+  serializedName: "CreateQueueBody",
+  xmlName: "entry",
+  xmlNamespace: "http://www.w3.org/2005/Atom",
+  type: {
+    name: "Composite",
+    className: "CreateQueueBody",
+    modelProperties: {
+      updated: {
+        serializedName: "updated",
+        xmlName: "updated",
+        xmlNamespace: "http://www.w3.org/2005/Atom",
+        type: {
+          name: "DateTime"
+        }
+      },
+      content: {
+        serializedName: "content",
+        xmlName: "content",
+        xmlNamespace: "http://www.w3.org/2005/Atom",
+        type: {
+          ...CreateQueueBodyContent.type
+        }
+      }
+    }
+  }
+};
+
 const internalMappers: any = {};
 
 internalMappers.SimpleProduct = {
@@ -748,6 +1011,11 @@ internalMappers.discriminators = {
   Pet: internalMappers.Pet,
   "Pet.Cat": internalMappers.Cat,
   "Pet.Dog": internalMappers.Dog
+};
+
+internalMappers.requestBody1 = {
+  parameterPath: "requestBody",
+  mapper: CreateQueueBody
 };
 
 export const Mappers = internalMappers;

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -54,33 +54,19 @@ export type Authenticator = (challenge: object) => Promise<string>;
 
 // @public (undocumented)
 export interface BaseMapper {
-    // (undocumented)
     constraints?: MapperConstraints;
-    // (undocumented)
     defaultValue?: any;
-    // (undocumented)
     isConstant?: boolean;
-    // (undocumented)
     nullable?: boolean;
-    // (undocumented)
     readOnly?: boolean;
-    // (undocumented)
     required?: boolean;
-    // (undocumented)
     serializedName?: string;
-    // (undocumented)
     type: MapperType;
-    // (undocumented)
     xmlElementName?: string;
-    // (undocumented)
     xmlIsAttribute?: boolean;
-    // (undocumented)
     xmlIsWrapped?: boolean;
-    // (undocumented)
     xmlName?: string;
-    // (undocumented)
     xmlNamespace?: string;
-    // (undocumented)
     xmlNamespacePrefix?: string;
 }
 

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -78,6 +78,10 @@ export interface BaseMapper {
     xmlIsWrapped?: boolean;
     // (undocumented)
     xmlName?: string;
+    // (undocumented)
+    xmlNamespace?: string;
+    // (undocumented)
+    xmlNamespacePrefix?: string;
 }
 
 // @public (undocumented)

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -594,7 +594,7 @@ function serializeCompositeType(
           const xmlnsKey = mapper.xmlNamespacePrefix
             ? `xmlns:${mapper.xmlNamespacePrefix}`
             : "xmlns";
-          parentObject.$ = { [xmlnsKey]: mapper.xmlNamespace };
+          parentObject.$ = { ...parentObject.$, [xmlnsKey]: mapper.xmlNamespace };
         }
         const propertyObjectName =
           propertyMapper.serializedName !== ""
@@ -616,14 +616,9 @@ function serializeCompositeType(
           toSerialize,
           propertyObjectName
         );
+
         if (serializedValue !== undefined && propName != undefined) {
-          const xmlnsKey = propertyMapper.xmlNamespacePrefix
-            ? `xmlns:${propertyMapper.xmlNamespacePrefix}`
-            : "xmlns";
-          const xmlNamespace = { [xmlnsKey]: propertyMapper.xmlNamespace };
-          const value = propertyMapper.xmlNamespace
-            ? { _: serializedValue, $: xmlNamespace }
-            : serializedValue;
+          const value = getXmlObjectValue(propertyMapper, serializedValue);
           if (propertyMapper.xmlIsAttribute) {
             // $ is the key attributes are kept under in xml2js.
             // This keeps things simple while preventing name collision
@@ -657,6 +652,22 @@ function serializeCompositeType(
     return payload;
   }
   return object;
+}
+
+function getXmlObjectValue(propertyMapper: Mapper, serializedValue: any) {
+  if (!propertyMapper.xmlNamespace) {
+    return serializedValue;
+  }
+
+  const xmlnsKey = propertyMapper.xmlNamespacePrefix
+    ? `xmlns:${propertyMapper.xmlNamespacePrefix}`
+    : "xmlns";
+  const xmlNamespace = { [xmlnsKey]: propertyMapper.xmlNamespace };
+
+  if (["Composite"].includes(propertyMapper.type.name)) {
+    return { $: xmlNamespace, ...serializedValue };
+  }
+  return { _: serializedValue, $: xmlNamespace };
 }
 
 function isSpecialXmlProperty(propertyName: string): boolean {

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -352,6 +352,7 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
       }
     }
   }
+
   return value;
 }
 
@@ -589,6 +590,12 @@ function serializeCompositeType(
       }
 
       if (parentObject != undefined) {
+        if (mapper.xmlNamespace) {
+          const xmlnsKey = mapper.xmlNamespacePrefix
+            ? `xmlns:${mapper.xmlNamespacePrefix}`
+            : "xmlns";
+          parentObject.$ = { [xmlnsKey]: mapper.xmlNamespace };
+        }
         const propertyObjectName =
           propertyMapper.serializedName !== ""
             ? objectName + "." + propertyMapper.serializedName
@@ -610,6 +617,13 @@ function serializeCompositeType(
           propertyObjectName
         );
         if (serializedValue !== undefined && propName != undefined) {
+          const xmlnsKey = propertyMapper.xmlNamespacePrefix
+            ? `xmlns:${propertyMapper.xmlNamespacePrefix}`
+            : "xmlns";
+          const xmlNamespace = { [xmlnsKey]: propertyMapper.xmlNamespace };
+          const value = propertyMapper.xmlNamespace
+            ? { _: serializedValue, $: xmlNamespace }
+            : serializedValue;
           if (propertyMapper.xmlIsAttribute) {
             // $ is the key attributes are kept under in xml2js.
             // This keeps things simple while preventing name collision
@@ -617,9 +631,9 @@ function serializeCompositeType(
             parentObject.$ = parentObject.$ || {};
             parentObject.$[propName] = serializedValue;
           } else if (propertyMapper.xmlIsWrapped) {
-            parentObject[propName] = { [propertyMapper.xmlElementName!]: serializedValue };
+            parentObject[propName] = { [propertyMapper.xmlElementName!]: value };
           } else {
-            parentObject[propName] = serializedValue;
+            parentObject[propName] = value;
           }
         }
       }
@@ -961,6 +975,8 @@ export interface EnumMapperType {
 
 export interface BaseMapper {
   xmlName?: string;
+  xmlNamespace?: string;
+  xmlNamespacePrefix?: string;
   xmlIsAttribute?: boolean;
   xmlElementName?: string;
   xmlIsWrapped?: boolean;

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -504,14 +504,12 @@ function serializeSequenceType(
         : "xmlns";
       if (elementType.type.name === "Composite") {
         tempArray[i] = { ...serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
-        continue;
       } else {
         tempArray[i] = { _: serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
-        continue;
       }
+    } else {
+      tempArray[i] = serializedValue;
     }
-
-    tempArray[i] = serializedValue;
   }
   return tempArray;
 }
@@ -544,16 +542,14 @@ function serializeDictionaryType(
       // If the value is an object the object's properties need to be siblings of the $ property
       if (valueType.type.name === "Composite") {
         tempDictionary[key] = { ...serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-        continue;
       } else {
         // When the value is not an object, it has to go under _
         tempDictionary[key] = { _: serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-        continue;
       }
+    } else {
+      // Add the serialized value when we are not serializing XML or it doesn't need a namespace
+      tempDictionary[key] = serializedValue;
     }
-
-    // Just add the value when we are not serializing XML or it doesn't need a namespace
-    tempDictionary[key] = serializedValue;
   }
 
   // Add the namespace to the root element if needed

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -535,21 +535,7 @@ function serializeDictionaryType(
   for (const key of Object.keys(object)) {
     const serializedValue = serializer.serialize(valueType, object[key], objectName);
     // If the element needs an XML namespace we need to add it within the $ property
-    if (isXml && valueType.xmlNamespace) {
-      const xmlnsKey = valueType.xmlNamespacePrefix
-        ? `xmlns:${valueType.xmlNamespacePrefix}`
-        : "xmlns";
-      // If the value is an object the object's properties need to be siblings of the $ property
-      if (valueType.type.name === "Composite") {
-        tempDictionary[key] = { ...serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-      } else {
-        // When the value is not an object, it has to go under _
-        tempDictionary[key] = { _: serializedValue, $: { [xmlnsKey]: valueType.xmlNamespace } };
-      }
-    } else {
-      // Add the serialized value when we are not serializing XML or it doesn't need a namespace
-      tempDictionary[key] = serializedValue;
-    }
+    tempDictionary[key] = getXmlObjectValue(valueType, serializedValue, isXml);
   }
 
   // Add the namespace to the root element if needed

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -563,7 +563,9 @@ export function serializeRequestBody(
             httpRequest.body = stringifyXML(
               utils.prepareXMLRootList(
                 value,
-                xmlElementName || xmlName || serializedName!
+                xmlElementName || xmlName || serializedName!,
+                xmlnsKey,
+                xmlNamespace
               ),
               { rootName: xmlName || serializedName }
             );

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -556,7 +556,12 @@ export function serializeRequestBody(
 
         if (operationSpec.isXML) {
             const xmlnsKey = xmlNamespacePrefix ? `xmlns:${xmlNamespacePrefix}` : "xmlns";
-            const value = getXmlValueWithNamespace(xmlNamespace, xmlnsKey, typeName, httpRequest.body);
+            const value = getXmlValueWithNamespace(
+              xmlNamespace,
+              xmlnsKey,
+              typeName,
+              httpRequest.body
+            );
           if (typeName === MapperType.Sequence) {
             httpRequest.body = stringifyXML(
               utils.prepareXMLRootList(

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -538,7 +538,14 @@ export function serializeRequestBody(
     );
 
     const bodyMapper = operationSpec.requestBody.mapper;
-    const { required, xmlName, xmlElementName, serializedName, xmlNamespace, xmlNamespacePrefix} = bodyMapper;
+    const {
+      required,
+      xmlName,
+      xmlElementName,
+      serializedName,
+      xmlNamespace,
+      xmlNamespacePrefix
+    } = bodyMapper;
     const typeName = bodyMapper.type.name;
 
     try {
@@ -555,13 +562,13 @@ export function serializeRequestBody(
         const isStream = typeName === MapperType.Stream;
 
         if (operationSpec.isXML) {
-            const xmlnsKey = xmlNamespacePrefix ? `xmlns:${xmlNamespacePrefix}` : "xmlns";
-            const value = getXmlValueWithNamespace(
-              xmlNamespace,
-              xmlnsKey,
-              typeName,
-              httpRequest.body
-            );
+          const xmlnsKey = xmlNamespacePrefix ? `xmlns:${xmlNamespacePrefix}` : "xmlns";
+          const value = getXmlValueWithNamespace(
+            xmlNamespace,
+            xmlnsKey,
+            typeName,
+            httpRequest.body
+          );
           if (typeName === MapperType.Sequence) {
             httpRequest.body = stringifyXML(
               utils.prepareXMLRootList(
@@ -622,11 +629,16 @@ export function serializeRequestBody(
 /**
  * Adds an xml namespace to the xml serialized object if needed, otherwise it just returns the value itself
  */
-function getXmlValueWithNamespace(xmlNamespace: string | undefined, xmlnsKey: string, typeName: string, serializedValue: any): any {
+function getXmlValueWithNamespace(
+  xmlNamespace: string | undefined,
+  xmlnsKey: string,
+  typeName: string,
+  serializedValue: any
+): any {
   // Composite and Sequence schemas already got their root namespace set during serialization
   // We just need to add xmlns to the other schema types
-  if(xmlNamespace && !["Composite", "Sequence"].includes(typeName)) {
-    return {_:serializedValue, $: {[xmlnsKey]: xmlNamespace}} ;
+  if (xmlNamespace && !["Composite", "Sequence", "Dictionary"].includes(typeName)) {
+    return { _: serializedValue, $: { [xmlnsKey]: xmlNamespace } };
   }
 
   return serializedValue;

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -283,6 +283,7 @@ export class ServiceClient {
         );
       }
     }
+    console.log("request info = ", httpRequest.url, httpRequest.operationSpec?.requestBody);
     return httpPipeline.sendRequest(httpRequest);
   }
 
@@ -489,6 +490,7 @@ export class ServiceClient {
       let rawResponse: HttpOperationResponse;
       let sendRequestError;
       try {
+        console.log(httpRequest);
         rawResponse = await this.sendRequest(httpRequest);
       } catch (error) {
         sendRequestError = error;
@@ -538,7 +540,7 @@ export function serializeRequestBody(
     );
 
     const bodyMapper = operationSpec.requestBody.mapper;
-    const { required, xmlName, xmlElementName, serializedName } = bodyMapper;
+    const { required, xmlName, xmlElementName, serializedName, xmlNamespace, xmlNamespacePrefix} = bodyMapper;
     const typeName = bodyMapper.type.name;
 
     try {
@@ -555,16 +557,18 @@ export function serializeRequestBody(
         const isStream = typeName === MapperType.Stream;
 
         if (operationSpec.isXML) {
+            const xmlnsKey = xmlNamespacePrefix ? `xmlns:${xmlNamespacePrefix}` : "xmlns";
+            const value = xmlNamespace && !["Composite", "Sequence"].includes(typeName) ? {_: httpRequest.body, $: {[xmlnsKey]: xmlNamespace}} : httpRequest.body;
           if (typeName === MapperType.Sequence) {
             httpRequest.body = stringifyXML(
               utils.prepareXMLRootList(
-                httpRequest.body,
+                value,
                 xmlElementName || xmlName || serializedName!
               ),
               { rootName: xmlName || serializedName }
             );
           } else if (!isStream) {
-            httpRequest.body = stringifyXML(httpRequest.body, {
+            httpRequest.body = stringifyXML(value, {
               rootName: xmlName || serializedName
             });
           }

--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -189,11 +189,21 @@ export function promiseToServiceCallback<T>(promise: Promise<HttpOperationRespon
   };
 }
 
-export function prepareXMLRootList(obj: any, elementName: string): { [s: string]: any } {
+export function prepareXMLRootList(
+  obj: any,
+  elementName: string,
+  xmlNamespaceKey?: string,
+  xmlNamespace?: string
+): { [s: string]: any } {
   if (!Array.isArray(obj)) {
     obj = [obj];
   }
-  return { [elementName]: obj };
+
+  if (!xmlNamespaceKey || !xmlNamespace) {
+    return { [elementName]: obj };
+  }
+
+  return { [elementName]: obj, $: {[xmlNamespaceKey]: xmlNamespace} };
 }
 
 /**

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -504,12 +504,11 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: new Serializer(),
+          serializer: new Serializer()
         }
       );
       assert.strictEqual(httpRequest.body, `"body value"`);
     });
-
 
     it("should serialize a JSON ByteArray request body", () => {
       const httpRequest = new WebResource();
@@ -559,13 +558,10 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: new Serializer(undefined, false /** isXML */),
+          serializer: new Serializer(undefined, false /** isXML */)
         }
       );
-      assert.strictEqual(
-        httpRequest.body,
-        `"SmF2YXNjcmlwdA=="`
-      );
+      assert.strictEqual(httpRequest.body, `"SmF2YXNjcmlwdA=="`);
     });
 
     it("should serialize a JSON Stream request body", () => {
@@ -707,7 +703,7 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: new Serializer(undefined, true/** isXml */),
+          serializer: new Serializer(undefined, true /** isXml */),
           isXML: true
         }
       );
@@ -715,6 +711,127 @@ describe("ServiceClient", function() {
         httpRequest.body,
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg>SmF2YXNjcmlwdA==</bodyArg>`
       );
+    });
+
+    it("should serialize an XML Dictionary request body", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true /** isXml */),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata><alpha>hello</alpha><beta>world</beta></metadata>`
+      );
+    });
+
+    it("should serialize an XML Dictionary request body, with namespace and prefix", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              xmlNamespacePrefix: "sample",
+              xmlNamespace: "https://microsoft.com",
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  xmlNamespacePrefix: "el",
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true /** isXml */),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns:sample="https://microsoft.com"><alpha xmlns:el="https://microsoft.com/element">hello</alpha><beta xmlns:el="https://microsoft.com/element">world</beta></metadata>`
+      );
+    });
+
+    it("should serialize a JSON Dictionary request body, ignoring xml metadata", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          metadata: {
+            alpha: "hello",
+            beta: "world"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "metadata",
+            mapper: {
+              xmlNamespacePrefix: "sample",
+              xmlNamespace: "https://microsoft.com",
+              serializedName: "metadata",
+              type: {
+                name: "Dictionary",
+                value: {
+                  xmlNamespacePrefix: "el",
+                  xmlNamespace: "https://microsoft.com/element",
+                  type: {
+                    name: "String"
+                  }
+                }
+              },
+              headerCollectionPrefix: "foo-bar-"
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer()
+        }
+      );
+      assert.deepEqual(httpRequest.body, `{"alpha":"hello","beta":"world"}`);
     });
 
     it("should serialize a Json ByteArray request body, ignoring namespace", () => {
@@ -739,15 +856,11 @@ describe("ServiceClient", function() {
             }
           },
           responses: { 200: {} },
-          serializer: new Serializer(undefined, false /** isXML */),
+          serializer: new Serializer(undefined, false /** isXML */)
         }
       );
-      assert.strictEqual(
-        httpRequest.body,
-        `"SmF2YXNjcmlwdA=="`
-      );
+      assert.strictEqual(httpRequest.body, `"SmF2YXNjcmlwdA=="`);
     });
-
 
     it("should serialize an XML ByteArray request body with namespace", () => {
       const httpRequest = new WebResource();
@@ -854,11 +967,14 @@ describe("ServiceClient", function() {
           httpMethod: "POST",
           requestBody: requestBody1,
           responses: { 200: {} },
-          serializer: new Serializer(),
+          serializer: new Serializer()
         }
       );
 
-      assert.deepEqual(httpRequest.body, '{"updated":"2020-08-12T23:36:18.308Z","content":{"type":"application/xml","queueDescription":{"maxDeliveryCount":15}}}');
+      assert.deepEqual(
+        httpRequest.body,
+        '{"updated":"2020-08-12T23:36:18.308Z","content":{"type":"application/xml","queueDescription":{"maxDeliveryCount":15}}}'
+      );
     });
 
     it("should serialize an XML Array request body with namespace and prefix", () => {
@@ -928,11 +1044,8 @@ describe("ServiceClient", function() {
           serializer: new Serializer()
         }
       );
-      assert.deepEqual(
-        httpRequest.body, JSON.stringify(["Foo", "Bar"])
-      );
+      assert.deepEqual(httpRequest.body, JSON.stringify(["Foo", "Bar"]));
     });
-
 
     it("should serialize an XML Array of composite elements, namespace and prefix", () => {
       const httpRequest = new WebResource();
@@ -940,7 +1053,11 @@ describe("ServiceClient", function() {
         new ServiceClient(),
         httpRequest,
         {
-          bodyArg: [ { foo: "Foo1", bar: "Bar1" },  { foo: "Foo2", bar: "Bar2" },  { foo: "Foo3", bar: "Bar3" }]
+          bodyArg: [
+            { foo: "Foo1", bar: "Bar1" },
+            { foo: "Foo2", bar: "Bar2" },
+            { foo: "Foo3", bar: "Bar3" }
+          ]
         },
         {
           httpMethod: "POST",

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -567,6 +567,38 @@ describe("ServiceClient", function() {
       );
     });
 
+    it("should serialize an XML String request body with namespace", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              type: {
+                name: MapperType.String
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true /** isXML*/),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com">body value</bodyArg>`
+      );
+    });
+
     it("should serialize an XML ByteArray request body", () => {
       const httpRequest = new WebResource();
       serializeRequestBody(
@@ -597,6 +629,206 @@ describe("ServiceClient", function() {
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg>SmF2YXNjcmlwdA==</bodyArg>`
       );
     });
+
+    it("should serialize an XML ByteArray request body with namespace", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: stringToByteArray("Javascript")
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              xmlNamespace: "https://microsoft.com",
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.ByteArray
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com">SmF2YXNjcmlwdA==</bodyArg>`
+      );
+    });
+
+    it("should serialize an XML ByteArray request body with namespace and prefix", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: stringToByteArray("Javascript")
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              xmlNamespace: "https://microsoft.com",
+              xmlNamespacePrefix: "sample",
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.ByteArray
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns:sample="https://microsoft.com">SmF2YXNjcmlwdA==</bodyArg>`
+      );
+    });
+
+    it("should serialize an XML Composite request body", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: {foo: "Foo", bar: "Bar"}
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.Composite,
+                modelProperties: {
+                  foo: {
+                    serializedName: "foo",
+                    xmlName: "Foo",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  bar: {
+                    xmlName: "Bar",
+                    serializedName: "bar",
+                    type: {
+                      name: "String"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg><Foo>Foo</Foo><Bar>Bar</Bar></bodyArg>`
+      );
+    });
+
+    it.skip("should serialize an XML Array request body with namespace and prefix", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: ["Foo", "Bar"]
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              xmlElementName: "testItem",
+              type: {
+                name: MapperType.Sequence,
+                element: {
+                  type: {name: "String"},
+                  xmlNamespace: "https://microsoft.com"
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><Foo xmlns="https://microsoft.com/foo">Foo</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar></bodyArg>`
+      );
+    })
+
+    it("should serialize an XML Composite request body with namespace and prefix", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: {foo: "Foo", bar: "Bar"}
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              xmlNamespace: "https://microsoft.com",
+              type: {
+                name: MapperType.Composite,
+                modelProperties: {
+                  foo: {
+                    serializedName: "foo",
+                    xmlNamespace: "https://microsoft.com/foo",
+                    xmlName: "Foo",
+                    type: {
+                      name: "String"
+                    }
+                  },
+                  bar: {
+                    xmlNamespacePrefix: "bar",
+                    xmlNamespace: "https://microsoft.com/bar",
+                    xmlName: "Bar",
+                    serializedName: "bar",
+                    type: {
+                      name: "String"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><Foo xmlns="https://microsoft.com/foo">Foo</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar></bodyArg>`
+      );
+    })
 
     it("should serialize an XML Stream request body", () => {
       const httpRequest = new WebResource();

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -26,6 +26,7 @@ import {
   OperationSpec
 } from "../src/coreHttp";
 import { ParameterPath } from "../src/operationParameter";
+import { requestBody1 } from "./testMappers";
 
 describe("ServiceClient", function() {
   it("should serialize headerCollectionPrefix", async function() {
@@ -701,36 +702,14 @@ describe("ServiceClient", function() {
         new ServiceClient(),
         httpRequest,
         {
-          bodyArg: {foo: "Foo", bar: "Bar"}
+          requestBody: {
+            updated: new Date("2020-08-12T23:36:18.308Z"),
+            content: { type: "application/xml", queueDescription: { maxDeliveryCount: 15 } }
+          }
         },
         {
           httpMethod: "POST",
-          requestBody: {
-            parameterPath: "bodyArg",
-            mapper: {
-              required: true,
-              serializedName: "bodyArg",
-              type: {
-                name: MapperType.Composite,
-                modelProperties: {
-                  foo: {
-                    serializedName: "foo",
-                    xmlName: "Foo",
-                    type: {
-                      name: "String"
-                    }
-                  },
-                  bar: {
-                    xmlName: "Bar",
-                    serializedName: "bar",
-                    type: {
-                      name: "String"
-                    }
-                  }
-                }
-              }
-            }
-          },
+          requestBody: requestBody1,
           responses: { 200: {} },
           serializer: new Serializer(undefined, true),
           isXML: true
@@ -738,7 +717,7 @@ describe("ServiceClient", function() {
       );
       assert.strictEqual(
         httpRequest.body,
-        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg><Foo>Foo</Foo><Bar>Bar</Bar></bodyArg>`
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><entry xmlns="http://www.w3.org/2005/Atom"><updated xmlns="http://www.w3.org/2005/Atom">2020-08-12T23:36:18.308Z</updated><content xmlns="http://www.w3.org/2005/Atom" type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"><MaxDeliveryCount xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">15</MaxDeliveryCount></QueueDescription></content></entry>`
       );
     });
 
@@ -762,7 +741,7 @@ describe("ServiceClient", function() {
               type: {
                 name: MapperType.Sequence,
                 element: {
-                  type: {name: "String"},
+                  type: { name: "String" },
                   xmlNamespace: "https://microsoft.com"
                 }
               }
@@ -777,7 +756,7 @@ describe("ServiceClient", function() {
         httpRequest.body,
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><Foo xmlns="https://microsoft.com/foo">Foo</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar></bodyArg>`
       );
-    })
+    });
 
     it("should serialize an XML Composite request body with namespace and prefix", () => {
       const httpRequest = new WebResource();
@@ -785,7 +764,7 @@ describe("ServiceClient", function() {
         new ServiceClient(),
         httpRequest,
         {
-          bodyArg: {foo: "Foo", bar: "Bar"}
+          bodyArg: { foo: "Foo", bar: "Bar" }
         },
         {
           httpMethod: "POST",
@@ -828,7 +807,7 @@ describe("ServiceClient", function() {
         httpRequest.body,
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><bodyArg xmlns="https://microsoft.com"><Foo xmlns="https://microsoft.com/foo">Foo</Foo><Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar></bodyArg>`
       );
-    })
+    });
 
     it("should serialize an XML Stream request body", () => {
       const httpRequest = new WebResource();

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -497,6 +497,8 @@ describe("ServiceClient", function() {
             parameterPath: "bodyArg",
             mapper: {
               required: true,
+              xmlNamespace: "https://example.com",
+              xmlNamespacePrefix: "foo",
               serializedName: "bodyArg",
               type: {
                 name: MapperType.String
@@ -1161,6 +1163,34 @@ describe("ServiceClient", function() {
     });
 
     it("should serialize an XML Stream request body", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.Stream
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(),
+          isXML: true
+        }
+      );
+      assert.strictEqual(httpRequest.body, "body value");
+    });
+
+    it("should serialize an XML Stream request body, with namespace", () => {
       const httpRequest = new WebResource();
       serializeRequestBody(
         new ServiceClient(),

--- a/sdk/core/core-http/test/testMappers.ts
+++ b/sdk/core/core-http/test/testMappers.ts
@@ -1,0 +1,266 @@
+import { CompositeMapper, OperationParameter } from "../src/coreHttp";
+
+const QueueDescription: CompositeMapper = {
+  serializedName: "QueueDescription",
+  xmlName: "QueueDescription",
+  xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+  type: {
+    name: "Composite",
+    className: "QueueDescription",
+    modelProperties: {
+      lockDuration: {
+        serializedName: "lockDuration",
+        xmlName: "LockDuration",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      maxSizeInMegabytes: {
+        serializedName: "maxSizeInMegabytes",
+        xmlName: "MaxSizeInMegabytes",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      requiresDuplicateDetection: {
+        serializedName: "requiresDuplicateDetection",
+        xmlName: "RequiresDuplicateDetection",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      requiresSession: {
+        serializedName: "requiresSession",
+        xmlName: "RequiresSession",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      defaultMessageTimeToLive: {
+        serializedName: "defaultMessageTimeToLive",
+        xmlName: "DefaultMessageTimeToLive",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      deadLetteringOnMessageExpiration: {
+        serializedName: "deadLetteringOnMessageExpiration",
+        xmlName: "DeadLetteringOnMessageExpiration",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      duplicateDetectionHistoryTimeWindow: {
+        serializedName: "duplicateDetectionHistoryTimeWindow",
+        xmlName: "DuplicateDetectionHistoryTimeWindow",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      maxDeliveryCount: {
+        serializedName: "maxDeliveryCount",
+        xmlName: "MaxDeliveryCount",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      enableBatchedOperations: {
+        serializedName: "enableBatchedOperations",
+        xmlName: "EnableBatchedOperations",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      sizeInBytes: {
+        serializedName: "sizeInBytes",
+        xmlName: "SizeInBytes",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      messageCount: {
+        serializedName: "messageCount",
+        xmlName: "MessageCount",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Number"
+        }
+      },
+      isAnonymousAccessible: {
+        serializedName: "isAnonymousAccessible",
+        xmlName: "IsAnonymousAccessible",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      status: {
+        serializedName: "status",
+        xmlName: "Status",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      forwardTo: {
+        serializedName: "forwardTo",
+        xmlName: "ForwardTo",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      userMetadata: {
+        serializedName: "userMetadata",
+        xmlName: "UserMetadata",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      createdAt: {
+        serializedName: "createdAt",
+        xmlName: "CreatedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      updatedAt: {
+        serializedName: "updatedAt",
+        xmlName: "UpdatedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      accessedAt: {
+        serializedName: "accessedAt",
+        xmlName: "AccessedAt",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "DateTime"
+        }
+      },
+      supportOrdering: {
+        serializedName: "supportOrdering",
+        xmlName: "SupportOrdering",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      autoDeleteOnIdle: {
+        serializedName: "autoDeleteOnIdle",
+        xmlName: "AutoDeleteOnIdle",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "TimeSpan"
+        }
+      },
+      enablePartitioning: {
+        serializedName: "enablePartitioning",
+        xmlName: "EnablePartitioning",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      entityAvailabilityStatus: {
+        serializedName: "entityAvailabilityStatus",
+        xmlName: "EntityAvailabilityStatus",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      },
+      enableExpress: {
+        serializedName: "enableExpress",
+        xmlName: "EnableExpress",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "Boolean"
+        }
+      },
+      forwardDeadLetteredMessagesTo: {
+        serializedName: "forwardDeadLetteredMessagesTo",
+        xmlName: "ForwardDeadLetteredMessagesTo",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+const CreateQueueBodyContent: CompositeMapper = {
+  serializedName: "CreateQueueBodyContent",
+  xmlNamespace: "http://www.w3.org/2005/Atom",
+  type: {
+    name: "Composite",
+    className: "CreateQueueBodyContent",
+    modelProperties: {
+      type: {
+        defaultValue: "application/xml",
+        serializedName: "type",
+        xmlName: "type",
+        xmlIsAttribute: true,
+        type: {
+          name: "String"
+        }
+      },
+      queueDescription: {
+        serializedName: "queueDescription",
+        xmlName: "QueueDescription",
+        xmlNamespace: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+        type: {
+          ...QueueDescription.type
+        }
+      }
+    }
+  }
+};
+
+const CreateQueueBody: CompositeMapper = {
+  serializedName: "CreateQueueBody",
+  xmlName: "entry",
+  xmlNamespace: "http://www.w3.org/2005/Atom",
+  type: {
+    name: "Composite",
+    className: "CreateQueueBody",
+    modelProperties: {
+      updated: {
+        serializedName: "updated",
+        xmlName: "updated",
+        xmlNamespace: "http://www.w3.org/2005/Atom",
+        type: {
+          name: "DateTime"
+        }
+      },
+      content: {
+        serializedName: "content",
+        xmlName: "content",
+        xmlNamespace: "http://www.w3.org/2005/Atom",
+        type: {
+          ...CreateQueueBodyContent.type
+        }
+      }
+    }
+  }
+};
+
+export const requestBody1: OperationParameter = {
+  parameterPath: "requestBody",
+  mapper: CreateQueueBody
+};


### PR DESCRIPTION
OpenAPI supports xml namespace and prefixes ([link](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#fixed-fields-22)). However `core-http` serializer doesn't honor them.

[ServiceBus swagger](https://github.com/Azure/azure-rest-api-specs/tree/sb_dataplane_namespace/specification/servicebus/data-plane), for example, uses XML namespaces.

Here are some samples on the expected output given a mapper:

### Basic type value
```javascript
const stringMapper = {
  serializedName: "testNode",
  xmlNamespace: "https://microsoft.com",
  type: {
    name: MapperType.String
  }
}
```
**Current**
```xml
<?xml version="1.0" encoding="UTF-8" ?><testNode>body value</testNode>
```

**Expected**
```xml
<?xml version="1.0" encoding="UTF-8" ?><testNode xmlns="https://microsoft.com">body value</testNode>
```

### Composite Type
```javascript
const compositeMapper = {
  required: true,
  serializedName: "bodyArg",
  xmlNamespace: "https://microsoft.com",
  type: {
    name: MapperType.Composite,
    modelProperties: {
      foo: {
        serializedName: "foo",
        xmlNamespace: "https://microsoft.com/foo",
        xmlName: "Foo",
        type: {
          name: "String"
        }
      },
      bar: {
        xmlNamespacePrefix: "bar",
        xmlNamespace: "https://microsoft.com/bar",
        xmlName: "Bar",
        serializedName: "bar",
        type: {
          name: "String"
        }
      }
    }
  }
};
```
**Current**
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<bodyArg>
   <Foo>Foo</Foo>
   <Bar>Bar</Bar>
</bodyArg>
```

**Expected**
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<bodyArg xmlns="https://microsoft.com">
   <Foo xmlns="https://microsoft.com/foo">Foo</Foo>
   <Bar xmlns:bar="https://microsoft.com/bar">Bar</Bar>
</bodyArg>
```
