### PR TITLE
Fix typos in README.md and Javascript samples for Azure Tables

### DIFF
--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -72,7 +72,7 @@ For example, you can create following CORS settings for debugging. But please cu
 
 ## Key concepts
 
-- `TableServiceClient` - Client that provides functions to interact at a Table Service level sucn as create, list and delete tables
+- `TableServiceClient` - Client that provides functions to interact at a Table Service level such as create, list and delete tables
 
 - `TableClient` - Client that provides functions to interact at an entity level such as create, list and delete entities within a table.
 
@@ -275,7 +275,7 @@ async function main() {
   let entitiesIter = client.listEntities();
   let i = 1;
   for await (const entity of entitiesIter) {
-    console.log(`Entity${i}: PartitionKey: ${entity.PartitionKey} RowKey: ${entity.RowKey}`);
+    console.log(`Entity${i}: PartitionKey: ${entity.partitionKey} RowKey: ${entity.rowKey}`);
     i++;
     // Output:
     // Entity1: PartitionKey: P1 RowKey: R1

--- a/sdk/tables/data-tables/samples/javascript/src/createAndDeleteEntities.js
+++ b/sdk/tables/data-tables/samples/javascript/src/createAndDeleteEntities.js
@@ -11,7 +11,7 @@ const tablesUrl = process.env["TABLES_URL"] || "";
 const accountName = process.env["ACCOUNT_NAME"] || "";
 const accountKey = process.env["ACCOUNT_KEY"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists

--- a/sdk/tables/data-tables/samples/javascript/src/createAndDeleteTable.js
+++ b/sdk/tables/data-tables/samples/javascript/src/createAndDeleteTable.js
@@ -9,7 +9,7 @@ dotenv.config();
 
 const sasConnectionString = process.env["SAS_CONNECTION_STRING"] || "";
 
-export async function createAndDeleteTable() {
+async function createAndDeleteTable() {
   console.log("== Delete and create table Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client
@@ -23,7 +23,7 @@ export async function createAndDeleteTable() {
   await serviceClient.deleteTable(tableName);
 }
 
-export async function createAndDeleteTableWithTableClient() {
+async function createAndDeleteTableWithTableClient() {
   // A table can also be created and deleted using a TableClient
   console.log("== Delete and create table with TableClient Sample ==");
 

--- a/sdk/tables/data-tables/samples/javascript/src/queryEntities.js
+++ b/sdk/tables/data-tables/samples/javascript/src/queryEntities.js
@@ -10,7 +10,7 @@ dotenv.config();
 const tablesUrl = process.env["TABLES_URL"] || "";
 const sasToken = process.env["SAS_TOKEN"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists

--- a/sdk/tables/data-tables/samples/javascript/src/queryTables.js
+++ b/sdk/tables/data-tables/samples/javascript/src/queryTables.js
@@ -9,7 +9,7 @@ dotenv.config();
 
 const accountConnectionString = process.env["ACCOUNT_CONNECTION_STRING"] || "";
 
-export async function queryTables() {
+async function queryTables() {
   console.log("== Query tables Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client

--- a/sdk/tables/data-tables/samples/javascript/src/updateAndUpsertEntities.js
+++ b/sdk/tables/data-tables/samples/javascript/src/updateAndUpsertEntities.js
@@ -10,7 +10,7 @@ dotenv.config();
 const tablesUrl = process.env["TABLES_URL"] || "";
 const sasToken = process.env["SAS_TOKEN"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists

--- a/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
@@ -74,7 +74,7 @@ async function countTablesWithClient(client: TableServiceClient) {
   console.log(`Listed ${count} tables`);
 }
 
-export async function main() {
+async function main() {
   console.log("== Client Authentication Methods Sample ==");
 
   await tableServiceClientWithSasConnectionString();

--- a/sdk/tables/data-tables/samples/typescript/src/createAndDeleteEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/createAndDeleteEntities.ts
@@ -11,7 +11,7 @@ const tablesUrl = process.env["TABLES_URL"] || "";
 const accountName = process.env["ACCOUNT_NAME"] || "";
 const accountKey = process.env["ACCOUNT_KEY"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists
@@ -44,7 +44,7 @@ interface Entity {
   quantity: number;
 }
 
-export async function main() {
+async function main() {
   await createAndDeleteEntities();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
@@ -9,7 +9,7 @@ dotenv.config();
 
 const sasConnectionString = process.env["SAS_CONNECTION_STRING"] || "";
 
-export async function createAndDeleteTable() {
+async function createAndDeleteTable() {
   console.log("== Delete and create table Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client
@@ -25,7 +25,7 @@ export async function createAndDeleteTable() {
   await serviceClient.deleteTable(tableName);
 }
 
-export async function createAndDeleteTableWithTableClient() {
+async function createAndDeleteTableWithTableClient() {
   // A table can also be created and deleted using a TableClient
   console.log("== Delete and create table with TableClient Sample ==");
 
@@ -44,7 +44,7 @@ export async function createAndDeleteTableWithTableClient() {
   await client.delete();
 }
 
-export async function main() {
+async function main() {
   await createAndDeleteTable();
   await createAndDeleteTableWithTableClient();
 }

--- a/sdk/tables/data-tables/samples/typescript/src/queryEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/queryEntities.ts
@@ -10,7 +10,7 @@ dotenv.config();
 const tablesUrl = process.env["TABLES_URL"] || "";
 const sasToken = process.env["SAS_TOKEN"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists
@@ -68,7 +68,7 @@ interface Entity {
   quantity: number;
 }
 
-export async function main() {
+async function main() {
   await createAndDeleteEntities();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
@@ -9,7 +9,7 @@ dotenv.config();
 
 const accountConnectionString = process.env["ACCOUNT_CONNECTION_STRING"] || "";
 
-export async function queryTables() {
+async function queryTables() {
   console.log("== Query tables Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client
@@ -37,7 +37,7 @@ export async function queryTables() {
   await serviceClient.deleteTable(tableName);
 }
 
-export async function main() {
+async function main() {
   await queryTables();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/updateAndUpsertEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/updateAndUpsertEntities.ts
@@ -10,7 +10,7 @@ dotenv.config();
 const tablesUrl = process.env["TABLES_URL"] || "";
 const sasToken = process.env["SAS_TOKEN"] || "";
 
-export async function createAndDeleteEntities() {
+async function createAndDeleteEntities() {
   console.log("== Create and delete entities Sample ==");
 
   // Note that this sample assumes that a table with tableName exists
@@ -57,7 +57,7 @@ interface Entity {
   brand?: string;
 }
 
-export async function main() {
+async function main() {
   await createAndDeleteEntities();
 }
 


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-js/issues/11489

- As the issue states, there are some unneeded exports in the Javascript samples for Azure Tables that have been removed.
- As reported by @joheredi , the following replacements in the `README.md` have been done (identified as a bug): `entity.PartitionKey` to `entity.partitionKey` and `entity.RowKey` to `entity.rowKey`.
- Also a little typo in the `README.md` in the same section has been fixed.