### PR TITLE
Add release date, re-order features in changelog

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,18 +1,19 @@
 # Release History
 
-## 7.0.0-preview.7 (Unreleased)
+## 7.0.0-preview.7 (2020-10-07)
 
 ### New features:
 
-- Options to create/update a queue, topic and subscription now support `availabilityStatus` property. `availabilityStatus` indicates the status of entity availability. Possible values are: Available, Limited, Renaming, Restoring and Unknown.
-  [PR 11152](https://github.com/Azure/azure-sdk-for-js/pull/11152)
-- `ServiceBusClient` now supports authentication with AAD credentials in the browser(can use `InteractiveBrowserCredential` from `@azure/identity`).
-  [PR 11250](https://github.com/Azure/azure-sdk-for-js/pull/11250)
-- "properties" in the correlation rule filter now supports `Date`.
-  [PR 11117](https://github.com/Azure/azure-sdk-for-js/pull/11117)
 - Message locks can be auto-renewed in all receive methods (receiver.receiveMessages, receiver.subcribe
   and receiver.getMessageIterator). This can be configured in options when calling `ServiceBusClient.createReceiver()`.
   [PR 11658](https://github.com/Azure/azure-sdk-for-js/pull/11658)
+- `ServiceBusClient` now supports authentication with AAD credentials in the browser(can use `InteractiveBrowserCredential` from `@azure/identity`).
+  [PR 11250](https://github.com/Azure/azure-sdk-for-js/pull/11250)
+- Options to create/update a queue, topic and subscription now support `availabilityStatus` property. `availabilityStatus` indicates the status of entity availability. Possible values are: Available, Limited, Renaming, Restoring and Unknown.
+  [PR 11152](https://github.com/Azure/azure-sdk-for-js/pull/11152)
+- "properties" in the correlation rule filter now supports `Date`.
+  [PR 11117](https://github.com/Azure/azure-sdk-for-js/pull/11117)
+
 
 ### Breaking changes
 


### PR DESCRIPTION
This PR adds the release date for Service Bus preview 7 and re-orders the "new features" in the order of relevance