### PR TITLE
[Logger] Cleaning up and fixing linting

### DIFF
--- a/sdk/core/logger/api-extractor.json
+++ b/sdk/core/logger/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "types/src/logger.d.ts",
+  "mainEntryPointFilePath": "types/src/index.d.ts",
   "docModel": {
     "enabled": true
   },

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -4,10 +4,13 @@
   "version": "1.0.1",
   "description": "Microsoft Azure SDK for JavaScript - Logger",
   "main": "./dist/index.js",
-  "module": "./dist-esm/src/logger.js",
+  "module": "dist-esm/src/index.js",
   "browser": {
     "./dist-esm/src/log.js": "./dist-esm/src/log.browser.js",
     "process": false
+  },
+  "engines": {
+    "node": ">=8.0.0"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
@@ -23,8 +26,8 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c ../../.eslintrc.old.json --fix --fix-type [problem,suggestion]",
-    "lint": "eslint -c ../../.eslintrc.old.json src test --ext .ts -f html -o logger-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "pretest": "npm run build:test",
@@ -46,10 +49,7 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
-  },
+  "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",
     "log",
@@ -58,19 +58,21 @@
     "node.js",
     "typescript",
     "javascript",
-    "browser"
+    "browser",
+    "cloud"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger/README.md",
   "sideEffects": false,
   "dependencies": {
     "tslib": "^2.0.0"
   },
   "devDependencies": {
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/core/logger/review/logger.api.md
+++ b/sdk/core/logger/review/logger.api.md
@@ -35,7 +35,7 @@ export interface Debugger {
 }
 
 // @public
-export function getLogLevel(): "verbose" | "info" | "warning" | "error" | undefined;
+export function getLogLevel(): AzureLogLevel | undefined;
 
 // @public
 export function setLogLevel(level?: AzureLogLevel): void;

--- a/sdk/core/logger/rollup.base.config.js
+++ b/sdk/core/logger/rollup.base.config.js
@@ -12,7 +12,7 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const pkg = require("./package.json");
 const depNames = Object.keys(pkg.dependencies);
 const devDepNames = Object.keys(pkg.devDependencies);
-const input = "./dist-esm/src/logger.js";
+const input = "./dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {

--- a/sdk/core/logger/src/debug.ts
+++ b/sdk/core/logger/src/debug.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/* eslint-disable no-invalid-this */
+
 import { log } from "./log";
 
 /**
@@ -156,7 +158,6 @@ function createDebugger(namespace: string): Debugger {
 }
 
 function destroy(this: Debugger): boolean {
-  // eslint-disable-next-line no-invalid-this
   const index = debuggers.indexOf(this);
   if (index >= 0) {
     debuggers.splice(index, 1);
@@ -166,9 +167,7 @@ function destroy(this: Debugger): boolean {
 }
 
 function extend(this: Debugger, namespace: string): Debugger {
-  // eslint-disable-next-line no-invalid-this
   const newDebugger = createDebugger(`${this.namespace}:${namespace}`);
-  // eslint-disable-next-line no-invalid-this
   newDebugger.log = this.log;
   return newDebugger;
 }

--- a/sdk/core/logger/src/index.ts
+++ b/sdk/core/logger/src/index.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import debug, { Debugger } from "./debug";
 export { Debugger } from "./debug";
@@ -60,7 +60,7 @@ if (logLevelFromEnv) {
  * - warning
  * - error
  */
-export function setLogLevel(level?: AzureLogLevel) {
+export function setLogLevel(level?: AzureLogLevel): void {
   if (level && !isAzureLogLevel(level)) {
     throw new Error(
       `Unknown log level '${level}'. Acceptable values: ${AZURE_LOG_LEVELS.join(",")}`
@@ -81,7 +81,7 @@ export function setLogLevel(level?: AzureLogLevel) {
 /**
  * Retrieves the currently specified log level.
  */
-export function getLogLevel() {
+export function getLogLevel(): AzureLogLevel | undefined {
   return azureLogLevel;
 }
 
@@ -158,7 +158,7 @@ function createLogger(parent: AzureClientLogger, level: AzureLogLevel): AzureDeb
   return logger;
 }
 
-function shouldEnable(logger: AzureDebugger) {
+function shouldEnable(logger: AzureDebugger): boolean {
   if (azureLogLevel && levelMap[logger.level] <= levelMap[azureLogLevel]) {
     return true;
   } else {

--- a/sdk/core/logger/src/log.browser.ts
+++ b/sdk/core/logger/src/log.browser.ts
@@ -1,7 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 const logFunction = console.debug || console.log;
-export function log(...args: any[]) {
+export function log(...args: any[]): void {
   logFunction(...args);
 }

--- a/sdk/core/logger/src/log.ts
+++ b/sdk/core/logger/src/log.ts
@@ -1,9 +1,9 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import util from "util";
 import { EOL } from "os";
 
-export function log(message: any, ...args: any[]) {
+export function log(message: any, ...args: any[]): void {
   process.stderr.write(`${util.format(message, ...args)}${EOL}`);
 }

--- a/sdk/core/logger/test/debug.spec.ts
+++ b/sdk/core/logger/test/debug.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import debug, { Debugger } from "../src/debug";
 import { stub } from "sinon";

--- a/sdk/core/logger/test/logger.spec.ts
+++ b/sdk/core/logger/test/logger.spec.ts
@@ -1,7 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
-import * as Logger from "../src/logger";
+import * as Logger from "../src";
 import * as assert from "assert";
 
 const testLogger = Logger.createClientLogger("test");


### PR DESCRIPTION
Switching the eslint configuration file used for `logging` to use the newer one in the root of the repository and fixing all the linting problems. Furthermore, enforce the absence of linting errors in CI.