### PR TITLE
[Communication] Add pipeline for Chat live tests

### DIFF
--- a/sdk/communication/communication-administration/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-administration/test/utils/recordedClient.ts
@@ -21,12 +21,6 @@ const replaceableVariables: { [k: string]: string } = {
   COMMUNICATION_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana"
 };
 
-export const testEnv = new Proxy(replaceableVariables, {
-  get: (target, key: string) => {
-    return env[key] || target[key];
-  }
-});
-
 export const environmentSetup: RecorderEnvironmentSetup = {
   replaceableVariables,
   customizationsOnRecordings: [
@@ -56,14 +50,11 @@ export const environmentSetup: RecorderEnvironmentSetup = {
   queryParametersToSkip: []
 };
 
-export function createRecordedCommunicationIdentityClient(
-  context: Context,
-  connectionString: string = testEnv.COMMUNICATION_CONNECTION_STRING
-): RecordedClient {
+export function createRecordedCommunicationIdentityClient(context: Context): RecordedClient {
   const recorder = record(context, environmentSetup);
 
   return {
-    client: new CommunicationIdentityClient(connectionString),
+    client: new CommunicationIdentityClient(env.COMMUNICATION_CONNECTION_STRING),
     recorder
   };
 }

--- a/sdk/communication/communication-chat/sample.env
+++ b/sdk/communication/communication-chat/sample.env
@@ -1,7 +1,6 @@
 # Used in most samples. Retrieve these values from a Communication Services instance
 # in the Azure Portal.
 COMMUNICATION_CONNECTION_STRING=""
-BASE_URL=""
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/communication/communication-chat/tests.yml
+++ b/sdk/communication/communication-chat/tests.yml
@@ -3,5 +3,5 @@ trigger: none
 extends:
   template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
   parameters:
-    PackageName: "@azure/communication-administration"
+    PackageName: "@azure/communication-chat"
     ResourceServiceDirectory: communication


### PR DESCRIPTION
Also some cleanup. The `testEnv` proxy isn't needed because `createRecorder` overrides the environment in playback mode already with the replace variables. (Which gave me lots of headaches until I realized that)