### PR TITLE
[service-bus] Check abortSignal in SessionReceiver.subscribe()

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -189,7 +189,7 @@ export interface MessageHandlerOptions extends MessageHandlerOptionsBase {
 }
 
 // @public
-export interface MessageHandlerOptionsBase {
+export interface MessageHandlerOptionsBase extends OperationOptionsBase {
     autoComplete?: boolean;
     maxConcurrentCalls?: number;
 }
@@ -459,7 +459,7 @@ export interface ServiceBusSessionReceiver<ReceivedMessageT extends ServiceBusRe
 }
 
 // @public
-export interface SessionSubscribeOptions extends OperationOptionsBase, MessageHandlerOptionsBase {
+export interface SessionSubscribeOptions extends MessageHandlerOptionsBase {
 }
 
 // @public
@@ -482,7 +482,7 @@ export interface SqlRuleFilter {
 export type SubQueue = "deadLetter" | "transferDeadLetter";
 
 // @public
-export interface SubscribeOptions extends OperationOptionsBase, MessageHandlerOptions {
+export interface SubscribeOptions extends MessageHandlerOptions {
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -120,18 +120,18 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {}
 /**
  * Options used when subscribing to a Service Bus queue or subscription.
  */
-export interface SubscribeOptions extends OperationOptionsBase, MessageHandlerOptions {}
+export interface SubscribeOptions extends MessageHandlerOptions {}
 
 /**
  * Options used when subscribing to a Service Bus queue or subscription.
  */
-export interface SessionSubscribeOptions extends OperationOptionsBase, MessageHandlerOptionsBase {}
+export interface SessionSubscribeOptions extends MessageHandlerOptionsBase {}
 
 /**
  * Describes the options passed to `registerMessageHandler` method when receiving messages from a
  * Queue/Subscription.
  */
-export interface MessageHandlerOptionsBase {
+export interface MessageHandlerOptionsBase extends OperationOptionsBase {
   /**
    * @property Indicates whether the `complete()` method on the message should automatically be
    * called by the sdk after the user provided onMessage handler has been executed.

--- a/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
@@ -18,6 +18,9 @@ import {
 import { createConnectionContextForTests } from "./unittestUtils";
 import { StandardAbortMessage } from "../../src/util/utils";
 import { isLinkLocked } from "../utils/misc";
+import { ServiceBusSessionReceiverImpl } from "../../src/receivers/sessionReceiver";
+import { Constants } from "@azure/core-amqp";
+import { ServiceBusReceiverImpl } from "../../src/receivers/receiver";
 
 describe("AbortSignal", () => {
   const testMessageThatDoesntMatter = {
@@ -312,6 +315,91 @@ describe("AbortSignal", () => {
       }
 
       assert.isFalse(isLinkLocked(messageReceiver));
+    });
+  });
+
+  describe("subscribe", () => {
+    /**
+     * SessionReceiver is a bit of an odd duck because it doesn't do initialization
+     * in its subscribe() call (like non-session receiver) so our normal abortSignal
+     * code isn't running there. So we have to check this _and_ Receiver.
+     */
+    it("SessionReceiver.subscribe", async () => {
+      const session = await ServiceBusSessionReceiverImpl.createInitializedSessionReceiver(
+        createConnectionContextForTests({
+          onCreateReceiverCalled: (receiver) => {
+            (receiver as any).source = {
+              filter: {
+                [Constants.sessionFilterName]: "hello"
+              }
+            };
+
+            (receiver as any).properties = {
+              ["com.microsoft:locked-until-utc"]: Date.now()
+            };
+          }
+        }),
+        "entityPath",
+        "peekLock",
+        {
+          sessionId: "hello"
+        }
+      );
+
+      try {
+        const abortSignal = createAbortSignalForTest(true);
+        const receivedErrors: Error[] = [];
+
+        session.subscribe(
+          {
+            processMessage: async (_msg) => {},
+            processError: async (err) => {
+              receivedErrors.push(err);
+            }
+          },
+          {
+            abortSignal
+          }
+        );
+
+        assert.equal(receivedErrors[0].message, "The operation was aborted.");
+        assert.equal(receivedErrors[0].name, "AbortError");
+      } finally {
+        await session.close();
+      }
+    });
+
+    it("Receiver.subscribe", async () => {
+      const receiver = new ServiceBusReceiverImpl(
+        createConnectionContextForTests(),
+        "entityPath",
+        "peekLock"
+      );
+
+      try {
+        const abortSignal = createAbortSignalForTest(true);
+        const receivedErrors: Error[] = [];
+
+        await new Promise<void>((resolve) => {
+          receiver.subscribe(
+            {
+              processMessage: async (_msg: any) => {},
+              processError: async (err: Error) => {
+                resolve();
+                receivedErrors.push(err);
+              }
+            },
+            {
+              abortSignal
+            }
+          );
+        });
+
+        assert.equal(receivedErrors[0].message, "The operation was aborted.");
+        assert.equal(receivedErrors[0].name, "AbortError");
+      } finally {
+        await receiver.close();
+      }
     });
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
@@ -322,7 +322,7 @@ describe("AbortSignal", () => {
     /**
      * SessionReceiver is a bit of an odd duck because it doesn't do initialization
      * in its subscribe() call (like non-session receiver) so our normal abortSignal
-     * code isn't running there. So we have to check this _and_ Receiver.
+     * code isn't running there. So we have to check this separately from Receiver.
      */
     it("SessionReceiver.subscribe", async () => {
       const session = await ServiceBusSessionReceiverImpl.createInitializedSessionReceiver(


### PR DESCRIPTION
Check the abort signal in sessionReceiver.subscribe().

Fixes #4375
(finally)