### PR TITLE
Aggregate report generation is failing due to ref to tools repo

### DIFF
--- a/sdk/eventgrid/eventgrid/tests.yml
+++ b/sdk/eventgrid/eventgrid/tests.yml
@@ -1,13 +1,5 @@
 trigger: none
-resources:
-  repositories:
-    - repository: azure-sdk-build-tools
-      type: git
-      name: internal/azure-sdk-build-tools
-    - repository: azure-sdk-tools
-      type: github
-      name: Azure/azure-sdk-tools
-      endpoint: azure
+
 jobs:
   - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
     parameters:


### PR DESCRIPTION
Removed reference to azure-sdk-build-tools and azure-sdk-tools repos. 
@ellismg  Is there any specific reason to reference these tools repo for eventgrid tests?