### PR TITLE
Logicapps sdk auth dependencies not in sync

### DIFF
--- a/sdk/logic/arm-logic/package.json
+++ b/sdk/logic/arm-logic/package.json
@@ -4,9 +4,9 @@
   "description": "LogicManagementClient Library with typescript type definitions for node.js and browser.",
   "version": "6.0.2",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.1",
-    "@azure/ms-rest-js": "^1.2.6",
-    "tslib": "^1.9.3"
+    "@azure/ms-rest-azure-js": "^2.0.1",
+    "@azure/ms-rest-js": "^2.0.4",
+    "tslib": "^1.10.0"
   },
   "keywords": [
     "node",
@@ -20,11 +20,11 @@
   "module": "./esm/logicManagementClient.js",
   "types": "./esm/logicManagementClient.d.ts",
   "devDependencies": {
-    "typescript": "^3.1.1",
-    "rollup": "^0.66.2",
-    "rollup-plugin-node-resolve": "^3.4.0",
+    "typescript": "^3.5.3",
+    "rollup": "^1.18.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "uglify-js": "^3.4.9"
+    "uglify-js": "^3.6.0"
   },
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/logic/arm-logic",
   "repository": {

--- a/sdk/logic/arm-logic/tsconfig.json
+++ b/sdk/logic/arm-logic/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
     "importHelpers": true


### PR DESCRIPTION
Current situation:
Logicapps sdk rest and auth dependencies are not in sync with e.g. resources sdk. Cannot use these sdks together.

This PR has fixed the package references which makes logicapps sdk compatible again.