### PR TITLE
Added default customDomainHttpsParameters value

### DIFF
--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-cdn",
   "author": "Microsoft Corporation",
   "description": "CdnManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^2.0.1",
     "@azure/ms-rest-js": "^2.0.4",

--- a/sdk/cdn/arm-cdn/src/cdnManagementClientContext.ts
+++ b/sdk/cdn/arm-cdn/src/cdnManagementClientContext.ts
@@ -13,7 +13,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 
 const packageName = "@azure/arm-cdn";
-const packageVersion = "5.0.0";
+const packageVersion = "5.1.0";
 
 export class CdnManagementClientContext extends msRestAzure.AzureServiceClient {
   credentials: msRest.ServiceClientCredentials;

--- a/sdk/cdn/arm-cdn/src/operations/customDomains.ts
+++ b/sdk/cdn/arm-cdn/src/operations/customDomains.ts
@@ -201,6 +201,7 @@ export class CustomDomains {
    */
   enableCustomHttps(resourceGroupName: string, profileName: string, endpointName: string, customDomainName: string, options: Models.CustomDomainsEnableCustomHttpsOptionalParams, callback: msRest.ServiceCallback<Models.CustomDomain>): void;
   enableCustomHttps(resourceGroupName: string, profileName: string, endpointName: string, customDomainName: string, options?: Models.CustomDomainsEnableCustomHttpsOptionalParams | msRest.ServiceCallback<Models.CustomDomain>, callback?: msRest.ServiceCallback<Models.CustomDomain>): Promise<Models.CustomDomainsEnableCustomHttpsResponse> {
+    // #region Added default values to add backwards compatibility
     let newOptions: Models.CustomDomainsEnableCustomHttpsOptionalParams = {};
 
     if (typeof options === "function") {
@@ -235,6 +236,7 @@ export class CustomDomains {
         enableCustomHttpsOperationSpec,
         callback) as Promise<Models.CustomDomainsEnableCustomHttpsResponse>
     );
+    // #endregion
   }
 
   /**
@@ -312,6 +314,7 @@ export class CustomDomains {
   }
 }
 
+// #region Added default values to add backwards compatibility
 class SkuNames {
   public static get standard_microsoft() { return "Standard_Microsoft"; }
   public static get standard_verizon() { return "Standard_Verizon"; }
@@ -348,6 +351,8 @@ function getDefaultCustomDomainHttpsParameters(profile: Models.Profile): Models.
       return undefined;
   }
 }
+
+// #endregion
 
 // Operation Specifications
 const serializer = new msRest.Serializer(Mappers);

--- a/sdk/cdn/arm-cdn/src/operations/customDomains.ts
+++ b/sdk/cdn/arm-cdn/src/operations/customDomains.ts
@@ -200,6 +200,25 @@ export class CustomDomains {
    */
   enableCustomHttps(resourceGroupName: string, profileName: string, endpointName: string, customDomainName: string, options: Models.CustomDomainsEnableCustomHttpsOptionalParams, callback: msRest.ServiceCallback<Models.CustomDomain>): void;
   enableCustomHttps(resourceGroupName: string, profileName: string, endpointName: string, customDomainName: string, options?: Models.CustomDomainsEnableCustomHttpsOptionalParams | msRest.ServiceCallback<Models.CustomDomain>, callback?: msRest.ServiceCallback<Models.CustomDomain>): Promise<Models.CustomDomainsEnableCustomHttpsResponse> {
+    if (typeof options === "function") {
+      callback = options;
+      options = undefined;
+    }
+
+    if (!options) {
+      options = {};
+    }
+    
+    if (!options.customDomainHttpsParameters) {
+      options.customDomainHttpsParameters = {
+                        certificateSource: "Cdn",
+                        certificateSourceParameters: {
+                            certificateType: "Dedicated"
+                        },
+                        protocolType: "ServerNameIndication"
+                    }
+    }
+    
     return this.client.sendOperationRequest(
       {
         resourceGroupName,


### PR DESCRIPTION
As issue #11567 says, there is an issue with enabling HTTPS for custom domains in the CDN. This is caused by the API requiring a customDomainHttpsParameters parameter. However, in the current version, this property is optional, causing problems.

This PR adds a hopefully reasonable default value if the property has not been set. This should make it usable if left out, and make it backwards compatible to v4.2 where it worked without providing it.