### PR TITLE
[Identity] Clearer message on the getToken methods

### DIFF
--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -11,6 +11,9 @@ export interface TokenCredential {
   /**
    * Gets the token provided by this credential.
    *
+   * This method is called automatically by Azure SDK client libraries. You may call this method
+   * directly, but you must also handle token caching and token refreshing.
+   *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this
    *                TokenCredential implementation might make.

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -43,6 +43,9 @@ export class ChainedTokenCredential implements TokenCredential {
    * `TokenCredential` implementations.  Throws an {@link AggregateAuthenticationError}
    * when one or more credentials throws an {@link AuthenticationError} and
    * no credentials have returned an access token.
+   * 
+   * This method is called automatically by Azure SDK client libraries. You may call this method
+   * directly, but you must also handle token caching and token refreshing.
    *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this


### PR DESCRIPTION
Since some of our customers have started to work with our credentials directly, we've agreed that we should let them know that if they decide to work with the `getToken` methods themselves, they will need to figure out caching and token refreshing.

Fixes #11343

The specific message the team wants to add is [this one](https://github.com/Azure/azure-sdk-for-js/issues/11343#issuecomment-698623222):

```
// This method is called automatically by Azure SDK client libraries. You may call this method
// directly, but you must also handle token caching and token refreshing.
```

The main change here is an extra comment on both `ChainedTokenCredential` and `TokenCredential` to help users see this if they decide to use any of both directly. `DefaultAzureCredential` gets automatically handled by `ChainedTokenCredential` since the method is inherited.

Feedback always appreciated 🙌❤