### PR TITLE
[Text Analytics] Removes the length property from output types

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.1.0-beta.2 (2020-10-02)
+## 5.1.0-beta.2 (unreleased)
 
 - The `length` property is removed from `SentenceSentiment`, `Entity`, `Match`, PiiEntity`, and`CategorizedEntity` because the length information can be accessed from the text property itself using the string's length property.
 

--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 5.1.0-beta.2 (Unreleased)
+## 5.1.0-beta.2 (2020-10-02)
 
+- The `length` property is removed from `SentenceSentiment`, `Entity`, `Match`, PiiEntity`, and`CategorizedEntity` because the length information can be accessed from the text property itself using the string's length property.
 
 ## 5.1.0-beta.1 (2020-09-17)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -45,7 +45,6 @@ export interface AspectConfidenceScoreLabel {
 // @public
 export interface AspectSentiment {
     confidenceScores: AspectConfidenceScoreLabel;
-    length: number;
     offset: number;
     sentiment: TokenSentimentValue;
     text: string;
@@ -100,7 +99,6 @@ export type DocumentSentimentLabel = "positive" | "neutral" | "negative" | "mixe
 export interface Entity {
     category: string;
     confidenceScore: number;
-    length: number;
     offset: number;
     subCategory?: string;
     text: string;
@@ -149,7 +147,6 @@ export interface LinkedEntity {
 // @public
 export interface Match {
     confidenceScore: number;
-    length: number;
     offset: number;
     text: string;
 }
@@ -240,7 +237,6 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
 export interface SentenceOpinion {
     confidenceScores: AspectConfidenceScoreLabel;
     isNegated: boolean;
-    length: number;
     offset: number;
     sentiment: TokenSentimentValue;
     text: string;
@@ -249,7 +245,6 @@ export interface SentenceOpinion {
 // @public
 export interface SentenceSentiment {
     confidenceScores: SentimentConfidenceScores;
-    length: number;
     minedOpinions: MinedOpinion[];
     offset: number;
     sentiment: SentenceSentimentLabel;

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -68,10 +68,6 @@ export interface SentenceSentiment {
    */
   offset: number;
   /**
-   * The length of the sentence text.
-   */
-  length: number;
-  /**
    * The list of opinions mined from this sentence. For example in "The food is
    * good, but the service is bad", we would mind these two opinions "food is
    * good", "service is bad". Only returned if `show_opinion_mining` is set to
@@ -106,10 +102,6 @@ export interface AspectSentiment {
    * The aspect text offset from the start of the sentence.
    */
   offset: number;
-  /**
-   * The length of the aspect text.
-   */
-  length: number;
 }
 
 /**
@@ -182,7 +174,6 @@ function convertGeneratedSentenceSentiment(
     confidenceScores: sentence.confidenceScores,
     sentiment: sentence.sentiment,
     text: sentence.text,
-    length: sentence.length,
     offset: sentence.offset,
     minedOpinions: sentence.aspects
       ? sentence.aspects.map(
@@ -191,8 +182,7 @@ function convertGeneratedSentenceSentiment(
               confidenceScores: aspect.confidenceScores,
               sentiment: aspect.sentiment,
               text: aspect.text,
-              offset: aspect.offset,
-              length: aspect.length
+              offset: aspect.offset
             },
             opinions: aspect.relations
               .filter((relation) => relation.relationType === "opinion")

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { GeneratedClientOptionalParams } from "./models";
 
 const packageName = "@azure/ai-text-analytics";
-const packageVersion = "5.1.0-beta.1";
+const packageVersion = "5.1.0-beta.2";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { GeneratedClientOptionalParams } from "./models";
 
 const packageName = "@azure/ai-text-analytics";
-const packageVersion = "5.1.0-beta.2";
+const packageVersion = "5.1.0-beta.1";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -95,10 +95,6 @@ export interface Entity {
    */
   offset: number;
   /**
-   * Length for the entity text.
-   */
-  length: number;
-  /**
    * Confidence score between 0 and 1 of the extracted entity.
    */
   confidenceScore: number;
@@ -348,10 +344,6 @@ export interface Match {
    * Start position for the entity match text.
    */
   offset: number;
-  /**
-   * Length for the entity match text.
-   */
-  length: number;
 }
 
 export interface KeyPhraseResult {
@@ -540,10 +532,6 @@ export interface SentenceSentiment {
    */
   offset: number;
   /**
-   * The length of the sentence.
-   */
-  length: number;
-  /**
    * The array of aspect object for the sentence.
    */
   aspects?: SentenceAspect[];
@@ -566,10 +554,6 @@ export interface SentenceAspect {
    * The aspect offset from the start of the sentence.
    */
   offset: number;
-  /**
-   * The length of the aspect.
-   */
-  length: number;
   /**
    * The aspect text detected.
    */
@@ -612,10 +596,6 @@ export interface SentenceOpinion {
    * The opinion offset from the start of the sentence.
    */
   offset: number;
-  /**
-   * The length of the opinion.
-   */
-  length: number;
   /**
    * The aspect text detected.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -170,13 +170,6 @@ export const Entity: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      length: {
-        serializedName: "length",
-        required: true,
-        type: {
-          name: "Number"
-        }
-      },
       confidenceScore: {
         serializedName: "confidenceScore",
         required: true,
@@ -651,13 +644,6 @@ export const Match: coreHttp.CompositeMapper = {
         type: {
           name: "Number"
         }
-      },
-      length: {
-        serializedName: "length",
-        required: true,
-        type: {
-          name: "Number"
-        }
       }
     }
   }
@@ -1067,13 +1053,6 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      length: {
-        serializedName: "length",
-        required: true,
-        type: {
-          name: "Number"
-        }
-      },
       aspects: {
         serializedName: "aspects",
         type: {
@@ -1114,13 +1093,6 @@ export const SentenceAspect: coreHttp.CompositeMapper = {
       },
       offset: {
         serializedName: "offset",
-        required: true,
-        type: {
-          name: "Number"
-        }
-      },
-      length: {
-        serializedName: "length",
         required: true,
         type: {
           name: "Number"
@@ -1214,13 +1186,6 @@ export const SentenceOpinion: coreHttp.CompositeMapper = {
       },
       offset: {
         serializedName: "offset",
-        required: true,
-        type: {
-          name: "Number"
-        }
-      },
-      length: {
-        serializedName: "length",
         required: true,
         type: {
           name: "Number"

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -14,7 +14,7 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.2/TextAnalytics.json
 add-credentials: false
-package-version: 5.1.0-beta.1
+package-version: 5.1.0-beta.2
 v3: true
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20200618.1"

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -155,6 +155,18 @@ directive:
       $["x-ms-client-name"] = "dataSourceEntityId";
 ```
 
+### Remove Entity/Match offset/length
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions..properties
+    transform: >
+      if ($.length !== undefined) {
+        $.length = undefined;
+      }
+```
+
 ### Rename SentimentConfidenceScorePerLabel -> SentimentConfidenceScores
 
 ```yaml

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -92,7 +92,7 @@ directive:
   - from: swagger-document
     where: $.definitions.DocumentStatistics
     transform: >
-        $["x-ms-client-name"] = "TextDocumentStatistics";
+      $["x-ms-client-name"] = "TextDocumentStatistics";
 ```
 
 ### RequestStatistics => TextDocumentBatchStatistics
@@ -102,7 +102,7 @@ directive:
   - from: swagger-document
     where: $.definitions.RequestStatistics
     transform: >
-     $["x-ms-client-name"] = "TextDocumentBatchStatistics";
+      $["x-ms-client-name"] = "TextDocumentBatchStatistics";
 ```
 
 ### Rename showStats -> includeStatistics
@@ -121,7 +121,7 @@ directive:
       }
 ```
 
-### Rename {Document,Sentence}SentimentValue -> Label 
+### Rename {Document,Sentence}SentimentValue -> Label
 
 ```yaml
 directive:
@@ -174,7 +174,7 @@ directive:
   - from: swagger-document
     where: $.definitions.SentimentConfidenceScorePerLabel
     transform: >
-     $["x-ms-client-name"] = "SentimentConfidenceScores";
+      $["x-ms-client-name"] = "SentimentConfidenceScores";
 ```
 
 ### Change some casing to use camelCase

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -201,7 +201,6 @@ describe("RecognizeCategorizedEntitiesResultArray", () => {
               text: "Microsoft",
               category: "Organization",
               confidenceScore: 0.9989,
-              length: 0,
               offset: 0
             }
           ],
@@ -215,7 +214,6 @@ describe("RecognizeCategorizedEntitiesResultArray", () => {
               category: "DateTime",
               subCategory: "DateRange",
               confidenceScore: 0.8,
-              length: 0,
               offset: 0
             }
           ],
@@ -268,7 +266,6 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
                 {
                   text: "Seattle",
                   confidenceScore: 0.15046201222847677,
-                  length: 0,
                   offset: 0
                 }
               ],
@@ -289,7 +286,6 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
                 {
                   text: "Microsoft",
                   confidenceScore: 0.1869365971673207,
-                  length: 0,
                   offset: 0
                 }
               ],
@@ -343,7 +339,6 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
                 text: "(555) 555-5555",
                 category: "US Phone Number",
                 confidenceScore: 0.9989,
-                length: 0,
                 offset: 0
               }
             ],
@@ -358,7 +353,6 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
                 category: "US Address",
                 subCategory: "",
                 confidenceScore: 0.8,
-                length: 0,
                 offset: 0
               }
             ],

--- a/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
@@ -185,7 +185,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           assert.isAtLeast(aspect.confidenceScores.positive, 0);
           assert.isAtLeast(aspect.confidenceScores.negative, 0);
           assert.equal(aspect.offset, 32);
-          assert.equal(aspect.length, 6);
+          assert.equal(aspect.text.length, 6);
 
           const sleekOpinion = opinion.opinions[0];
           assert.equal("sleek", sleekOpinion.text);
@@ -194,7 +194,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           assert.isAtLeast(sleekOpinion.confidenceScores.positive, 0);
           assert.isFalse(sleekOpinion.isNegated);
           assert.equal(sleekOpinion.offset, 9);
-          assert.equal(sleekOpinion.length, 5);
+          assert.equal(sleekOpinion.text.length, 5);
 
           const premiumOpinion = opinion.opinions[1];
           assert.equal("premium", premiumOpinion.text);
@@ -203,7 +203,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           assert.isAtLeast(premiumOpinion.confidenceScores.positive, 0);
           assert.isFalse(premiumOpinion.isNegated);
           assert.equal(premiumOpinion.offset, 15);
-          assert.equal(premiumOpinion.length, 7);
+          assert.equal(premiumOpinion.text.length, 7);
         })
       );
     });
@@ -679,7 +679,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 8);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -689,7 +689,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 10);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -699,7 +699,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 17);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -709,7 +709,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 25);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -719,7 +719,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 9);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -729,7 +729,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 10);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -739,7 +739,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 8);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -749,7 +749,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 8);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
 
@@ -759,7 +759,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       ]);
       if (!result.error) {
         assert.equal(result.entities[0].offset, 121);
-        assert.equal(result.entities[0].length, 11);
+        assert.equal(result.entities[0].text.length, 11);
       }
     });
   });


### PR DESCRIPTION
The feature crew agreed on removing the `length` property from output types because it is redundant to the `.text.length` one. This change is potentially getting released on 10/02.