### PR TITLE
[schema registry] Minor follow-up

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -5,6 +5,11 @@ providing schema storage, versioning, and management. This package provides an
 Avro serializer capable of serializing and deserializing payloads containing
 Schema Registry schema identifiers and Avro-encoded data.
 
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry-avro) |
+[Package (npm)](https://www.npmjs.com/package/@azure/schema-registry-avro) |
+[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/schema-registry-avro) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry-avro/samples)
+
 ## Getting started
 
 - Node.js version 8.x.x or higher
@@ -28,7 +33,7 @@ npm install @azure/schema-registry-avro
 
 Provides API to serialize to and deserialize from Avro Binary Encoding plus a
 header with schema ID. Uses
-`SchemaRegistryClient` from the [@azure/schema-registry](https://docs.microsoft.com/javascript/api/@azure/schema-registry/) package
+`SchemaRegistryClient` from the [@azure/schema-registry](https://www.npmjs.com/package/@azure/schema-registry) package
 to get schema IDs from schema content or vice versa.
 
 ### Message format

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -28,7 +28,7 @@ npm install @azure/schema-registry-avro
 
 Provides API to serialize to and deserialize from Avro Binary Encoding plus a
 header with schema ID. Uses
-`SchemaRegistryClient` from the [@azure/schema-registry](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry) package
+`SchemaRegistryClient` from the [@azure/schema-registry](https://docs.microsoft.com/javascript/api/@azure/schema-registry/) package
 to get schema IDs from schema content or vice versa.
 
 ### Message format

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -60,7 +60,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/schema-registry": "1.0.0-beta.1",
+    "@azure/schema-registry": "1.0.0-beta.2",
     "@azure/core-http": "^1.1.6",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -22,8 +22,6 @@ import * as avro from "avsc";
 //      - UTF-8 hexadecimal representation of GUID.
 //      - 32 hex digits, no hyphens.
 //      - Same format and byte order as string from Schema Registry service.
-//      - This will soon be revised to an 8 byte long value with the format
-//        indicator bumped.
 //
 // - [Remaining bytes: Avro payload (in general, format-specific payload)]
 //     - Avro Binary Encoding

--- a/sdk/schemaregistry/schema-registry/README.md
+++ b/sdk/schemaregistry/schema-registry/README.md
@@ -58,7 +58,7 @@ schema registry.
 
 ### SchemaRegistry serializers
 
-- [@azure/schema-registry-avro](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry-avro)
+- [@azure/schema-registry-avro](https://docs.microsoft.com/javascript/api/@azure/schema-registry-avro/)
   is a separate package that uses `SchemaRegistryClient` to pair schema ID along
   with Avro Binary Encoding.
 

--- a/sdk/schemaregistry/schema-registry/README.md
+++ b/sdk/schemaregistry/schema-registry/README.md
@@ -5,6 +5,11 @@ providing schema storage, versioning, and management. The registry is leveraged
 by serializers to reduce payload size while describing payload structure with
 schema identifiers rather than full schemas.
 
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry) |
+[Package (npm)](https://www.npmjs.com/package/@azure/schema-registry) |
+[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/schema-registry) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/schemaregistry/schema-registry/samples)
+
 ## Getting started
 
 - Node.js version 8.x.x or higher
@@ -58,7 +63,7 @@ schema registry.
 
 ### SchemaRegistry serializers
 
-- [@azure/schema-registry-avro](https://docs.microsoft.com/javascript/api/@azure/schema-registry-avro/)
+- [@azure/schema-registry-avro](https://www.npmjs.com/package/@azure/schema-registry-avro)
   is a separate package that uses `SchemaRegistryClient` to pair schema ID along
   with Avro Binary Encoding.
 


### PR DESCRIPTION
1. Use 1.0.0.beta.2 for schema-registry-avro -> schema-registry so we are building and testing against what will go out in next release.

2. Remove comment about the serialization format changing, decision has been made to keep this through GA

3. Use reference doc links for links between packages

Contributes to #10950 