### PR TITLE
[Text Analytics] Does not ignore ts-naming options

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -177,9 +177,6 @@ export enum PiiEntityDomainType {
 export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;
 
 // @public
-export type RecognizeCategorizedEntitiesOptions = TextAnalyticsOperationOptions;
-
-// @public
 export type RecognizeCategorizedEntitiesResult = RecognizeCategorizedEntitiesSuccessResult | RecognizeCategorizedEntitiesErrorResult;
 
 // @public
@@ -193,8 +190,8 @@ export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalytics
     readonly entities: CategorizedEntity[];
 }
 
-// @public (undocumented)
-export type RecognizeEntitiesOptions = RecognizeCategorizedEntitiesOptions;
+// @public
+export type RecognizeEntitiesOptions = TextAnalyticsOperationOptions;
 
 // @public
 export type RecognizeLinkedEntitiesErrorResult = TextAnalyticsErrorResult;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -193,6 +193,9 @@ export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalytics
     readonly entities: CategorizedEntity[];
 }
 
+// @public (undocumented)
+export type RecognizeEntitiesOptions = RecognizeCategorizedEntitiesOptions;
+
 // @public
 export type RecognizeLinkedEntitiesErrorResult = TextAnalyticsErrorResult;
 
@@ -281,8 +284,8 @@ export class TextAnalyticsClient {
     readonly endpointUrl: string;
     extractKeyPhrases(documents: string[], language?: string, options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultArray>;
     extractKeyPhrases(documents: TextDocumentInput[], options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultArray>;
-    recognizeEntities(documents: string[], language?: string, options?: RecognizeCategorizedEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultArray>;
-    recognizeEntities(documents: TextDocumentInput[], options?: RecognizeCategorizedEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultArray>;
+    recognizeEntities(documents: string[], language?: string, options?: RecognizeEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultArray>;
+    recognizeEntities(documents: TextDocumentInput[], options?: RecognizeEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultArray>;
     recognizeLinkedEntities(documents: string[], language?: string, options?: RecognizeLinkedEntitiesOptions): Promise<RecognizeLinkedEntitiesResultArray>;
     recognizeLinkedEntities(documents: TextDocumentInput[], options?: RecognizeLinkedEntitiesOptions): Promise<RecognizeLinkedEntitiesResultArray>;
     recognizePiiEntities(inputs: string[], language?: string, options?: RecognizePiiEntitiesOptions): Promise<RecognizePiiEntitiesResultArray>;

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -13,7 +13,8 @@ export {
   RecognizePiiEntitiesOptions,
   RecognizeLinkedEntitiesOptions,
   TextAnalyticsOperationOptions,
-  PiiEntityDomainType
+  PiiEntityDomainType,
+  RecognizeEntitiesOptions
 } from "./textAnalyticsClient";
 export {
   DetectLanguageResult,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -7,14 +7,13 @@ export {
   TextAnalyticsClient,
   TextAnalyticsClientOptions,
   DetectLanguageOptions,
-  RecognizeCategorizedEntitiesOptions,
+  RecognizeEntitiesOptions,
   AnalyzeSentimentOptions,
   ExtractKeyPhrasesOptions,
   RecognizePiiEntitiesOptions,
   RecognizeLinkedEntitiesOptions,
   TextAnalyticsOperationOptions,
-  PiiEntityDomainType,
-  RecognizeEntitiesOptions
+  PiiEntityDomainType
 } from "./textAnalyticsClient";
 export {
   DetectLanguageResult,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -92,7 +92,7 @@ export type DetectLanguageOptions = TextAnalyticsOperationOptions;
 /**
  * Options for the recognize entities operation.
  */
-export type RecognizeCategorizedEntitiesOptions = TextAnalyticsOperationOptions;
+export type RecognizeEntitiesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the analyze sentiment operation.
@@ -140,8 +140,6 @@ export type ExtractKeyPhrasesOptions = TextAnalyticsOperationOptions;
  * Options for the recognize linked entities operation.
  */
 export type RecognizeLinkedEntitiesOptions = TextAnalyticsOperationOptions;
-
-export type RecognizeEntitiesOptions = RecognizeCategorizedEntitiesOptions;
 
 /**
  * Client class for interacting with Azure Text Analytics.
@@ -352,10 +350,10 @@ export class TextAnalyticsClient {
   ): Promise<RecognizeCategorizedEntitiesResultArray>;
   public async recognizeEntities(
     documents: string[] | TextDocumentInput[],
-    languageOrOptions?: string | RecognizeCategorizedEntitiesOptions,
+    languageOrOptions?: string | RecognizeEntitiesOptions,
     options?: RecognizeEntitiesOptions
   ): Promise<RecognizeCategorizedEntitiesResultArray> {
-    let realOptions: RecognizeCategorizedEntitiesOptions;
+    let realOptions: RecognizeEntitiesOptions;
     let realInputs: TextDocumentInput[];
 
     if (!Array.isArray(documents) || documents.length === 0) {
@@ -368,7 +366,7 @@ export class TextAnalyticsClient {
       realOptions = options || {};
     } else {
       realInputs = documents;
-      realOptions = (languageOrOptions as RecognizeCategorizedEntitiesOptions) || {};
+      realOptions = (languageOrOptions as RecognizeEntitiesOptions) || {};
     }
 
     const { span, updatedOptions: finalOptions } = createSpan(

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -141,6 +141,8 @@ export type ExtractKeyPhrasesOptions = TextAnalyticsOperationOptions;
  */
 export type RecognizeLinkedEntitiesOptions = TextAnalyticsOperationOptions;
 
+export type RecognizeEntitiesOptions = RecognizeCategorizedEntitiesOptions;
+
 /**
  * Client class for interacting with Azure Text Analytics.
  */
@@ -331,8 +333,7 @@ export class TextAnalyticsClient {
   public async recognizeEntities(
     documents: string[],
     language?: string,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: RecognizeCategorizedEntitiesOptions
+    options?: RecognizeEntitiesOptions
   ): Promise<RecognizeCategorizedEntitiesResultArray>;
   /**
    * Runs a predictive model to identify a collection of named entities
@@ -347,14 +348,12 @@ export class TextAnalyticsClient {
    */
   public async recognizeEntities(
     documents: TextDocumentInput[],
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: RecognizeCategorizedEntitiesOptions
+    options?: RecognizeEntitiesOptions
   ): Promise<RecognizeCategorizedEntitiesResultArray>;
   public async recognizeEntities(
     documents: string[] | TextDocumentInput[],
     languageOrOptions?: string | RecognizeCategorizedEntitiesOptions,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: RecognizeCategorizedEntitiesOptions
+    options?: RecognizeEntitiesOptions
   ): Promise<RecognizeCategorizedEntitiesResultArray> {
     let realOptions: RecognizeCategorizedEntitiesOptions;
     let realInputs: TextDocumentInput[];


### PR DESCRIPTION
We were ignoring `ts-naming-options` for no good reason as far as I can tell here so I did the fix and re-enabling the rule in those places again.