### PR TITLE
[service-bus] Sample fixes (stale usage of API and use the proper env variable name)

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -17,8 +17,8 @@ dotenv.config();
 const serviceBusConnectionString =
   process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
-// NOTE: this sample uses a queue but would also work a session enabled subscription.
-const queueName = process.env.QUEUE_NAME || "<queue name>";
+// NOTE: this sample uses a session enabled queue but would also work a session enabled subscription.
+const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 
 const maxSessionsToProcessSimultaneously = 8;
 const sessionIdleTimeoutMs = 3 * 1000;

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
@@ -2,9 +2,10 @@
   Copyright (c) Microsoft Corporation. All rights reserved.
   Licensed under the MIT Licence.
 
-  **NOTE**: If you are using version 1.1.x or lower, then please use the link below:
+  **NOTE**: This sample uses the preview of the next version of the @azure/service-bus package.
+  For samples using the current stable version of the package, please use the link below:
   https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/samples-v1
-
+  
   This sample demonstrates usage of SessionState.
 
   We take for example the context of an online shopping app and see how we can use Session State
@@ -97,13 +98,11 @@ async function sendMessagesForSession(shoppingEvents, sessionId) {
   await sender.close();
 }
 async function processMessageFromSession(sessionId) {
-  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
-  const sessionReceiver = await sbClient.createSessionReceiver(userEventsQueueName, {
-    sessionId
-  });
+  // If receiving from a subscription you can use the acceptSession(topic, subscription, sessionId) overload
+  const sessionReceiver = await sbClient.acceptSession(userEventsQueueName, sessionId);
 
   const messages = await sessionReceiver.receiveMessages(1, {
-    maxWaitTimeSeconds: 10
+    maxWaitTimeInMs: 10000
   });
   // Custom logic for processing the messages
   if (messages.length > 0) {

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -23,8 +23,8 @@ dotenv.config();
 const serviceBusConnectionString =
   process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
-// NOTE: this sample uses a queue but would also work a session enabled subscription.
-const queueName = process.env.QUEUE_NAME || "<queue name>";
+// NOTE: this sample uses a session enabled queue but would also work a session enabled subscription.
+const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 
 const maxSessionsToProcessSimultaneously = 8;
 const sessionIdleTimeoutMs = 3 * 1000;


### PR DESCRIPTION
* Swap to using the session queue name from the .env file rather than pointing to QUEUE_NAME
* sessionState.js was incorrect and didn't match the typescript one (using old stuff).