### PR TITLE
Regenerated Computer Vision SDK

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-computervision/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-computervision",
   "author": "Microsoft Corporation",
   "description": "ComputerVisionClient Library with typescript type definitions for node.js and browser.",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-computervision";
-const packageVersion = "7.0.1";
+const packageVersion = "7.1.0";
 
 export class ComputerVisionClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -42,7 +42,7 @@ export class ComputerVisionClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/vision/v3.0";
+    this.baseUri = "{Endpoint}/vision/v3.1";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
     this.credentials = credentials;

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
@@ -864,12 +864,12 @@ export interface ComputerVisionClientGenerateThumbnailOptionalParams extends msR
  */
 export interface ComputerVisionClientReadOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The BCP-47 language code of the text to be detected in the image. In future versions, when
-   * language parameter is not passed, language detection will be used to determine the language.
-   * However, in the current version, missing language parameter will cause English to be used. To
-   * ensure that your document is always parsed in English without the use of language detection in
-   * the future, pass “en” in the language parameter. Possible values include: 'en', 'es', 'fr',
-   * 'de', 'it', 'nl', 'pt'. Default value: 'en'.
+   * The BCP-47 language code of the text in the document. Currently, only English ('en'), Dutch
+   * (‘nl’), French (‘fr’), German (‘de’), Italian (‘it’), Portuguese (‘pt), and Spanish ('es') are
+   * supported. Read supports auto language identification and multi-language documents, so only
+   * provide a language code if you would like to force the documented to be processed as that
+   * specific language. Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'. Default
+   * value: 'en'.
    */
   language?: OcrDetectionLanguage;
 }
@@ -988,12 +988,12 @@ export interface ComputerVisionClientTagImageInStreamOptionalParams extends msRe
  */
 export interface ComputerVisionClientReadInStreamOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The BCP-47 language code of the text to be detected in the image. In future versions, when
-   * language parameter is not passed, language detection will be used to determine the language.
-   * However, in the current version, missing language parameter will cause English to be used. To
-   * ensure that your document is always parsed in English without the use of language detection in
-   * the future, pass “en” in the language parameter. Possible values include: 'en', 'es', 'fr',
-   * 'de', 'it', 'nl', 'pt'. Default value: 'en'.
+   * The BCP-47 language code of the text in the document. Currently, only English ('en'), Dutch
+   * (‘nl’), French (‘fr’), German (‘de’), Italian (‘it’), Portuguese (‘pt), and Spanish ('es') are
+   * supported. Read supports auto language identification and multi-language documents, so only
+   * provide a language code if you would like to force the documented to be processed as that
+   * specific language. Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'. Default
+   * value: 'en'.
    */
   language?: OcrDetectionLanguage;
 }


### PR DESCRIPTION
Based on request from @lmazuel (Issue: https://github.com/Azure/sdk-release-request/issues/797) , I have regenerated the Cognitive Services Computer Vision TS SDK in this PR. Command Used:

```
autorest --reset && autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=C:\Users\sarajama\Projects\azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=7.1.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/ComputerVision/readme.md
```

As you can see from the PR, only the service version info changed. Other than that, the only other information is 2 new comments. Updated the version 7.0.1 -> 7.1.0. 

@lmazuel FYI
@ramya-rao-a Please review and approve.

