### PR TITLE
[Eslint Plugin] Update ts-naming-options rule to expect a more reasonable name for constructor options

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md
@@ -8,10 +8,13 @@ Requires client method options parameter types to be suffixed with `Options` and
 
 ```ts
 class ServiceClient {
+  constructor(options: ServiceClientOptions) {
+    /* code */
+  }
   createItem(options: CreateItemOptions): Item {
     /* code to return instance of Item */
   }
-  upsertItem(options: UpsertItemOptions): Item {
+  insertItem(options: InsertItemOptions): Item {
     /* code to return instance of Item */
   }
 }
@@ -21,6 +24,9 @@ class ServiceClient {
 
 ```ts
 class ServiceClient {
+  constructor(options: Options) {
+    /* code */
+  }
   createItem(options: Options): Item {
     /* code to return instance of Item */
   }

--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md
@@ -14,7 +14,7 @@ class ServiceClient {
   createItem(options: CreateItemOptions): Item {
     /* code to return instance of Item */
   }
-  insertItem(options: InsertItemOptions): Item {
+  upsertItem(options: UpsertItemOptions): Item {
     /* code to return instance of Item */
   }
 }

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
@@ -32,6 +32,10 @@ ruleTester.run("ts-naming-options", rule, {
       code:
         "class ExampleClient { createExample(options: CreateExampleOptions) {}; upsertExample(options: UpsertExampleOptions) {}; };"
     },
+    // class constructor
+    {
+      code: "class ExampleClient { constructor(options: ExampleClientOptions) {}; };"
+    },
     // not a client
     {
       code: "class Example { createExample(options: Options) {}; };"
@@ -43,6 +47,14 @@ ruleTester.run("ts-naming-options", rule, {
       errors: [
         {
           message: "options parameter type is not prefixed with the method name"
+        }
+      ]
+    },
+    {
+      code: "class ExampleClient { constructor(options: Options) {}; };",
+      errors: [
+        {
+          message: "options parameter type is not prefixed with the class name"
         }
       ]
     }


### PR DESCRIPTION
Currently `ts-naming-options` expects the type of the options parameter to the constructor of a client class to be named `ConstructorOptions`, but I think a more reasonable behavior would be to expect `<class name>Options` instead and this PR implements this. Suggestions for alternative behaviors are welcome!