### PR TITLE
[Schema Registry] Stop linting tsconfig, run lint:fix

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -24,8 +24,8 @@
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json tsconfig.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json tsconfig.json api-extractor.json src test --ext .ts -f html -o schema-registry-avro-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o schema-registry-avro-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -42,10 +42,9 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/schemaregistry/schema-registry-avro"
+  "repository": "github:Azure/azure-sdk-for-js",
+  "engines": {
+    "node": ">=8.0.0"
   },
   "keywords": [
     "azure",

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -180,7 +180,7 @@ export class SchemaRegistryAvroSerializer {
   }
 
   private async getSchemaByContent(schema: string): Promise<CacheEntry> {
-    let cached = this.cacheByContent.get(schema);
+    const cached = this.cacheByContent.get(schema);
     if (cached) {
       return cached;
     }

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -24,8 +24,8 @@
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json tsconfig.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json tsconfig.json api-extractor.json src test --ext .ts -f html -o schema-registry-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o schema-registry-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -58,10 +58,9 @@
       }
     ]
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git",
-    "directory": "sdk/schemaregistry/schema-registry"
+  "repository": "github:Azure/azure-sdk-for-js",
+  "engines": {
+    "node": ">=8.0.0"
   },
   "keywords": [
     "azure",


### PR DESCRIPTION
This PR has changes from running the lint:fix script on the Schema Registry packages with hopes of reducing the noise when someone wants to work on #10779

This also removes tsconfig.json from being linted as per reasons in #10361