### PR TITLE
[Anomaly Detector] Does not ignore ts-naming options

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/review/ai-anomaly-detector.api.md
+++ b/sdk/anomalydetector/ai-anomaly-detector/review/ai-anomaly-detector.api.md
@@ -13,9 +13,9 @@ import { TokenCredential } from '@azure/core-auth';
 // @public
 export class AnomalyDetectorClient {
     constructor(endpointUrl: string, credential: TokenCredential | KeyCredential, options?: AnomalyDetectorClientOptions);
-    detectChangePoint(body: DetectChangePointRequest, options?: OperationOptions): Promise<AnomalyDetectorClientDetectChangePointResponse>;
-    detectEntireSeries(body: DetectRequest, options?: OperationOptions): Promise<AnomalyDetectorClientDetectEntireResponse>;
-    detectLastPoint(body: DetectRequest, options?: OperationOptions): Promise<AnomalyDetectorClientDetectLastPointResponse>;
+    detectChangePoint(body: DetectChangePointRequest, options?: DetectChangePointOptions): Promise<AnomalyDetectorClientDetectChangePointResponse>;
+    detectEntireSeries(body: DetectRequest, options?: DetectEntireSeriesOptions): Promise<AnomalyDetectorClientDetectEntireResponse>;
+    detectLastPoint(body: DetectRequest, options?: DetectLastPointOptions): Promise<AnomalyDetectorClientDetectLastPointResponse>;
     }
 
 // @public
@@ -47,6 +47,9 @@ export interface AnomalyDetectorClientOptions extends PipelineOptions {
 }
 
 // @public (undocumented)
+export type DetectChangePointOptions = OperationOptions;
+
+// @public (undocumented)
 export interface DetectChangePointRequest {
     customInterval?: number;
     granularity: TimeGranularity;
@@ -73,6 +76,12 @@ export interface DetectEntireResponse {
     period: number;
     upperMargins: number[];
 }
+
+// @public (undocumented)
+export type DetectEntireSeriesOptions = OperationOptions;
+
+// @public (undocumented)
+export type DetectLastPointOptions = OperationOptions;
 
 // @public (undocumented)
 export interface DetectLastPointResponse {

--- a/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
@@ -29,6 +29,10 @@ import { logger } from "./logger";
 import { createSpan } from "./tracing";
 import { CanonicalCode } from "@opentelemetry/api";
 
+export type DetectEntireSeriesOptions = OperationOptions;
+export type DetectLastPointOptions = OperationOptions;
+export type DetectChangePointOptions = OperationOptions;
+
 /**
  * Client class for interacting with Azure Anomaly Detector service.
  */
@@ -109,8 +113,7 @@ export class AnomalyDetectorClient {
    */
   public detectEntireSeries(
     body: DetectRequest,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: OperationOptions
+    options?: DetectEntireSeriesOptions
   ): Promise<AnomalyDetectorClientDetectEntireResponse> {
     const realOptions = options || {};
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -141,8 +144,7 @@ export class AnomalyDetectorClient {
    */
   public detectLastPoint(
     body: DetectRequest,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: OperationOptions
+    options?: DetectLastPointOptions
   ): Promise<AnomalyDetectorClientDetectLastPointResponse> {
     const realOptions = options || {};
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -171,8 +173,7 @@ export class AnomalyDetectorClient {
    */
   detectChangePoint(
     body: DetectChangePointRequest,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: OperationOptions
+    options?: DetectChangePointOptions
   ): Promise<AnomalyDetectorClientDetectChangePointResponse> {
     const realOptions = options || {};
     const { span, updatedOptions: finalOptions } = createSpan(

--- a/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/AnomalyDetectorClient.ts
@@ -64,7 +64,6 @@ export class AnomalyDetectorClient {
   constructor(
     endpointUrl: string,
     credential: TokenCredential | KeyCredential,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: AnomalyDetectorClientOptions
   ) {
     this.endpointUrl = endpointUrl;

--- a/sdk/anomalydetector/ai-anomaly-detector/src/index.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/index.ts
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { AnomalyDetectorClient } from "./AnomalyDetectorClient";
+export {
+  AnomalyDetectorClient,
+  DetectEntireSeriesOptions,
+  DetectLastPointOptions,
+  DetectChangePointOptions
+} from "./AnomalyDetectorClient";
 export * from "./models";


### PR DESCRIPTION
Now that https://github.com/Azure/azure-sdk-for-js/pull/11403 has been merged, we can get rid of a few ignoring comments of `ts-naming-options` linting rule. Furthermore, we were ignoring `ts-naming-options` in other places for no good reason as far as I can tell so I did the fix and re-enabling the rule in those places again.