### PR TITLE
Add testcases for handling odata

### DIFF
--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -4,6 +4,10 @@
 function escapeQuotesIfString(input: unknown, previous: string): string | unknown {
   let result = input;
 
+  if(input == null) {
+    return "null";
+  }
+
   if (typeof input === "string") {
     result = input.replace(/'/g, "''");
     // check if we need to escape this literal
@@ -11,6 +15,7 @@ function escapeQuotesIfString(input: unknown, previous: string): string | unknow
       result = `'${result}'`;
     }
   }
+
   return result;
 }
 

--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 function formatNullAndUndefined(input: unknown): string | unknown {
-  if (input == null || input == undefined) {
+  if (input === null || input === undefined) {
     return "null";
   }
 

--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -4,7 +4,7 @@
 function escapeQuotesIfString(input: unknown, previous: string): string | unknown {
   let result = input;
 
-  if(input == null) {
+  if (input == null) {
     return "null";
   }
 

--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-function escapeQuotesIfString(input: unknown, previous: string): string | unknown {
-  let result = input;
-
-  if (input == null) {
+function formatNullAndUndefined(input: unknown): string | unknown {
+  if (input == null || input == undefined) {
     return "null";
   }
+
+  return input;
+}
+
+function escapeQuotesIfString(input: unknown, previous: string): string | unknown {
+  let result = input;
 
   if (typeof input === "string") {
     result = input.replace(/'/g, "''");
@@ -36,7 +40,11 @@ export function odata(strings: TemplateStringsArray, ...values: unknown[]): stri
   for (let i = 0; i < strings.length; i++) {
     results.push(strings[i]);
     if (i < values.length) {
-      results.push(escapeQuotesIfString(values[i], strings[i]));
+      if(values[i] == null || values[i] == undefined) {
+        results.push(formatNullAndUndefined(values[i]));
+      } else {
+        results.push(escapeQuotesIfString(values[i], strings[i]));
+      }
     }
   }
   return results.join("");

--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -40,7 +40,7 @@ export function odata(strings: TemplateStringsArray, ...values: unknown[]): stri
   for (let i = 0; i < strings.length; i++) {
     results.push(strings[i]);
     if (i < values.length) {
-      if (values[i] == null || values[i] == undefined) {
+      if (values[i] === null || values[i] === undefined) {
         results.push(formatNullAndUndefined(values[i]));
       } else {
         results.push(escapeQuotesIfString(values[i], strings[i]));

--- a/sdk/search/search-documents/src/odata.ts
+++ b/sdk/search/search-documents/src/odata.ts
@@ -40,7 +40,7 @@ export function odata(strings: TemplateStringsArray, ...values: unknown[]): stri
   for (let i = 0; i < strings.length; i++) {
     results.push(strings[i]);
     if (i < values.length) {
-      if(values[i] == null || values[i] == undefined) {
+      if (values[i] == null || values[i] == undefined) {
         results.push(formatNullAndUndefined(values[i]));
       } else {
         results.push(escapeQuotesIfString(values[i], strings[i]));

--- a/sdk/search/search-documents/test/odata.spec.ts
+++ b/sdk/search/search-documents/test/odata.spec.ts
@@ -30,6 +30,64 @@ describe("odata", () => {
     assert.strictEqual(result, "search.ismatch('you''re', 'Description')");
   });
 
+  it("no arguments", () => {
+    assert.strictEqual(odata`Foo eq 2`, "Foo eq 2");
+  });
+
+  it("one argument", () => {
+     assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
+  });
+
+  it("many arguments", () => {
+    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3}`, "Foo eq 2 and Bar eq 3");
+    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4}`, "Foo eq 2 and Bar eq 3 and Baz eq 4");
+    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5}`, "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5");
+    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5} and Quux eq ${6}`, "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5 and Quux eq 6");
+  });
+
+  it("null", () => {
+    assert.strictEqual(odata`Foo eq ${null}`, "Foo eq null");
+  });
+
+  it("bool", () => {
+    let x:boolean = true;
+    assert.strictEqual(odata`Foo eq ${x}`, "Foo eq true");
+    assert.strictEqual(odata`Foo eq ${true}`, "Foo eq true");
+
+    x = false;
+    assert.strictEqual(odata`Foo eq ${x}`, "Foo eq false");
+    assert.strictEqual(odata`Foo eq ${false}`, "Foo eq false");
+  });
+
+  it("numbers", () => {
+    assert.strictEqual(odata`Foo eq ${0}`, "Foo eq 0");
+    assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
+    assert.strictEqual(odata`Foo eq ${-2}`, "Foo eq -2");
+    assert.strictEqual(odata`Foo eq ${2.5}`, "Foo eq 2.5");    
+  });
+
+  it("limits", () => {
+    assert.strictEqual(odata`Foo eq ${Number.NEGATIVE_INFINITY}`, "Foo eq -Infinity");
+    assert.strictEqual(odata`Foo eq ${Number.POSITIVE_INFINITY}`, "Foo eq Infinity");
+    assert.strictEqual(odata`Foo eq ${Number.NaN}`, "Foo eq NaN");
+    assert.strictEqual(odata`Foo eq ${Number.MAX_VALUE}`, "Foo eq 1.7976931348623157e+308");
+    assert.strictEqual(odata`Foo eq ${Number.MIN_VALUE}`, "Foo eq 5e-324");
+  });
+
+  it("dates", () => {
+    const result:string = odata`Foo eq ${new Date(1912, 6, 23, 11, 59, 59)}`;
+    assert.strictEqual(result.includes("Tue Jul 23 1912 11:59:59"), true);
+  });
+
+  it("text", () => {
+    assert.strictEqual(odata`Foo eq ${'x'}`, "Foo eq 'x'");
+    assert.strictEqual(odata`Foo eq ${'\''}`, "Foo eq ''''");
+    assert.strictEqual(odata`Foo eq ${'"'}`, "Foo eq '\"'");
+    assert.strictEqual(odata`Foo eq ${"bar"}`, "Foo eq 'bar'" );
+    assert.strictEqual(odata`Foo eq ${"bar's"}`, "Foo eq 'bar''s'" );
+    assert.strictEqual(odata`Foo eq ${"\"bar\""}`, "Foo eq '\"bar\"'" );
+  });
+
   afterEach(() => {
     sinon.restore();
   });

--- a/sdk/search/search-documents/test/odata.spec.ts
+++ b/sdk/search/search-documents/test/odata.spec.ts
@@ -39,15 +39,6 @@ describe("odata", () => {
   });
 
   it("many arguments", () => {
-    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3}`, "Foo eq 2 and Bar eq 3");
-    assert.strictEqual(
-      odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4}`,
-      "Foo eq 2 and Bar eq 3 and Baz eq 4"
-    );
-    assert.strictEqual(
-      odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5}`,
-      "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5"
-    );
     assert.strictEqual(
       odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5} and Quux eq ${6}`,
       "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5 and Quux eq 6"
@@ -62,10 +53,6 @@ describe("odata", () => {
     let x: boolean = true;
     assert.strictEqual(odata`Foo eq ${x}`, "Foo eq true");
     assert.strictEqual(odata`Foo eq ${true}`, "Foo eq true");
-
-    x = false;
-    assert.strictEqual(odata`Foo eq ${x}`, "Foo eq false");
-    assert.strictEqual(odata`Foo eq ${false}`, "Foo eq false");
   });
 
   it("numbers", () => {
@@ -79,8 +66,6 @@ describe("odata", () => {
     assert.strictEqual(odata`Foo eq ${Number.NEGATIVE_INFINITY}`, "Foo eq -Infinity");
     assert.strictEqual(odata`Foo eq ${Number.POSITIVE_INFINITY}`, "Foo eq Infinity");
     assert.strictEqual(odata`Foo eq ${Number.NaN}`, "Foo eq NaN");
-    assert.strictEqual(odata`Foo eq ${Number.MAX_VALUE}`, "Foo eq 1.7976931348623157e+308");
-    assert.strictEqual(odata`Foo eq ${Number.MIN_VALUE}`, "Foo eq 5e-324");
   });
 
   it("dates", () => {

--- a/sdk/search/search-documents/test/odata.spec.ts
+++ b/sdk/search/search-documents/test/odata.spec.ts
@@ -35,14 +35,23 @@ describe("odata", () => {
   });
 
   it("one argument", () => {
-     assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
+    assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
   });
 
   it("many arguments", () => {
     assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3}`, "Foo eq 2 and Bar eq 3");
-    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4}`, "Foo eq 2 and Bar eq 3 and Baz eq 4");
-    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5}`, "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5");
-    assert.strictEqual(odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5} and Quux eq ${6}`, "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5 and Quux eq 6");
+    assert.strictEqual(
+      odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4}`,
+      "Foo eq 2 and Bar eq 3 and Baz eq 4"
+    );
+    assert.strictEqual(
+      odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5}`,
+      "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5"
+    );
+    assert.strictEqual(
+      odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5} and Quux eq ${6}`,
+      "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5 and Quux eq 6"
+    );
   });
 
   it("null", () => {
@@ -50,7 +59,7 @@ describe("odata", () => {
   });
 
   it("bool", () => {
-    let x:boolean = true;
+    let x: boolean = true;
     assert.strictEqual(odata`Foo eq ${x}`, "Foo eq true");
     assert.strictEqual(odata`Foo eq ${true}`, "Foo eq true");
 
@@ -63,7 +72,7 @@ describe("odata", () => {
     assert.strictEqual(odata`Foo eq ${0}`, "Foo eq 0");
     assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
     assert.strictEqual(odata`Foo eq ${-2}`, "Foo eq -2");
-    assert.strictEqual(odata`Foo eq ${2.5}`, "Foo eq 2.5");    
+    assert.strictEqual(odata`Foo eq ${2.5}`, "Foo eq 2.5");
   });
 
   it("limits", () => {
@@ -75,17 +84,17 @@ describe("odata", () => {
   });
 
   it("dates", () => {
-    const result:string = odata`Foo eq ${new Date(1912, 6, 23, 11, 59, 59)}`;
+    const result: string = odata`Foo eq ${new Date(1912, 6, 23, 11, 59, 59)}`;
     assert.strictEqual(result.includes("Tue Jul 23 1912 11:59:59"), true);
   });
 
   it("text", () => {
-    assert.strictEqual(odata`Foo eq ${'x'}`, "Foo eq 'x'");
-    assert.strictEqual(odata`Foo eq ${'\''}`, "Foo eq ''''");
+    assert.strictEqual(odata`Foo eq ${"x"}`, "Foo eq 'x'");
+    assert.strictEqual(odata`Foo eq ${"'"}`, "Foo eq ''''");
     assert.strictEqual(odata`Foo eq ${'"'}`, "Foo eq '\"'");
-    assert.strictEqual(odata`Foo eq ${"bar"}`, "Foo eq 'bar'" );
-    assert.strictEqual(odata`Foo eq ${"bar's"}`, "Foo eq 'bar''s'" );
-    assert.strictEqual(odata`Foo eq ${"\"bar\""}`, "Foo eq '\"bar\"'" );
+    assert.strictEqual(odata`Foo eq ${"bar"}`, "Foo eq 'bar'");
+    assert.strictEqual(odata`Foo eq ${"bar's"}`, "Foo eq 'bar''s'");
+    assert.strictEqual(odata`Foo eq ${'"bar"'}`, "Foo eq '\"bar\"'");
   });
 
   afterEach(() => {


### PR DESCRIPTION
For the October release, one of the tasks was to  add odata expression helpers and keep in sync with .NET. When I started testing it, I found we are already doing almost everything that .NET does. I added the code related to null and added all the testcases from .NET [Link](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/search/Azure.Search.Documents/tests/Serialization/SearchFilterTests.cs)

@xirzec Please review and approve.

@ramya-rao-a FYI... 