### PR TITLE
[Tables] Remove some of the ignoring comments of ts-naming-options

### DIFF
--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -77,7 +77,6 @@ export class TableClient {
     url: string,
     tableName: string,
     credential: TablesSharedKeyCredential,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: TableClientOptions
   );
   /**
@@ -103,13 +102,11 @@ export class TableClient {
    * ```
    */
 
-  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
   constructor(url: string, tableName: string, options?: TableClientOptions);
   constructor(
     url: string,
     tableName: string,
     credentialOrOptions?: TablesSharedKeyCredential | TableClientOptions,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: TableClientOptions = {}
   ) {
     const credential =

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -67,11 +67,9 @@ export class TableServiceClient {
    * );
    * ```
    */
-  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
   constructor(
     url: string,
     credential: TablesSharedKeyCredential,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: TableServiceClientOptions
   );
   /**
@@ -92,12 +90,10 @@ export class TableServiceClient {
    * );
    * ```
    */
-  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
   constructor(url: string, options?: TableServiceClientOptions);
   constructor(
     url: string,
     credentialOrOptions?: TablesSharedKeyCredential | TableServiceClientOptions,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: TableServiceClientOptions
   ) {
     const credential =


### PR DESCRIPTION
Now that https://github.com/Azure/azure-sdk-for-js/pull/11403 has been merged, we can get rid of a few ignoring comments of `ts-naming-options` linting rule.