### PR TITLE
[Identity] Idea for the Device Code Credential Use Console Feature

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -96,7 +96,7 @@ export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
 
 // @public
 export class DeviceCodeCredential implements TokenCredential {
-    constructor(tenantId: string | "organizations", clientId: string, userPromptCallback: DeviceCodePromptCallback, options?: TokenCredentialOptions);
+    constructor(tenantId: string | "organizations", clientId: string, userPromptCallback?: DeviceCodePromptCallback, options?: TokenCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
 
@@ -135,7 +135,7 @@ export { GetTokenOptions }
 export class InteractiveBrowserCredential implements TokenCredential {
     constructor(options?: InteractiveBrowserCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
-}
+    }
 
 // @public
 export interface InteractiveBrowserCredentialOptions extends TokenCredentialOptions {

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -47,7 +47,7 @@ const logger = credentialLogger("DeviceCodeCredential");
  * @param deviceCodeInfo The device code.
  */
 export function defaultDeviceCodePromptCallback(deviceCodeInfo: DeviceCodeInfo): void {
-  console.log(deviceCodeInfo.userCode);
+  console.log(deviceCodeInfo.message);
 }
 
 /**
@@ -70,7 +70,7 @@ export class DeviceCodeCredential implements TokenCredential {
    *                 'organizations' may be used when dealing with multi-tenant scenarios.
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param userPromptCallback A callback function that will be invoked to show
-                               {@link DeviceCodeInfo} to the user. If left unassigned, a function will automatically log the user code in the console.
+                               {@link DeviceCodeInfo} to the user. If left unassigned, we will automatically log the device code information and the authentication instructions in the console.
    * @param options Options for configuring the client which makes the authentication request.
    */
   constructor(

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -43,6 +43,14 @@ export type DeviceCodePromptCallback = (deviceCodeInfo: DeviceCodeInfo) => void;
 const logger = credentialLogger("DeviceCodeCredential");
 
 /**
+ * Method that logs the user code from the DeviceCodeCredential.
+ * @param deviceCodeInfo The device code.
+ */
+export function defaultDeviceCodePromptCallback(deviceCodeInfo: DeviceCodeInfo): void {
+  console.log(deviceCodeInfo.userCode);
+}
+
+/**
  * Enables authentication to Azure Active Directory using a device code
  * that the user can enter into https://microsoft.com/devicelogin.
  */
@@ -62,13 +70,13 @@ export class DeviceCodeCredential implements TokenCredential {
    *                 'organizations' may be used when dealing with multi-tenant scenarios.
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param userPromptCallback A callback function that will be invoked to show
-                               {@link DeviceCodeInfo} to the user.
+                               {@link DeviceCodeInfo} to the user. If left unassigned, a function will automatically log the user code in the console.
    * @param options Options for configuring the client which makes the authentication request.
    */
   constructor(
     tenantId: string | "organizations",
     clientId: string,
-    userPromptCallback: DeviceCodePromptCallback,
+    userPromptCallback: DeviceCodePromptCallback = defaultDeviceCodePromptCallback,
     options?: TokenCredentialOptions
   ) {
     this.identityClient = new IdentityClient(options);


### PR DESCRIPTION
If I'm reading .Net's PR correctly: https://github.com/Azure/azure-sdk-for-net/pull/15266

This PR should be about providing a default way to low the user code through the DeviceCodeCredential.

If so, then this is exactly the solution.

I could be missing something! Feedback appreciated.

If reviewed, approved and merged,
Fixes #10229