### PR TITLE
Add tests.yml for schema-registry

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/tests.yml
+++ b/sdk/schemaregistry/schema-registry-avro/tests.yml
@@ -1,0 +1,11 @@
+trigger: none
+
+extends:
+  template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+  parameters:
+    PackageName: "@azure/schema-registry"
+    ResourceServiceDirectory: schemaregistry
+    EnvVars:
+      AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+      AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/schemaregistry/schema-registry-avro/tests.yml
+++ b/sdk/schemaregistry/schema-registry-avro/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 extends:
   template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
   parameters:
-    PackageName: "@azure/schema-registry"
+    PackageName: "@azure/schema-registry-avro"
     ResourceServiceDirectory: schemaregistry
     EnvVars:
       AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/schemaregistry/schema-registry/tests.yml
+++ b/sdk/schemaregistry/schema-registry/tests.yml
@@ -1,0 +1,11 @@
+trigger: none
+
+extends:
+  template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+  parameters:
+    PackageName: "@azure/schema-registry-avro"
+    ResourceServiceDirectory: schemaregistry
+    EnvVars:
+      AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+      AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/schemaregistry/schema-registry/tests.yml
+++ b/sdk/schemaregistry/schema-registry/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 extends:
   template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
   parameters:
-    PackageName: "@azure/schema-registry-avro"
+    PackageName: "@azure/schema-registry"
     ResourceServiceDirectory: schemaregistry
     EnvVars:
       AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
This is a prereq for getting live nightly tests working for schema registry.  The change is trivial, adding two vanilla tests.yml files.

Tests won't pass yet, but these files need to be present to create the pipelines on the backend. Once the pipelines are set-up, I will iterate on the tests using a draft PR. test-resources.json and any test changes needed will be part of that draft PR, and once I get a green run on that, I'll open the draft up for review to actually have nightly live tests working.
