### PR TITLE
[Monitor] remove unnecessary returns

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test/common/assert.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/common/assert.ts
@@ -27,7 +27,6 @@ export const assertTrace = (actual: Envelope[], expectation: Expectation): void 
   );
   if (envelope.length !== 1) {
     assert.ok(false, `assertTrace: could not find exported envelope: ${expectation.name}`);
-    return;
   }
   const operationId = envelope[0].tags[AI_OPERATION_ID];
 
@@ -74,7 +73,6 @@ export const assertExpectation = (actual: Envelope[], expectations: Expectation[
     );
     if (envelope.length !== 1) {
       assert.ok(false, `assertExpectation: could not find exported envelope: ${expectation.name}`);
-      return;
     }
 
     for (const [key, value] of Object.entries(expectation) as [keyof Expectation, unknown][]) {


### PR DESCRIPTION
Remove unnecessary returns that are blocking some of the build machines.