### PR TITLE
[event-hubs] Update doc for subscription.close() to mention checkpoint store updating.

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -209,6 +209,10 @@ export interface SubscribeOptions {
 export interface Subscription {
   /**
    * Stops the subscription from receiving more messages.
+   * 
+   * If a checkpoint store has been configured this will also mark this subscription's
+   * partitions as abandoned, freeing them up to be read by other consumers.
+   * 
    * @returns Promise<void>
    * @throws Error if the underlying connection encounters an error while closing.
    */


### PR DESCRIPTION
As part of investigating #11316 we found it was non-obvious that we would be using the checkpoint store when closing. 

The reason we use it is when we close the subscription we also mark, in the checkpoint store, that the partitions are abandoned. This lets other consumers more quickly pick up abandoned partitions rather than forcing them to wait for an expiration interval and discover it.

Fixes #11316