### PR TITLE
[Key Vault] All of the Key Vault changelog entries for the upcoming release

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
 
 ## 4.2.0-beta.2 (Unreleased)
-
+- Added the `oct-HSM` type to `KeyType`.
+- Added encryption, decryption, wrapping and unwrapping service support for the algorithms "A128GCM", "A192GCM", "A256GCM", "A128KW", "A192KW", "A256KW", "A128CBC", "A192CBC", "A256CBC", "A128CBCPAD", "A192CBCPAD", "A256CBCPAD".
+- The encryption, decryption, wrapping and unwrapping operations now support the following optional parameters:
+  - `additionalAuthenticatedData`, Additional data to authenticate but not encrypt/decrypt when using authenticated cryptography algorithms.
+  - `iv`, the initialization vector for symmetric algorithms.
+  - `tag`, the tag to authenticate when performing decryption with an authenticated algorithm.
 
 ## 4.2.0-beta.1 (2020-09-11)
 


### PR DESCRIPTION
This is an experiment. It's a separate PR with the changelog entry for this previous PRs that have changed the Key Vault packages.

This includes only the changes relevant to our customers. Therefore, the following PRs:

- [Key Vault Keys] Add new algorithms, remote only #11260
- Add oct-HSM support #11027

Notes:

- Even though we did update all the packages to the latest swagger, the only public API change was on Key Vault Keys: https://github.com/Azure/azure-sdk-for-js/pull/11370/files#diff-91e6187853dc6c6c676058faaa81d8e2R212

I'll add more as we go through the remaining budget for this upcoming release.

Feedback appreciated ✨