### PR TITLE
[Service Bus] Run live tests in the canary region

### DIFF
--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -7,6 +7,7 @@ extends:
     ResourceServiceDirectory: servicebus
     TimeoutInMinutes: 180
     TestSamples: false
+    TestCanary: true
     EnvVars:
       AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
       AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
Similar to what we did for event-hubs... https://github.com/Azure/azure-sdk-for-js/pull/11318

Java - https://github.com/Azure/azure-sdk-for-java/pull/15844
.NET - https://github.com/Azure/azure-sdk-for-net/pull/15592