### PR TITLE
Fix ADT relationship paging (#11555)

### DIFF
--- a/sdk/digitaltwins/digital-twins/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins/src/digitalTwinsClient.ts
@@ -367,8 +367,8 @@ export class DigitalTwinsClient {
     }
     while (continuationState.continuationToken) {
       const listRelationshipResponse = await this.client.digitalTwins.listRelationshipsNext(
-        continuationState.continuationToken,
         "",
+        continuationState.continuationToken,
         options
       );
 
@@ -446,8 +446,8 @@ export class DigitalTwinsClient {
     }
     while (continuationState.continuationToken) {
       const listIncomingRelationshipsResponse = await this.client.digitalTwins.listIncomingRelationshipsNext(
-        continuationState.continuationToken,
         "",
+        continuationState.continuationToken,
         options
       );
 


### PR DESCRIPTION
From what I can see, this issue (#11555) can be fixed by reordering the parameters passed to the underlying REST client. The continuation token is expected to be the second parameter (rather than the first).