### PR TITLE
[core-http] Find additionalProperties in referenced mapper

### DIFF
--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -11,7 +11,8 @@ import {
   SequenceMapper,
   CompositeMapper,
   PolymorphicDiscriminator,
-  EnumMapper
+  EnumMapper,
+  BaseMapper
 } from "./interfaces";
 
 class SerializerImpl implements Serializer {
@@ -566,6 +567,52 @@ function serializeDictionaryType(
 }
 
 /**
+ * Resolves the additionalProperties property from a referenced mapper
+ * @param serializer the serializer containing the entire set of mappers
+ * @param mapper the composite mapper to resolve
+ * @param objectName name of the object being serialized
+ */
+function resolveAdditionalProperties(
+  serializer: Serializer,
+  mapper: CompositeMapper,
+  objectName: string
+): SequenceMapper | BaseMapper | CompositeMapper | DictionaryMapper | EnumMapper | undefined {
+  const additionalProperties = mapper.type.additionalProperties;
+
+  if (!additionalProperties && mapper.type.className) {
+    const modelMapper = resolveReferencedMapper(serializer, mapper, objectName);
+    return modelMapper?.type.additionalProperties;
+  }
+
+  return additionalProperties;
+}
+
+/**
+ * Finds the mapper referenced by className
+ * @param serializer the serializer containing the entire set of mappers
+ * @param mapper the composite mapper to resolve
+ * @param objectName name of the object being serialized
+ */
+function resolveReferencedMapper(
+  serializer: Serializer,
+  mapper: CompositeMapper,
+  objectName: string
+): CompositeMapper | undefined {
+  const className = mapper.type.className;
+  if (!className) {
+    throw new Error(
+      `Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(
+        mapper,
+        undefined,
+        2
+      )}".`
+    );
+  }
+
+  return serializer.modelMappers[className];
+}
+
+/**
  * Resolves a composite mapper's modelProperties.
  * @param serializer the serializer containing the entire set of mappers
  * @param mapper the composite mapper to resolve
@@ -577,28 +624,17 @@ function resolveModelProperties(
 ): { [propertyName: string]: Mapper } {
   let modelProps = mapper.type.modelProperties;
   if (!modelProps) {
-    const className = mapper.type.className;
-    if (!className) {
-      throw new Error(
-        `Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(
-          mapper,
-          undefined,
-          2
-        )}".`
-      );
-    }
-
-    const modelMapper = serializer.modelMappers[className];
+    const modelMapper = resolveReferencedMapper(serializer, mapper, objectName);
     if (!modelMapper) {
-      throw new Error(`mapper() cannot be null or undefined for model "${className}".`);
+      throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}".`);
     }
-    modelProps = modelMapper.type.modelProperties;
+    modelProps = modelMapper?.type.modelProperties;
     if (!modelProps) {
       throw new Error(
         `modelProperties cannot be null or undefined in the ` +
-          `mapper "${JSON.stringify(
-            modelMapper
-          )}" of type "${className}" for object "${objectName}".`
+          `mapper "${JSON.stringify(modelMapper)}" of type "${
+            mapper.type.className
+          }" for object "${objectName}".`
       );
     }
   }
@@ -695,7 +731,7 @@ function serializeCompositeType(
       }
     }
 
-    const additionalPropertiesMapper = mapper.type.additionalProperties;
+    const additionalPropertiesMapper = resolveAdditionalProperties(serializer, mapper, objectName);
     if (additionalPropertiesMapper) {
       const propNames = Object.keys(modelProps);
       for (const clientPropName in object) {

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -208,6 +208,40 @@ describe("ServiceClient", function() {
   });
 
   describe("serializeRequestBody()", () => {
+    it("should serialize additional properties when the mapper is refd by className", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      const body = [
+        {
+          version: 1,
+          name: "Test",
+          time: new Date("2020-09-24T17:31:35.034Z"),
+          data: {
+            baseData: {
+              test: "Hello!",
+              extraProp: "FooBar"
+            }
+          }
+        }
+      ];
+
+      serializeRequestBody(
+        httpRequest,
+        {
+          body
+        },
+        {
+          httpMethod: "POST",
+          requestBody: Mappers.body,
+          responses: { 200: {} },
+          serializer: createSerializer(Mappers)
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `[{"ver":1,"name":"Test","time":"2020-09-24T17:31:35.034Z","data":{"baseData":{"test":"Hello!","extraProp":"FooBar"}}}]`
+      );
+    });
+
     it("should serialize a JSON String request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(

--- a/sdk/core/core-client/test/testMappers.ts
+++ b/sdk/core/core-client/test/testMappers.ts
@@ -1018,4 +1018,120 @@ internalMappers.requestBody1 = {
   mapper: CreateQueueBody
 };
 
+internalMappers.TelemetryItem = {
+  type: {
+    name: "Composite",
+    className: "TelemetryItem",
+    modelProperties: {
+      version: {
+        defaultValue: 1,
+        serializedName: "ver",
+        type: {
+          name: "Number"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      time: {
+        serializedName: "time",
+        required: true,
+        type: {
+          name: "DateTime"
+        }
+      },
+      sampleRate: {
+        defaultValue: 100,
+        serializedName: "sampleRate",
+        type: {
+          name: "Number"
+        }
+      },
+      sequence: {
+        constraints: {
+          MaxLength: 64
+        },
+        serializedName: "seq",
+        type: {
+          name: "String"
+        }
+      },
+      instrumentationKey: {
+        serializedName: "iKey",
+        type: {
+          name: "String"
+        }
+      },
+      tags: {
+        serializedName: "tags",
+        type: {
+          name: "Dictionary",
+          value: { type: { name: "String" } }
+        }
+      },
+      data: {
+        serializedName: "data",
+        type: {
+          name: "Composite",
+          className: "MonitorBase"
+        }
+      }
+    }
+  }
+};
+
+internalMappers.MonitorBase = {
+  type: {
+    name: "Composite",
+    className: "MonitorBase",
+    modelProperties: {
+      baseType: {
+        serializedName: "baseType",
+        type: {
+          name: "String"
+        }
+      },
+      baseData: {
+        serializedName: "baseData",
+        type: {
+          name: "Composite",
+          className: "MonitorDomain"
+        }
+      }
+    }
+  }
+};
+
+internalMappers.MonitorDomain = {
+  type: {
+    name: "Composite",
+    className: "MonitorDomain",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      test: {
+        serializedName: "test",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+internalMappers.body = {
+  parameterPath: "body",
+  mapper: {
+    serializedName: "body",
+    required: true,
+    type: {
+      name: "Sequence",
+      element: { type: { name: "Composite", className: "TelemetryItem" } }
+    }
+  }
+};
+
 export const Mappers = internalMappers;

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -549,6 +549,45 @@ function serializeDictionaryType(
 }
 
 /**
+ * Resolves the additionalProperties property from a referenced mapper
+ * @param serializer the serializer containing the entire set of mappers
+ * @param mapper the composite mapper to resolve
+ * @param objectName name of the object being serialized
+ */
+function resolveAdditionalProperties(serializer: Serializer, mapper: CompositeMapper, objectName: string): SequenceMapper | BaseMapper | CompositeMapper | DictionaryMapper | EnumMapper | undefined
+{
+  const additionalProperties = mapper.type.additionalProperties;
+
+  if (!additionalProperties && mapper.type.className) {
+    const modelMapper = resolveReferencedMapper(serializer, mapper, objectName);
+    return modelMapper?.type.additionalProperties;
+  }
+
+  return additionalProperties;
+}
+
+/**
+ * Finds the mapper referenced by className
+ * @param serializer the serializer containing the entire set of mappers
+ * @param mapper the composite mapper to resolve
+ * @param objectName name of the object being serialized
+ */
+function resolveReferencedMapper(serializer: Serializer, mapper: CompositeMapper, objectName: string): CompositeMapper | undefined {
+  const className = mapper.type.className;
+  if (!className) {
+    throw new Error(
+      `Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(
+        mapper,
+        undefined,
+        2
+      )}".`
+    );
+  }
+
+  return serializer.modelMappers[className];
+}
+
+/**
  * Resolves a composite mapper's modelProperties.
  * @param serializer the serializer containing the entire set of mappers
  * @param mapper the composite mapper to resolve
@@ -560,28 +599,17 @@ function resolveModelProperties(
 ): { [propertyName: string]: Mapper } {
   let modelProps = mapper.type.modelProperties;
   if (!modelProps) {
-    const className = mapper.type.className;
-    if (!className) {
-      throw new Error(
-        `Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(
-          mapper,
-          undefined,
-          2
-        )}".`
-      );
-    }
-
-    const modelMapper = serializer.modelMappers[className];
+    const modelMapper = resolveReferencedMapper(serializer, mapper, objectName);
     if (!modelMapper) {
-      throw new Error(`mapper() cannot be null or undefined for model "${className}".`);
+      throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}".`);
     }
-    modelProps = modelMapper.type.modelProperties;
+    modelProps = modelMapper?.type.modelProperties;
     if (!modelProps) {
       throw new Error(
         `modelProperties cannot be null or undefined in the ` +
           `mapper "${JSON.stringify(
             modelMapper
-          )}" of type "${className}" for object "${objectName}".`
+          )}" of type "${mapper.type.className}" for object "${objectName}".`
       );
     }
   }
@@ -678,7 +706,7 @@ function serializeCompositeType(
       }
     }
 
-    const additionalPropertiesMapper = mapper.type.additionalProperties;
+    const additionalPropertiesMapper = resolveAdditionalProperties(serializer, mapper, objectName);
     if (additionalPropertiesMapper) {
       const propNames = Object.keys(modelProps);
       for (const clientPropName in object) {

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -554,8 +554,11 @@ function serializeDictionaryType(
  * @param mapper the composite mapper to resolve
  * @param objectName name of the object being serialized
  */
-function resolveAdditionalProperties(serializer: Serializer, mapper: CompositeMapper, objectName: string): SequenceMapper | BaseMapper | CompositeMapper | DictionaryMapper | EnumMapper | undefined
-{
+function resolveAdditionalProperties(
+  serializer: Serializer,
+  mapper: CompositeMapper,
+  objectName: string
+): SequenceMapper | BaseMapper | CompositeMapper | DictionaryMapper | EnumMapper | undefined {
   const additionalProperties = mapper.type.additionalProperties;
 
   if (!additionalProperties && mapper.type.className) {
@@ -572,7 +575,11 @@ function resolveAdditionalProperties(serializer: Serializer, mapper: CompositeMa
  * @param mapper the composite mapper to resolve
  * @param objectName name of the object being serialized
  */
-function resolveReferencedMapper(serializer: Serializer, mapper: CompositeMapper, objectName: string): CompositeMapper | undefined {
+function resolveReferencedMapper(
+  serializer: Serializer,
+  mapper: CompositeMapper,
+  objectName: string
+): CompositeMapper | undefined {
   const className = mapper.type.className;
   if (!className) {
     throw new Error(
@@ -607,9 +614,9 @@ function resolveModelProperties(
     if (!modelProps) {
       throw new Error(
         `modelProperties cannot be null or undefined in the ` +
-          `mapper "${JSON.stringify(
-            modelMapper
-          )}" of type "${mapper.type.className}" for object "${objectName}".`
+          `mapper "${JSON.stringify(modelMapper)}" of type "${
+            mapper.type.className
+          }" for object "${objectName}".`
       );
     }
   }

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -26,7 +26,7 @@ import {
   OperationSpec
 } from "../src/coreHttp";
 import { ParameterPath } from "../src/operationParameter";
-import { requestBody1 } from "./testMappers";
+import * as Mappers from "./testMappers";
 
 describe("ServiceClient", function() {
   it("should serialize headerCollectionPrefix", async function() {
@@ -483,6 +483,38 @@ describe("ServiceClient", function() {
       assert.strictEqual(httpRequest.body, `"body value"`);
     });
 
+    it("should serialize additional properties when the mapper is refd by className", () => {
+      const httpRequest = new WebResource();
+      const body = [
+        {
+          version: 1,
+          name: "Test",
+          time: new Date("2020-09-24T17:31:35.034Z"),
+          data: {
+            baseData: {
+              test: "Hello!",
+              extraProp: "FooBar"
+            }
+          }
+        }
+      ];
+
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          body
+        },
+        {
+          httpMethod: "POST",
+          requestBody: Mappers.body,
+          responses: { 200: {} },
+          serializer: new Serializer(Mappers)
+        }
+      );
+      assert.strictEqual(httpRequest.body, `[{"ver":1,"name":"Test","time":"2020-09-24T17:31:35.034Z","data":{"baseData":{"test":"Hello!","extraProp":"FooBar"}}}]`);
+    });
+
     it("should serialize a JSON String request body with namespace, ignoring namespace", () => {
       const httpRequest = new WebResource();
       serializeRequestBody(
@@ -937,12 +969,15 @@ describe("ServiceClient", function() {
         {
           requestBody: {
             updated: new Date("2020-08-12T23:36:18.308Z"),
-            content: { type: "application/xml", queueDescription: { maxDeliveryCount: 15 } }
+            content: {
+              type: "application/xml",
+              queueDescription: { maxDeliveryCount: 15 }
+            }
           }
         },
         {
           httpMethod: "POST",
-          requestBody: requestBody1,
+          requestBody: Mappers.requestBody1,
           responses: { 200: {} },
           serializer: new Serializer(undefined, true /** isXML */),
           isXML: true
@@ -962,12 +997,15 @@ describe("ServiceClient", function() {
         {
           requestBody: {
             updated: new Date("2020-08-12T23:36:18.308Z"),
-            content: { type: "application/xml", queueDescription: { maxDeliveryCount: 15 } }
+            content: {
+              type: "application/xml",
+              queueDescription: { maxDeliveryCount: 15 }
+            }
           }
         },
         {
           httpMethod: "POST",
-          requestBody: requestBody1,
+          requestBody: Mappers.requestBody1,
           responses: { 200: {} },
           serializer: new Serializer()
         }

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -512,7 +512,10 @@ describe("ServiceClient", function() {
           serializer: new Serializer(Mappers)
         }
       );
-      assert.strictEqual(httpRequest.body, `[{"ver":1,"name":"Test","time":"2020-09-24T17:31:35.034Z","data":{"baseData":{"test":"Hello!","extraProp":"FooBar"}}}]`);
+      assert.strictEqual(
+        httpRequest.body,
+        `[{"ver":1,"name":"Test","time":"2020-09-24T17:31:35.034Z","data":{"baseData":{"test":"Hello!","extraProp":"FooBar"}}}]`
+      );
     });
 
     it("should serialize a JSON String request body with namespace, ignoring namespace", () => {

--- a/sdk/core/core-http/test/testMappers.ts
+++ b/sdk/core/core-http/test/testMappers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { CompositeMapper, OperationParameter } from "../src/coreHttp";
 
 const QueueDescription: CompositeMapper = {
@@ -263,4 +266,120 @@ const CreateQueueBody: CompositeMapper = {
 export const requestBody1: OperationParameter = {
   parameterPath: "requestBody",
   mapper: CreateQueueBody
+};
+
+export const TelemetryItem: CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "TelemetryItem",
+    modelProperties: {
+      version: {
+        defaultValue: 1,
+        serializedName: "ver",
+        type: {
+          name: "Number"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      time: {
+        serializedName: "time",
+        required: true,
+        type: {
+          name: "DateTime"
+        }
+      },
+      sampleRate: {
+        defaultValue: 100,
+        serializedName: "sampleRate",
+        type: {
+          name: "Number"
+        }
+      },
+      sequence: {
+        constraints: {
+          MaxLength: 64
+        },
+        serializedName: "seq",
+        type: {
+          name: "String"
+        }
+      },
+      instrumentationKey: {
+        serializedName: "iKey",
+        type: {
+          name: "String"
+        }
+      },
+      tags: {
+        serializedName: "tags",
+        type: {
+          name: "Dictionary",
+          value: { type: { name: "String" } }
+        }
+      },
+      data: {
+        serializedName: "data",
+        type: {
+          name: "Composite",
+          className: "MonitorBase"
+        }
+      }
+    }
+  }
+};
+
+export const MonitorBase: CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MonitorBase",
+    modelProperties: {
+      baseType: {
+        serializedName: "baseType",
+        type: {
+          name: "String"
+        }
+      },
+      baseData: {
+        serializedName: "baseData",
+        type: {
+          name: "Composite",
+          className: "MonitorDomain"
+        }
+      }
+    }
+  }
+};
+
+export const MonitorDomain: CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MonitorDomain",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      test: {
+        serializedName: "test",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const body: OperationParameter = {
+  parameterPath: "body",
+  mapper: {
+    serializedName: "body",
+    required: true,
+    type: {
+      name: "Sequence",
+      element: { type: { name: "Composite", className: "TelemetryItem" } }
+    }
+  }
 };


### PR DESCRIPTION
When serializing object using mappers with references to other mappers, core-http doesn't look at the referenced mapper for `additionalProperties` it only looks for it in the source mapper.

Sample of a referenced mapper:

```typescript
export const MonitorBase: CompositeMapper = {
  type: {
    name: "Composite",
    className: "MonitorBase",
    modelProperties: {
      baseType: {
        serializedName: "baseType",
        type: {
          name: "String"
        }
      },
      baseData: {
        serializedName: "baseData",
        type: {
          name: "Composite",
          className: "MonitorDomain" // this is a reference to MonitorDomainMapper
        }
      }
    }
  }
};

export const MonitorDomain: CompositeMapper = {
  type: {
    name: "Composite",
    className: "MonitorDomain",
    additionalProperties: { type: { name: "Object" } },
    modelProperties: {
      test: {
        serializedName: "test",
        type: {
          name: "String"
        }
      }
    }
  }
};
```

This PR modifies the serializer and deserializer so that they also look at the referenced mapper for `additionalProperties` and ports the changes to `core-client`