### PR TITLE
[Service Bus] Remove stream-browserify dependency

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -23,7 +23,6 @@
     "./dist-esm/src/util/crypto.js": "./dist-esm/src/util/crypto.browser.js",
     "./dist-esm/src/util/parseUrl.js": "./dist-esm/src/util/parseUrl.browser.js",
     "buffer": "buffer",
-    "stream": "stream-browserify",
     "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js"
   },
   "types": "./types/latest/service-bus.d.ts",


### PR DESCRIPTION
Resolves #9283

Based on the investigation in #10425, we know that Event Hubs does not need `stream-browserify`.
The same can be extended to Service Bus as the two have same set of dependencies apart from the ServiceBusAdministrationClient needing `@azure/core-http`.
So, removing this dependency from Service Bus. 