### PR TITLE
[Identity] Changelog entry for the recent DeviceCodeCredential change

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
 ## 1.2.0-beta.2 (Unreleased)
-- Reverted change in 1.2.0-beta.1 which moved @rollup/plugin-json from devDependencies to dependencies.
+
 - `DefaultAzureCredential` now by default shows the Device Code message on the console. This can still be overwritten with a custom behavior by specifying a function as the third parameter, `userPromptCallback`.
+- Reverted a change in 1.2.0-beta.1 which moved `@rollup/plugin-json` from `devDependencies` to `dependencies`. `@rollup/plugin-json` was placed as a dependency due to an oversight, and it is not a necessary dependency for `@azure/identity`.
 
 ## 1.2.0-beta.1 (2020-09-08)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.2.0-beta.2 (Unreleased)
 - Reverted change in 1.2.0-beta.1 which moved @rollup/plugin-json from devDependencies to dependencies.
-- `DefaultAzureCredential` now by default shows the Device Code message on the console.  
-  This can still be overwritten with a custom behavior by specifying a function as the third parameter, `userPromptCallback`.
+- `DefaultAzureCredential` now by default shows the Device Code message on the console. This can still be overwritten with a custom behavior by specifying a function as the third parameter, `userPromptCallback`.
 
 ## 1.2.0-beta.1 (2020-09-08)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
 ## 1.2.0-beta.2 (Unreleased)
-- Reverted change in 1.2.0-beta.1 which moved @rollup/plugin-json from devDependencies to dependencies
+- Reverted change in 1.2.0-beta.1 which moved @rollup/plugin-json from devDependencies to dependencies.
+- `DefaultAzureCredential` now by default shows the Device Code message on the console.  
+  This can still be overwritten with a custom behavior by specifying a function as the third parameter, `userPromptCallback`.
 
 ## 1.2.0-beta.1 (2020-09-08)
 


### PR DESCRIPTION
This is an experiment. It's a separate PR with the changelog entry for this previous PR: https://github.com/Azure/azure-sdk-for-js/pull/11355

I'm trying to separate the code changes from the changes related to documentation etc. I'm wondering if it is easier to review this this way or if I should always add the changelog entry as part of the PR with the code changes.