### PR TITLE
[Key Vault Keys] Fixed wrong method in a readme sample

### DIFF
--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -641,7 +641,7 @@ async function main() {
   let digest = hash.update(signatureValue).digest();
   console.log("digest: ", digest);
 
-  const signResult = await cryptographyClient.signData("RS256", digest);
+  const signResult = await cryptographyClient.sign("RS256", digest);
   console.log("sign result: ", signResult.result);
 }
 


### PR DESCRIPTION
The readme sample for the `sign` method of the CryptographyClient was using `signData`.

Fixes #11493

@zzhxiaofeng thank you!

Reviews appreciated.