### PR TITLE
[MetricsAdvisor,test] Fix listing datafeed live tests

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -373,6 +373,38 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       }
     });
 
+    it("creates an Azure SQL Server Feed", async () => {
+      const expectedSource: DataFeedSource = {
+        dataSourceType: "SqlServer",
+        dataSourceParameter: {
+          connectionString: testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_CONNECTION_STRING,
+          query: testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY
+        }
+      };
+      const actual = await client.createDataFeed({
+        name: sqlServerFeedName,
+        source: expectedSource,
+        granularity,
+        schema: dataFeedSchema,
+        ingestionSettings: dataFeedIngestion,
+        options
+      });
+
+      assert.ok(actual.id, "Expecting valid data feed id");
+      createdSqlServerFeedId = actual.id;
+      assert.equal(actual.source.dataSourceType, "SqlServer");
+      if (actual.source.dataSourceType === "SqlServer") {
+        assert.equal(
+          actual.source.dataSourceParameter.connectionString,
+          testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_CONNECTION_STRING
+        );
+        assert.equal(
+          actual.source.dataSourceParameter.query,
+          testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY
+        );
+      }
+    });
+
     it("lists datafeed", async function() {
       const iterator = client.listDataFeeds({
         filter: {
@@ -405,38 +437,6 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
 
     it("deletes an Azure Application Insights feed", async function() {
       await verifyDataFeedDeletion(client, createdAppFeedId);
-    });
-
-    it("creates an Azure SQL Server Feed", async () => {
-      const expectedSource: DataFeedSource = {
-        dataSourceType: "SqlServer",
-        dataSourceParameter: {
-          connectionString: testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_CONNECTION_STRING,
-          query: testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY
-        }
-      };
-      const actual = await client.createDataFeed({
-        name: sqlServerFeedName,
-        source: expectedSource,
-        granularity,
-        schema: dataFeedSchema,
-        ingestionSettings: dataFeedIngestion,
-        options
-      });
-
-      assert.ok(actual.id, "Expecting valid data feed id");
-      createdSqlServerFeedId = actual.id;
-      assert.equal(actual.source.dataSourceType, "SqlServer");
-      if (actual.source.dataSourceType === "SqlServer") {
-        assert.equal(
-          actual.source.dataSourceParameter.connectionString,
-          testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_CONNECTION_STRING
-        );
-        assert.equal(
-          actual.source.dataSourceParameter.query,
-          testEnv.METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY
-        );
-      }
     });
 
     it("deletes an Azure SQL Server feed", async function() {


### PR DESCRIPTION
We have a scenario to rename a data feed so the listing by the
"js-test" prefix would only return one result thus break listing
tests' assumption of at least two results.

Fixed by moving listing to after creating three data feeds so we still
have two data feeds with "js-test" prefix.