### PR TITLE
[service-bus] Fixing broken option - we renamed maxWaitTimeInSeconds to maxWaitTimeInMs

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
@@ -28,7 +28,7 @@ async function main() {
   try {
     for (let i = 0; i < 10; i++) {
       const messages = await queueReceiver.receiveMessages(1, {
-        maxWaitTimeSeconds: 5
+        maxWaitTimeInMs: 5000
       });
       if (!messages.length) {
         console.log("No more messages to receive");


### PR DESCRIPTION
Error spotted in sample where we're using the old setting (maxWaitTimeInSeconds) rather than maxWaitTimeInMs. 

Spotted by @lilyjma.
