### PR TITLE
[ESLint Plugin] Enforce inclusion of dist-esm and exclusion of src in files field in package.json

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
@@ -2,7 +2,7 @@
 
 Requires `files` in `package.json` to contain paths to the package contents.
 
-Specifically, this rule looks for inclusion of `dist`, `dist-esm/src`, and `src` as either just those directories or specific subdirectories
+Specifically, this rule looks for inclusion of `dist`, and the exclusion of `dist-esm/src`, and `src` as either just those directories or specific subdirectories
 
 This rule is fixable using the `--fix` option.
 
@@ -12,41 +12,25 @@ This rule is fixable using the `--fix` option.
 
 ```json
 {
-    "files": [
-        "dist",
-        "dist-esm/src"
-        "src"
-    ]
+  "files": ["dist"]
 }
 ```
 
 ```json
 {
-    "files": [
-        "./dist",
-        "./dist-esm/src"
-        "./src"
-    ]
+  "files": ["./dist"]
 }
 ```
 
 ```json
 {
-    "files": [
-        "dist/",
-        "dist-esm/src/"
-        "src/"
-    ]
+  "files": ["dist/"]
 }
 ```
 
 ```json
 {
-    "files": [
-        "dist/lib",
-        "dist-esm/src/lib"
-        "src/lib"
-    ]
+  "files": ["dist/lib"]
 }
 ```
 
@@ -55,12 +39,6 @@ This rule is fixable using the `--fix` option.
 ```json
 {
   "files": ["dist", "dist-esm/src"]
-}
-```
-
-```json
-{
-  "files": ["dist"]
 }
 ```
 

--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
@@ -2,7 +2,7 @@
 
 Requires `files` in `package.json` to contain paths to the package contents.
 
-Specifically, this rule looks for inclusion of `dist`, and the exclusion of `dist-esm/src`, and `src` as either just those directories or specific subdirectories
+Specifically, this rule looks for inclusion of `dist`, `dist-esm/src`, and `src` as either just those directories or specific subdirectories
 
 This rule is fixable using the `--fix` option.
 
@@ -12,25 +12,25 @@ This rule is fixable using the `--fix` option.
 
 ```json
 {
-  "files": ["dist"]
+  "files": ["dist", "dist-esm/src"]
 }
 ```
 
 ```json
 {
-  "files": ["./dist"]
+  "files": ["./dist", "./dist-esm/src"]
 }
 ```
 
 ```json
 {
-  "files": ["dist/"]
+  "files": ["dist/", "dist-esm/"]
 }
 ```
 
 ```json
 {
-  "files": ["dist/lib"]
+  "files": ["dist/lib", "dist-esm/src/lib"]
 }
 ```
 
@@ -38,7 +38,13 @@ This rule is fixable using the `--fix` option.
 
 ```json
 {
-  "files": ["dist", "dist-esm/src"]
+  "files": ["dist", "src"]
+}
+```
+
+```json
+{
+  "files": ["dist"]
 }
 ```
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -25,12 +25,10 @@ function addRequiredPattern(pattern: string, suggestion?: string): void {
  * is the list of patterns that should be.
  */
 const badPatterns: string[] = ["src"];
-const requiredPatterns: string[] = [];
+let requiredPatterns: string[];
 addRequiredPattern("dist");
 addRequiredPattern("dist-esm", "src");
-requiredPatternSuggestionMap.forEach((_, pat) => {
-  requiredPatterns.push(pat);
-});
+requiredPatterns = Array.from(requiredPatternSuggestionMap.keys());
 
 export = {
   meta: getRuleMetaData(

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -24,11 +24,10 @@ function addRequiredPattern(pattern: string, suggestion?: string): void {
  * patterns that should not be in package.json's files list and requiredPatterns
  * is the list of patterns that should be.
  */
-const badPatterns: string[] = ["src"];
-let requiredPatterns: string[];
+const badPatterns = ["src"];
 addRequiredPattern("dist");
 addRequiredPattern("dist-esm", "src");
-requiredPatterns = Array.from(requiredPatternSuggestionMap.keys());
+const requiredPatterns = Array.from(requiredPatternSuggestionMap.keys());
 
 export = {
   meta: getRuleMetaData(

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -20,7 +20,8 @@ import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../util
  * the list of patterns that should be.
  */
 const badPatterns: string[] = ["src"];
-const goodPatterns = ["dist", "dist-esm/src"];
+const distEsmPattern = "dist-esm";
+const goodPatterns = ["dist", distEsmPattern];
 
 export = {
   meta: getRuleMetaData(
@@ -73,7 +74,7 @@ export = {
                 if (badPatterns.indexOf(patternRoot) >= 0) {
                   currBadPatterns.push(patternMatchResult[fullMatchIndex]);
                 } else if (goodPatterns.indexOf(patternRoot) >= 0) {
-                  currGoodPatterns.splice(currGoodPatterns.indexOf(patternRoot));
+                  currGoodPatterns.splice(currGoodPatterns.indexOf(patternRoot), 1);
                 }
               }
             });
@@ -90,12 +91,16 @@ export = {
               if (message.length > 0) {
                 message = message + " and ";
               }
+              const distEsmIndex = currGoodPatterns.indexOf(distEsmPattern);
+              if (distEsmIndex >= 0) {
+                currGoodPatterns[distEsmIndex] = "dist-esm/src";
+              }
+              elementValues = elementValues.concat(currGoodPatterns);
               message =
                 message +
                 `${currGoodPatterns.join()} ${
                   currGoodPatterns.length === 1 ? "is" : "are"
                 } not included in files`;
-              elementValues = elementValues.concat(currGoodPatterns);
             }
             if (message.length > 0) {
               context.report({

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -16,12 +16,12 @@ import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../util
 
 /**
  * The rule is configurable by those two vars, where badPatterns is the list of
- * patterns that should not be in package.json's files list and goodPatterns is
- * the list of patterns that should be.
+ * patterns that should not be in package.json's files list and requiredPatterns
+ * is the list of patterns that should be.
  */
 const badPatterns: string[] = ["src"];
 const distEsmPattern = "dist-esm";
-const goodPatterns = ["dist", distEsmPattern];
+const requiredPatterns = ["dist", distEsmPattern];
 
 export = {
   meta: getRuleMetaData(
@@ -36,7 +36,7 @@ export = {
     // sorting the patterns descendingly so in cases of overlap between patterns
     // (e.g. dist and dist-esm), the regex tries to match the longer first.
     const regExprStr = `^(?:.\/)?(${badPatterns
-      .concat(goodPatterns)
+      .concat(requiredPatterns)
       .sort()
       .reverse()
       .join("|")})(?:\/)?(?:.+)?`;
@@ -64,7 +64,7 @@ export = {
             let elementValues = elements.map((element: Literal): unknown => element.value);
 
             let currBadPatterns: string[] = [];
-            let currGoodPatterns = [...goodPatterns];
+            let currRequiredPatterns = [...requiredPatterns];
             const fullMatchIndex = 0;
             const patternRootMatchIndex = 1;
             elements.forEach((element) => {
@@ -73,8 +73,8 @@ export = {
                 const patternRoot = patternMatchResult[patternRootMatchIndex];
                 if (badPatterns.indexOf(patternRoot) >= 0) {
                   currBadPatterns.push(patternMatchResult[fullMatchIndex]);
-                } else if (goodPatterns.indexOf(patternRoot) >= 0) {
-                  currGoodPatterns.splice(currGoodPatterns.indexOf(patternRoot), 1);
+                } else if (requiredPatterns.indexOf(patternRoot) >= 0) {
+                  currRequiredPatterns.splice(currRequiredPatterns.indexOf(patternRoot), 1);
                 }
               }
             });
@@ -87,19 +87,19 @@ export = {
                 (element) => currBadPatterns.indexOf(element as string) < 0
               );
             }
-            if (currGoodPatterns.length > 0) {
+            if (currRequiredPatterns.length > 0) {
               if (message.length > 0) {
                 message = message + " and ";
               }
-              const distEsmIndex = currGoodPatterns.indexOf(distEsmPattern);
+              const distEsmIndex = currRequiredPatterns.indexOf(distEsmPattern);
               if (distEsmIndex >= 0) {
-                currGoodPatterns[distEsmIndex] = "dist-esm/src";
+                currRequiredPatterns[distEsmIndex] = "dist-esm/src";
               }
-              elementValues = elementValues.concat(currGoodPatterns);
+              elementValues = elementValues.concat(currRequiredPatterns);
               message =
                 message +
-                `${currGoodPatterns.join()} ${
-                  currGoodPatterns.length === 1 ? "is" : "are"
+                `${currRequiredPatterns.join()} ${
+                  currRequiredPatterns.length === 1 ? "is" : "are"
                 } not included in files`;
             }
             if (message.length > 0) {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -19,8 +19,8 @@ import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../util
  * patterns that should not be in package.json's files list and goodPatterns is
  * the list of patterns that should be.
  */
-const badPatterns: string[] = ["src", "dist-esm"];
-const goodPatterns = ["dist"];
+const badPatterns: string[] = ["src"];
+const goodPatterns = ["dist", "dist-esm/src"];
 
 export = {
   meta: getRuleMetaData(

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -46,7 +46,6 @@ export = {
           // check to see if files exists at the outermost level
           "ExpressionStatement > ObjectExpression": verifiers.existsInFile,
 
-          // check that files contains dist, and do not include dist-esm, and src
           "ExpressionStatement > ObjectExpression > Property[key.value='files']": (
             node: Property
           ): void => {

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -314,30 +314,40 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "dist is not included in files"
+          message: "dist,dist-esm/src are not included in files"
         }
       ],
-      output: '{"files": ["types/package.d.ts", "dist"]}'
+      output: '{"files": ["types/package.d.ts", "dist", "dist-esm/src"]}'
     },
     {
       code: '{"files": ["dist", "src", "dist-esm/src"]}',
       filename: "package.json",
       errors: [
         {
-          message: "src,dist-esm/src are included in files"
+          message: "src is included in files"
         }
       ],
-      output: '{"files": ["dist"]}'
+      output: '{"files": ["dist", "dist-esm/src"]}'
     },
     {
       code: '{"files": ["dist-esm/src"]}',
       filename: "package.json",
       errors: [
         {
-          message: "dist-esm/src is included in files and dist is not included in files"
+          message: "dist is not included in files"
         }
       ],
-      output: '{"files": ["dist"]}'
+      output: '{"files": ["dist-esm/src", "dist"]}'
+    },
+    {
+      code: '{"files": ["src"]}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "src is included in files and dist,dist-esm/src are not included in files"
+        }
+      ],
+      output: '{"files": ["dist", "dist-esm/src"]}'
     },
     {
       // example file with src not in files
@@ -345,7 +355,7 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "dist-esm/src is included in files and dist is not included in files"
+          message: "dist is not included in files"
         }
       ]
     }

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -230,8 +230,7 @@ const examplePackageBad = `{
   },
   "files": [
     "typings/service-bus.d.ts",
-    "tsconfig.json",
-    "dist-esm/src"
+    "tsconfig.json"
   ],
   "sideEffects": false
 }`;
@@ -269,6 +268,11 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json"
     },
     {
+      // mixed
+      code: '{"files": ["dist/", "./dist-esm/src/"]}',
+      filename: "package.json"
+    },
+    {
       // a full example package.json (taken from https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/package.json with "scripts" removed for testing purposes)
       code: examplePackageGood,
       filename: "package.json"
@@ -291,7 +295,7 @@ ruleTester.run("ts-package-json-files-required", rule, {
     },
     {
       // name is in a nested object
-      code: '{"outer": {"files": ["dist"]}}',
+      code: '{"outer": {"files": ["dist", "dist-esm/src"]}}',
       filename: "package.json",
       errors: [
         {
@@ -311,21 +315,21 @@ ruleTester.run("ts-package-json-files-required", rule, {
       output: '{"files": ["dist", "dist-esm/src"]}'
     },
     {
-      code: '{"files": ["types/package.d.ts"]}',
+      code: '{"files": ["src", "dist-esm/src"]}',
       filename: "package.json",
       errors: [
         {
-          message: "dist,dist-esm/src are not included in files"
+          message: "src is included in files and dist is not included in files"
         }
       ],
-      output: '{"files": ["types/package.d.ts", "dist", "dist-esm/src"]}'
+      output: '{"files": ["dist-esm/src", "dist"]}'
     },
     {
-      code: '{"files": ["dist", "src", "dist-esm/src"]}',
+      code: '{"files": ["dist"]}',
       filename: "package.json",
       errors: [
         {
-          message: "src is included in files"
+          message: "dist-esm/src is not included in files"
         }
       ],
       output: '{"files": ["dist", "dist-esm/src"]}'
@@ -341,11 +345,11 @@ ruleTester.run("ts-package-json-files-required", rule, {
       output: '{"files": ["dist-esm/src", "dist"]}'
     },
     {
-      code: '{"files": ["src"]}',
+      code: '{"files": []}',
       filename: "package.json",
       errors: [
         {
-          message: "src is included in files and dist,dist-esm/src are not included in files"
+          message: "dist,dist-esm/src are not included in files"
         }
       ],
       output: '{"files": ["dist", "dist-esm/src"]}'
@@ -356,7 +360,7 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "dist is not included in files"
+          message: "dist,dist-esm/src are not included in files"
         }
       ]
     }

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -119,8 +119,7 @@ const examplePackageGood = `{
   "files": [
     "typings/service-bus.d.ts",
     "tsconfig.json",
-    "dist",
-    "dist-esm/src"
+    "dist"
   ],
   "sideEffects": false
 }`;
@@ -230,7 +229,8 @@ const examplePackageBad = `{
   },
   "files": [
     "typings/service-bus.d.ts",
-    "tsconfig.json"
+    "tsconfig.json",
+    "dist-esm/src"
   ],
   "sideEffects": false
 }`;
@@ -251,25 +251,20 @@ ruleTester.run("ts-package-json-files-required", rule, {
   valid: [
     {
       // only the fields we care about
-      code: '{"files": ["dist", "dist-esm/src"]}',
+      code: '{"files": ["dist"]}',
       filename: "package.json"
     },
     // other valid formats
     {
-      code: '{"files": ["dist/", "dist-esm/src/"]}',
+      code: '{"files": ["dist/"]}',
       filename: "package.json"
     },
     {
-      code: '{"files": ["./dist", "./dist-esm/src"]}',
+      code: '{"files": ["./dist"]}',
       filename: "package.json"
     },
     {
-      code: '{"files": ["./dist/", "./dist-esm/src/"]}',
-      filename: "package.json"
-    },
-    {
-      // mixed
-      code: '{"files": ["dist/", "./dist-esm/src/"]}',
+      code: '{"files": ["./dist/"]}',
       filename: "package.json"
     },
     {
@@ -295,7 +290,7 @@ ruleTester.run("ts-package-json-files-required", rule, {
     },
     {
       // name is in a nested object
-      code: '{"outer": {"files": ["dist", "dist-esm/src"]}}',
+      code: '{"outer": {"files": ["dist"]}}',
       filename: "package.json",
       errors: [
         {
@@ -309,50 +304,37 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "dist-esm/src is not included in files"
+          message: "src is included in files"
         }
       ],
-      output: '{"files": ["dist", "src", "dist-esm/src"]}'
+      output: '{"files": ["dist"]}'
     },
     {
-      code: '{"files": ["src", "dist-esm/src"]}',
+      code: '{"files": ["types/package.d.ts"]}',
       filename: "package.json",
       errors: [
         {
           message: "dist is not included in files"
         }
       ],
-      output: '{"files": ["src", "dist-esm/src", "dist"]}'
+      output: '{"files": ["types/package.d.ts", "dist"]}'
     },
     {
-      code: '{"files": ["dist"]}',
+      code: '{"files": ["dist", "src", "dist-esm/src"]}',
       filename: "package.json",
       errors: [
         {
-          message: "dist-esm/src is not included in files"
+          message: "src,dist-esm/src are included in files"
         }
       ],
-      output: '{"files": ["dist", "dist-esm/src"]}'
+      output: '{"files": ["dist"]}'
     },
     {
       code: '{"files": ["dist-esm/src"]}',
       filename: "package.json",
       errors: [
         {
-          message: "dist is not included in files"
-        }
-      ],
-      output: '{"files": ["dist-esm/src", "dist"]}'
-    },
-    {
-      code: '{"files": []}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "dist is not included in files"
-        },
-        {
-          message: "dist-esm/src is not included in files"
+          message: "dist-esm/src is included in files and dist is not included in files"
         }
       ],
       output: '{"files": ["dist"]}'
@@ -363,10 +345,7 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "dist is not included in files"
-        },
-        {
-          message: "dist-esm/src is not included in files"
+          message: "dist-esm/src is included in files and dist is not included in files"
         }
       ]
     }

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -119,7 +119,8 @@ const examplePackageGood = `{
   "files": [
     "typings/service-bus.d.ts",
     "tsconfig.json",
-    "dist"
+    "dist",
+    "dist-esm/src"
   ],
   "sideEffects": false
 }`;
@@ -251,20 +252,20 @@ ruleTester.run("ts-package-json-files-required", rule, {
   valid: [
     {
       // only the fields we care about
-      code: '{"files": ["dist"]}',
+      code: '{"files": ["dist", "dist-esm/src"]}',
       filename: "package.json"
     },
     // other valid formats
     {
-      code: '{"files": ["dist/"]}',
+      code: '{"files": ["dist/", "dist-esm/src/"]}',
       filename: "package.json"
     },
     {
-      code: '{"files": ["./dist"]}',
+      code: '{"files": ["./dist", "./dist-esm/src"]}',
       filename: "package.json"
     },
     {
-      code: '{"files": ["./dist/"]}',
+      code: '{"files": ["./dist/", "./dist-esm/src/"]}',
       filename: "package.json"
     },
     {
@@ -304,10 +305,10 @@ ruleTester.run("ts-package-json-files-required", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "src is included in files"
+          message: "src is included in files and dist-esm/src is not included in files"
         }
       ],
-      output: '{"files": ["dist"]}'
+      output: '{"files": ["dist", "dist-esm/src"]}'
     },
     {
       code: '{"files": ["types/package.d.ts"]}',

--- a/sdk/storage/storage-datalake/package.json
+++ b/sdk/storage/storage-datalake/package.json
@@ -43,7 +43,6 @@
     "esm/**/*.js.map",
     "esm/**/*.d.ts",
     "esm/**/*.d.ts.map",
-    "src/**/*.ts",
     "README.md",
     "rollup.config.js",
     "tsconfig.json"


### PR DESCRIPTION
~This change updates the `ts-package-json-files-required` rule to check for the absence of `src` and `dist-esm` in the `files` list in `package.json` since sourcemaps now have the sources embedded. It is based on discussion with @xirzec here https://github.com/Azure/azure-sdk-for-js/pull/11273#discussion_r492975784. Related issue: https://github.com/Azure/azure-sdk-for-js/pull/7615.~

~TODO in this PR: update every package's `package.json` to conform to the final rule before merging.~
After discussion with @willmtemple, @bterlson, and @xirzec here, this PR updates the eslint plugin to make sure `dist-esm` is included and `src` is not in `package'json`'s `files` list.