### PR TITLE
[service-bus] Update readme to contain an actual snippet of code showing the constructor

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -87,11 +87,13 @@ const credential = new DefaultAzureCredential();
 const serviceBusClient = new ServiceBusClient(endpoint, credential);
 ```
 
-    NOTE: If you're using your own implementation of the `TokenCredential` interface
-    against AAD, then set the "scopes" for service-bus to the following to get
-    the appropriate token:
+> NOTE: If you're using your own implementation of the `TokenCredential` interface
+> against AAD, then set the "scopes" for service-bus to the following to get
+> the appropriate token:
 
-    ["https://servicebus.azure.net//user_impersonation"]
+> ```typescript
+> ["https://servicebus.azure.net//user_impersonation"]
+> ```
 
 More information about this constructor is available in the [API documentation][sbclient_tokencred_overload]
 

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -55,18 +55,45 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 ### Authenticate the client
 
-Interaction with Service Bus starts with an instance of the [ServiceBusClient][sbclient] class.
+Interaction with Service Bus starts with an instance of the [ServiceBusClient][sbclient] class. You can
+authenticate to Service Bus using a connection string or using a service principal.
 
-You can instantiate this class using its constructors:
+#### Using a connection string
 
-- [Create using a connection string][sbclient_constructor]
-  - This method takes the connection string to your Service Bus instance. You can get the connection string
-    from the Azure portal.
-- [Create using a TokenCredential][sbclient_tokencred_overload]
-  - This method takes the host name of your Service Bus instance and a credentials object that you need
-    to generate using the [@azure/identity](https://www.npmjs.com/package/@azure/identity)
-    library. The host name is of the format `name-of-service-bus-instance.servicebus.windows.net`.
-    If you're using an own implementation of the `TokenCredential` interface against AAD, then set the "scopes" for service-bus to be `["https://servicebus.azure.net//user_impersonation"]` to get the appropriate token.
+This method takes the connection string to your Service Bus instance. You can get
+the connection string from the Azure portal.
+
+```javascript
+const { ServiceBusClient } = require("@azure/service-bus");
+
+const serviceBusClient = new ServiceBusClient(connectionString);
+```
+
+More information about this constructor is available in the [API documentation][sbclient_constructor].
+
+#### Using an Azure Active Directory Credential
+
+Authentication with Azure Active Directory uses the [Azure Identity library][azure_identity].
+
+The example below uses the [DefaultAzureCredential][defaultazurecredential], one of many
+available credential providers from the `@azure/identity` library.
+
+```javascript
+const { ServiceBusClient } = require("@azure/service-bus");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const endpoint = "<name-of-service-bus-instance>.servicebus.windows.net";
+const credential = new DefaultAzureCredential();
+const serviceBusClient = new ServiceBusClient(endpoint, credential);
+```
+
+    NOTE: If you're using your own implementation of the `TokenCredential` interface
+    against AAD, then set the "scopes" for service-bus to the following to get
+    the appropriate token:
+
+    ["https://servicebus.azure.net//user_impersonation"]
+
+More information about this constructor is available in the [API documentation][sbclient_tokencred_overload]
 
 ### Key concepts
 
@@ -342,6 +369,8 @@ If you'd like to contribute to this library, please read the [contributing guide
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fservicebus%2Fservice-bus%2FREADME.png)
 
 [apiref]: https://aka.ms/azsdk/js/service-bus/docs
+[azure_identity]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md
+[defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential
 [sbclient]: https://docs.microsoft.com/javascript/api/%40azure/service-bus/servicebusclient?view=azure-node-preview
 [sbclient_constructor]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#servicebusclient-string--servicebusclientoptions-
 [sbclient_tokencred_overload]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#servicebusclient-string--tokencredential--servicebusclientoptions-

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -56,7 +56,7 @@ To use this client library in the browser, first you need to use a bundler. For 
 ### Authenticate the client
 
 Interaction with Service Bus starts with an instance of the [ServiceBusClient][sbclient] class. You can
-authenticate to Service Bus using a connection string or using a service principal.
+authenticate to Service Bus using a connection string or using an Azure Active Directory credential.
 
 #### Using a connection string
 


### PR DESCRIPTION
During the UX study we realized we don't actually have a code snippet in the readme to show how to construct the ServiceBusClient (there were links, but no actual code).

I fixed that and added in a bit more explanatory text showing how to use `DefaultAzureCredential`.