### PR TITLE
Regeneration of search-documents SDK

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -81,6 +81,18 @@ export interface AzureActiveDirectoryApplicationCredentials {
 export { AzureKeyCredential }
 
 // @public
+export type BlobIndexerDataToExtract = 'storageMetadata' | 'allMetadata' | 'contentAndMetadata';
+
+// @public
+export type BlobIndexerImageAction = 'none' | 'generateNormalizedImages' | 'generateNormalizedImagePerPage';
+
+// @public
+export type BlobIndexerParsingMode = 'default' | 'text' | 'delimitedText' | 'json' | 'jsonArray' | 'jsonLines';
+
+// @public
+export type BlobIndexerPDFTextRotationAlgorithm = 'none' | 'detectAngles';
+
+// @public
 export interface BM25Similarity {
     b?: number;
     k1?: number;
@@ -452,6 +464,9 @@ export interface IndexDocumentsResult {
 }
 
 // @public
+export type IndexerExecutionEnvironment = 'standard' | 'private';
+
+// @public
 export interface IndexerExecutionResult {
     readonly endTime?: Date;
     readonly errorMessage?: string;
@@ -474,11 +489,31 @@ export type IndexerStatus = 'unknown' | 'error' | 'running';
 // @public
 export interface IndexingParameters {
     batchSize?: number;
-    configuration?: {
-        [propertyName: string]: any;
-    };
+    // (undocumented)
+    configuration?: IndexingParametersConfiguration;
     maxFailedItems?: number;
     maxFailedItemsPerBatch?: number;
+}
+
+// @public
+export interface IndexingParametersConfiguration {
+    [property: string]: any;
+    allowSkillsetToReadFileData?: boolean;
+    dataToExtract?: BlobIndexerDataToExtract;
+    delimitedTextDelimiter?: string;
+    delimitedTextHeaders?: string;
+    documentRoot?: string;
+    excludedFileNameExtensions?: string;
+    executionEnvironment?: IndexerExecutionEnvironment;
+    failOnUnprocessableDocument?: boolean;
+    failOnUnsupportedContentType?: boolean;
+    firstLineContainsHeaders?: boolean;
+    imageAction?: BlobIndexerImageAction;
+    indexedFileNameExtensions?: string;
+    indexStorageMetadataOnlyForOversizedDocuments?: boolean;
+    parsingMode?: BlobIndexerParsingMode;
+    pdfTextRotationAlgorithm?: BlobIndexerPDFTextRotationAlgorithm;
+    queryTimeout?: string;
 }
 
 // @public

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -981,6 +981,9 @@ export interface ScoringProfile {
 }
 
 // @public
+export type ScoringStatistics = 'local' | 'global';
+
+// @public
 export class SearchClient<T> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
@@ -1212,10 +1215,12 @@ export interface SearchRequest {
     queryType?: QueryType;
     scoringParameters?: string[];
     scoringProfile?: string;
+    scoringStatistics?: ScoringStatistics;
     searchFields?: string;
     searchMode?: SearchMode;
     searchText?: string;
     select?: string;
+    sessionId?: string;
     skip?: number;
     top?: number;
 }
@@ -1233,9 +1238,11 @@ export interface SearchRequestOptions<Fields> {
     queryType?: QueryType;
     scoringParameters?: string[];
     scoringProfile?: string;
+    scoringStatistics?: ScoringStatistics;
     searchFields?: Fields[];
     searchMode?: SearchMode;
     select?: Fields[];
+    sessionId?: string;
     skip?: number;
     top?: number;
 }

--- a/sdk/search/search-documents/src/generated/data/models/index.ts
+++ b/sdk/search/search-documents/src/generated/data/models/index.ts
@@ -112,6 +112,22 @@ export interface SearchRequest {
    */
   queryType?: QueryType;
   /**
+   * A value that specifies whether we want to calculate scoring statistics (such as document
+   * frequency) globally for more consistent scoring, or locally, for lower latency. The default is
+   * 'local'. Use 'global' to aggregate scoring statistics globally before scoring. Using global
+   * scoring statistics can increase latency of search queries. Possible values include: 'Local',
+   * 'Global'
+   */
+  scoringStatistics?: ScoringStatistics;
+  /**
+   * A value to be used to create a sticky session, which can help getting more consistent results.
+   * As long as the same sessionId is used, a best-effort attempt will be made to target the same
+   * replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the
+   * load balancing of the requests across replicas and adversely affect the performance of the
+   * search service. The value used as sessionId cannot start with a '_' character.
+   */
+  sessionId?: string;
+  /**
    * The list of parameter values to be used in scoring functions (for example,
    * referencePointParameter) using the format name-values. For example, if the scoring profile
    * defines a function with a parameter called 'mylocation' the parameter string would be
@@ -554,6 +570,20 @@ export interface SearchOptions {
    */
   searchMode?: SearchMode;
   /**
+   * A value that specifies whether we want to calculate scoring statistics (such as document
+   * frequency) globally for more consistent scoring, or locally, for lower latency. Possible
+   * values include: 'Local', 'Global'
+   */
+  scoringStatistics?: ScoringStatistics;
+  /**
+   * A value to be used to create a sticky session, which can help to get more consistent results.
+   * As long as the same sessionId is used, a best-effort attempt will be made to target the same
+   * replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the
+   * load balancing of the requests across replicas and adversely affect the performance of the
+   * search service. The value used as sessionId cannot start with a '_' character.
+   */
+  sessionId?: string;
+  /**
    * The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema
    * are included.
    */
@@ -734,6 +764,14 @@ export interface DocumentsAutocompleteGetOptionalParams extends coreHttp.Request
  * @enum {string}
  */
 export type QueryType = 'simple' | 'full';
+
+/**
+ * Defines values for ScoringStatistics.
+ * Possible values include: 'Local', 'Global'
+ * @readonly
+ * @enum {string}
+ */
+export type ScoringStatistics = 'local' | 'global';
 
 /**
  * Defines values for SearchMode.

--- a/sdk/search/search-documents/src/generated/data/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/data/models/mappers.ts
@@ -159,6 +159,22 @@ export const SearchRequest: coreHttp.CompositeMapper = {
           ]
         }
       },
+      scoringStatistics: {
+        serializedName: "scoringStatistics",
+        type: {
+          name: "Enum",
+          allowedValues: [
+            "local",
+            "global"
+          ]
+        }
+      },
+      sessionId: {
+        serializedName: "sessionId",
+        type: {
+          name: "String"
+        }
+      },
       scoringParameters: {
         serializedName: "scoringParameters",
         type: {
@@ -817,6 +833,20 @@ export const SearchOptions: coreHttp.CompositeMapper = {
             "any",
             "all"
           ]
+        }
+      },
+      scoringStatistics: {
+        type: {
+          name: "Enum",
+          allowedValues: [
+            "local",
+            "global"
+          ]
+        }
+      },
+      sessionId: {
+        type: {
+          name: "String"
         }
       },
       select: {

--- a/sdk/search/search-documents/src/generated/data/models/parameters.ts
+++ b/sdk/search/search-documents/src/generated/data/models/parameters.ts
@@ -365,6 +365,23 @@ export const scoringProfile: coreHttp.OperationQueryParameter = {
     }
   }
 };
+export const scoringStatistics: coreHttp.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "searchOptions",
+    "scoringStatistics"
+  ],
+  mapper: {
+    serializedName: "scoringStatistics",
+    type: {
+      name: "Enum",
+      allowedValues: [
+        "local",
+        "global"
+      ]
+    }
+  }
+};
 export const searchFields0: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
@@ -516,6 +533,19 @@ export const selectedFields: coreHttp.OperationQueryParameter = {
     }
   },
   collectionFormat: coreHttp.QueryCollectionFormat.Csv
+};
+export const sessionId: coreHttp.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "searchOptions",
+    "sessionId"
+  ],
+  mapper: {
+    serializedName: "sessionId",
+    type: {
+      name: "String"
+    }
+  }
 };
 export const skip: coreHttp.OperationQueryParameter = {
   parameterPath: [

--- a/sdk/search/search-documents/src/generated/data/operations/documents.ts
+++ b/sdk/search/search-documents/src/generated/data/operations/documents.ts
@@ -339,6 +339,8 @@ const searchGetOperationSpec: coreHttp.OperationSpec = {
     Parameters.scoringProfile,
     Parameters.searchFields0,
     Parameters.searchMode,
+    Parameters.scoringStatistics,
+    Parameters.sessionId,
     Parameters.select0,
     Parameters.skip,
     Parameters.top0

--- a/sdk/search/search-documents/src/generated/service/models/index.ts
+++ b/sdk/search/search-documents/src/generated/service/models/index.ts
@@ -1627,6 +1627,102 @@ export interface IndexingSchedule {
 }
 
 /**
+ * A dictionary of indexer-specific configuration properties. Each name is the name of a specific
+ * property. Each value must be of a primitive type.
+ */
+export interface IndexingParametersConfiguration {
+  /**
+   * Possible values include: 'Default', 'Text', 'DelimitedText', 'Json', 'JsonArray', 'JsonLines'.
+   * Default value: 'default'.
+   */
+  parsingMode?: BlobIndexerParsingMode;
+  /**
+   * Comma-delimited list of filename extensions to ignore when processing from Azure blob storage.
+   * For example, you could exclude ".png, .mp4" to skip over those files during indexing. Default
+   * value: ''.
+   */
+  excludedFileNameExtensions?: string;
+  /**
+   * Comma-delimited list of filename extensions to select when processing from Azure blob storage.
+   * For example, you could focus indexing on specific application files ".docx, .pptx, .msg" to
+   * specifically include those file types. Default value: ''.
+   */
+  indexedFileNameExtensions?: string;
+  /**
+   * For Azure blobs, set to false if you want to continue indexing when an unsupported content
+   * type is encountered, and you don't know all the content types (file extensions) in advance.
+   * Default value: false.
+   */
+  failOnUnsupportedContentType?: boolean;
+  /**
+   * For Azure blobs, set to false if you want to continue indexing if a document fails indexing.
+   * Default value: false.
+   */
+  failOnUnprocessableDocument?: boolean;
+  /**
+   * For Azure blobs, set this property to true to still index storage metadata for blob content
+   * that is too large to process. Oversized blobs are treated as errors by default. For limits on
+   * blob size, see https://docs.microsoft.com/azure/search/search-limits-quotas-capacity. Default
+   * value: false.
+   */
+  indexStorageMetadataOnlyForOversizedDocuments?: boolean;
+  /**
+   * For CSV blobs, specifies a comma-delimited list of column headers, useful for mapping source
+   * fields to destination fields in an index.
+   */
+  delimitedTextHeaders?: string;
+  /**
+   * For CSV blobs, specifies the end-of-line single-character delimiter for CSV files where each
+   * line starts a new document (for example, "|").
+   */
+  delimitedTextDelimiter?: string;
+  /**
+   * For CSV blobs, indicates that the first (non-blank) line of each blob contains headers.
+   * Default value: true.
+   */
+  firstLineContainsHeaders?: boolean;
+  /**
+   * For JSON arrays, given a structured or semi-structured document, you can specify a path to the
+   * array using this property.
+   */
+  documentRoot?: string;
+  /**
+   * Possible values include: 'StorageMetadata', 'AllMetadata', 'ContentAndMetadata'. Default
+   * value: 'contentAndMetadata'.
+   */
+  dataToExtract?: BlobIndexerDataToExtract;
+  /**
+   * Possible values include: 'None', 'GenerateNormalizedImages', 'GenerateNormalizedImagePerPage'.
+   * Default value: 'none'.
+   */
+  imageAction?: BlobIndexerImageAction;
+  /**
+   * If true, will create a path //document//file_data that is an object representing the original
+   * file data downloaded from your blob data source.  This allows you to pass the original file
+   * data to a custom skill for processing within the enrichment pipeline, or to the Document
+   * Extraction skill. Default value: false.
+   */
+  allowSkillsetToReadFileData?: boolean;
+  /**
+   * Possible values include: 'None', 'DetectAngles'. Default value: 'none'.
+   */
+  pdfTextRotationAlgorithm?: BlobIndexerPDFTextRotationAlgorithm;
+  /**
+   * Possible values include: 'standard', 'private'. Default value: 'standard'.
+   */
+  executionEnvironment?: IndexerExecutionEnvironment;
+  /**
+   * Increases the timeout beyond the 5-minute default for Azure SQL database data sources,
+   * specified in the format "hh:mm:ss". Default value: '00:05:00'.
+   */
+  queryTimeout?: string;
+  /**
+   * Describes unknown properties. The value of an unknown property can be of "any" type.
+   */
+  [property: string]: any;
+}
+
+/**
  * Represents parameters for indexer execution.
  */
 export interface IndexingParameters {
@@ -1645,11 +1741,7 @@ export interface IndexingParameters {
    * considered successful. -1 means no limit. Default is 0. Default value: 0.
    */
   maxFailedItemsPerBatch?: number;
-  /**
-   * A dictionary of indexer-specific configuration properties. Each name is the name of a specific
-   * property. Each value must be of a primitive type.
-   */
-  configuration?: { [propertyName: string]: any };
+  configuration?: IndexingParametersConfiguration;
 }
 
 /**
@@ -3770,6 +3862,46 @@ export type StopwordsList = 'arabic' | 'armenian' | 'basque' | 'brazilian' | 'bu
  * @enum {string}
  */
 export type SearchIndexerDataSourceType = 'azuresql' | 'cosmosdb' | 'azureblob' | 'azuretable' | 'mysql';
+
+/**
+ * Defines values for BlobIndexerParsingMode.
+ * Possible values include: 'Default', 'Text', 'DelimitedText', 'Json', 'JsonArray', 'JsonLines'
+ * @readonly
+ * @enum {string}
+ */
+export type BlobIndexerParsingMode = 'default' | 'text' | 'delimitedText' | 'json' | 'jsonArray' | 'jsonLines';
+
+/**
+ * Defines values for BlobIndexerDataToExtract.
+ * Possible values include: 'StorageMetadata', 'AllMetadata', 'ContentAndMetadata'
+ * @readonly
+ * @enum {string}
+ */
+export type BlobIndexerDataToExtract = 'storageMetadata' | 'allMetadata' | 'contentAndMetadata';
+
+/**
+ * Defines values for BlobIndexerImageAction.
+ * Possible values include: 'None', 'GenerateNormalizedImages', 'GenerateNormalizedImagePerPage'
+ * @readonly
+ * @enum {string}
+ */
+export type BlobIndexerImageAction = 'none' | 'generateNormalizedImages' | 'generateNormalizedImagePerPage';
+
+/**
+ * Defines values for BlobIndexerPDFTextRotationAlgorithm.
+ * Possible values include: 'None', 'DetectAngles'
+ * @readonly
+ * @enum {string}
+ */
+export type BlobIndexerPDFTextRotationAlgorithm = 'none' | 'detectAngles';
+
+/**
+ * Defines values for IndexerExecutionEnvironment.
+ * Possible values include: 'standard', 'private'
+ * @readonly
+ * @enum {string}
+ */
+export type IndexerExecutionEnvironment = 'standard' | 'private';
 
 /**
  * Defines values for IndexerExecutionStatus.

--- a/sdk/search/search-documents/src/generated/service/models/indexersMappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/indexersMappers.ts
@@ -12,6 +12,7 @@ export {
   FieldMappingFunction,
   IndexerExecutionResult,
   IndexingParameters,
+  IndexingParametersConfiguration,
   IndexingSchedule,
   ListIndexersResult,
   SearchError,

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -1962,12 +1962,14 @@ export const BM25Similarity: coreHttp.CompositeMapper = {
     modelProperties: {
       ...Similarity.type.modelProperties,
       k1: {
+        nullable: true,
         serializedName: "k1",
         type: {
           name: "Number"
         }
       },
       b: {
+        nullable: true,
         serializedName: "b",
         type: {
           name: "Number"
@@ -2161,6 +2163,7 @@ export const SearchIndexerDataSource: coreHttp.CompositeMapper = {
         }
       },
       dataChangeDetectionPolicy: {
+        nullable: true,
         serializedName: "dataChangeDetectionPolicy",
         type: {
           name: "Composite",
@@ -2168,6 +2171,7 @@ export const SearchIndexerDataSource: coreHttp.CompositeMapper = {
         }
       },
       dataDeletionDetectionPolicy: {
+        nullable: true,
         serializedName: "dataDeletionDetectionPolicy",
         type: {
           name: "Composite",
@@ -2231,6 +2235,130 @@ export const IndexingSchedule: coreHttp.CompositeMapper = {
   }
 };
 
+export const IndexingParametersConfiguration: coreHttp.CompositeMapper = {
+  serializedName: "IndexingParametersConfiguration",
+  type: {
+    name: "Composite",
+    className: "IndexingParametersConfiguration",
+    modelProperties: {
+      parsingMode: {
+        serializedName: "parsingMode",
+        defaultValue: 'default',
+        type: {
+          name: "String"
+        }
+      },
+      excludedFileNameExtensions: {
+        serializedName: "excludedFileNameExtensions",
+        defaultValue: '',
+        type: {
+          name: "String"
+        }
+      },
+      indexedFileNameExtensions: {
+        serializedName: "indexedFileNameExtensions",
+        defaultValue: '',
+        type: {
+          name: "String"
+        }
+      },
+      failOnUnsupportedContentType: {
+        serializedName: "failOnUnsupportedContentType",
+        defaultValue: false,
+        type: {
+          name: "Boolean"
+        }
+      },
+      failOnUnprocessableDocument: {
+        serializedName: "failOnUnprocessableDocument",
+        defaultValue: false,
+        type: {
+          name: "Boolean"
+        }
+      },
+      indexStorageMetadataOnlyForOversizedDocuments: {
+        serializedName: "indexStorageMetadataOnlyForOversizedDocuments",
+        defaultValue: false,
+        type: {
+          name: "Boolean"
+        }
+      },
+      delimitedTextHeaders: {
+        serializedName: "delimitedTextHeaders",
+        type: {
+          name: "String"
+        }
+      },
+      delimitedTextDelimiter: {
+        serializedName: "delimitedTextDelimiter",
+        type: {
+          name: "String"
+        }
+      },
+      firstLineContainsHeaders: {
+        serializedName: "firstLineContainsHeaders",
+        defaultValue: true,
+        type: {
+          name: "Boolean"
+        }
+      },
+      documentRoot: {
+        serializedName: "documentRoot",
+        type: {
+          name: "String"
+        }
+      },
+      dataToExtract: {
+        serializedName: "dataToExtract",
+        defaultValue: 'contentAndMetadata',
+        type: {
+          name: "String"
+        }
+      },
+      imageAction: {
+        serializedName: "imageAction",
+        defaultValue: 'none',
+        type: {
+          name: "String"
+        }
+      },
+      allowSkillsetToReadFileData: {
+        serializedName: "allowSkillsetToReadFileData",
+        defaultValue: false,
+        type: {
+          name: "Boolean"
+        }
+      },
+      pdfTextRotationAlgorithm: {
+        serializedName: "pdfTextRotationAlgorithm",
+        defaultValue: 'none',
+        type: {
+          name: "String"
+        }
+      },
+      executionEnvironment: {
+        serializedName: "executionEnvironment",
+        defaultValue: 'standard',
+        type: {
+          name: "String"
+        }
+      },
+      queryTimeout: {
+        serializedName: "queryTimeout",
+        defaultValue: '00:05:00',
+        type: {
+          name: "String"
+        }
+      }
+    },
+    additionalProperties: {
+      type: {
+        name: "Object"
+      }
+    }
+  }
+};
+
 export const IndexingParameters: coreHttp.CompositeMapper = {
   serializedName: "IndexingParameters",
   type: {
@@ -2238,12 +2366,14 @@ export const IndexingParameters: coreHttp.CompositeMapper = {
     className: "IndexingParameters",
     modelProperties: {
       batchSize: {
+        nullable: true,
         serializedName: "batchSize",
         type: {
           name: "Number"
         }
       },
       maxFailedItems: {
+        nullable: true,
         serializedName: "maxFailedItems",
         defaultValue: 0,
         type: {
@@ -2251,6 +2381,7 @@ export const IndexingParameters: coreHttp.CompositeMapper = {
         }
       },
       maxFailedItemsPerBatch: {
+        nullable: true,
         serializedName: "maxFailedItemsPerBatch",
         defaultValue: 0,
         type: {
@@ -2260,8 +2391,9 @@ export const IndexingParameters: coreHttp.CompositeMapper = {
       configuration: {
         serializedName: "configuration",
         type: {
-          name: "Dictionary",
-          value: {
+          name: "Composite",
+          className: "IndexingParametersConfiguration",
+          additionalProperties: {
             type: {
               name: "Object"
             }
@@ -2320,6 +2452,7 @@ export const FieldMapping: coreHttp.CompositeMapper = {
         }
       },
       mappingFunction: {
+        nullable: true,
         serializedName: "mappingFunction",
         type: {
           name: "Composite",
@@ -2370,6 +2503,7 @@ export const SearchIndexer: coreHttp.CompositeMapper = {
         }
       },
       schedule: {
+        nullable: true,
         serializedName: "schedule",
         type: {
           name: "Composite",
@@ -2377,6 +2511,7 @@ export const SearchIndexer: coreHttp.CompositeMapper = {
         }
       },
       parameters: {
+        nullable: true,
         serializedName: "parameters",
         type: {
           name: "Composite",
@@ -2408,6 +2543,7 @@ export const SearchIndexer: coreHttp.CompositeMapper = {
         }
       },
       isDisabled: {
+        nullable: true,
         serializedName: "disabled",
         defaultValue: false,
         type: {
@@ -2585,6 +2721,7 @@ export const IndexerExecutionResult: coreHttp.CompositeMapper = {
         }
       },
       endTime: {
+        nullable: true,
         readOnly: true,
         serializedName: "endTime",
         type: {
@@ -3098,6 +3235,7 @@ export const ScoringProfile: coreHttp.CompositeMapper = {
         }
       },
       textWeights: {
+        nullable: true,
         serializedName: "text",
         type: {
           name: "Composite",
@@ -3305,6 +3443,7 @@ export const SearchIndex: coreHttp.CompositeMapper = {
         }
       },
       corsOptions: {
+        nullable: true,
         serializedName: "corsOptions",
         type: {
           name: "Composite",
@@ -3372,6 +3511,7 @@ export const SearchIndex: coreHttp.CompositeMapper = {
         }
       },
       encryptionKey: {
+        nullable: true,
         serializedName: "encryptionKey",
         type: {
           name: "Composite",
@@ -4084,6 +4224,7 @@ export const SynonymMap: coreHttp.CompositeMapper = {
         }
       },
       encryptionKey: {
+        nullable: true,
         serializedName: "encryptionKey",
         type: {
           name: "Composite",

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -111,7 +111,8 @@ export {
   IndexDocumentsResult,
   IndexingResult,
   QueryType,
-  SearchMode
+  SearchMode,
+  ScoringStatistics
 } from "./generated/data/models";
 export {
   RegexFlags,

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -222,6 +222,12 @@ export {
   ResourceCounter,
   LexicalAnalyzerName,
   ClassicSimilarity,
-  BM25Similarity
+  BM25Similarity,
+  IndexingParametersConfiguration,
+  BlobIndexerDataToExtract,
+  IndexerExecutionEnvironment,
+  BlobIndexerImageAction,
+  BlobIndexerParsingMode,
+  BlobIndexerPDFTextRotationAlgorithm
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -7,7 +7,8 @@ import {
   SearchMode,
   FacetResult,
   AutocompleteMode,
-  IndexActionType
+  IndexActionType,
+  ScoringStatistics
 } from "./generated/data/models";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
@@ -153,6 +154,22 @@ export interface SearchRequest {
    */
   queryType?: QueryType;
   /**
+   * A value that specifies whether we want to calculate scoring statistics (such as document
+   * frequency) globally for more consistent scoring, or locally, for lower latency. The default is
+   * 'local'. Use 'global' to aggregate scoring statistics globally before scoring. Using global
+   * scoring statistics can increase latency of search queries. Possible values include: 'Local',
+   * 'Global'
+   */
+  scoringStatistics?: ScoringStatistics;
+  /**
+   * A value to be used to create a sticky session, which can help getting more consistent results.
+   * As long as the same sessionId is used, a best-effort attempt will be made to target the same
+   * replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the
+   * load balancing of the requests across replicas and adversely affect the performance of the
+   * search service. The value used as sessionId cannot start with a '_' character.
+   */
+  sessionId?: string;
+  /**
    * The list of parameter values to be used in scoring functions (for example,
    * referencePointParameter) using the format name-values. For example, if the scoring profile
    * defines a function with a parameter called 'mylocation' the parameter string would be
@@ -276,6 +293,20 @@ export interface SearchRequestOptions<Fields> {
    * count the document as a match. Possible values include: 'any', 'all'
    */
   searchMode?: SearchMode;
+  /**
+   * A value that specifies whether we want to calculate scoring statistics (such as document
+   * frequency) globally for more consistent scoring, or locally, for lower latency. Possible
+   * values include: 'Local', 'Global'
+   */
+  scoringStatistics?: ScoringStatistics;
+  /**
+   * A value to be used to create a sticky session, which can help to get more consistent results.
+   * As long as the same sessionId is used, a best-effort attempt will be made to target the same
+   * replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the
+   * load balancing of the requests across replicas and adversely affect the performance of the
+   * search service. The value used as sessionId cannot start with a '_' character.
+   */
+  sessionId?: string;
   /**
    * The list of fields to retrieve. If unspecified, all fields marked as
    * retrievable in the schema are included.


### PR DESCRIPTION
The Swaggers for search documents have been updated. I have regenerated Search Documents SDK based on the swagger. For Data.md regeneration, there was minimal amount of custom code to be added. For Service.md, no custom code addition is required. 

@xirzec Please review and approve. 