### PR TITLE
[Metrics Advisor] address some CR feedback to #11593

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -39,25 +39,13 @@ export interface Anomaly {
 
 // @public
 export interface AnomalyAlertConfiguration {
-    crossMetricsOperator?: AnomalyAlertingConfigurationCrossMetricsOperator;
+    crossMetricsOperator?: MetricAnomalyAlertConfigurationsOperator;
     description?: string;
     hookIds: string[];
     id: string;
     metricAlertConfigurations: MetricAlertConfiguration[];
     name: string;
 }
-
-// @public
-export interface AnomalyAlertConfigurationPatch {
-    crossMetricsOperator?: AnomalyAlertingConfigurationCrossMetricsOperator;
-    description?: string;
-    hookIds?: string[];
-    metricAlertConfigurations?: MetricAlertConfiguration[];
-    name?: string;
-}
-
-// @public
-export type AnomalyAlertingConfigurationCrossMetricsOperator = "AND" | "OR" | "XOR";
 
 // @public
 export interface AnomalyDetectionConfiguration {
@@ -71,15 +59,6 @@ export interface AnomalyDetectionConfiguration {
 }
 
 // @public
-export interface AnomalyDetectionConfigurationPatch {
-    description?: string;
-    name?: string;
-    seriesDetectionConditions?: MetricSingleSeriesDetectionCondition[];
-    seriesGroupDetectionConditions?: MetricSeriesGroupDetectionCondition[];
-    wholeSeriesDetectionCondition?: MetricDetectionCondition;
-}
-
-// @public
 export type AnomalyDetectorDirection = "Both" | "Down" | "Up";
 
 // @public
@@ -89,12 +68,6 @@ export type AnomalyValue = "AutoDetect" | "Anomaly" | "NotAnomaly";
 export type AzureApplicationInsightsDataFeedSource = {
     dataSourceType: "AzureApplicationInsights";
     dataSourceParameter: AzureApplicationInsightsParameter;
-};
-
-// @public
-export type AzureApplicationInsightsDataFeedSourcePatch = {
-    dataSourceType: "AzureApplicationInsights";
-    dataSourceParameter?: AzureApplicationInsightsParameter;
 };
 
 // @public (undocumented)
@@ -111,12 +84,6 @@ export type AzureBlobDataFeedSource = {
     dataSourceParameter: AzureBlobParameter;
 };
 
-// @public
-export type AzureBlobDataFeedSourcePatch = {
-    dataSourceType: "AzureBlob";
-    dataSourceParameter?: AzureBlobParameter;
-};
-
 // @public (undocumented)
 export interface AzureBlobParameter {
     blobTemplate: string;
@@ -128,12 +95,6 @@ export interface AzureBlobParameter {
 export type AzureCosmosDBDataFeedSource = {
     dataSourceType: "AzureCosmosDB";
     dataSourceParameter: AzureCosmosDBParameter;
-};
-
-// @public
-export type AzureCosmosDBDataFeedSourcePatch = {
-    dataSourceType: "AzureCosmosDB";
-    dataSourceParameter?: AzureCosmosDBParameter;
 };
 
 // @public (undocumented)
@@ -151,21 +112,9 @@ export type AzureDataExplorerDataFeedSource = {
 };
 
 // @public
-export type AzureDataExplorerDataFeedSourcePatch = {
-    dataSourceType: "AzureDataExplorer";
-    dataSourceParameter?: SqlSourceParameter;
-};
-
-// @public
 export type AzureDataLakeStorageGen2DataFeedSource = {
     dataSourceType: "AzureDataLakeStorageGen2";
     dataSourceParameter: AzureDataLakeStorageGen2Parameter;
-};
-
-// @public
-export type AzureDataLakeStorageGen2DataFeedSourcePatch = {
-    dataSourceType: "AzureDataLakeStorageGen2";
-    dataSourceParameter?: AzureDataLakeStorageGen2Parameter;
 };
 
 // @public (undocumented)
@@ -181,12 +130,6 @@ export interface AzureDataLakeStorageGen2Parameter {
 export type AzureTableDataFeedSource = {
     dataSourceType: "AzureTable";
     dataSourceParameter: AzureTableParameter;
-};
-
-// @public
-export type AzureTableDataFeedSourcePatch = {
-    dataSourceType: "AzureTable";
-    dataSourceParameter?: AzureTableParameter;
 };
 
 // @public (undocumented)
@@ -217,6 +160,7 @@ export type CreateDataFeedOptions = DataFeedOptions & OperationOptions;
 // @public
 export interface DataFeed {
     createdTime: Date;
+    creator: string;
     granularity: DataFeedGranularity;
     id: string;
     ingestionSettings: DataFeedIngestionSettings;
@@ -233,7 +177,7 @@ export interface DataFeed {
 export type DataFeedAccessMode = "Private" | "Public";
 
 // @public
-export type DataFeedDetailPatchStatus = "Active" | "Paused";
+export type DataFeedDetailStatus = "Active" | "Paused";
 
 // @public
 export type DataFeedGranularity = {
@@ -282,12 +226,12 @@ export interface DataFeedPatch {
     ingestionSettings?: DataFeedIngestionSettings;
     name?: string;
     options?: DataFeedOptions & {
-        status?: DataFeedDetailPatchStatus;
+        status?: DataFeedDetailStatus;
     };
     schema?: {
         timestampColumn?: string;
     };
-    source: DataFeedSourcePatchUnion;
+    source: DataFeedSourcePatch;
 }
 
 // @public
@@ -317,7 +261,9 @@ export interface DataFeedSchema {
 export type DataFeedSource = AzureApplicationInsightsDataFeedSource | AzureBlobDataFeedSource | AzureCosmosDBDataFeedSource | AzureDataExplorerDataFeedSource | AzureDataLakeStorageGen2DataFeedSource | AzureTableDataFeedSource | ElasticsearchDataFeedSource | HttpRequestDataFeedSource | InfluxDBDataFeedSource | MySqlDataFeedSource | PostgreSqlDataFeedSource | SQLServerDataFeedSource | MongoDBDataFeedSource;
 
 // @public
-export type DataFeedSourcePatchUnion = AzureApplicationInsightsDataFeedSourcePatch | AzureBlobDataFeedSourcePatch | AzureCosmosDBDataFeedSourcePatch | AzureDataExplorerDataFeedSourcePatch | AzureDataLakeStorageGen2DataFeedSourcePatch | AzureTableDataFeedSourcePatch | ElasticsearchDataFeedSourcePatch | HttpRequestDataFeedSourcePatch | InfluxDBDataFeedSourcePatch | MySqlDataFeedSourcePatch | PostgreSqlDataFeedSourcePatch | SQLServerDataFeedSourcePatch | MongoDBDataFeedSourcePatch;
+export type DataFeedSourcePatch = Omit<DataFeedSource, "dataSourceParameter"> & {
+    [P in "dataSourceParameter"]?: DataFeedSource[P];
+};
 
 // @public
 export type DataSourceType = "AzureApplicationInsights" | "AzureBlob" | "AzureCosmosDB" | "AzureDataExplorer" | "AzureDataLakeStorageGen2" | "AzureTable" | "Elasticsearch" | "HttpRequest" | "InfluxDB" | "MongoDB" | "MySql" | "PostgreSql" | "SqlServer";
@@ -325,12 +271,15 @@ export type DataSourceType = "AzureApplicationInsights" | "AzureBlob" | "AzureCo
 // @public
 export interface DetectionConditionsCommon {
     changeThresholdCondition?: ChangeThresholdConditionUnion;
-    conditionOperator?: WholeMetricConfigurationConditionOperator;
+    conditionOperator?: DetectionConditionsOperator;
     hardThresholdCondition?: HardThresholdConditionUnion;
     smartDetectionCondition?: SmartDetectionCondition;
 }
 
-// @public (undocumented)
+// @public
+export type DetectionConditionsOperator = "AND" | "OR";
+
+// @public
 export interface Dimension {
     displayName?: string;
     name: string;
@@ -345,12 +294,6 @@ export type DimensionKey = {
 export type ElasticsearchDataFeedSource = {
     dataSourceType: "Elasticsearch";
     dataSourceParameter: ElasticsearchParameter;
-};
-
-// @public
-export type ElasticsearchDataFeedSourcePatch = {
-    dataSourceType: "Elasticsearch";
-    dataSourceParameter?: ElasticsearchParameter;
 };
 
 // @public (undocumented)
@@ -509,15 +452,15 @@ export interface HookCommon {
     readonly admins?: string[];
     description?: string;
     externalLink?: string;
-    hookName: string;
     readonly id?: string;
+    name: string;
 }
 
 // @public
 export type HookPatchCommon = {
-    hookName?: string | undefined;
-    description?: string | undefined;
-    externalLink?: string | undefined;
+    hookName?: string;
+    description?: string;
+    externalLink?: string;
 };
 
 // @public
@@ -527,12 +470,6 @@ export type HookUnion = EmailHook | WebhookHook;
 export type HttpRequestDataFeedSource = {
     dataSourceType: "HttpRequest";
     dataSourceParameter: HttpRequestParameter;
-};
-
-// @public
-export type HttpRequestDataFeedSourcePatch = {
-    dataSourceType: "HttpRequest";
-    dataSourceParameter?: HttpRequestParameter;
 };
 
 // @public (undocumented)
@@ -567,12 +504,6 @@ export interface IncidentRootCause {
 export type InfluxDBDataFeedSource = {
     dataSourceType: "InfluxDB";
     dataSourceParameter: InfluxDBParameter;
-};
-
-// @public
-export type InfluxDBDataFeedSourcePatch = {
-    dataSourceType: "InfluxDB";
-    dataSourceParameter?: InfluxDBParameter;
 };
 
 // @public (undocumented)
@@ -814,7 +745,7 @@ export type ListMetricSeriesPageResponse = {
     };
 };
 
-// @public (undocumented)
+// @public
 export interface Metric {
     description?: string;
     displayName?: string;
@@ -836,6 +767,9 @@ export interface MetricAlertConfiguration {
     negationOperation?: boolean;
     snoozeCondition?: AlertSnoozeCondition;
 }
+
+// @public
+export type MetricAnomalyAlertConfigurationsOperator = "AND" | "OR" | "XOR";
 
 // @public
 export type MetricAnomalyAlertScope = {
@@ -929,30 +863,30 @@ export type MetricPeriodFeedback = {
 // @public
 export class MetricsAdvisorAdministrationClient {
     constructor(endpointUrl: string, credential: MetricsAdvisorKeyCredential, options?: MetricsAdvisorAdministrationClientOptions);
-    createAnomalyAlertConfiguration(name: string, crossMetricsOperator: AnomalyAlertingConfigurationCrossMetricsOperator, metricAlertConfigurations: MetricAlertConfiguration[], hookIds?: string[], description?: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
-    createDataFeed(name: string, source: DataFeedSource, granularity: DataFeedGranularity, schema: DataFeedSchema, ingestionSettings: DataFeedIngestionSettings, options?: CreateDataFeedOptions): Promise<GetDataFeedResponse>;
+    createAnomalyAlertConfiguration(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    createDataFeed(feed: Omit<DataFeed, "id" | "metricIds" | "isAdmin" | "status" | "creator" | "createdTime">, operationOptions?: OperationOptions): Promise<GetDataFeedResponse>;
     createHook(hookInfo: EmailHook | WebhookHook, options?: OperationOptions): Promise<GetHookResponse>;
-    createMetricAnomalyDetectionConfiguration(name: string, metricId: string, wholeMetricConditions: MetricDetectionCondition, description?: string, dimensionGroupOverrideConditions?: MetricSeriesGroupDetectionCondition[], seriesOverrideConditions?: MetricSingleSeriesDetectionCondition[], options?: {}): Promise<GetAnomalyDetectionConfigurationResponse>;
-    deleteAnomalyAlertConfiguration(alertConfigurationId: string, options?: OperationOptions): Promise<RestResponse>;
-    deleteDataFeed(dataFeedId: string, options?: OperationOptions): Promise<RestResponse>;
-    deleteHook(hookId: string, options?: OperationOptions): Promise<RestResponse>;
-    deleteMetricAnomalyDetectionConfiguration(detectionConfigurationId: string, options?: OperationOptions): Promise<RestResponse>;
+    createMetricAnomalyDetectionConfiguration(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    deleteAnomalyAlertConfiguration(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteDataFeed(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteHook(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteMetricAnomalyDetectionConfiguration(id: string, options?: OperationOptions): Promise<RestResponse>;
     readonly endpointUrl: string;
-    getAnomalyAlertConfiguration(alertConfigurationId: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
-    getDataFeed(dataFeedId: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
+    getAnomalyAlertConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    getDataFeed(id: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
     getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GeneratedClientGetIngestionProgressResponse>;
-    getHook(hookId: string, options?: OperationOptions): Promise<GetHookResponse>;
-    getMetricAnomalyDetectionConfiguration(detectionConfigurationId: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
-    listAnomalyAlertConfigurations(detectionConfigurationId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, ListAnomalyAlertConfigurationsPageResponse, undefined>;
+    getHook(id: string, options?: OperationOptions): Promise<GetHookResponse>;
+    getMetricAnomalyDetectionConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    listAnomalyAlertConfigurations(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, ListAnomalyAlertConfigurationsPageResponse, undefined>;
     listDataFeedIngestionStatus(dataFeedId: string, startTime: Date, endTime: Date, options?: ListDataFeedIngestionStatusOptions): PagedAsyncIterableIterator<IngestionStatus, ListDataFeedIngestionStatusPageResponse>;
     listDataFeeds(options?: ListDataFeedsOptions): PagedAsyncIterableIterator<DataFeed, ListDataFeedsPageResponse>;
     listHooks(options?: ListHooksOptions): PagedAsyncIterableIterator<HookUnion, ListHooksPageResponse>;
     listMetricAnomalyDetectionConfigurations(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, ListAnomalyDetectionConfigurationsPageResponse, undefined>;
     refreshDataFeedIngestion(dataFeedId: string, startTime: Date, endTime: Date, options?: OperationOptions): Promise<RestResponse>;
-    updateAnomalyAlertConfiguration(alertConfigurationId: string, patch: AnomalyAlertConfigurationPatch, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    updateAnomalyAlertConfiguration(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     updateDataFeed(dataFeedId: string, patch: DataFeedPatch, options?: OperationOptions): Promise<GetDataFeedResponse>;
-    updateHook(hookId: string, patch: EmailHookPatch | WebhookHookPatch, options?: OperationOptions): Promise<GetHookResponse>;
-    updateMetricAnomalyDetectionConfiguration(detectionConfigurationId: string, patch: AnomalyDetectionConfigurationPatch, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    updateHook(id: string, patch: EmailHookPatch | WebhookHookPatch, options?: OperationOptions): Promise<GetHookResponse>;
+    updateMetricAnomalyDetectionConfiguration(id: string, patch: Partial<Omit<AnomalyDetectionConfiguration, "id" | "metricId">>, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
 }
 
 // @public
@@ -962,18 +896,18 @@ export interface MetricsAdvisorAdministrationClientOptions extends PipelineOptio
 // @public
 export class MetricsAdvisorClient {
     constructor(endpointUrl: string, credential: MetricsAdvisorKeyCredential, options?: MetricsAdvisorClientOptions);
-    createMetricFeedback(feedback: MetricFeedbackUnion, options?: {}): Promise<GetFeedbackResponse>;
+    createMetricFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
     readonly endpointUrl: string;
-    getIncidentRootCauses(detectionConfigurationId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
-    getMetricEnrichedSeriesData(detectionConfigurationId: string, startTime: Date, endTime: Date, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
-    getMetricFeedback(feedbackId: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
+    getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
+    getMetricEnrichedSeriesData(detectionConfigId: string, startTime: Date, endTime: Date, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
+    getMetricFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getMetricSeriesData(metricId: string, startTime: Date, endTime: Date, seriesToFilter: Record<string, string>[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
-    listAlertsForAlertConfiguration(alertConfigurationId: string, startTime: Date, endTime: Date, timeMode: TimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<Alert, ListAlertsForAlertConfigurationPageResponse>;
-    listAnomaliesForAlert(alertConfigurationId: string, alertId: string, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForAlertPageResponse>;
-    listAnomaliesForDetectionConfiguration(detectionConfigurationId: string, startTime: Date, endTime: Date, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForDetectionConfigurationPageResponse>;
-    listDimensionValuesForDetectionConfiguration(detectionConfigurationId: string, startTime: Date, endTime: Date, dimensionName: string, options?: ListDimensionValuesForDetectionConfigurationOptions): PagedAsyncIterableIterator<string, ListDimensionValuesForDetectionConfigurationPageResponse>;
-    listIncidentsForAlert(alertConfigurationId: string, alertId: string, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<Incident, ListIncidentsForAlertPageResponse>;
-    listIncidentsForDetectionConfiguration(detectionConfigurationId: string, startTime: Date, endTime: Date, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<Incident, ListIncidentsByDetectionConfigurationPageResponse>;
+    listAlertsForAlertConfiguration(alertConfigId: string, startTime: Date, endTime: Date, timeMode: TimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<Alert, ListAlertsForAlertConfigurationPageResponse>;
+    listAnomaliesForAlert(alertConfigId: string, alertId: string, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForAlertPageResponse>;
+    listAnomaliesForDetectionConfiguration(detectionConfigId: string, startTime: Date, endTime: Date, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForDetectionConfigurationPageResponse>;
+    listDimensionValuesForDetectionConfiguration(detectionConfigId: string, startTime: Date, endTime: Date, dimensionName: string, options?: ListDimensionValuesForDetectionConfigurationOptions): PagedAsyncIterableIterator<string, ListDimensionValuesForDetectionConfigurationPageResponse>;
+    listIncidentsForAlert(alertConfigId: string, alertId: string, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<Incident, ListIncidentsForAlertPageResponse>;
+    listIncidentsForDetectionConfiguration(detectionConfigId: string, startTime: Date, endTime: Date, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<Incident, ListIncidentsByDetectionConfigurationPageResponse>;
     listMetricDimensionValues(metricId: string, dimensionName: string, options?: ListMetricDimensionValuesOptions): PagedAsyncIterableIterator<string, ListMetricDimensionValuesPageResponse>;
     listMetricEnrichmentStatus(metricId: string, startTime: Date, endTime: Date, options?: ListMetricEnrichmentStatusOptions): PagedAsyncIterableIterator<EnrichmentStatus, ListMetricEnrichmentStatusPageResponse>;
     listMetricFeedbacks(metricId: string, options?: ListFeedbacksOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, ListMetricFeedbackPageResponse>;
@@ -1022,12 +956,6 @@ export type MongoDBDataFeedSource = {
     dataSourceParameter: MongoDBParameter;
 };
 
-// @public
-export type MongoDBDataFeedSourcePatch = {
-    dataSourceType: "MongoDB";
-    dataSourceParameter?: MongoDBParameter;
-};
-
 // @public (undocumented)
 export interface MongoDBParameter {
     command: string;
@@ -1042,21 +970,9 @@ export type MySqlDataFeedSource = {
 };
 
 // @public
-export type MySqlDataFeedSourcePatch = {
-    dataSourceType: "MySql";
-    dataSourceParameter?: SqlSourceParameter;
-};
-
-// @public
 export type PostgreSqlDataFeedSource = {
     dataSourceType: "PostgreSql";
     dataSourceParameter: SqlSourceParameter;
-};
-
-// @public
-export type PostgreSqlDataFeedSourcePatch = {
-    dataSourceType: "PostgreSql";
-    dataSourceParameter?: SqlSourceParameter;
 };
 
 // @public
@@ -1089,12 +1005,6 @@ export type SnoozeScope = "Metric" | "Series";
 export type SQLServerDataFeedSource = {
     dataSourceType: "SqlServer";
     dataSourceParameter: SqlSourceParameter;
-};
-
-// @public
-export type SQLServerDataFeedSourcePatch = {
-    dataSourceType: "SqlServer";
-    dataSourceParameter?: SqlSourceParameter;
 };
 
 // @public (undocumented)
@@ -1142,9 +1052,6 @@ export type WebhookHookPatch = {
     hookType: "Webhook";
     hookParameter?: WebhookHookParameter;
 } & HookPatchCommon;
-
-// @public
-export type WholeMetricConfigurationConditionOperator = "AND" | "OR";
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
@@ -52,13 +52,13 @@ async function createAlertConfig(adminClient, detectionConfigId) {
       scopeType: "All"
     }
   };
-  const result = await adminClient.createAnomalyAlertConfiguration(
-    "js alerting config name " + new Date().getTime().toString(),
-    "AND",
-    [metricAlertingConfig, metricAlertingConfig],
-    [],
-    "alerting config description"
-  );
+  const result = await adminClient.createAnomalyAlertConfiguration({
+    name: "js alerting config name " + new Date().getTime().toString(),
+    crossMetricsOperator: "AND",
+    metricAlertConfigurations: [metricAlertingConfig, metricAlertingConfig],
+    hookIds: [],
+    description: "alerting config description"
+  });
   console.log(result);
   return result;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
@@ -92,7 +92,7 @@ async function createDataFeed(client) {
     ingestionRetryDelayInSeconds: -1,
     stopRetryAfterInSeconds: -1
   };
-  const granualarity = {
+  const granularity = {
     granularityType: "Daily"
   };
   const source = {
@@ -120,14 +120,14 @@ async function createDataFeed(client) {
   };
 
   console.log("Creating Datafeed...");
-  const result = await client.createDataFeed(
-    "js-test-create-datafeed" + new Date().getTime().toString(),
+  const result = await client.createDataFeed({
+    name: "test-datafeed-" + new Date().getTime().toFixed(),
     source,
-    granualarity,
-    dataFeedSchema,
-    dataFeedIngestion,
+    granularity,
+    schema: dataFeedSchema,
+    ingestionSettings: dataFeedIngestion,
     options
-  );
+  });
   console.dir(result);
   return result;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
@@ -57,7 +57,7 @@ async function createDetectionConfig(adminClient, metricId) {
     name: "fresh detection" + new Date().getTime().toString(),
     description: "fresh detection",
     metricId,
-    wholeMetricConfiguration: {
+    wholeSeriesDetectionCondition: {
       conditionOperator: "AND",
       changeThresholdCondition: {
         anomalyDetectorDirection: "Both",
@@ -74,14 +74,7 @@ async function createDetectionConfig(adminClient, metricId) {
     }
   };
   console.log("Creating a new anomaly detection configuration...");
-  return await adminClient.createMetricAnomalyDetectionConfiguration(
-    config.name,
-    config.metricId,
-    config.wholeMetricConfiguration,
-    config.description,
-    config.dimensionGroupOverrideConfigurations,
-    config.seriesOverrideConfigurations
-  );
+  return await adminClient.createMetricAnomalyDetectionConfiguration(config);
 }
 
 // updating an detection configuration

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
@@ -31,7 +31,7 @@ async function createWebHook(client) {
   console.log("Creating a new web hook...");
   const hook = {
     hookType: "Webhook",
-    hookName: "js web hook example" + new Date().getTime().toFixed(),
+    name: "js web hook example" + new Date().getTime().toFixed(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",
@@ -50,7 +50,7 @@ async function createEmailHook(client) {
   console.log("Creating a new email hook...");
   const hook = {
     hookType: "Email",
-    hookName: "js email hook example" + new Date().getTime().toFixed(),
+    name: "js email hook example" + new Date().getTime().toFixed(),
     description: "description",
     hookParameter: { toList: ["test@example.com"] }
   };

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
@@ -11,8 +11,8 @@ dotenv.config();
 import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
-  AnomalyAlertConfigurationPatch,
-  MetricAlertConfiguration
+  MetricAlertConfiguration,
+  AnomalyAlertConfiguration
 } from "@azure/ai-metrics-advisor";
 
 main()
@@ -57,13 +57,13 @@ async function createAlertConfig(
       scopeType: "All"
     }
   };
-  const result = await adminClient.createAnomalyAlertConfiguration(
-    "js alerting config name " + new Date().getTime().toString(),
-    "AND",
-    [metricAlertingConfig, metricAlertingConfig],
-    [],
-    "alerting config description"
-  );
+  const result = await adminClient.createAnomalyAlertConfiguration({
+    name: "js alerting config name " + new Date().getTime().toString(),
+    crossMetricsOperator: "AND",
+    metricAlertConfigurations: [metricAlertingConfig, metricAlertingConfig],
+    hookIds: [],
+    description: "alerting config description"
+  });
   console.log(result);
   return result;
 }
@@ -81,7 +81,7 @@ async function updateAlertConfig(
       scopeType: "All"
     }
   };
-  const patch: AnomalyAlertConfigurationPatch = {
+  const patch: Omit<AnomalyAlertConfiguration, "id"> = {
     name: "new Name",
     //description: "new description",
     hookIds,

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
@@ -104,7 +104,7 @@ async function createDataFeed(
     ingestionRetryDelayInSeconds: -1,
     stopRetryAfterInSeconds: -1
   };
-  const granualarity: DataFeedGranularity = {
+  const granularity: DataFeedGranularity = {
     granularityType: "Daily"
   };
   const source: DataFeedSource = {
@@ -132,17 +132,17 @@ async function createDataFeed(
   };
 
   console.log("Creating Datafeed...");
-  const res2 = await client.createDataFeed(
-    "test-datafeed",
+  const result = await client.createDataFeed({
+    name: "test-datafeed-" + new Date().getTime().toFixed(),
     source,
-    granualarity,
-    dataFeedSchema,
-    dataFeedIngestion,
+    granularity,
+    schema: dataFeedSchema,
+    ingestionSettings: dataFeedIngestion,
     options
-  );
+  });
 
-  console.dir(res2);
-  return res2;
+  console.dir(result);
+  return result;
 }
 
 async function getDataFeed(client: MetricsAdvisorAdministrationClient, dataFeedId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
@@ -11,7 +11,6 @@ dotenv.config();
 import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
-  AnomalyDetectionConfigurationPatch,
   AnomalyDetectionConfiguration
 } from "@azure/ai-metrics-advisor";
 
@@ -81,19 +80,10 @@ async function createDetectionConfig(
         upperBound: 400,
         suppressCondition: { minNumber: 2, minRatio: 2 }
       }
-    },
-    seriesGroupDetectionConditions: [],
-    seriesDetectionConditions: []
+    }
   };
   console.log("Creating a new anomaly detection configuration...");
-  return await adminClient.createMetricAnomalyDetectionConfiguration(
-    config.name,
-    config.metricId,
-    config.wholeSeriesDetectionCondition,
-    config.description,
-    config.seriesGroupDetectionConditions,
-    config.seriesDetectionConditions
-  );
+  return await adminClient.createMetricAnomalyDetectionConfiguration(config);
 }
 
 // updating an detection configuration
@@ -101,7 +91,7 @@ async function updateDetectionConfig(
   adminClient: MetricsAdvisorAdministrationClient,
   configId: string
 ) {
-  const patch: AnomalyDetectionConfigurationPatch = {
+  const patch: Omit<AnomalyDetectionConfiguration, "id" | "metricId"> = {
     name: "new Name",
     description: "new description",
     wholeSeriesDetectionCondition: {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
@@ -35,7 +35,7 @@ async function createWebHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new web hook...");
   const hook: WebhookHook = {
     hookType: "Webhook",
-    hookName: "js web hook example" + new Date().getTime().toFixed(),
+    name: "js web hook example" + new Date().getTime().toFixed(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",
@@ -54,7 +54,7 @@ async function createEmailHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new email hook...");
   const hook: EmailHook = {
     hookType: "Email",
-    hookName: "js email hook example" + new Date().getTime().toFixed(),
+    name: "js email hook example" + new Date().getTime().toFixed(),
     description: "description",
     hookParameter: { toList: ["test@example.com"] }
   };
@@ -66,7 +66,7 @@ async function createEmailHook(client: MetricsAdvisorAdministrationClient) {
 async function getHook(client: MetricsAdvisorAdministrationClient, hookId: string) {
   console.log(`Retrieving an existing hook for id ${hookId}...`);
   const result = await client.getHook(hookId);
-  console.log(result.hookName);
+  console.log(result.name);
   console.log(result.description);
   console.log(result.admins);
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -122,7 +122,7 @@ async function createDataFeed(
     ingestionRetryDelayInSeconds: -1,
     stopRetryAfterInSeconds: -1
   };
-  const granualarity: DataFeedGranularity = {
+  const granularity: DataFeedGranularity = {
     granularityType: "Daily"
   };
   const source: DataFeedSource = {
@@ -146,14 +146,14 @@ async function createDataFeed(
   };
 
   console.log("Creating Datafeed...");
-  const result = await adminClient.createDataFeed(
-    "test_datafeed_" + new Date().getTime().toFixed(),
+  const result = await adminClient.createDataFeed({
+    name: "test_datafeed_" + new Date().getTime().toFixed(),
     source,
-    granualarity,
-    dataFeedSchema,
-    dataFeedIngestion,
+    granularity,
+    schema: dataFeedSchema,
+    ingestionSettings: dataFeedIngestion,
     options
-  );
+  });
 
   return result;
 }
@@ -180,10 +180,10 @@ async function configureAnomalyDetectionConfiguration(
   metricId: string
 ) {
   console.log(`Creating an anomaly detection configuration on metric '${metricId}'...`);
-  return await adminClient.createMetricAnomalyDetectionConfiguration(
-    "test_detection_configuration" + new Date().getTime().toString(),
+  return await adminClient.createMetricAnomalyDetectionConfiguration({
+    name: "test_detection_configuration" + new Date().getTime().toString(),
     metricId,
-    {
+    wholeSeriesDetectionCondition: {
       smartDetectionCondition: {
         sensitivity: 100,
         anomalyDetectorDirection: "Both",
@@ -193,17 +193,15 @@ async function configureAnomalyDetectionConfiguration(
         }
       }
     },
-    "Detection configuration description",
-    [],
-    []
-  );
+    description: "Detection configuration description"
+  });
 }
 
 async function createWebhookHook(adminClient: MetricsAdvisorAdministrationClient) {
   console.log("Creating a webhook hook");
   const hook: WebhookHook = {
     hookType: "Webhook",
-    hookName: "web hook " + new Date().getTime().toFixed(),
+    name: "web hook " + new Date().getTime().toFixed(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",
@@ -220,7 +218,7 @@ async function createWebhookHook(adminClient: MetricsAdvisorAdministrationClient
 async function configureAlertConfiguration(
   adminClient: MetricsAdvisorAdministrationClient,
   detectionConfigId: string,
-  hoookIds: string[]
+  hookIds: string[]
 ) {
   console.log("Creating a new alerting configuration...");
   const metricAlertingConfig: MetricAlertConfiguration = {
@@ -237,13 +235,13 @@ async function configureAlertConfiguration(
       onlyForSuccessive: true
     }
   };
-  return await adminClient.createAnomalyAlertConfiguration(
-    "test_alert_config_" + new Date().getTime().toString(),
-    "AND",
-    [metricAlertingConfig],
-    hoookIds,
-    "Alerting config description"
-  );
+  return await adminClient.createAnomalyAlertConfiguration({
+    name: "test_alert_config_" + new Date().getTime().toString(),
+    crossMetricsOperator: "AND",
+    metricAlertConfigurations: [metricAlertingConfig],
+    hookIds,
+    description: "Alerting config description"
+  });
 }
 
 async function queryAlerts(

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
@@ -805,6 +805,9 @@ export interface DataFeedDetail {
   actionLinkTemplate?: string;
 }
 
+/**
+ * Represents a metric of an ingested data feed
+ */
 export interface Metric {
   /**
    * metric id
@@ -824,6 +827,9 @@ export interface Metric {
   description?: string;
 }
 
+/**
+ * Represents a dimension of an ingested data feed
+ */
 export interface Dimension {
   /**
    * dimension name
@@ -1004,11 +1010,11 @@ export interface HookInfo {
   /**
    * Hook unique id
    */
-  readonly hookId?: string;
+  readonly id?: string;
   /**
    * hook unique name
    */
-  hookName: string;
+  name: string;
   /**
    * hook description
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/mappers.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/mappers.ts
@@ -2123,14 +2123,14 @@ export const HookInfo: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      hookId: {
+      id: {
         serializedName: "hookId",
         readOnly: true,
         type: {
           name: "Uuid"
         }
       },
-      hookName: {
+      name: {
         serializedName: "hookName",
         required: true,
         type: {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -141,6 +141,9 @@ export type ListFeedbacksOptions = {
 
 export type ListMetricSeriesDefinitionsOptions = {
   skip?: number;
+  /**
+   * filter specfic dimension name and values
+   */
   dimensionFilter?: Record<string, string[]>;
 } & OperationOptions;
 
@@ -234,7 +237,7 @@ export class MetricsAdvisorClient {
    * List alert segments for alerting configuration
    */
   private async *listSegmentOfAlertsForAlertingConfig(
-    alertConfigurationId: string,
+    alertConfigId: string,
     startTime: Date,
     endTime: Date,
     timeMode: TimeMode,
@@ -249,7 +252,7 @@ export class MetricsAdvisorClient {
     };
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getAlertsByAnomalyAlertingConfiguration(
-        alertConfigurationId,
+        alertConfigId,
         optionsBody,
         {
           ...options,
@@ -300,14 +303,14 @@ export class MetricsAdvisorClient {
    * List alert items for alerting configuration
    */
   private async *listItemsOfAlertsForAlertingConfig(
-    alertConfigurationId: string,
+    alertConfigId: string,
     startTime: Date,
     endTime: Date,
     timeMode: TimeMode,
     options: ListAlertsOptions
   ): AsyncIterableIterator<Alert> {
     for await (const segment of this.listSegmentOfAlertsForAlertingConfig(
-      alertConfigurationId,
+      alertConfigId,
       startTime,
       endTime,
       timeMode,
@@ -370,7 +373,7 @@ export class MetricsAdvisorClient {
    * }
    *
    * ```
-   * @param alertConfigurationId  anomaly alerting configuration unique id
+   * @param alertConfigId  anomaly alerting configuration unique id
    * @param startTime The start of time range to query alert items for alerting configuration
    * @param endTime The end of time range to query alert items for alerting configuration
    * @param timeMode Query time mode - "AnomalyTime" | "CreatedTime" | "ModifiedTime"
@@ -378,14 +381,14 @@ export class MetricsAdvisorClient {
    */
 
   public listAlertsForAlertConfiguration(
-    alertConfigurationId: string,
+    alertConfigId: string,
     startTime: Date,
     endTime: Date,
     timeMode: TimeMode,
     options: ListAlertsOptions = {}
   ): PagedAsyncIterableIterator<Alert, ListAlertsForAlertConfigurationPageResponse> {
     const iter = this.listItemsOfAlertsForAlertingConfig(
-      alertConfigurationId,
+      alertConfigId,
       startTime,
       endTime,
       timeMode,
@@ -409,7 +412,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentOfAlertsForAlertingConfig(
-          alertConfigurationId,
+          alertConfigId,
           startTime,
           endTime,
           timeMode,
@@ -428,7 +431,7 @@ export class MetricsAdvisorClient {
    * List anomalies for alerting configuration - segments
    */
   private async *listSegmentsOfAnomaliesForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     continuationToken?: string,
     options: ListAnomaliesForAlertConfigurationOptions & { maxPageSize?: number } = {}
@@ -436,7 +439,7 @@ export class MetricsAdvisorClient {
     let segmentResponse;
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getAnomaliesFromAlertByAnomalyAlertingConfiguration(
-        alertConfigurationId,
+        alertConfigId,
         alertId,
         {
           ...options,
@@ -467,7 +470,7 @@ export class MetricsAdvisorClient {
     delete options.skip;
     while (continuationToken) {
       segmentResponse = await this.client.getAnomaliesFromAlertByAnomalyAlertingConfigurationNext(
-        alertConfigurationId,
+        alertConfigId,
         alertId,
         continuationToken,
         {
@@ -501,12 +504,12 @@ export class MetricsAdvisorClient {
    * listing anomalies for alerting configuration - items
    */
   private async *listItemsOfAnomaliesForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     options: ListAnomaliesForAlertConfigurationOptions & { maxPageSize?: number } = {}
   ): AsyncIterableIterator<Anomaly> {
     for await (const segment of this.listSegmentsOfAnomaliesForAlert(
-      alertConfigurationId,
+      alertConfigId,
       alertId,
       undefined,
       options
@@ -563,17 +566,17 @@ export class MetricsAdvisorClient {
    * }
    *
    * ```
-   * @param alertConfigurationId Anomaly alert configuration id
+   * @param alertConfigId Anomaly alert configuration id
    * @param alertId Alert id
    * @param options The options parameter.
    */
 
   public listAnomaliesForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     options: ListAnomaliesForAlertConfigurationOptions = {}
   ): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForAlertPageResponse> {
-    const iter = this.listItemsOfAnomaliesForAlert(alertConfigurationId, alertId, options);
+    const iter = this.listItemsOfAnomaliesForAlert(alertConfigId, alertId, options);
     return {
       /**
        * @member {Promise} [next] The next method, part of the iteration protocol
@@ -592,7 +595,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfAnomaliesForAlert(
-          alertConfigurationId,
+          alertConfigId,
           alertId,
           settings.continuationToken,
           {
@@ -609,7 +612,7 @@ export class MetricsAdvisorClient {
    * listing incidents for alert - segments
    */
   private async *listSegmentsOfIncidentsForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     continuationToken?: string,
     options: ListIncidentsForAlertOptions & { maxPageSize?: number } = {}
@@ -617,7 +620,7 @@ export class MetricsAdvisorClient {
     let segmentResponse;
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getIncidentsFromAlertByAnomalyAlertingConfiguration(
-        alertConfigurationId,
+        alertConfigId,
         alertId,
         {
           ...options,
@@ -647,7 +650,7 @@ export class MetricsAdvisorClient {
     delete options.skip;
     while (continuationToken) {
       segmentResponse = await this.client.getIncidentsFromAlertByAnomalyAlertingConfigurationNext(
-        alertConfigurationId,
+        alertConfigId,
         alertId,
         continuationToken,
         {
@@ -680,12 +683,12 @@ export class MetricsAdvisorClient {
    * listing incidents for alert - items
    */
   private async *listItemsOfIncidentsForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     options: ListIncidentsForAlertOptions = {}
   ): AsyncIterableIterator<Incident> {
     for await (const segment of this.listSegmentsOfIncidentsForAlert(
-      alertConfigurationId,
+      alertConfigId,
       alertId,
       undefined,
       options
@@ -742,16 +745,16 @@ export class MetricsAdvisorClient {
    *  page = await pages.next();
    * }
    * ```
-   * @param alertConfigurationId  Anomaly alert configuration id
+   * @param alertConfigId  Anomaly alert configuration id
    * @param alertId  Alert id
    * @param options The options parameter.
    */
   public listIncidentsForAlert(
-    alertConfigurationId: string,
+    alertConfigId: string,
     alertId: string,
     options: ListIncidentsForAlertOptions = {}
   ): PagedAsyncIterableIterator<Incident, ListIncidentsForAlertPageResponse> {
-    const iter = this.listItemsOfIncidentsForAlert(alertConfigurationId, alertId, options);
+    const iter = this.listItemsOfIncidentsForAlert(alertConfigId, alertId, options);
     return {
       /**
        * @member {Promise} [next] The next method, part of the iteration protocol
@@ -770,7 +773,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfIncidentsForAlert(
-          alertConfigurationId,
+          alertConfigId,
           alertId,
           settings.continuationToken,
           {
@@ -785,14 +788,14 @@ export class MetricsAdvisorClient {
   /**
    * Retrieves enriched metric series data for a detection configuration
    *
-   * @param detectionConfigurationId Anomaly detection configuration id
+   * @param detectionConfigId Anomaly detection configuration id
    * @param startTime The start of time range to query metric enriched series data
    * @param endTime The end of time range to query metric enriched series data
    * @param seriesToFilter Series to retrieve their data
    * @param options The options parameter.
    */
   public async getMetricEnrichedSeriesData(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     seriesToFilter: DimensionKey[],
@@ -804,7 +807,7 @@ export class MetricsAdvisorClient {
       series: seriesToFilter
     };
     const result = await this.client.getSeriesByAnomalyDetectionConfiguration(
-      detectionConfigurationId,
+      detectionConfigId,
       optionsBody,
       options
     );
@@ -820,7 +823,7 @@ export class MetricsAdvisorClient {
    */
 
   private async *listSegmentsOfAnomaliesForDetectionConfig(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListAnomaliesForDetectionConfigurationOptions & { maxPageSize?: number },
@@ -840,7 +843,7 @@ export class MetricsAdvisorClient {
     };
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getAnomaliesByAnomalyDetectionConfiguration(
-        detectionConfigurationId,
+        detectionConfigId,
         optionsBody,
         {
           ...options,
@@ -849,7 +852,7 @@ export class MetricsAdvisorClient {
       );
       const anomalies = segmentResponse.value?.map((a) => {
         return {
-          detectionConfigurationId: detectionConfigurationId,
+          detectionConfigurationId: detectionConfigId,
           metricId: a.metricId,
           timestamp: a.timestamp,
           createdOn: a.createdTime,
@@ -877,7 +880,7 @@ export class MetricsAdvisorClient {
       continuationToken = segmentResponse.nextLink;
       const anomalies = segmentResponse.value?.map((a) => {
         return {
-          detectionConfigurationId: detectionConfigurationId,
+          detectionConfigurationId: detectionConfigId,
           metricId: a.metricId,
           timestamp: a.timestamp,
           createdOn: a.createdTime,
@@ -900,13 +903,13 @@ export class MetricsAdvisorClient {
    */
 
   private async *listItemsOfAnomaliesForDetectionConfig(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListAnomaliesForDetectionConfigurationOptions
   ): AsyncIterableIterator<Anomaly> {
     for await (const segment of this.listSegmentsOfAnomaliesForDetectionConfig(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       options
@@ -965,19 +968,19 @@ export class MetricsAdvisorClient {
    * }
    *
    * ```
-   * @param detectionConfigurationId  Anomaly detection configuration id
+   * @param detectionConfigId Anomaly detection configuration id
    * @param startTime The start of time range to query anomalies
    * @param endTime The end of time range to query anomalies
    * @param options The options parameter.
    */
   public listAnomaliesForDetectionConfiguration(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListAnomaliesForDetectionConfigurationOptions = {}
   ): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForDetectionConfigurationPageResponse> {
     const iter = this.listItemsOfAnomaliesForDetectionConfig(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       options
@@ -1000,7 +1003,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfAnomaliesForDetectionConfig(
-          detectionConfigurationId,
+          detectionConfigId,
           startTime,
           endTime,
           {
@@ -1015,7 +1018,7 @@ export class MetricsAdvisorClient {
 
   // ## list dimension values for detection config - segments
   private async *listSegmentsOfDimensionValuesForDetectionConfig(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     dimensionName: string,
@@ -1031,7 +1034,7 @@ export class MetricsAdvisorClient {
     };
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getDimensionOfAnomaliesByAnomalyDetectionConfiguration(
-        detectionConfigurationId,
+        detectionConfigId,
         optionsBody,
         {
           ...options,
@@ -1063,14 +1066,14 @@ export class MetricsAdvisorClient {
 
   // ## list dimension values for detection config - items
   private async *listItemsOfDimensionValues(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     dimensionName: string,
     options: ListDimensionValuesForDetectionConfigurationOptions
   ): AsyncIterableIterator<string> {
     for await (const segment of this.listSegmentsOfDimensionValuesForDetectionConfig(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       dimensionName,
@@ -1135,20 +1138,20 @@ export class MetricsAdvisorClient {
    *   page = await pages.next();
    * }
    * ```
-   * @param detectionConfigurationId  Anomaly detection configuration id
+   * @param detectionConfigId  Anomaly detection configuration id
    * @param startTime The start of time range to query anomalies
    * @param endTime The end of time range to query anomalies
    * @param options The options parameter.
    */
   public listDimensionValuesForDetectionConfiguration(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     dimensionName: string,
     options: ListDimensionValuesForDetectionConfigurationOptions = {}
   ): PagedAsyncIterableIterator<string, ListDimensionValuesForDetectionConfigurationPageResponse> {
     const iter = this.listItemsOfDimensionValues(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       dimensionName,
@@ -1172,7 +1175,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfDimensionValuesForDetectionConfig(
-          detectionConfigurationId,
+          detectionConfigId,
           startTime,
           endTime,
           dimensionName,
@@ -1188,7 +1191,7 @@ export class MetricsAdvisorClient {
 
   // ## listing incidents for detection config - segments
   private async *listSegmentsOfIncidentsForDetectionConfig(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListIncidentsForDetectionConfigurationOptions & { maxPageSize?: number },
@@ -1204,7 +1207,7 @@ export class MetricsAdvisorClient {
     };
     if (continuationToken === undefined) {
       segmentResponse = await this.client.getIncidentsByAnomalyDetectionConfiguration(
-        detectionConfigurationId,
+        detectionConfigId,
         optionsBody,
         {
           ...options,
@@ -1215,7 +1218,7 @@ export class MetricsAdvisorClient {
         return {
           id: incident.incidentId,
           metricId: incident.metricId,
-          detectionConfigurationId: detectionConfigurationId,
+          detectionConfigurationId: detectionConfigId,
           dimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
@@ -1232,7 +1235,7 @@ export class MetricsAdvisorClient {
 
     while (continuationToken) {
       segmentResponse = await this.client.getIncidentsByAnomalyDetectionConfigurationNext(
-        detectionConfigurationId,
+        detectionConfigId,
         optionsBody,
         continuationToken,
         {
@@ -1244,7 +1247,7 @@ export class MetricsAdvisorClient {
         return {
           id: incident.incidentId,
           metricId: incident.metricId,
-          detectionConfigurationId: detectionConfigurationId,
+          detectionConfigurationId: detectionConfigId,
           dimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
@@ -1262,13 +1265,13 @@ export class MetricsAdvisorClient {
 
   // ## listing incidents for detection config - items
   private async *listItemsOfIncidentsForDetectionConfig(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListIncidentsForDetectionConfigurationOptions
   ): AsyncIterableIterator<Incident> {
     for await (const segment of this.listSegmentsOfIncidentsForDetectionConfig(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       options
@@ -1327,19 +1330,19 @@ export class MetricsAdvisorClient {
    *  page = await pages.next();
    * }
    * ```
-   * @param detectionConfigurationId  Anomaly detection configuration id
+   * @param detectionConfigId  Anomaly detection configuration id
    * @param startTime The start of time range to query for incidents
    * @param endTime The end of time range to query for incidents
    * @param options The options parameter.
    */
   public listIncidentsForDetectionConfiguration(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     startTime: Date,
     endTime: Date,
     options: ListIncidentsForDetectionConfigurationOptions = {}
   ): PagedAsyncIterableIterator<Incident, ListIncidentsByDetectionConfigurationPageResponse> {
     const iter = this.listItemsOfIncidentsForDetectionConfig(
-      detectionConfigurationId,
+      detectionConfigId,
       startTime,
       endTime,
       options
@@ -1362,7 +1365,7 @@ export class MetricsAdvisorClient {
        */
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfIncidentsForDetectionConfig(
-          detectionConfigurationId,
+          detectionConfigId,
           startTime,
           endTime,
           {
@@ -1378,12 +1381,12 @@ export class MetricsAdvisorClient {
   /**
    * Gets the root causes of an incident.
    *
-   * @param detectionConfigurationId Anomaly detection configuration id
+   * @param detectionConfigId Anomaly detection configuration id
    * @param incidentId Incident id
    * @param options The options parameter
    */
   public async getIncidentRootCauses(
-    detectionConfigurationId: string,
+    detectionConfigId: string,
     incidentId: string,
     options: OperationOptions = {}
   ): Promise<GetIncidentRootCauseResponse> {
@@ -1395,7 +1398,7 @@ export class MetricsAdvisorClient {
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       const result = await this.client.getRootCauseOfIncidentByAnomalyDetectionConfiguration(
-        detectionConfigurationId,
+        detectionConfigId,
         incidentId,
         requestOptions
       );
@@ -1430,7 +1433,7 @@ export class MetricsAdvisorClient {
    */
   public async createMetricFeedback(
     feedback: MetricFeedbackUnion,
-    options = {}
+    options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createMetricFeedback",
@@ -1460,11 +1463,11 @@ export class MetricsAdvisorClient {
 
   /**
    * Retrives a metric feedback for the given feedback id.
-   * @param feedbackId Id of the feedback to retrieve
+   * @param id Id of the feedback to retrieve
    * @param options The options parameter
    */
   public async getMetricFeedback(
-    feedbackId: string,
+    id: string,
     options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -1474,7 +1477,7 @@ export class MetricsAdvisorClient {
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-      const result = await this.client.getMetricFeedback(feedbackId, requestOptions);
+      const result = await this.client.getMetricFeedback(id, requestOptions);
       return {
         ...fromServiceMetricFeedbackUnion(result),
         _response: result._response

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -24,13 +24,18 @@ import {
   TopNGroupScope,
   SeverityCondition,
   AlertSnoozeCondition,
-  AnomalyAlertingConfigurationCrossMetricsOperator,
-  WholeMetricConfigurationConditionOperator,
   EnrichmentStatus,
-  DataFeedDetailPatchStatus
+  DataFeedDetailStatus
 } from "./generated/models";
 
 export {
+  Dimension,
+  Metric,
+  SeverityCondition,
+  AlertSnoozeCondition,
+  SmartDetectionCondition,
+  TopNGroupScope,
+  EnrichmentStatus,
   IngestionStatus,
   AzureApplicationInsightsParameter,
   AzureBlobParameter,
@@ -45,29 +50,21 @@ export {
   SuppressCondition,
   EmailHookParameter,
   WebhookHookParameter,
-  DataFeedDetailPatchStatus
+  DataFeedDetailStatus
 };
 
+// not used directly here but needed by public API surface.
 export {
   AnomalyValue,
-  AnomalyAlertingConfigurationCrossMetricsOperator,
-  WholeMetricConfigurationConditionOperator,
   DataFeedIngestionProgress,
   GeneratedClientGetIngestionProgressResponse,
-  SmartDetectionCondition,
-  Dimension,
-  Metric,
   IngestionStatusType,
-  SeverityCondition,
-  AlertSnoozeCondition,
-  TopNGroupScope,
   DataSourceType,
   EntityStatus,
   SeverityFilterCondition,
   SnoozeScope,
   Severity,
   AnomalyDetectorDirection,
-  EnrichmentStatus,
   TimeMode,
   FeedbackType,
   FeedbackQueryTimeMode
@@ -260,6 +257,10 @@ export interface DataFeed {
    */
   isAdmin: boolean;
   /**
+   * data feed creator
+   */
+  creator: string;
+  /**
    * Source of the data feed.
    */
   source: DataFeedSource;
@@ -414,7 +415,7 @@ export interface DataFeedPatch {
   /**
    * Source of the data feed.
    */
-  source: DataFeedSourcePatchUnion;
+  source: DataFeedSourcePatch;
   /**
    * Schema of the data in the data feed, including names of metrics, dimensions, and timestamp columns.
    */
@@ -435,187 +436,28 @@ export interface DataFeedPatch {
     /**
      * Status of the data feed.
      */
-    status?: DataFeedDetailPatchStatus;
+    status?: DataFeedDetailStatus;
   };
 }
 
 /**
- * A union type of supported data sources to pass to Update Data Feed operation.
+ * A alias type of supported data sources to pass to Update Data Feed operation.
  *
  * When not changing the data source type, the dataSourceParameter is not required.
  * When changing to a different data source type, both dataSourceType and dataSourceParameter are required.
  */
-export type DataFeedSourcePatchUnion =
-  | AzureApplicationInsightsDataFeedSourcePatch
-  | AzureBlobDataFeedSourcePatch
-  | AzureCosmosDBDataFeedSourcePatch
-  | AzureDataExplorerDataFeedSourcePatch
-  | AzureDataLakeStorageGen2DataFeedSourcePatch
-  | AzureTableDataFeedSourcePatch
-  | ElasticsearchDataFeedSourcePatch
-  | HttpRequestDataFeedSourcePatch
-  | InfluxDBDataFeedSourcePatch
-  | MySqlDataFeedSourcePatch
-  | PostgreSqlDataFeedSourcePatch
-  | SQLServerDataFeedSourcePatch
-  | MongoDBDataFeedSourcePatch;
+export type DataFeedSourcePatch = Omit<DataFeedSource, "dataSourceParameter"> &
+  { [P in "dataSourceParameter"]?: DataFeedSource[P] };
 
 /**
- * Represents Azure Application Insights data source to pass to Update Data Feed operation.
+ * The logical operator to apply across multiple {@link MetricAlertConfiguration}
  */
-export type AzureApplicationInsightsDataFeedSourcePatch = {
-  dataSourceType: "AzureApplicationInsights";
-  dataSourceParameter?: AzureApplicationInsightsParameter;
-};
+export type MetricAnomalyAlertConfigurationsOperator = "AND" | "OR" | "XOR";
 
 /**
- * Represents Azure Blob Storage data source to pass to Update Data Feed operation.
+ * The logical operator to apply across anomaly detection conditions.
  */
-export type AzureBlobDataFeedSourcePatch = {
-  dataSourceType: "AzureBlob";
-  dataSourceParameter?: AzureBlobParameter;
-};
-
-/**
- * Represents Azure CosmosDB data source to pass to Update Data Feed operation.
- */
-export type AzureCosmosDBDataFeedSourcePatch = {
-  dataSourceType: "AzureCosmosDB";
-  dataSourceParameter?: AzureCosmosDBParameter;
-};
-
-/**
- * Represents Azure Data Explorer data source to pass to Update Data Feed operation.
- */
-export type AzureDataExplorerDataFeedSourcePatch = {
-  dataSourceType: "AzureDataExplorer";
-  dataSourceParameter?: SqlSourceParameter;
-};
-
-/**
- * Represents Azure DataLake Storage Gen2 data source to pass to Update Data Feed operation.
- */
-export type AzureDataLakeStorageGen2DataFeedSourcePatch = {
-  dataSourceType: "AzureDataLakeStorageGen2";
-  dataSourceParameter?: AzureDataLakeStorageGen2Parameter;
-};
-
-/**
- * Represents Elasticsearch data source to pass to Update Data Feed operation.
- */
-export type ElasticsearchDataFeedSourcePatch = {
-  dataSourceType: "Elasticsearch";
-  dataSourceParameter?: ElasticsearchParameter;
-};
-
-/**
- * Represents Azure Table data source to pass to Update Data Feed operation.
- */
-export type AzureTableDataFeedSourcePatch = {
-  dataSourceType: "AzureTable";
-  dataSourceParameter?: AzureTableParameter;
-};
-
-/**
- * Represents Http Request data source to pass to Update Data Feed operation.
- */
-export type HttpRequestDataFeedSourcePatch = {
-  dataSourceType: "HttpRequest";
-  dataSourceParameter?: HttpRequestParameter;
-};
-
-/**
- * Represents InfluxDB data source to pass to Update Data Feed operation.
- */
-export type InfluxDBDataFeedSourcePatch = {
-  dataSourceType: "InfluxDB";
-  dataSourceParameter?: InfluxDBParameter;
-};
-
-/**
- * Represents MySQL data source to pass to Update Data Feed operation.
- */
-export type MySqlDataFeedSourcePatch = {
-  dataSourceType: "MySql";
-  dataSourceParameter?: SqlSourceParameter;
-};
-
-/**
- * Represents PostgreSQL data source to pass to Update Data Feed operation.
- */
-export type PostgreSqlDataFeedSourcePatch = {
-  dataSourceType: "PostgreSql";
-  dataSourceParameter?: SqlSourceParameter;
-};
-
-/**
- * Represents MongoDB data source to pass to Update Data Feed operation.
- */
-export type MongoDBDataFeedSourcePatch = {
-  dataSourceType: "MongoDB";
-  dataSourceParameter?: MongoDBParameter;
-};
-
-/**
- * Represents SQL Server data source to pass to Update Data Feed operation.
- */
-export type SQLServerDataFeedSourcePatch = {
-  dataSourceType: "SqlServer";
-  dataSourceParameter?: SqlSourceParameter;
-};
-
-/**
- * Represents the input type to the Update Alert Configuration operation.
- */
-export interface AnomalyAlertConfigurationPatch {
-  /**
-   * Anomaly alerting configuration name
-   */
-  name?: string;
-  /**
-   * anomaly alerting configuration description
-   */
-  description?: string;
-  /**
-   * cross metrics operator
-   */
-  crossMetricsOperator?: AnomalyAlertingConfigurationCrossMetricsOperator;
-  /**
-   * unique hook ids
-   */
-  hookIds?: string[];
-  /**
-   * Anomaly alerting configurations
-   */
-  metricAlertConfigurations?: MetricAlertConfiguration[];
-}
-
-/**
- * Represents the input type to the Update Detection Configuration operation.
- */
-export interface AnomalyDetectionConfigurationPatch {
-  /**
-   * anomaly detection configuration name
-   */
-  name?: string;
-  /**
-   * anomaly detection configuration description
-   */
-  description?: string;
-
-  /**
-   * Conditions that applies to all time series of a metric
-   */
-  wholeSeriesDetectionCondition?: MetricDetectionCondition;
-  /**
-   * detection conditions for series groups. This overrides the whole series detection conditions.
-   */
-  seriesGroupDetectionConditions?: MetricSeriesGroupDetectionCondition[];
-  /**
-   * detection conditions for specific series. This overrides the whole series detection conditions and the series group detection conditions.
-   */
-  seriesDetectionConditions?: MetricSingleSeriesDetectionCondition[];
-}
+export type DetectionConditionsOperator = "AND" | "OR";
 
 /**
  * Represents properties common to anomaly detection conditions.
@@ -624,7 +466,7 @@ export interface DetectionConditionsCommon {
   /**
    * Condition operator
    */
-  conditionOperator?: WholeMetricConfigurationConditionOperator;
+  conditionOperator?: DetectionConditionsOperator;
   /**
    * Specifies the condition for Smart Detection
    */
@@ -905,7 +747,7 @@ export interface HookCommon {
   /**
    * hook unique name
    */
-  hookName: string;
+  name: string;
   /**
    * hook description
    */
@@ -948,15 +790,15 @@ export type HookPatchCommon = {
   /**
    * new hook name
    */
-  hookName?: string | undefined;
+  hookName?: string;
   /**
    * new hook description
    */
-  description?: string | undefined;
+  description?: string;
   /**
    * new hook external link
    */
-  externalLink?: string | undefined;
+  externalLink?: string;
 };
 
 /**
@@ -1232,11 +1074,10 @@ export interface AnomalyAlertConfiguration {
    */
   description?: string;
   /**
-   * cross metrics operator
+   * logical operator to apply across metric alert configurations in {@link metricAlertConfigurations}
    *
-   * It should be specified when setting up multiple metric alerting configurations
    */
-  crossMetricsOperator?: AnomalyAlertingConfigurationCrossMetricsOperator;
+  crossMetricsOperator?: MetricAnomalyAlertConfigurationsOperator;
   /**
    * unique hook ids
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -209,6 +209,7 @@ export function fromServiceDataFeedDetailUnion(original: ServiceDataFeedDetailUn
     createdTime: original.createdTime!,
     status: original.status!,
     isAdmin: original.isAdmin!,
+    creator: original.creator!,
     schema: {
       metrics: original.metrics,
       dimensions: original.dimension,
@@ -397,8 +398,8 @@ export function fromServiceDataFeedDetailUnion(original: ServiceDataFeedDetailUn
 
 export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): HookUnion {
   const common: HookCommon = {
-    id: original.hookId,
-    hookName: original.hookName,
+    id: original.id,
+    name: original.name,
     description: original.description,
     externalLink: original.externalLink,
     admins: original.admins

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -26,7 +26,7 @@ use-extension:
 See the [AutoRest samples](https://github.com/Azure/autorest/tree/master/Samples/3b-custom-transformations)
 for more about how we're customizing things.
 
-### Metric output type - remvoing metric prefix from property names
+### Metric output type - remvoing `metric` prefix from property names and add description
 
 ```yaml
 directive:
@@ -37,9 +37,10 @@ directive:
       $.properties.metricName["x-ms-client-name"] = "name";
       $.properties.metricDisplayName["x-ms-client-name"] = "displayName";
       $.properties.metricDescription["x-ms-client-name"] = "description";
+      $.description = "Represents a metric of an ingested data feed"
 ```
 
-### Dimension output type - remvoing metric prefix from property names
+### Dimension output type - remvoing `dimension` prefix from property names and add description
 
 ```yaml
 directive:
@@ -48,6 +49,18 @@ directive:
     transform: >
       $.properties.dimensionName["x-ms-client-name"] = "name";
       $.properties.dimensionDisplayName["x-ms-client-name"] = "displayName";
+      $.description = "Represents a dimension of an ingested data feed"
+```
+
+### Hook output type - remvoing `hook` prefix from property names
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.HookInfo
+    transform: >
+      $.properties.hookId["x-ms-client-name"] = "id";
+      $.properties.hookName["x-ms-client-name"] = "name";
 ```
 
 ### Add x-ms-paths section if not exists

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -8,9 +8,7 @@ dotenv.config();
 
 import {
   AnomalyAlertConfiguration,
-  AnomalyAlertConfigurationPatch,
   AnomalyDetectionConfiguration,
-  AnomalyDetectionConfigurationPatch,
   MetricAlertConfiguration,
   MetricsAdvisorAdministrationClient,
   MetricsAdvisorKeyCredential
@@ -133,14 +131,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         seriesDetectionConditions: []
       };
 
-      const actual = await client.createMetricAnomalyDetectionConfiguration(
-        expected.name,
-        expected.metricId,
-        expected.wholeSeriesDetectionCondition,
-        expected.description,
-        expected.seriesGroupDetectionConditions,
-        expected.seriesDetectionConditions
-      );
+      const actual = await client.createMetricAnomalyDetectionConfiguration(expected);
 
       assert.ok(actual.id, "Expecting valid detecion config");
       createdDetectionConfigId = actual.id!;
@@ -160,7 +151,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
     });
 
     it("updates a detection configuration", async function() {
-      const expected: AnomalyDetectionConfigurationPatch = {
+      const expected: Partial<Omit<AnomalyDetectionConfiguration, "id" | "metricId">> = {
         name: "new Name",
         description: "new description",
         wholeSeriesDetectionCondition: {
@@ -270,13 +261,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         hookIds: []
       };
 
-      const actual = await client.createAnomalyAlertConfiguration(
-        expectedAlertConfig.name,
-        expectedAlertConfig.crossMetricsOperator!,
-        expectedAlertConfig.metricAlertConfigurations,
-        expectedAlertConfig.hookIds,
-        expectedAlertConfig.description
-      );
+      const actual = await client.createAnomalyAlertConfiguration(expectedAlertConfig);
 
       assert.ok(actual.id, "Expecting valid alert config");
       createdAlertConfigId = actual.id;
@@ -310,7 +295,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
           }
         }
       };
-      const patch: AnomalyAlertConfigurationPatch = {
+      const patch: Partial<Omit<AnomalyAlertConfiguration, "id">> = {
         name: "new alert config name",
         description: "new alert config description",
         crossMetricsOperator: "OR",
@@ -342,12 +327,12 @@ describe("MetricsAdvisorAdministrationClient", () => {
           scopeType: "All"
         }
       };
-      const secondAlertConfig = await client.createAnomalyAlertConfiguration(
-        secondAlertConfigName,
-        "OR",
-        [metricAlertConfig],
-        []
-      );
+      const secondAlertConfig = await client.createAnomalyAlertConfiguration({
+        name: secondAlertConfigName,
+        crossMetricsOperator: "OR",
+        metricAlertConfigurations: [metricAlertConfig],
+        hookIds: []
+      });
       try {
         const iterator = client.listAnomalyAlertConfigurations(createdDetectionConfigId);
         let result = await iterator.next();

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -125,7 +125,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     };
-    const granualarity: DataFeedGranularity = {
+    const granularity: DataFeedGranularity = {
       granularityType: "Daily"
     };
     const options: DataFeedOptions = {
@@ -151,14 +151,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           blobTemplate: testEnv.METRICS_ADVISOR_AZURE_BLOB_TEMPLATE
         }
       };
-      const actual = await client.createDataFeed(
-        feedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: feedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdAzureBlobDataFeedId = actual.id;
@@ -167,7 +167,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       assert.equal(actual.schema.dimensions?.length, 2, "Expecting two dimensions");
       assert.equal(actual.name, feedName);
       assert.deepStrictEqual(actual.source, expectedSource, "Source mismatch!");
-      assert.deepStrictEqual(actual.granularity, granualarity, "Granualarity mismatch!");
+      assert.deepStrictEqual(actual.granularity, granularity, "Granualarity mismatch!");
       assert.equal(
         actual.schema.metrics[0].name,
         dataFeedSchema.metrics[0].name,
@@ -253,7 +253,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       assert.equal(actual.schema.dimensions?.length, 2, "Expecting two dimensions");
       assert.equal(actual.name, feedName);
       assert.deepStrictEqual(actual.source, expectedSource, "Source mismatch!");
-      assert.deepStrictEqual(actual.granularity, granualarity, "Granualarity mismatch!");
+      assert.deepStrictEqual(actual.granularity, granularity, "Granualarity mismatch!");
       assert.equal(
         actual.schema.metrics[0].name,
         dataFeedSchema.metrics[0].name,
@@ -344,14 +344,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: testEnv.METRICS_ADVISOR_AZURE_APPINSIGHTS_QUERY
         }
       };
-      const actual = await client.createDataFeed(
-        appInsightsFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: appInsightsFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdAppFeedId = actual.id;
@@ -415,14 +415,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY
         }
       };
-      const actual = await client.createDataFeed(
-        sqlServerFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: sqlServerFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdSqlServerFeedId = actual.id;
@@ -453,14 +453,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           collectionId: "sample"
         }
       };
-      const actual = await client.createDataFeed(
-        cosmosFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: cosmosFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdCosmosFeedId = actual.id;
@@ -491,14 +491,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: "let starttime=datetime(@StartTime); let endtime=starttime"
         }
       };
-      const actual = await client.createDataFeed(
-        dataExplorerFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: dataExplorerFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdAzureDataExplorerFeedId = actual.id;
@@ -528,14 +528,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: "partition-key eq @start-time"
         }
       };
-      const actual = await client.createDataFeed(
-        azureTableFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: azureTableFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdAzureTableFeedId = actual.id;
@@ -564,14 +564,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           payload: "{start-time: @start-time}"
         }
       };
-      const actual = await client.createDataFeed(
-        httpRequestFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: httpRequestFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdHttpRequestFeedId = actual.id;
@@ -599,14 +599,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: "partition-key eq @start-time"
         }
       };
-      const actual = await client.createDataFeed(
-        influxDbFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: influxDbFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdInfluxFeedId = actual.id;
@@ -636,14 +636,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           command: "{ find: mongodb,filter: { Time: @StartTime },batch: 200 }"
         }
       };
-      const actual = await client.createDataFeed(
-        mongoDbFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: mongoDbFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdMongoDbFeedId = actual.id;
@@ -673,14 +673,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: "{ find: mongodb,filter: { Time: @StartTime },batch: 200 }"
         }
       };
-      const actual = await client.createDataFeed(
-        mySqlFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: mySqlFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdMySqlFeedId = actual.id;
@@ -709,14 +709,14 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           query: "{ find: postgresql,filter: { Time: @StartTime },batch: 200 }"
         }
       };
-      const actual = await client.createDataFeed(
-        postgreSqlFeedName,
-        expectedSource,
-        granualarity,
-        dataFeedSchema,
-        dataFeedIngestion,
+      const actual = await client.createDataFeed({
+        name: postgreSqlFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
         options
-      );
+      });
 
       assert.ok(actual.id, "Expecting valid data feed id");
       createdPostGreSqlId = actual.id;

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
@@ -49,7 +49,7 @@ describe("MetricsAdvisorClient hooks", () => {
   it("creates email Hook", async () => {
     const hook: EmailHook = {
       hookType: "Email",
-      hookName: emailHookName,
+      name: emailHookName,
       description: "description",
       hookParameter: {
         toList: ["test@example.com"]
@@ -63,7 +63,7 @@ describe("MetricsAdvisorClient hooks", () => {
   it("creates web Hook", async () => {
     const hook: WebhookHook = {
       hookType: "Webhook",
-      hookName: webHookName,
+      name: webHookName,
       description: "description",
       hookParameter: {
         endpoint: "https://httpbin.org/post",
@@ -111,9 +111,9 @@ describe("MetricsAdvisorClient hooks", () => {
       hookName: "js-test"
     });
     let result = await iterator.next();
-    assert.ok(result.value.hookName, "Expecting first definition");
+    assert.ok(result.value.name, "Expecting first definition");
     result = await iterator.next();
-    assert.ok(result.value.hookName, "Expecting second definition");
+    assert.ok(result.value.name, "Expecting second definition");
   });
 
   it("lists hooks by page", async function() {


### PR DESCRIPTION
- Rename `*id` to just id for get/update/delete methods

- also shorten `*ConfigurationId` to `*ConfigId`

- Improve README

- Swagger transform to add ref docs for `Metric` and `Dimension`

- Swagger transform to remove `hook` prefix from `hookId` and `hookName`

- Replace all `*DataFeedSourcePatch` types with a mapped type

- Add missing DataFeed.creator property

- Use mapped type for input of `create*()` methods instead of multiple ordered parameters.

- Replace configuration patch types with mapped types from their full result types.