### PR TITLE
[schema registry] live tests

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/karma.conf.js
+++ b/sdk/schemaregistry/schema-registry-avro/karma.conf.js
@@ -45,7 +45,13 @@ module.exports = function(config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [],
+    envPreprocessor: [
+      "TEST_MODE",
+      "SCHEMA_REGISTRY_ENDPOINT",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_TENANT_ID"
+    ],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -73,6 +73,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
+    "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-inject": "^4.0.0",

--- a/sdk/schemaregistry/schema-registry-avro/rollup.base.config.js
+++ b/sdk/schemaregistry/schema-registry-avro/rollup.base.config.js
@@ -16,7 +16,16 @@ const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["fs", "util", "stream", "zlib", "crypto", "path", "events"];
+  const externalNodeBuiltins = [
+    "fs",
+    "util",
+    "stream",
+    "zlib",
+    "crypto",
+    "path",
+    "events",
+    "process"
+  ];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
@@ -68,7 +77,7 @@ export function browserConfig(test = false, production = false) {
       globals: { "@azure/core-http": "Azure.Core.HTTP" }
     },
     preserveSymlinks: false,
-    external: [],
+    external: ["fs-extra"],
     plugins: [
       sourcemaps(),
       replace({
@@ -79,12 +88,14 @@ export function browserConfig(test = false, production = false) {
         "if (isNode)": "if (false)"
       }),
       shim({
+        constants: `export default {}`,
         fs: `export default {}`,
         stream: `export default {}`,
         zlib: `export default {}`,
         crypto: `export default {}`,
         os: `export default {}`,
-        path: `export default {}`
+        path: `export default {}`,
+        dotenv: `export function config() { }`
       }),
       nodeResolve({
         mainFields: ["module", "browser"],

--- a/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/schemaRegistryAvroSerializer.spec.ts
@@ -5,6 +5,8 @@ import { SchemaRegistryAvroSerializer } from "../src";
 import { assert, use as chaiUse } from "chai";
 import * as avro from "avsc/";
 import chaiPromises from "chai-as-promised";
+import { env, isLiveMode } from "@azure/test-utils-recorder";
+import { ClientSecretCredential } from "@azure/identity";
 
 import {
   GetSchemaByIdOptions,
@@ -13,8 +15,12 @@ import {
   Schema,
   SchemaDescription,
   SchemaId,
-  SchemaRegistry
+  SchemaRegistry,
+  SchemaRegistryClient
 } from "@azure/schema-registry";
+
+import * as dotenv from "dotenv";
+dotenv.config();
 
 chaiUse(chaiPromises);
 
@@ -34,6 +40,8 @@ const testSchemaObject = {
   ]
 };
 
+const testGroup = "azsdk_js_test_group";
+
 const testSchemaIds = [
   "{773E17BE-793E-40B0-98F1-0A6EA3C11895}",
   "{DC7EF290-CDB1-4245-8EE8-3DD52965866E}"
@@ -45,28 +53,31 @@ const testAvroType = avro.Type.forSchema(<any>testSchemaObject);
 
 describe("SchemaRegistryAvroSerializer", function() {
   it("rejects buffers that are too small", async () => {
-    await assert.isRejected(createTestSerializer().deserialize(Buffer.alloc(3)), /small/);
+    const serializer = await createTestSerializer();
+    await assert.isRejected(serializer.deserialize(Buffer.alloc(3)), /small/);
   });
 
   it("rejects invalid format", async () => {
+    const serializer = await createTestSerializer();
     const buffer = Buffer.alloc(42);
     buffer.writeUInt32BE(0x1234, 0);
-    await assert.isRejected(createTestSerializer().deserialize(buffer), /format.*0x1234/);
+    await assert.isRejected(serializer.deserialize(buffer), /format.*0x1234/);
   });
 
   it("rejects schema with no name", async () => {
+    const serializer = await createTestSerializer();
     const schema = JSON.stringify({ type: "record", fields: [] });
-    await assert.isRejected(createTestSerializer().serialize({}, schema), /name/);
+    await assert.isRejected(serializer.serialize({}, schema), /name/);
   });
 
   it("rejects a schema with different serialization type", async () => {
-    const registry = createTestRegistry();
-    const serializer = createTestSerializer(false, registry);
+    const registry = createTestRegistry(true); // true means never live, we can't register non-avro schema in live service
+    const serializer = await createTestSerializer(false, registry);
     const schema = await registry.registerSchema({
       name: "_",
       content: "_",
       serializationType: "NotAvro",
-      group: "TestGroup"
+      group: testGroup
     });
 
     const buffer = Buffer.alloc(36);
@@ -78,26 +89,30 @@ describe("SchemaRegistryAvroSerializer", function() {
   });
 
   it("serializes to the expected format", async () => {
-    const buffer = await createTestSerializer().serialize(testValue, testSchema);
+    const registry = createTestRegistry();
+    const schemaId = await registerTestSchema(registry);
+    const serializer = await createTestSerializer(false, registry);
+    const buffer = await serializer.serialize(testValue, testSchema);
     assert.equal(0x0, buffer.readUInt32BE(0));
-    assert.equal(testSchemaIds[0], buffer.toString("utf-8", 4, 36));
-
+    assert.equal(schemaId, buffer.toString("utf-8", 4, 36));
     const payload = buffer.slice(36);
     assertSameJsonRepresentation(testAvroType.fromBuffer(payload), testValue);
   });
 
   it("deserializes from the expected format", async () => {
-    const serializer = createTestSerializer(false);
+    const registry = createTestRegistry();
+    const schemaId = await registerTestSchema(registry);
+    const serializer = await createTestSerializer(false, registry);
     const payload = testAvroType.toBuffer(testValue);
     const buffer = Buffer.alloc(36 + payload.length);
 
-    buffer.write(testSchemaIds[0], 4, 32, "utf-8");
+    buffer.write(schemaId, 4, 32, "utf-8");
     payload.copy(buffer, 36);
     assertSameJsonRepresentation(await serializer.deserialize(buffer), testValue);
   });
 
   it("serializes and deserializes in round trip", async () => {
-    let serializer = createTestSerializer();
+    let serializer = await createTestSerializer();
     let buffer = await serializer.serialize(testValue, testSchema);
     assertSameJsonRepresentation(await serializer.deserialize(buffer), testValue);
 
@@ -106,16 +121,16 @@ describe("SchemaRegistryAvroSerializer", function() {
     assertSameJsonRepresentation(await serializer.deserialize(buffer), testValue);
 
     // throw away serializer for cache miss coverage on deserialize
-    serializer = createTestSerializer(false);
+    serializer = await createTestSerializer(false);
     assertSameJsonRepresentation(await serializer.deserialize(buffer), testValue);
 
     // thow away serializer again and cover getSchemaId instead of registerSchema
-    serializer = createTestSerializer(false);
+    serializer = await createTestSerializer(false);
     assert.deepStrictEqual(await serializer.serialize(testValue, testSchema), buffer);
   });
 
   it("works with trivial example in README", async () => {
-    const serializer = createTestSerializer();
+    const serializer = await createTestSerializer();
 
     // Example Avro schema
     const schema = JSON.stringify({
@@ -146,23 +161,36 @@ function assertSameJsonRepresentation(actual: any, expected: any) {
   assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected));
 }
 
-function createTestSerializer(
+async function createTestSerializer(
   autoRegisterSchemas = true,
   registry = createTestRegistry()
-): SchemaRegistryAvroSerializer {
+): Promise<SchemaRegistryAvroSerializer> {
   if (!autoRegisterSchemas) {
-    registry.registerSchema({
-      name: `${testSchemaObject.namespace}.${testSchemaObject.name}`,
-      group: "TestGroup",
-      content: testSchema,
-      serializationType: "avro"
-    });
+    await registerTestSchema(registry);
   }
-
-  return new SchemaRegistryAvroSerializer(registry, "TestGroup", { autoRegisterSchemas });
+  return new SchemaRegistryAvroSerializer(registry, testGroup, { autoRegisterSchemas });
 }
 
-function createTestRegistry(): SchemaRegistry {
+async function registerTestSchema(registry: SchemaRegistry): Promise<string> {
+  const schema = await registry.registerSchema({
+    name: `${testSchemaObject.namespace}.${testSchemaObject.name}`,
+    group: testGroup,
+    content: testSchema,
+    serializationType: "avro"
+  });
+  return schema.id;
+}
+
+function createTestRegistry(neverLive = false): SchemaRegistry {
+  if (!neverLive && isLiveMode()) {
+    // NOTE: These tests don't record, they use a mocked schema registry
+    // implemented below, but if we're running live, then use the real
+    // service for end-to-end integration testing.
+    return new SchemaRegistryClient(
+      env.SCHEMA_REGISTRY_ENDPOINT,
+      new ClientSecretCredential(env.AZURE_TENANT_ID, env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET)
+    );
+  }
   const mapById = new Map<string, Schema>();
   const mapByContent = new Map<string, Schema>();
   let idCounter = 0;

--- a/sdk/schemaregistry/test-resources.json
+++ b/sdk/schemaregistry/test-resources.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "baseName": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]",
+      "metadata": {
+        "description": "The base resource name."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "metadata": {
+        "description": "The tenant ID to which the application and resources belong."
+      }
+    },
+    "testApplicationId": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client ID used to run tests."
+      }
+    },
+    "testApplicationSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client secret used to run tests."
+      }
+    },
+    "testApplicationOid": {
+      "type": "string",
+      "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
+      "metadata": {
+        "description": "The client OID to grant access to test resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the resource. By default, this is the same as the resource group."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2018-01-01-preview",
+    "schemaRegistryGroup": "azsdk_js_test_group",
+    "schemaRegistryEndpoint": "[format('https://{0}.servicebus.windows.net', parameters('baseName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.EventHub/namespaces",
+      "apiVersion": "[variables('apiVersion')]",
+      "name": "[parameters('baseName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard",
+        "capacity": 5
+      },
+      "properties": {
+        "zoneRedundant": false,
+        "isAutoInflateEnabled": false,
+        "maximumThroughputUnits": 0,
+        "kafkaEnabled": true
+      }
+    },
+    {
+      "type": "Microsoft.EventHub/namespaces/schemagroups",
+      "apiVersion": "[variables('apiVersion')]",
+      "name": "[format('{0}/{1}', parameters('baseName'), variables('schemaRegistryGroup'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": ["[resourceId('Microsoft.EventHub/namespaces',parameters('baseName'))]"],
+      "properties": {
+        "schemaType": "avro"
+      }
+    }
+  ],
+  "outputs": {
+    "AZURE_TENANT_ID": {
+      "type": "string",
+      "value": "[parameters('tenantId')]"
+    },
+    "AZURE_CLIENT_ID": {
+      "type": "string",
+      "value": "[parameters('testApplicationId')]"
+    },
+    "AZURE_CLIENT_SECRET": {
+      "type": "string",
+      "value": "[parameters('testApplicationSecret')]"
+    },
+    "SCHEMA_REGISTRY_GROUP": {
+      "type": "string",
+      "value": "[variables('schemaRegistryGroup')]"
+    },
+    "SCHEMA_REGISTRY_ENDPOINT": {
+      "type": "string",
+      "value": "[variables('schemaRegistryEndpoint')]"
+    }
+  }
+}


### PR DESCRIPTION
Get nightly live tests of schema-registry and schema-registry-avro running.

* Add test-resources.json to provision service
* Update schema-registry-avro tests to use real service in live test mode rather than its usual mocking.

