### PR TITLE
Use absolute link for samples as relative links are not allowed

### DIFF
--- a/sdk/cosmosdb/cosmos/README.md
+++ b/sdk/cosmosdb/cosmos/README.md
@@ -259,7 +259,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 [cosmos_item]: https://docs.microsoft.com/azure/cosmos-db/databases-containers-items#azure-cosmos-items
 [cosmos_request_units]: https://docs.microsoft.com/azure/cosmos-db/request-units
 [cosmos_resources]: https://docs.microsoft.com/azure/cosmos-db/databases-containers-items
-[cosmos_samples]: ./samples
+[cosmos_samples]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/cosmosdb/cosmos/samples
 [cosmos_sql_queries]: https://docs.microsoft.com/azure/cosmos-db/how-to-sql-query
 [cosmos_ttl]: https://docs.microsoft.com/azure/cosmos-db/time-to-live
 [npm]: https://www.npmjs.com/package/@azure/cosmos


### PR DESCRIPTION
- Merging of PR https://github.com/Azure/azure-sdk-for-js/pull/11063/ that had a relative link caused pipeline failures. This PR uses absolute link for the relative link that was merged in
- The new updated checks do not allow relative links for the readme - refer link guidelines -  https://aka.ms/azsdk/guideline/links