### PR TITLE
[core-http] fix An exception thrown on Safari 5.0

### DIFF
--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -362,7 +362,7 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
         objectType !== "function" &&
         !(value instanceof ArrayBuffer) &&
         !ArrayBuffer.isView(value) &&
-        !(typeof Blob === "function" && value instanceof Blob)
+        !((typeof Blob === "function" || typeof Blob === "object") && value instanceof Blob)
       ) {
         throw new Error(
           `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or a function returning NodeJS.ReadableStream.`


### PR DESCRIPTION
Fixes #11758

When uploading files on Safari 5.0, An exception `body must be a string, Blob, ArrayBuffer, ArrayBufferView, or a function returning NodeJS.ReadableStream.` will thrown.