### PR TITLE
[core] Mark core 2.0 packages as publishable

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -42,13 +42,19 @@ extends:
         safeName: azurecoreasynciteratorpolyfill
       - name: azure-core-auth
         safeName: azurecoreauth
+      - name: azure-core-client
+        safeName: azurecoreclient
       - name: azure-core-http
         safeName: azurecorehttp
+      - name: azure-core-https
+        safeName: azurecorehttps
       - name: azure-core-lro
         safeName: azurecorelro
       - name: azure-core-paging
         safeName: azurecorepaging
       - name: azure-core-tracing
         safeName: azurecoretracing
+      - name: azure-core-xml
+        safeName: azurecorexml
       - name: azure-logger
         safeName: azurelogger

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0.preview.1 (UNRELEASED)
+## 1.0.0.beta.1 (UNRELEASED)

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0.beta.1 (UNRELEASED)
+## 1.0.0-beta.1 (UNRELEASED)

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.0.0-preview.1",
-  "private": true,
+  "version": "1.0.0-beta.1",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -77,13 +77,13 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-https": "1.0.0-preview.1",
+    "@azure/core-https": "1.0.0-beta.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@azure/core-xml": "1.0.0-preview.1",
+    "@azure/core-xml": "1.0.0-beta.1",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0 (UNRELEASED)
+## 1.0.0-beta.1 (UNRELEASED)

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@azure/core-https",
-  "version": "1.0.0-preview.1",
-  "private": true,
+  "version": "1.0.0-beta.1",
   "description": "Isomorphic client library for making HTTPS requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0.preview.1 (UNRELEASED)
+## 1.0.0-beta.1 (UNRELEASED)

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.0.0-preview.1",
-  "private": true,
+  "version": "1.0.0-beta.1",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
This will allow us to test nightlies of these packages against Autorest.TypeScript.