### PR TITLE
[Cosmos] Adding missing copyright headers

### DIFF
--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { JSONObject } from "../queryExecutionContext";
 import { extractPartitionKey } from "../extractPartitionKey";
 import { PartitionKeyDefinition } from "../documents";

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/number.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/number.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import JSBI from "jsbi";
 import { BytePrefix } from "./prefix";
 

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/prefix.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/prefix.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export const BytePrefix = {
   Undefined: "00",
   Null: "01",

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/string.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/string.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { BytePrefix } from "./prefix";
 
 export function writeStringForBinaryEncoding(payload: string) {

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/v1.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/v1.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { doubleToByteArrayJSBI, writeNumberForBinaryEncodingJSBI } from "./encoding/number";
 import { writeStringForBinaryEncoding } from "./encoding/string";
 import { BytePrefix } from "./encoding/prefix";

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/v2.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/v2.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { doubleToByteArrayJSBI } from "./encoding/number";
 import { BytePrefix } from "./encoding/prefix";
 import MurmurHash from "./murmurHash";

--- a/sdk/cosmosdb/cosmos/src/utils/offers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/offers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { ContainerRequest } from "../client/Container/ContainerRequest";
 
 export function validateOffer(body: ContainerRequest): void {

--- a/sdk/cosmosdb/cosmos/test/unit/hashing/v1.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/unit/hashing/v1.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import assert from "assert";
 import { hashV1PartitionKey } from "../../../src/utils/hashing/v1";
 

--- a/sdk/cosmosdb/cosmos/test/unit/hashing/v2.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/unit/hashing/v2.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import assert from "assert";
 import { hashV2PartitionKey } from "../../../src/utils/hashing/v2";
 


### PR DESCRIPTION
This PR adds the missing copyright headers in the source files in the cosmos package with an intention to reduce noise for when #10776 is picked up