### PR TITLE
Increment version for communication releases

### DIFF
--- a/sdk/communication/communication-administration/CHANGELOG.md
+++ b/sdk/communication/communication-administration/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+
 ## 1.0.0-beta.1 (2020-09-22)
 
 The Azure Communication Administration Client library contains code which facilitates user token administration.

--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-administration",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "SDK for Azure Communication service which facilitates user token administration.",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/communication-common": "1.0.0-beta.1",
+    "@azure/communication-common": "1.0.0-beta.2",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.1.6",
     "@azure/core-paging": "^1.1.1",

--- a/sdk/communication/communication-administration/src/communicationIdentity/generated/src/generatedCommunicationIdentityClientContext.ts
+++ b/sdk/communication/communication-administration/src/communicationIdentity/generated/src/generatedCommunicationIdentityClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-communication-administration-identity";
-const packageVersion = "1.0.0-beta.1";
+const packageVersion = "1.0.0-beta.2";
 
 export class GeneratedCommunicationIdentityClientContext extends coreHttp.ServiceClient {
   /**

--- a/sdk/communication/communication-administration/swagger/CommunicationIdentity.md
+++ b/sdk/communication/communication-administration/swagger/CommunicationIdentity.md
@@ -9,7 +9,7 @@ package-name: azure-communication-administration-identity
 title: CommunicationIdentityConfigurationClient
 override-client-name: GeneratedCommunicationIdentityClient
 description: Communication identity configuration client
-package-version: 1.0.0-beta.1
+package-version: 1.0.0-beta.2
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/communicationIdentity/generated

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+
 ## 1.0.0-beta.1 (2020-09-22)
 
 The first preview of the Azure Communication Chat Client has the following features:

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -8,7 +8,7 @@
   "types": "types/communication-chat.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --version=3.0.6267 --v3 --package-version=1.0.0-beta.1 && rushx format",
+    "build:autorest": "autorest ./swagger/README.md --typescript --version=3.0.6267 --v3 --package-version=1.0.0-beta.2 && rushx format",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "cd samples && tsc -p .",
@@ -65,7 +65,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "1.0.0-beta.1",
+    "@azure/communication-common": "1.0.0-beta.2",
     "@azure/communication-signaling": "1.0.0-beta.1",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.1.6",
@@ -77,7 +77,7 @@
     "@azure/core-paging": "^1.1.1"
   },
   "devDependencies": {
-    "@azure/communication-administration": "1.0.0-beta.1",
+    "@azure/communication-administration": "1.0.0-beta.2",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/communication/communication-chat/src/generated/src/chatApiClientContext.ts
+++ b/sdk/communication/communication-chat/src/generated/src/chatApiClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ChatApiClientOptionalParams } from "./models";
 
 const packageName = "azure-communication-chat";
-const packageVersion = "1.0.0-beta.1";
+const packageVersion = "1.0.0-beta.2";
 
 export class ChatApiClientContext extends coreHttp.ServiceClient {
   endpoint: string;

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+
 ## 1.0.0-beta.1 (2020-09-22)
 
 The Azure Communication Common Client library contains common code such as the CommunicationUserCredential that is being used by other Azure Communication Services.

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-common",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Common package for Azure Communication services.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/communication/communication-sms/CHANGELOG.md
+++ b/sdk/communication/communication-sms/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+
 ## 1.0.0-beta.1 (2020-09-22)
 
 The first preview of the Azure Communication Sms Client has the following features:

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-sms",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "SDK for Azure Communication SMS service which facilitates the sending of SMS messages.",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -12,7 +12,7 @@
   "types": "types/communication-sms.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --v3 --package-version=1.0.0-beta.1 && rushx format",
+    "build:autorest": "autorest ./swagger/README.md --typescript --v3 --package-version=1.0.0-beta.2 && rushx format",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "cd samples && tsc -p .",
@@ -65,7 +65,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "1.0.0-beta.1",
+    "@azure/communication-common": "1.0.0-beta.2",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.1.6",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/communication/communication-sms/src/generated/src/smsApiClientContext.ts
+++ b/sdk/communication/communication-sms/src/generated/src/smsApiClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-communication-sms";
-const packageVersion = "1.0.0-beta.1";
+const packageVersion = "1.0.0-beta.2";
 
 export class SmsApiClientContext extends coreHttp.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
Replaces auto-generated https://github.com/Azure/azure-sdk-for-js/pull/11387

In addition to the generated version bump, this PR increments package-version for autorest and fixes the dependencies.