### PR TITLE
Fix linting errors in the eslint plugin

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
+++ b/common/tools/eslint-plugin-azure-sdk/.eslintrc.json
@@ -21,7 +21,7 @@
   "parser": "@typescript-eslint/parser",
   "rules": {
     "@typescript-eslint/indent": "off",
-    "@typescript-eslint/no-magic-numbers": ["error", { "ignore": [0] }],
+    "@typescript-eslint/no-magic-numbers": ["error", { "ignore": [0], "ignoreArrayIndexes": true }],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "arrow-body-style": ["error", "as-needed"],


### PR DESCRIPTION
Recent updates to the file [ts-versioning-semver.ts](https://github.com/Azure/azure-sdk-for-js/blob/071ce6890278feae206adf75e80a34fdbf636c12/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts) file makes use of regular expressions. The particular usage causes the file to fail the [no-magic-numbers](https://eslint.org/docs/rules/no-magic-numbers) linting rule .

This PR updates the linter rule to ignore the array index as this is a normal use of String.match() outputs

 