### PR TITLE
Disable smoke test for storage-blob-changefeed

### DIFF
--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -161,5 +161,8 @@
     "typescript": "~3.9.3",
     "util": "^0.12.1",
     "sinon": "^9.0.2"
+  },
+  "//smokeTestConfiguration": {
+    "skipFolder": true
   }
 }


### PR DESCRIPTION
Smoke test is not working for storage-blob-changefeed. Disabling smoke test for this package temporarily until issue is resolved.