### PR TITLE
[EventGrid] Prepare for 3.0.0-beta.2 release

### DIFF
--- a/sdk/eventgrid/eventgrid/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.2 (Unreleased)
+## 3.0.0-beta.2 (2020-09-24)
 
 - Added support for system events sent by the Azure Communication Services.
 


### PR DESCRIPTION
We are doing an off-cycle release today to ship the definitions of the system events for Azure Communication Services.