### PR TITLE
[EventHubs] Canary support for event-hubs live tests

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -44,6 +44,9 @@ parameters:
 - name: TestSame
   type: boolean
   default: false
+- name: TestCanary
+  type: boolean
+  default: false
 - name: Matrix
   type: object
   default:
@@ -127,7 +130,17 @@ jobs:
             TestType: "node"
             DependencyVersion: same
             NodeTestVersion: "12.x"
-            TestResultsFiles: "**/test-results.xml"            
+            TestResultsFiles: "**/test-results.xml"   
+
+        # Add matrix entry for canary testing
+        ${{ if eq(parameters.TestCanary, 'true') }}:
+          CanaryTest_Node:
+            OSVmImage: "ubuntu-18.04"
+            TestType: "node"
+            NodeTestVersion: "12.x"
+            TestResultsFiles: "**/test-results.xml"
+            SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+            ResourceGroupLocation: centraluseuap
     pool:
       vmImage: "$(OSVmImage)"
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -29,6 +29,9 @@ parameters:
 - name: ResourceGroupLocation
   type: string
   default: ""
+- name: ResourceGroupLocationCanary
+  type: string
+  default: "centraluseuap"
 - name: ArmTemplateParameters
   type: string
   default: "@{}"
@@ -140,7 +143,7 @@ jobs:
             NodeTestVersion: "12.x"
             TestResultsFiles: "**/test-results.xml"
             SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-            ResourceGroupLocation: centraluseuap
+            ResourceGroupLocation: ${{ parameters.SubscriptionConfigurationCanary }}
     pool:
       vmImage: "$(OSVmImage)"
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -143,7 +143,7 @@ jobs:
             NodeTestVersion: "12.x"
             TestResultsFiles: "**/test-results.xml"
             SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-            ResourceGroupLocation: ${{ parameters.SubscriptionConfigurationCanary }}
+            ResourceGroupLocation: ${{ parameters.ResourceGroupLocationCanary }}
     pool:
       vmImage: "$(OSVmImage)"
 

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -6,6 +6,7 @@ extends:
     PackageName: "@azure/event-hubs"
     ResourceServiceDirectory: eventhub
     TestSamples: false
+    TestCanary: true
     EnvVars:
       AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
       AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
Last triggered pipeline - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=552802&view=results

With this PR, our test subscription (preview) creates the event-hubs resources in the canary regions for testing ('Central US EUAP' and 'EAST US 2 EUAP' regions as suggested by the service team).
Many thanks to @danieljurek!! 

JAVA - https://github.com/Azure/azure-sdk-for-java/pull/15345 
.NET - https://github.com/Azure/azure-sdk-for-net/pull/15265 