### PR TITLE
[Test Utils] Use our ESLint plugin

### DIFF
--- a/sdk/test-utils/perfstress/.eslintrc.json
+++ b/sdk/test-utils/perfstress/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["../../.eslintrc.old.json", "plugin:@azure/azure-sdk/recommended"],
-  "parserOptions": {
-    "createDefaultProgram": true
-  }
-}

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -21,7 +21,7 @@
     "integration-test:node": "node dist-esm/test/index.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
+    "lint": "eslint package.json src test --ext .ts -f html -o perfstress-lintReport.html || exit 0",
     "lint:terminal": "eslint package.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -21,7 +21,7 @@
     "integration-test:node": "node dist-esm/test/index.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
+    "lint": "eslint package.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
     "lint:terminal": "eslint package.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -20,8 +20,8 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "node dist-esm/test/index.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c ../../.eslintrc.json --fix --fix-type [problem,suggestion]",
-    "lint": "eslint -c ../../.eslintrc.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
     "lint:terminal": "eslint package.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
@@ -71,6 +71,7 @@
     "@types/minimist": "~1.2.0"
   },
   "devDependencies": {
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@types/node": "^8.0.0",
     "@types/node-fetch": "^2.5.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -21,8 +21,8 @@
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c ../../.eslintrc.old.json --fix --fix-type [problem,suggestion]",
-    "lint": "eslint -c ../../.eslintrc.old.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "unit-test:browser": "karma start --single-run",
@@ -67,6 +67,7 @@
     "md5": "^2.2.1"
   },
   "devDependencies": {
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",


### PR DESCRIPTION
Switching the eslint configuration file to use the newer one in the root of the repository. See https://github.com/Azure/azure-sdk-for-js/issues/11256.