### PR TITLE
[Service Bus] Bug Fix: Incorrect connection-config in the token credential path

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.0.0-preview.7 (Unreleased)
 
+### New features:
+- `ServiceBusClient` now supports authentication with AAD credentials in the browser(can use `InteractiveBrowserCredential` from `@azure/identity`).
+  [PR 11250](https://github.com/Azure/azure-sdk-for-js/pull/11250)
 
 ## 7.0.0-preview.6 (2020-09-10)
 

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -33,28 +33,6 @@ export interface ServiceBusClientOptions {
 }
 
 /**
- * @param connectionString
- * @param options
- * @internal
- * @ignore
- */
-export function createConnectionContextForConnectionString(
-  connectionString: string,
-  options: ServiceBusClientOptions = {}
-): ConnectionContext {
-  const config = ConnectionConfig.create(connectionString);
-
-  config.webSocket = options?.webSocketOptions?.webSocket;
-  config.webSocketEndpointPath = "$servicebus/websocket";
-  config.webSocketConstructorOptions = options?.webSocketOptions?.webSocketConstructorOptions;
-
-  const credential = SharedKeyCredential.fromConnectionString(connectionString);
-
-  validate(config);
-  return ConnectionContext.create(config, credential, options);
-}
-
-/**
  * @internal
  * @ignore
  *
@@ -67,6 +45,43 @@ function validate(config: ConnectionConfig) {
   config.entityPath = config.entityPath ?? "";
 
   ConnectionConfig.validate(config);
+}
+
+/**
+ * @internal
+ * @ignore
+ *
+ * @param {string} connectionString
+ * @param {(SharedKeyCredential | TokenCredential)} credential
+ * @param {ServiceBusClientOptions} options
+ */
+function createConnectionContext(
+  connectionString: string,
+  credential: SharedKeyCredential | TokenCredential,
+  options: ServiceBusClientOptions
+): ConnectionContext {
+  const config = ConnectionConfig.create(connectionString);
+
+  config.webSocket = options?.webSocketOptions?.webSocket;
+  config.webSocketEndpointPath = "$servicebus/websocket";
+  config.webSocketConstructorOptions = options?.webSocketOptions?.webSocketConstructorOptions;
+
+  validate(config);
+  return ConnectionContext.create(config, credential, options);
+}
+
+/**
+ * @param connectionString
+ * @param options
+ * @internal
+ * @ignore
+ */
+export function createConnectionContextForConnectionString(
+  connectionString: string,
+  options: ServiceBusClientOptions = {}
+): ConnectionContext {
+  const credential = SharedKeyCredential.fromConnectionString(connectionString);
+  return createConnectionContext(connectionString, credential, options);
 }
 
 /**
@@ -91,10 +106,7 @@ export function createConnectionContextForTokenCredential(
     host += "/";
   }
   const connectionString = `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;SharedAccessKey=defaultKeyValue;`;
-  const config = ConnectionConfig.create(connectionString);
-  
-  validate(config);
-  return ConnectionContext.create(config, credential, options);
+  return createConnectionContext(connectionString, credential, options);
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -55,7 +55,7 @@ function validate(config: ConnectionConfig) {
  * @param {(SharedKeyCredential | TokenCredential)} credential
  * @param {ServiceBusClientOptions} options
  */
-function createConnectionContext(
+export function createConnectionContext(
   connectionString: string,
   credential: SharedKeyCredential | TokenCredential,
   options: ServiceBusClientOptions

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -5,8 +5,12 @@ import { extractReceiverArguments, ServiceBusClient } from "../../src/serviceBus
 import chai from "chai";
 import { CreateSessionReceiverOptions } from "../../src/models";
 import { entityPathMisMatchError } from "../../src/util/errors";
-import { createConnectionContext } from "../../src/constructorHelpers";
-import { SharedKeyCredential } from "@azure/core-amqp";
+import {
+  createConnectionContextForConnectionString,
+  createConnectionContextForTokenCredential
+} from "../../src/constructorHelpers";
+import { TokenCredential } from "@azure/core-http";
+import { ConnectionContext } from "../../src/connectionContext";
 const assert = chai.assert;
 
 const allLockModes: ("peekLock" | "receiveAndDelete")[] = ["peekLock", "receiveAndDelete"];
@@ -150,16 +154,11 @@ describe("serviceBusClient unit tests", () => {
     });
   });
 
-  describe("createConnectionContext", () => {
-    it("Websocket endpoint and constructor options are populated in the config", () => {
-      const connString =
-        "Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=some-queue";
-      const options = { randomOption: 123 };
-      const connectionContext = createConnectionContext(
-        connString,
-        SharedKeyCredential.fromConnectionString(connString),
-        { webSocketOptions: { webSocketConstructorOptions: options } }
-      );
+  describe("Create ConnectionContext helpers", () => {
+    function validateWebsocketInfo(
+      connectionContext: ConnectionContext,
+      providedWebsocketConstructorOptions: any
+    ) {
       assert.equal(
         connectionContext.config.webSocketEndpointPath,
         "$servicebus/websocket",
@@ -167,23 +166,62 @@ describe("serviceBusClient unit tests", () => {
       );
       assert.equal(
         connectionContext.config.webSocketConstructorOptions,
-        options,
+        providedWebsocketConstructorOptions,
         "Unexpected webSocketEndpointPath in the connection config"
       );
+    }
+
+    describe("createConnectionContextForConnectionString", () => {
+      it("Websocket endpoint and constructor options are populated in the config", () => {
+        const connString =
+          "Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=some-queue";
+        const options = { randomOption: 123 };
+        const connectionContext = createConnectionContextForConnectionString(connString, {
+          webSocketOptions: { webSocketConstructorOptions: options }
+        });
+        validateWebsocketInfo(connectionContext, options);
+      });
+
+      it("undefined entity path is translated to ''", () => {
+        const connString = "Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;";
+        const connectionContext = createConnectionContextForConnectionString(connString, {});
+        assert.equal(
+          connectionContext.config.entityPath,
+          "",
+          "Unexpected entityPath in the connection config"
+        );
+      });
     });
 
-    it("undefined entity path is translated to ''", () => {
-      const connString = "Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;";
-      const connectionContext = createConnectionContext(
-        connString,
-        SharedKeyCredential.fromConnectionString(connString),
-        {}
-      );
-      assert.equal(
-        connectionContext.config.entityPath,
-        "",
-        "Unexpected entityPath in the connection config"
-      );
+    describe("createConnectionContextForTokenCredential", () => {
+      const pseudoTokenCred: TokenCredential = {
+        async getToken() {
+          return { expiresOnTimestamp: 0, token: "" };
+        }
+      };
+      const endpoint = "endpoint";
+      it("Websocket endpoint and constructor options are populated in the config", () => {
+        const options = { randomOption: 123 };
+        const connectionContext = createConnectionContextForTokenCredential(
+          pseudoTokenCred,
+          endpoint,
+          { webSocketOptions: { webSocketConstructorOptions: options } }
+        );
+        validateWebsocketInfo(connectionContext, options);
+      });
+
+      it("undefined entity path is translated to ''", () => {
+        const connectionContext = createConnectionContextForTokenCredential(
+          pseudoTokenCred,
+          endpoint,
+          {}
+        );
+        assert.equal(
+          connectionContext.config.entityPath,
+          "",
+          "Unexpected entityPath in the connection config"
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #11223 and https://github.com/Azure/azure-sdk-for-js/issues/10710

### Fix
Websocket info is not being passed in the token-credential-path resulting in an incomplete connection config, this PR updates the code related to the generating connection context with expected websocket info in the config similar to the connection-string-path.

With this, methods on the SBClient should work fine in the browser when used AAD for auth.