### PR TITLE
[Cosmos] Does not use .eslintrc.old.json

### DIFF
--- a/sdk/cosmosdb/cosmos/.eslintrc.json
+++ b/sdk/cosmosdb/cosmos/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "plugins": ["@azure/azure-sdk", "@typescript-eslint/tslint"],
-  "extends": ["../../.eslintrc.old.json", "plugin:@azure/azure-sdk/recommended"],
+  "extends": ["plugin:@azure/azure-sdk/recommended"],
   "parserOptions": {
     "createDefaultProgram": true
   },


### PR DESCRIPTION
We are planning on removing `.eslintrc.old.json` file and this PR removes its use in `cosmos` package. See https://github.com/Azure/azure-sdk-for-js/issues/11256.