### PR TITLE
[MetricsAdvisor] better names

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -451,7 +451,7 @@ async function queryAnomaliesByAlert(client, alertConfigId, alertId) {
   );
   for await (const anomaly of client.listAnomaliesForAlert(alertConfigId, alertId)) {
     console.log(
-      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.dimension} ${anomaly.timestamp}`
+      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`
     );
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -158,7 +158,7 @@ async function main() {
 }
 
 async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQuery) {
-  const metric = [
+  const metrics = [
     {
       name: "revenue",
       displayName: "revenue",
@@ -170,13 +170,13 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       description: "Metric2 description"
     }
   ];
-  const dimension = [
+  const dimensions = [
     { name: "city", displayName: "city display" },
     { name: "category", displayName: "category display" }
   ];
   const dataFeedSchema = {
-    metrics: metric,
-    dimensions: dimension,
+    metrics,
+    dimensions,
     timestampColumn: null
   };
   const dataFeedIngestion = {
@@ -211,7 +211,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
 
   console.log("Creating Datafeed...");
   const result = await adminClient.createDataFeed({
-    name: "test_datafeed_" + new Date().getTime().toFixed(),
+    name: "test_datafeed_" + new Date().getTime().toString(),
     source,
     granularity,
     schema: dataFeedSchema,
@@ -334,7 +334,7 @@ async function createWebhookHook(adminClient) {
   console.log("Creating a webhook hook");
   const hook = {
     hookType: "Webhook",
-    name: "web hook " + new Date().getTime().toFixed(),
+    name: "web hook " + new Date().getTime().toString(),
     description: "description",
     hookParameter: {
       endpoint: "https://example.com/handleAlerts",

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -206,7 +206,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    admins: ["xyz@example.com"]
+    adminEmails: ["xyz@example.com"]
   };
 
   console.log("Creating Datafeed...");

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -824,14 +824,14 @@ export type MetricDetectionCondition = DetectionConditionsCommon;
 
 // @public
 export interface MetricEnrichedSeriesData {
-    expectedValueList?: number[];
-    isAnomalyList?: boolean[];
-    lowerBoundaryList?: number[];
-    periodList?: number[];
+    expectedValues?: number[];
+    isAnomaly?: boolean[];
+    lowerBounds?: number[];
+    periods?: number[];
     series: DimensionKey;
-    timestampList?: Date[];
-    upperBoundaryList?: number[];
-    valueList?: number[];
+    timestamps?: Date[];
+    upperBounds?: number[];
+    values?: number[];
 }
 
 // @public
@@ -923,8 +923,8 @@ export class MetricsAdvisorKeyCredential {
 // @public
 export interface MetricSeriesData {
     definition: MetricSeriesDefinition;
-    timestampList?: Date[];
-    valueList?: number[];
+    timestamps?: Date[];
+    values?: number[];
 }
 
 // @public

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -894,7 +894,7 @@ export class MetricsAdvisorClient {
     getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
     getMetricEnrichedSeriesData(detectionConfigId: string, startTime: Date, endTime: Date, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
     getMetricFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
-    getMetricSeriesData(metricId: string, startTime: Date, endTime: Date, seriesToFilter: Record<string, string>[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
+    getMetricSeriesData(metricId: string, startTime: Date, endTime: Date, seriesToFilter: DimensionKey[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
     listAlertsForAlertConfiguration(alertConfigId: string, startTime: Date, endTime: Date, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, ListAlertsForAlertConfigurationPageResponse>;
     listAnomaliesForAlert(alertConfigId: string, alertId: string, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, ListAnomaliesForAlertPageResponse>;
     listAnomaliesForDetectionConfiguration(detectionConfigId: string, startTime: Date, endTime: Date, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, ListAnomaliesForDetectionConfigurationPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -55,10 +55,10 @@ export type AnomalyDetectorDirection = "Both" | "Down" | "Up";
 // @public
 export interface AnomalyIncident {
     detectionConfigurationId: string;
-    dimensionKey: DimensionKey;
     id: string;
     lastOccuredTime: Date;
     metricId?: string;
+    seriesKey: DimensionKey;
     severity: AnomalySeverity;
     startTime?: Date;
     status?: AnomalyStatus;
@@ -295,9 +295,9 @@ export type DataFeedStatus = "Paused" | "Active";
 export interface DataPointAnomaly {
     createdOn?: Date;
     detectionConfigurationId: string;
-    dimension: Record<string, string>;
     metricId?: string;
     modifiedOn?: Date;
+    seriesKey: DimensionKey;
     severity: AnomalySeverity;
     status?: AnomalyStatus;
     timestamp: Date;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -237,11 +237,11 @@ export type DataFeedMissingDataPointFillSettings = {
 export interface DataFeedOptions {
     accessMode?: DataFeedAccessMode;
     actionLinkTemplate?: string;
-    admins?: string[];
+    adminEmails?: string[];
     dataFeedDescription?: string;
     missingDataPointFillSettings?: DataFeedMissingDataPointFillSettings;
     rollupSettings?: DataFeedRollupSettings;
-    viewers?: string[];
+    viewerEmails?: string[];
 }
 
 // @public
@@ -964,7 +964,7 @@ export type MySqlDataFeedSource = {
 
 // @public
 export interface NotificationHook {
-    readonly admins?: string[];
+    readonly adminEmails?: string[];
     description?: string;
     externalLink?: string;
     readonly id?: string;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -58,7 +58,7 @@ export interface AnomalyIncident {
     id: string;
     lastOccuredTime: Date;
     metricId?: string;
-    seriesKey: DimensionKey;
+    rootDimensionKey: DimensionKey;
     severity: AnomalySeverity;
     startTime?: Date;
     status?: AnomalyStatus;
@@ -361,9 +361,6 @@ export interface EnrichmentStatus {
 }
 
 // @public
-export type EntityStatus = "Active" | "Paused";
-
-// @public
 export type FeedbackQueryTimeMode = "MetricTimestamp" | "FeedbackCreatedTime";
 
 // @public
@@ -496,9 +493,9 @@ export interface HttpRequestParameter {
 // @public
 export interface IncidentRootCause {
     description: string;
-    dimensionKey: DimensionKey;
     path: string[];
     score: number;
+    seriesKey: DimensionKey;
 }
 
 // @public
@@ -609,7 +606,7 @@ export type ListDataFeedsOptions = {
         dataFeedName?: string;
         dataSourceType?: DataSourceType;
         granularity?: DataFeedGranularity;
-        status?: EntityStatus;
+        status?: DataFeedStatus;
         creator?: string;
     };
 } & OperationOptions;

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
@@ -46,16 +46,25 @@ async function main() {
 // create a new alerting configuration
 async function createAlertConfig(adminClient, detectionConfigId) {
   console.log("Creating an alerting configuration...");
-  const metricAlertingConfig = {
+  const metricAlertingConfig1 = {
     detectionConfigurationId: detectionConfigId,
     alertScope: {
       scopeType: "All"
     }
   };
+  const metricAlertingConfig2 = {
+    detectionConfigurationId: detectionConfigId,
+    alertScope: {
+      scopeType: "Dimension",
+      dimensionAnomalyScope: {
+        dimension: { city: "Manila", category: "Handmade" }
+      }
+    }
+  };
   const result = await adminClient.createAnomalyAlertConfiguration({
     name: "js alerting config name " + new Date().getTime().toString(),
     crossMetricsOperator: "AND",
-    metricAlertConfigurations: [metricAlertingConfig, metricAlertingConfig],
+    metricAlertConfigurations: [metricAlertingConfig1, metricAlertingConfig2],
     hookIds: [],
     description: "alerting config description"
   });

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
@@ -76,13 +76,13 @@ async function createDataFeed(client) {
       description: ""
     }
   ];
-  const dimension = [
+  const dimensions = [
     { name: "Dim1", displayName: "Dim1 display" },
     { name: "Dim2", displayName: "Dim2 display" }
   ];
   const dataFeedSchema = {
     metrics,
-    dimensions: dimension,
+    dimensions,
     timestampColumn: null
   };
   const dataFeedIngestion = {
@@ -110,7 +110,7 @@ async function createDataFeed(client) {
     rollupSettings: {
       rollupType: "AutoRollup",
       rollupMethod: "Sum",
-      rollupIdentificationValue: "__CUSTOM_SUM__"
+      rollupIdentificationValue: "__SUM__"
     },
     missingDataPointFillSettings: {
       fillType: "CustomValue",
@@ -121,7 +121,7 @@ async function createDataFeed(client) {
 
   console.log("Creating Datafeed...");
   const result = await client.createDataFeed({
-    name: "test-datafeed-" + new Date().getTime().toFixed(),
+    name: "test-datafeed-" + new Date().getTime().toString(),
     source,
     granularity,
     schema: dataFeedSchema,

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
@@ -53,11 +53,32 @@ async function getDetectionConfig(adminClient, detectionConfigId) {
 
 // create a new detection configuration
 async function createDetectionConfig(adminClient, metricId) {
-  const config = {
-    name: "fresh detection" + new Date().getTime().toString(),
-    description: "fresh detection",
-    metricId,
-    wholeSeriesDetectionCondition: {
+  const wholeSeriesDetectionCondition = {
+    conditionOperator: "AND",
+    smartDetectionCondition: {
+      sensitivity: 50,
+      anomalyDetectorDirection: "Both",
+      suppressCondition: {
+        minNumber: 50,
+        minRatio: 50
+      }
+    },
+    changeThresholdCondition: {
+      anomalyDetectorDirection: "Both",
+      shiftPoint: 1,
+      changePercentage: 33,
+      withinRange: true,
+      suppressCondition: { minNumber: 2, minRatio: 2 }
+    },
+    hardThresholdCondition: {
+      anomalyDetectorDirection: "Up",
+      upperBound: 400,
+      suppressCondition: { minNumber: 2, minRatio: 2 }
+    }
+  };
+  const seriesGroupDetectionConditions = [
+    {
+      group: { dimension: { Dim1: "Common Lime" } },
       conditionOperator: "AND",
       changeThresholdCondition: {
         anomalyDetectorDirection: "Both",
@@ -65,13 +86,28 @@ async function createDetectionConfig(adminClient, metricId) {
         changePercentage: 33,
         withinRange: true,
         suppressCondition: { minNumber: 2, minRatio: 2 }
-      },
+      }
+    }
+  ];
+  const seriesDetectionConditions = [
+    {
+      series: { dimension: { Dim1: "Common Beech", Dim2: "Ant" } },
+      conditionOperator: "AND",
       hardThresholdCondition: {
         anomalyDetectorDirection: "Up",
         upperBound: 400,
         suppressCondition: { minNumber: 2, minRatio: 2 }
       }
     }
+  ];
+
+  const config = {
+    name: "fresh detection" + new Date().getTime().toString(),
+    description: "fresh detection",
+    metricId,
+    wholeSeriesDetectionCondition,
+    seriesGroupDetectionConditions,
+    seriesDetectionConditions
   };
   console.log("Creating a new anomaly detection configuration...");
   return await adminClient.createMetricAnomalyDetectionConfiguration(config);

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
@@ -66,7 +66,7 @@ async function createEmailHook(client) {
 async function getHook(client, hookId) {
   console.log(`Retrieving an existing hook for id ${hookId}...`);
   const result = await client.getHook(hookId);
-  console.log(result.hookName);
+  console.log(result.name);
   console.log(result.description);
   console.log(result.adminEmails);
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
@@ -68,7 +68,7 @@ async function getHook(client, hookId) {
   const result = await client.getHook(hookId);
   console.log(result.hookName);
   console.log(result.description);
-  console.log(result.admins);
+  console.log(result.adminEmails);
 }
 
 async function updateEmailHook(client, hookId) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/hooks.js
@@ -31,7 +31,7 @@ async function createWebHook(client) {
   console.log("Creating a new web hook...");
   const hook = {
     hookType: "Webhook",
-    name: "js web hook example" + new Date().getTime().toFixed(),
+    name: "js web hook example" + new Date().getTime().toString(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",
@@ -54,7 +54,7 @@ async function createEmailHook(client) {
   console.log("Creating a new email hook...");
   const hook = {
     hookType: "Email",
-    name: "js email hook example" + new Date().getTime().toFixed(),
+    name: "js email hook example" + new Date().getTime().toString(),
     description: "description",
     hookParameter: { toList: ["test@example.com"] }
   };

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/incidentsAndAlerts.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/incidentsAndAlerts.js
@@ -38,12 +38,16 @@ async function listIncidentsForDetectionConfig(client, detectionConfigId) {
   for await (const incident of client.listIncidentsForDetectionConfiguration(
     detectionConfigId,
     new Date("09/06/2020"),
-    new Date("09/11/2020")
+    new Date("09/11/2020"),
+    {
+      dimensionFilter: [{ dimension: { city: "Manila", category: "Shoes Handbags & Sunglasses" } }]
+    }
   )) {
     console.log("    Incident");
     console.log(`      id: ${incident.id}`);
     console.log(`      severity: ${incident.severity}`);
     console.log(`      status: ${incident.status}`);
+    console.log(`      startTime: ${incident.rootDimensionKey}`);
     console.log(`      startTime: ${incident.startTime}`);
     console.log(`      last occured: ${incident.lastOccuredTime}`);
     console.log(`      detection config id: ${incident.detectionConfigurationId}`);
@@ -65,6 +69,7 @@ async function listIncidentsForDetectionConfig(client, detectionConfigId) {
       "id",
       "severity",
       "status",
+      "rootDimensionKey",
       "startTime",
       "lastOccuredTime",
       "detectionConfigurationId"
@@ -85,9 +90,13 @@ async function listAnomaliesForDetectionConfig(client, detectionConfigId) {
     }
   )) {
     console.log("    Anomaly");
-    console.log(`      timestamp: ${anomaly.timestamp}`);
+    console.log(`      metric id: ${anomaly.metricId}`);
+    console.log(`      detection config id: ${anomaly.detectionConfigurationId}`);
+    console.log(`      created on: ${anomaly.createdOn}`);
+    console.log(`      modified on: ${anomaly.modifiedOn}`);
     console.log(`      severity: ${anomaly.severity}`);
-    console.log(`      dimension: ${anomaly.dimension}`);
+    console.log(`      status: ${anomaly.status}`);
+    console.log(`      series key: ${anomaly.seriesKey}`);
   }
 
   console.log(`  by pages`);
@@ -105,7 +114,7 @@ async function listAnomaliesForDetectionConfig(client, detectionConfigId) {
 
   while (!result.done) {
     console.log("    -- Page --");
-    console.table(result.value.anomalies, ["timestamp", "severity", "dimension"]);
+    console.table(result.value.anomalies, ["timestamp", "severity", "seriesKey"]);
     result = await iterator.next();
   }
 }
@@ -113,7 +122,13 @@ async function listAnomaliesForDetectionConfig(client, detectionConfigId) {
 async function getRootCauses(client, detectionConfigId, incidentId) {
   console.log("Retrieving root causes...");
   const result = await client.getIncidentRootCauses(detectionConfigId, incidentId);
-  console.table(result.rootCauses, [""]);
+  for (const rootcause of result.rootCauses) {
+    console.log(`Root cause`);
+    console.log(`  Trace the path for the incident root cause ${rootcause.path.join(" => ")}`);
+    console.log(`  Series key: ${rootcause.seriesKey}`);
+    console.log(`  Description: ${rootcause.description}`);
+    console.log(`  ranking score: ${rootcause.score}`);
+  }
 }
 
 async function listAlerts(client, alertConfigId) {
@@ -159,6 +174,7 @@ async function listIncidentsForAlert(client, alertConfigId, alertId) {
     console.log(`      id: ${incident.id}`);
     console.log(`      severity: ${incident.severity}`);
     console.log(`      status: ${incident.status}`);
+    console.log(`      startTime: ${incident.rootDimensionKey}`);
     console.log(`      startTime: ${incident.startTime}`);
     console.log(`      last occured: ${incident.lastOccuredTime}`);
     console.log(`      detection config id: ${incident.detectionConfigurationId}`);
@@ -174,6 +190,7 @@ async function listIncidentsForAlert(client, alertConfigId, alertId) {
       "id",
       "severity",
       "status",
+      "rootDimensionKey",
       "startTime",
       "lastOccuredTime",
       "detectionConfigurationId"
@@ -189,9 +206,13 @@ async function listAnomaliesForAlert(client, alertConfigId, alertId) {
   console.log("  using for-await-of syntax");
   for await (const anomaly of client.listAnomaliesForAlert(alertConfigId, alertId)) {
     console.log("    Anomaly");
-    console.log(`      timestamp: ${anomaly.timestamp}`);
-    console.log(`      dimension: ${anomaly.dimension}`);
+    console.log(`      metric id: ${anomaly.metricId}`);
+    console.log(`      detection config id: ${anomaly.detectionConfigurationId}`);
+    console.log(`      created on: ${anomaly.createdOn}`);
+    console.log(`      modified on: ${anomaly.modifiedOn}`);
+    console.log(`      severity: ${anomaly.severity}`);
     console.log(`      status: ${anomaly.status}`);
+    console.log(`      series key: ${anomaly.seriesKey}`);
   }
 
   console.log(`  by pages`);
@@ -200,7 +221,7 @@ async function listAnomaliesForAlert(client, alertConfigId, alertId) {
   let result = await iterator.next();
   while (!result.done) {
     console.log("    -- Page --");
-    console.table(result.value.anomalies, ["timestamp", "dimension", "status"]);
+    console.table(result.value.anomalies, ["timestamp", "seriesKey", "status"]);
     result = await iterator.next();
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
@@ -88,7 +88,7 @@ async function listFeedback(client, metricId, startTime, endTime) {
   for await (const feedback of client.listMetricFeedbacks(metricId, {
     filter: {
       startTime: new Date("08/01/2020"),
-      endTime: new Date("08/11/2020"),
+      endTime: new Date("08/03/2020"),
       timeMode: "MetricTimestamp"
     }
   })) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -77,7 +77,7 @@ async function main() {
 }
 
 async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQuery) {
-  const metric = [
+  const metrics = [
     {
       name: "revenue",
       displayName: "revenue",
@@ -89,13 +89,13 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       description: "Metric2 description"
     }
   ];
-  const dimension = [
+  const dimensions = [
     { name: "city", displayName: "city display" },
     { name: "category", displayName: "category display" }
   ];
   const dataFeedSchema = {
-    metrics: metric,
-    dimensions: dimension,
+    metrics,
+    dimensions,
     timestampColumn: null
   };
   const dataFeedIngestion = {
@@ -119,7 +119,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
     rollupSettings: {
       rollupType: "AutoRollup",
       rollupMethod: "Sum",
-      rollupIdentificationValue: "__CUSTOM_SUM__"
+      rollupIdentificationValue: "__SUM__"
     },
     missingDataPointFillSettings: {
       fillType: "SmartFilling"
@@ -130,7 +130,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
 
   console.log("Creating Datafeed...");
   const result = await adminClient.createDataFeed({
-    name: "test_datafeed_" + new Date().getTime().toFixed(),
+    name: "test_datafeed_" + new Date().getTime().toString(),
     source,
     granularity,
     schema: dataFeedSchema,
@@ -176,7 +176,7 @@ async function createWebhookHook(adminClient) {
   console.log("Creating a webhook hook");
   const hook = {
     hookType: "Webhook",
-    name: "web hook " + new Date().getTime().toFixed(),
+    name: "web hook " + new Date().getTime().toString(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -125,7 +125,7 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    admins: ["xyz@microsoft.com"]
+    adminEmails: ["xyz@microsoft.com"]
   };
 
   console.log("Creating Datafeed...");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -257,7 +257,7 @@ async function queryAnomaliesByAlert(client, alertConfigId, alertId) {
   );
   for await (const anomaly of client.listAnomaliesForAlert(alertConfigId, alertId)) {
     console.log(
-      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.dimension} ${anomaly.timestamp}`
+      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`
     );
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
@@ -71,8 +71,8 @@ async function getMetricSeriesData(client, metricId) {
       new Date("09/01/2020"),
       new Date("09/12/2020"),
       [
-        { Dim1: "Common Lime", Dim2: "Amphibian" },
-        { Dim1: "Common Beech", Dim2: "Ant" }
+        { dimension: { Dim1: "Common Lime", Dim2: "Amphibian" } },
+        { dimension: { Dim1: "Common Beech", Dim2: "Ant" } }
       ]
     );
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
@@ -44,16 +44,16 @@ async function getEnrichedSeriesData(client, detectionConfigId) {
     for (const enriched of result.results || []) {
       console.log("enriched series:");
       console.log(enriched.series);
-      if (enriched.timestampList && enriched.timestampList.length > 0) {
-        for (let i = 0; i < enriched.timestampList.length; i++) {
+      if (enriched.timestamps && enriched.timestamps.length > 0) {
+        for (let i = 0; i < enriched.timestamps.length; i++) {
           console.log("  ----");
-          console.log(`  timestamp: ${enriched.timestampList[i]}`);
-          console.log(`  is abnormal?: ${enriched.isAnomalyList[i]}`);
-          console.log(`  value: ${enriched.valueList[i]}`);
-          console.log(`  expected value: ${enriched.expectedValueList[i]}`);
-          console.log(`  lower bound: ${enriched.lowerBoundaryList[i]}`);
-          console.log(`  upper bound: ${enriched.upperBoundaryList[i]}`);
-          console.log(`  period: ${enriched.periodList[i]}`);
+          console.log(`  timestamp: ${enriched.timestamps[i]}`);
+          console.log(`  is abnormal?: ${enriched.isAnomaly[i]}`);
+          console.log(`  value: ${enriched.values[i]}`);
+          console.log(`  expected value: ${enriched.expectedValues[i]}`);
+          console.log(`  lower bound: ${enriched.lowerBounds[i]}`);
+          console.log(`  upper bound: ${enriched.upperBounds[i]}`);
+          console.log(`  period: ${enriched.periods[i]}`);
         }
       }
     }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/seriesData.js
@@ -78,10 +78,10 @@ async function getMetricSeriesData(client, metricId) {
 
     for (const series of result.metricSeriesDataList || []) {
       console.log(series.definition);
-      if (series.timestampList && series.timestampList.length > 0)
-        for (let i = 0; i < series.timestampList.length; i++) {
-          console.log(`  ${series.timestampList[i]}`);
-          console.log(`  ${series.valueList[i]}`);
+      if (series.timestamps && series.timestamps.length > 0)
+        for (let i = 0; i < series.timestamps.length; i++) {
+          console.log(`  ${series.timestamps[i]}`);
+          console.log(`  ${series.values[i]}`);
         }
     }
   } catch (err) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
@@ -51,16 +51,25 @@ async function createAlertConfig(
   detectionConfigId: string
 ) {
   console.log("Creating a new alerting configuration...");
-  const metricAlertingConfig: MetricAlertConfiguration = {
+  const metricAlertingConfig1: MetricAlertConfiguration = {
     detectionConfigurationId: detectionConfigId,
     alertScope: {
       scopeType: "All"
     }
   };
+  const metricAlertingConfig2: MetricAlertConfiguration = {
+    detectionConfigurationId: detectionConfigId,
+    alertScope: {
+      scopeType: "Dimension",
+      dimensionAnomalyScope: {
+        dimension: { city: "Manila", category: "Handmade" }
+      }
+    }
+  };
   const result = await adminClient.createAnomalyAlertConfiguration({
     name: "js alerting config name " + new Date().getTime().toString(),
     crossMetricsOperator: "AND",
-    metricAlertConfigurations: [metricAlertingConfig, metricAlertingConfig],
+    metricAlertConfigurations: [metricAlertingConfig1, metricAlertingConfig2],
     hookIds: [],
     description: "alerting config description"
   });

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
@@ -76,7 +76,7 @@ async function listDataFeeds(client: MetricsAdvisorAdministrationClient) {
 async function createDataFeed(
   client: MetricsAdvisorAdministrationClient
 ): Promise<GetDataFeedResponse> {
-  const metric: DataFeedMetric[] = [
+  const metrics: DataFeedMetric[] = [
     {
       name: "Metric1",
       displayName: "Metric1 display",
@@ -88,13 +88,13 @@ async function createDataFeed(
       description: ""
     }
   ];
-  const dimension: DataFeedDimension[] = [
+  const dimensions: DataFeedDimension[] = [
     { name: "Dim1", displayName: "Dim1 display" },
     { name: "Dim2", displayName: "Dim2 display" }
   ];
   const dataFeedSchema: DataFeedSchema = {
-    metrics: metric,
-    dimensions: dimension,
+    metrics,
+    dimensions,
     timestampColumn: undefined
   };
   const dataFeedIngestion: DataFeedIngestionSettings = {
@@ -133,7 +133,7 @@ async function createDataFeed(
 
   console.log("Creating Datafeed...");
   const result = await client.createDataFeed({
-    name: "test-datafeed-" + new Date().getTime().toFixed(),
+    name: "test-datafeed-" + new Date().getTime().toString(),
     source,
     granularity,
     schema: dataFeedSchema,

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
@@ -11,8 +11,8 @@ import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
   DataFeedSchema,
-  Metric,
-  Dimension,
+  DataFeedMetric,
+  DataFeedDimension,
   DataFeedIngestionSettings,
   DataFeedGranularity,
   DataFeedSource,
@@ -76,7 +76,7 @@ async function listDataFeeds(client: MetricsAdvisorAdministrationClient) {
 async function createDataFeed(
   client: MetricsAdvisorAdministrationClient
 ): Promise<GetDataFeedResponse> {
-  const metric: Metric[] = [
+  const metric: DataFeedMetric[] = [
     {
       name: "Metric1",
       displayName: "Metric1 display",
@@ -88,7 +88,7 @@ async function createDataFeed(
       description: ""
     }
   ];
-  const dimension: Dimension[] = [
+  const dimension: DataFeedDimension[] = [
     { name: "Dim1", displayName: "Dim1 display" },
     { name: "Dim2", displayName: "Dim2 display" }
   ];

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
@@ -3,9 +3,9 @@ dotenv.config();
 import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
-  EmailHook,
-  WebhookHook,
-  EmailHookPatch
+  EmailNotificationHook,
+  WebNotificationHook,
+  EmailNotificationHookPatch
 } from "@azure/ai-metrics-advisor";
 
 export async function main() {
@@ -33,7 +33,7 @@ export async function main() {
 
 async function createWebHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new web hook...");
-  const hook: WebhookHook = {
+  const hook: WebNotificationHook = {
     hookType: "Webhook",
     name: "js web hook example" + new Date().getTime().toFixed(),
     description: "description",
@@ -56,7 +56,7 @@ async function createWebHook(client: MetricsAdvisorAdministrationClient) {
 
 async function createEmailHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new email hook...");
-  const hook: EmailHook = {
+  const hook: EmailNotificationHook = {
     hookType: "Email",
     name: "js email hook example" + new Date().getTime().toFixed(),
     description: "description",
@@ -77,7 +77,7 @@ async function getHook(client: MetricsAdvisorAdministrationClient, hookId: strin
 
 async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookId: string) {
   console.log(`Updating hook ${hookId}`);
-  const emailPatch: EmailHookPatch = {
+  const emailPatch: EmailNotificationHookPatch = {
     hookType: "Email",
     hookParameter: {
       toList: ["test2@example.com", "test3@example.com"]

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
@@ -72,7 +72,7 @@ async function getHook(client: MetricsAdvisorAdministrationClient, hookId: strin
   const result = await client.getHook(hookId);
   console.log(result.name);
   console.log(result.description);
-  console.log(result.admins);
+  console.log(result.adminEmails);
 }
 
 async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/hooks.ts
@@ -35,7 +35,7 @@ async function createWebHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new web hook...");
   const hook: WebNotificationHook = {
     hookType: "Webhook",
-    name: "js web hook example" + new Date().getTime().toFixed(),
+    name: "js web hook example" + new Date().getTime().toString(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",
@@ -58,7 +58,7 @@ async function createEmailHook(client: MetricsAdvisorAdministrationClient) {
   console.log("Creating a new email hook...");
   const hook: EmailNotificationHook = {
     hookType: "Email",
-    name: "js email hook example" + new Date().getTime().toFixed(),
+    name: "js email hook example" + new Date().getTime().toString(),
     description: "description",
     hookParameter: { toList: ["test@example.com"] }
   };

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
@@ -96,7 +96,7 @@ async function listFeedback(client: MetricsAdvisorClient, metricId: string) {
   for await (const feedback of client.listMetricFeedbacks(metricId, {
     filter: {
       startTime: new Date("08/01/2020"),
-      endTime: new Date("08/11/2020"),
+      endTime: new Date("08/03/2020"),
       timeMode: "MetricTimestamp"
     }
   })) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -21,8 +21,7 @@ import {
   GetDataFeedResponse,
   MetricsAdvisorClient,
   WebNotificationHook,
-  MetricAlertConfiguration,
-  AnomalyAlert
+  MetricAlertConfiguration
 } from "@azure/ai-metrics-advisor";
 
 export async function main() {
@@ -94,7 +93,7 @@ async function createDataFeed(
   sqlServerConnectionString: string,
   sqlServerQuery: string
 ): Promise<GetDataFeedResponse> {
-  const metric: DataFeedMetric[] = [
+  const metrics: DataFeedMetric[] = [
     {
       name: "revenue",
       displayName: "revenue",
@@ -106,13 +105,13 @@ async function createDataFeed(
       description: "Metric2 description"
     }
   ];
-  const dimension: DataFeedDimension[] = [
+  const dimensions: DataFeedDimension[] = [
     { name: "city", displayName: "city display" },
     { name: "category", displayName: "category display" }
   ];
   const dataFeedSchema: DataFeedSchema = {
-    metrics: metric,
-    dimensions: dimension,
+    metrics,
+    dimensions,
     timestampColumn: undefined
   };
   const dataFeedIngestion: DataFeedIngestionSettings = {
@@ -136,7 +135,7 @@ async function createDataFeed(
     rollupSettings: {
       rollupType: "AutoRollup",
       rollupMethod: "Sum",
-      rollupIdentificationValue: "__CUSTOM_SUM__"
+      rollupIdentificationValue: "__SUM__"
     },
     missingDataPointFillSettings: {
       fillType: "SmartFilling"
@@ -147,7 +146,7 @@ async function createDataFeed(
 
   console.log("Creating Datafeed...");
   const result = await adminClient.createDataFeed({
-    name: "test_datafeed_" + new Date().getTime().toFixed(),
+    name: "test_datafeed_" + new Date().getTime().toString(),
     source,
     granularity,
     schema: dataFeedSchema,
@@ -201,7 +200,7 @@ async function createWebhookHook(adminClient: MetricsAdvisorAdministrationClient
   console.log("Creating a webhook hook");
   const hook: WebNotificationHook = {
     hookType: "Webhook",
-    name: "web hook " + new Date().getTime().toFixed(),
+    name: "web hook " + new Date().getTime().toString(),
     description: "description",
     hookParameter: {
       endpoint: "https://httpbin.org/post",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -142,7 +142,7 @@ async function createDataFeed(
       fillType: "SmartFilling"
     },
     accessMode: "Private",
-    admins: ["xyz@microsoft.com"]
+    adminEmails: ["xyz@microsoft.com"]
   };
 
   console.log("Creating Datafeed...");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -295,7 +295,7 @@ async function queryAnomaliesByAlert(
   );
   for await (const anomaly of client.listAnomaliesForAlert(alertConfigId, alertId)) {
     console.log(
-      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.dimension} ${anomaly.timestamp}`
+      `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`
     );
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -12,17 +12,17 @@ import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
   DataFeedSchema,
-  Metric,
-  Dimension,
+  DataFeedMetric,
+  DataFeedDimension,
   DataFeedIngestionSettings,
   DataFeedGranularity,
   DataFeedSource,
   DataFeedOptions,
   GetDataFeedResponse,
   MetricsAdvisorClient,
-  WebhookHook,
+  WebNotificationHook,
   MetricAlertConfiguration,
-  Alert
+  AnomalyAlert
 } from "@azure/ai-metrics-advisor";
 
 export async function main() {
@@ -94,7 +94,7 @@ async function createDataFeed(
   sqlServerConnectionString: string,
   sqlServerQuery: string
 ): Promise<GetDataFeedResponse> {
-  const metric: Metric[] = [
+  const metric: DataFeedMetric[] = [
     {
       name: "revenue",
       displayName: "revenue",
@@ -106,7 +106,7 @@ async function createDataFeed(
       description: "Metric2 description"
     }
   ];
-  const dimension: Dimension[] = [
+  const dimension: DataFeedDimension[] = [
     { name: "city", displayName: "city display" },
     { name: "category", displayName: "category display" }
   ];
@@ -199,7 +199,7 @@ async function configureAnomalyDetectionConfiguration(
 
 async function createWebhookHook(adminClient: MetricsAdvisorAdministrationClient) {
   console.log("Creating a webhook hook");
-  const hook: WebhookHook = {
+  const hook: WebNotificationHook = {
     hookType: "Webhook",
     name: "web hook " + new Date().getTime().toFixed(),
     description: "description",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
@@ -72,8 +72,8 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
       new Date("09/01/2020"),
       new Date("09/12/2020"),
       [
-        { Dim1: "Common Lime", Dim2: "Amphibian" },
-        { Dim1: "Common Beech", Dim2: "Ant" }
+        { dimension: { Dim1: "Common Lime", Dim2: "Amphibian" } },
+        { dimension: { Dim1: "Common Beech", Dim2: "Ant" } }
       ]
     );
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
@@ -45,16 +45,16 @@ async function getEnrichedSeriesData(client: MetricsAdvisorClient, detectionConf
     for (const enriched of result.results || []) {
       console.log("enriched series:");
       console.log(enriched.series);
-      if (enriched.timestampList?.length) {
-        for (let i = 0; i < enriched.timestampList!.length; i++) {
+      if (enriched.timestamps && enriched.timestamps.length > 0) {
+        for (let i = 0; i < enriched.timestamps.length; i++) {
           console.log("  ----");
-          console.log(`  timestamp: ${enriched.timestampList![i]}`);
-          console.log(`  is abnormal?: ${enriched.isAnomalyList![i]}`);
-          console.log(`  value: ${enriched.valueList![i]}`);
-          console.log(`  expected value: ${enriched.expectedValueList![i]}`);
-          console.log(`  lower bound: ${enriched.lowerBoundaryList![i]}`);
-          console.log(`  upper bound: ${enriched.upperBoundaryList![i]}`);
-          console.log(`  period: ${enriched.periodList![i]}`);
+          console.log(`  timestamp: ${enriched.timestamps[i]}`);
+          console.log(`  is abnormal?: ${enriched.isAnomaly[i]}`);
+          console.log(`  value: ${enriched.values[i]}`);
+          console.log(`  expected value: ${enriched.expectedValues[i]}`);
+          console.log(`  lower bound: ${enriched.lowerBounds[i]}`);
+          console.log(`  upper bound: ${enriched.upperBounds[i]}`);
+          console.log(`  period: ${enriched.periods[i]}`);
         }
       }
     }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/seriesData.ts
@@ -49,12 +49,12 @@ async function getEnrichedSeriesData(client: MetricsAdvisorClient, detectionConf
         for (let i = 0; i < enriched.timestamps.length; i++) {
           console.log("  ----");
           console.log(`  timestamp: ${enriched.timestamps[i]}`);
-          console.log(`  is abnormal?: ${enriched.isAnomaly[i]}`);
-          console.log(`  value: ${enriched.values[i]}`);
-          console.log(`  expected value: ${enriched.expectedValues[i]}`);
-          console.log(`  lower bound: ${enriched.lowerBounds[i]}`);
-          console.log(`  upper bound: ${enriched.upperBounds[i]}`);
-          console.log(`  period: ${enriched.periods[i]}`);
+          console.log(`  is abnormal?: ${enriched.isAnomaly![i]}`);
+          console.log(`  value: ${enriched.values![i]}`);
+          console.log(`  expected value: ${enriched.expectedValues![i]}`);
+          console.log(`  lower bound: ${enriched.lowerBounds![i]}`);
+          console.log(`  upper bound: ${enriched.upperBounds![i]}`);
+          console.log(`  period: ${enriched.periods![i]}`);
         }
       }
     }
@@ -79,10 +79,10 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
 
     for (const series of result.metricSeriesDataList || []) {
       console.log(series.definition);
-      if (series.timestampList?.length)
-        for (let i = 0; i < series.timestampList!.length; i++) {
-          console.log(`  ${series.timestampList![i]}`);
-          console.log(`  ${series.valueList![i]}`);
+      if (series.timestamps?.length)
+        for (let i = 0; i < series.timestamps!.length; i++) {
+          console.log(`  ${series.timestamps![i]}`);
+          console.log(`  ${series.values![i]}`);
         }
     }
   } catch (err) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -25,17 +25,17 @@ import {
   DataFeedOptions,
   DataFeed,
   DataFeedPatch,
-  WebhookHook,
-  EmailHook,
-  WebhookHookPatch,
-  EmailHookPatch,
+  WebNotificationHook,
+  EmailNotificationHook,
+  WebNotificationHookPatch,
+  EmailNotificationHookPatch,
   AnomalyDetectionConfiguration,
   AnomalyAlertConfiguration,
   GetDataFeedResponse,
   GetAnomalyDetectionConfigurationResponse,
   GetAnomalyAlertConfigurationResponse,
   GetHookResponse,
-  HookUnion,
+  NotificationHookUnion,
   DataFeedRollupMethod,
   ListDataFeedsPageResponse,
   ListDataFeedIngestionStatusPageResponse,
@@ -947,7 +947,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
   public async createHook(
-    hookInfo: EmailHook | WebhookHook,
+    hookInfo: EmailNotificationHook | WebNotificationHook,
     options: OperationOptions = {}
   ): Promise<GetHookResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -999,7 +999,9 @@ export class MetricsAdvisorAdministrationClient {
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       const result = await this.client.getHook(id, requestOptions);
-      const resultHookResponse: HookUnion = fromServiceHookInfoUnion(result._response.parsedBody);
+      const resultHookResponse: NotificationHookUnion = fromServiceHookInfoUnion(
+        result._response.parsedBody
+      );
       return { ...resultHookResponse, _response: result._response };
     } catch (e) {
       span.setStatus({
@@ -1051,7 +1053,7 @@ export class MetricsAdvisorAdministrationClient {
 
   private async *listItemsOfHooks(
     options: ListHooksOptions = {}
-  ): AsyncIterableIterator<HookUnion> {
+  ): AsyncIterableIterator<NotificationHookUnion> {
     for await (const segment of this.listSegmentOfHooks(undefined, options)) {
       if (segment?.hooks) {
         yield* segment.hooks;
@@ -1111,7 +1113,7 @@ export class MetricsAdvisorAdministrationClient {
 
   public listHooks(
     options: ListHooksOptions = {}
-  ): PagedAsyncIterableIterator<HookUnion, ListHooksPageResponse> {
+  ): PagedAsyncIterableIterator<NotificationHookUnion, ListHooksPageResponse> {
     const iter = this.listItemsOfHooks(options);
     return {
       /**
@@ -1146,7 +1148,7 @@ export class MetricsAdvisorAdministrationClient {
    */
   public async updateHook(
     id: string,
-    patch: EmailHookPatch | WebhookHookPatch,
+    patch: EmailNotificationHookPatch | WebNotificationHookPatch,
     options: OperationOptions = {}
   ): Promise<GetHookResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -227,6 +227,8 @@ export class MetricsAdvisorAdministrationClient {
         fillMissingPointType,
         fillMissingPointValue,
         viewMode: options?.accessMode,
+        admins: options?.adminEmails,
+        viewers: options?.viewerEmails,
         ...finalOptions
       };
       const result = await this.client.createDataFeed(body, requestOptions);
@@ -460,8 +462,8 @@ export class MetricsAdvisorAdministrationClient {
             : undefined,
         // other options
         viewMode: patch.options?.accessMode,
-        admins: patch.options?.admins,
-        viewers: patch.options?.viewers,
+        admins: patch.options?.adminEmails,
+        viewers: patch.options?.viewerEmails,
         status: patch.options?.status,
         actionLinkTemplate: patch.options?.actionLinkTemplate
       };

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -41,11 +41,11 @@ import {
   ListDataFeedIngestionStatusPageResponse,
   ListAnomalyAlertConfigurationsPageResponse,
   ListAnomalyDetectionConfigurationsPageResponse,
-  ListHooksPageResponse
+  ListHooksPageResponse,
+  DataFeedStatus
 } from "./models";
 import {
   DataSourceType,
-  EntityStatus,
   GeneratedClientGetIngestionProgressResponse,
   NeedRollupEnum
 } from "./generated/models";
@@ -100,7 +100,7 @@ export type ListDataFeedsOptions = {
     /**
      * filter data feed by its status
      */
-    status?: EntityStatus;
+    status?: DataFeedStatus;
     /**
      * filter data feed by its creator
      */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -812,7 +812,18 @@ export class MetricsAdvisorClient {
       options
     );
     return {
-      results: result.value,
+      results: result.value.map((d) => {
+        return {
+          series: d.series,
+          timestamps: d.timestampList,
+          values: d.valueList,
+          expectedValues: d.expectedValueList,
+          lowerBounds: d.lowerBoundaryList,
+          upperBounds: d.upperBoundaryList,
+          isAnomaly: d.isAnomalyList,
+          periods: d.periodList
+        };
+      }),
       _response: result._response
     };
   }
@@ -1660,8 +1671,8 @@ export class MetricsAdvisorClient {
       metricSeriesDataList: result.value?.map((s) => {
         return {
           definition: { metricId: s.id!.metricId!, dimension: s.id!.dimension! },
-          timestampList: s.timestampList,
-          valueList: s.valueList
+          timestamps: s.timestampList,
+          values: s.valueList
         };
       }),
       _response: result._response

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -18,9 +18,9 @@ import { MetricsAdvisorKeyCredential } from "./metricsAdvisorKeyCredentialPolicy
 import { CanonicalCode } from "@opentelemetry/api";
 import {
   MetricFeedbackUnion,
-  Incident,
-  Anomaly,
-  Alert,
+  AnomalyIncident,
+  DataPointAnomaly,
+  AnomalyAlert,
   GetMetricEnrichedSeriesDataResponse,
   GetIncidentRootCauseResponse,
   GetFeedbackResponse,
@@ -36,12 +36,12 @@ import {
   DimensionKey,
   GetMetricSeriesDataResponse,
   ListMetricDimensionValuesPageResponse,
-  ListMetricFeedbackPageResponse
+  ListMetricFeedbackPageResponse,
+  AlertQueryTimeMode
 } from "./models";
 import {
   SeverityFilterCondition,
   EnrichmentStatus,
-  TimeMode,
   FeedbackType,
   FeedbackQueryTimeMode
 } from "./generated/models";
@@ -240,7 +240,7 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     startTime: Date,
     endTime: Date,
-    timeMode: TimeMode,
+    timeMode: AlertQueryTimeMode,
     continuationToken?: string,
     options: ListAlertsOptions & { maxPageSize?: number } = {}
   ): AsyncIterableIterator<ListAlertsForAlertConfigurationPageResponse> {
@@ -306,9 +306,9 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     startTime: Date,
     endTime: Date,
-    timeMode: TimeMode,
+    timeMode: AlertQueryTimeMode,
     options: ListAlertsOptions
-  ): AsyncIterableIterator<Alert> {
+  ): AsyncIterableIterator<AnomalyAlert> {
     for await (const segment of this.listSegmentOfAlertsForAlertingConfig(
       alertConfigId,
       startTime,
@@ -384,9 +384,9 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     startTime: Date,
     endTime: Date,
-    timeMode: TimeMode,
+    timeMode: AlertQueryTimeMode,
     options: ListAlertsOptions = {}
-  ): PagedAsyncIterableIterator<Alert, ListAlertsForAlertConfigurationPageResponse> {
+  ): PagedAsyncIterableIterator<AnomalyAlert, ListAlertsForAlertConfigurationPageResponse> {
     const iter = this.listItemsOfAlertsForAlertingConfig(
       alertConfigId,
       startTime,
@@ -507,7 +507,7 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     alertId: string,
     options: ListAnomaliesForAlertConfigurationOptions & { maxPageSize?: number } = {}
-  ): AsyncIterableIterator<Anomaly> {
+  ): AsyncIterableIterator<DataPointAnomaly> {
     for await (const segment of this.listSegmentsOfAnomaliesForAlert(
       alertConfigId,
       alertId,
@@ -575,7 +575,7 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     alertId: string,
     options: ListAnomaliesForAlertConfigurationOptions = {}
-  ): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForAlertPageResponse> {
+  ): PagedAsyncIterableIterator<DataPointAnomaly, ListAnomaliesForAlertPageResponse> {
     const iter = this.listItemsOfAnomaliesForAlert(alertConfigId, alertId, options);
     return {
       /**
@@ -686,7 +686,7 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     alertId: string,
     options: ListIncidentsForAlertOptions = {}
-  ): AsyncIterableIterator<Incident> {
+  ): AsyncIterableIterator<AnomalyIncident> {
     for await (const segment of this.listSegmentsOfIncidentsForAlert(
       alertConfigId,
       alertId,
@@ -753,7 +753,7 @@ export class MetricsAdvisorClient {
     alertConfigId: string,
     alertId: string,
     options: ListIncidentsForAlertOptions = {}
-  ): PagedAsyncIterableIterator<Incident, ListIncidentsForAlertPageResponse> {
+  ): PagedAsyncIterableIterator<AnomalyIncident, ListIncidentsForAlertPageResponse> {
     const iter = this.listItemsOfIncidentsForAlert(alertConfigId, alertId, options);
     return {
       /**
@@ -907,7 +907,7 @@ export class MetricsAdvisorClient {
     startTime: Date,
     endTime: Date,
     options: ListAnomaliesForDetectionConfigurationOptions
-  ): AsyncIterableIterator<Anomaly> {
+  ): AsyncIterableIterator<DataPointAnomaly> {
     for await (const segment of this.listSegmentsOfAnomaliesForDetectionConfig(
       detectionConfigId,
       startTime,
@@ -978,7 +978,10 @@ export class MetricsAdvisorClient {
     startTime: Date,
     endTime: Date,
     options: ListAnomaliesForDetectionConfigurationOptions = {}
-  ): PagedAsyncIterableIterator<Anomaly, ListAnomaliesForDetectionConfigurationPageResponse> {
+  ): PagedAsyncIterableIterator<
+    DataPointAnomaly,
+    ListAnomaliesForDetectionConfigurationPageResponse
+  > {
     const iter = this.listItemsOfAnomaliesForDetectionConfig(
       detectionConfigId,
       startTime,
@@ -1269,7 +1272,7 @@ export class MetricsAdvisorClient {
     startTime: Date,
     endTime: Date,
     options: ListIncidentsForDetectionConfigurationOptions
-  ): AsyncIterableIterator<Incident> {
+  ): AsyncIterableIterator<AnomalyIncident> {
     for await (const segment of this.listSegmentsOfIncidentsForDetectionConfig(
       detectionConfigId,
       startTime,
@@ -1340,7 +1343,10 @@ export class MetricsAdvisorClient {
     startTime: Date,
     endTime: Date,
     options: ListIncidentsForDetectionConfigurationOptions = {}
-  ): PagedAsyncIterableIterator<Incident, ListIncidentsByDetectionConfigurationPageResponse> {
+  ): PagedAsyncIterableIterator<
+    AnomalyIncident,
+    ListIncidentsByDetectionConfigurationPageResponse
+  > {
     const iter = this.listItemsOfIncidentsForDetectionConfig(
       detectionConfigId,
       startTime,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -1657,13 +1657,13 @@ export class MetricsAdvisorClient {
     metricId: string,
     startTime: Date,
     endTime: Date,
-    seriesToFilter: Record<string, string>[],
+    seriesToFilter: DimensionKey[],
     options: GetMetricSeriesDataOptions = {}
   ): Promise<GetMetricSeriesDataResponse> {
     const optionsBody = {
       startTime: startTime,
       endTime: endTime,
-      series: seriesToFilter
+      series: seriesToFilter.map((f) => f.dimension)
     };
     const result = await this.client.getMetricData(metricId, optionsBody, options);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -453,7 +453,7 @@ export class MetricsAdvisorClient {
           timestampe: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          dimension: a.dimension,
+          seriesKey: { dimension: a.dimension },
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus,
           timestamp: a.timestamp
@@ -485,7 +485,7 @@ export class MetricsAdvisorClient {
           timestampe: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          dimension: a.dimension,
+          seriesKey: { dimension: a.dimension },
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus,
           timestamp: a.timestamp
@@ -632,7 +632,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: incident.anomalyDetectionConfigurationId!,
-          dimensionKey: incident.rootNode,
+          seriesKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -663,7 +663,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: incident.anomalyDetectionConfigurationId!,
-          dimensionKey: incident.rootNode,
+          seriesKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -868,7 +868,7 @@ export class MetricsAdvisorClient {
           timestamp: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          dimension: a.dimension,
+          seriesKey: { dimension: a.dimension },
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus
         };
@@ -896,7 +896,7 @@ export class MetricsAdvisorClient {
           timestamp: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          dimension: a.dimension,
+          seriesKey: { dimension: a.dimension },
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus
         };
@@ -1233,7 +1233,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: detectionConfigId,
-          dimensionKey: incident.rootNode,
+          seriesKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -1262,7 +1262,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: detectionConfigId,
-          dimensionKey: incident.rootNode,
+          seriesKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -632,7 +632,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: incident.anomalyDetectionConfigurationId!,
-          seriesKey: incident.rootNode,
+          rootDimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -663,7 +663,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: incident.anomalyDetectionConfigurationId!,
-          seriesKey: incident.rootNode,
+          rootDimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -1233,7 +1233,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: detectionConfigId,
-          seriesKey: incident.rootNode,
+          rootDimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -1262,7 +1262,7 @@ export class MetricsAdvisorClient {
           id: incident.incidentId,
           metricId: incident.metricId,
           detectionConfigurationId: detectionConfigId,
-          seriesKey: incident.rootNode,
+          rootDimensionKey: incident.rootNode,
           status: incident.property.incidentStatus!,
           severity: incident.property.maxSeverity,
           startTime: incident.startTime,
@@ -1421,7 +1421,7 @@ export class MetricsAdvisorClient {
       );
       const transformed = result.value?.map((r) => {
         return {
-          dimensionKey: r.rootCause,
+          seriesKey: r.rootCause,
           path: r.path,
           score: r.score,
           description: r.description

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -870,7 +870,7 @@ export interface AnomalyIncident {
   /**
    * identifies the time series or time series group
    */
-  dimensionKey: DimensionKey;
+  seriesKey: DimensionKey;
   /**
    * metric unique id
    *
@@ -934,7 +934,7 @@ export interface DataPointAnomaly {
   /**
    * dimension specified for series
    */
-  dimension: Record<string, string>;
+  seriesKey: DimensionKey;
   /**
    * anomaly severity
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1216,11 +1216,11 @@ export interface MetricSeriesData {
   /**
    * timestamp list
    */
-  timestampList?: Date[];
+  timestamps?: Date[];
   /**
    * value list
    */
-  valueList?: number[];
+  values?: number[];
 }
 
 /**
@@ -1234,31 +1234,31 @@ export interface MetricEnrichedSeriesData {
   /**
    * timestamp list
    */
-  timestampList?: Date[];
+  timestamps?: Date[];
   /**
    * value list
    */
-  valueList?: number[];
+  values?: number[];
   /**
    * list of booleans incidating whether a data point is anomaly or not
    */
-  isAnomalyList?: boolean[];
+  isAnomaly?: boolean[];
   /**
    * list of expected values
    */
-  expectedValueList?: number[];
+  expectedValues?: number[];
   /**
    * list of lower bounds
    */
-  lowerBoundaryList?: number[];
+  lowerBounds?: number[];
   /**
    * list of upper bounds
    */
-  upperBoundaryList?: number[];
+  upperBounds?: number[];
   /**
    * list of period values
    */
-  periodList?: number[];
+  periods?: number[];
 }
 
 // Response types

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -56,7 +56,6 @@ export {
   GeneratedClientGetIngestionProgressResponse,
   IngestionStatusType,
   DataSourceType,
-  EntityStatus,
   SeverityFilterCondition,
   SnoozeScope,
   AnomalyDetectorDirection,
@@ -870,7 +869,7 @@ export interface AnomalyIncident {
   /**
    * identifies the time series or time series group
    */
-  seriesKey: DimensionKey;
+  rootDimensionKey: DimensionKey;
   /**
    * metric unique id
    *
@@ -1176,7 +1175,7 @@ export interface IncidentRootCause {
   /**
    * identifies the contributing time series.
    */
-  dimensionKey: DimensionKey;
+  seriesKey: DimensionKey;
   /**
    * drilling down path from query anomaly to root cause
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -224,14 +224,14 @@ export interface DataFeedOptions {
   accessMode?: DataFeedAccessMode;
 
   /**
-   * data feed administrators
+   * email addresses of data feed administrators
    */
-  admins?: string[];
+  adminEmails?: string[];
 
   /**
-   * data feed viewers
+   * email addresses of data feed viewers
    */
-  viewers?: string[];
+  viewerEmails?: string[];
 
   /**
    * action link template for alert
@@ -789,9 +789,9 @@ export interface NotificationHook {
    */
   externalLink?: string;
   /**
-   * hook administrators
+   * email addresses of hook administrators
    */
-  readonly admins?: string[];
+  readonly adminEmails?: string[];
 }
 
 /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -243,8 +243,8 @@ export function fromServiceDataFeedDetailUnion(original: ServiceDataFeedDetailUn
               fillType: original.fillMissingPointType!
             },
       accessMode: original.viewMode,
-      admins: original.admins,
-      viewers: original.viewers
+      adminEmails: original.admins,
+      viewerEmails: original.viewers
     }
   };
   switch (original.dataSourceType) {
@@ -402,7 +402,7 @@ export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): Notifi
     name: original.name,
     description: original.description,
     externalLink: original.externalLink,
-    admins: original.admins
+    adminEmails: original.admins
   };
   switch (original.hookType) {
     case "Email": {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -39,10 +39,10 @@ import {
   MySqlDataFeedSource,
   PostgreSqlDataFeedSource,
   SQLServerDataFeedSource,
-  HookUnion,
+  NotificationHookUnion,
   DataFeedRollupSettings,
   MetricFeedbackCommon,
-  HookCommon,
+  NotificationHook,
   ElasticsearchDataFeedSource,
   AnomalyAlertConfiguration,
   MetricAnomalyAlertScope,
@@ -396,8 +396,8 @@ export function fromServiceDataFeedDetailUnion(original: ServiceDataFeedDetailUn
   }
 }
 
-export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): HookUnion {
-  const common: HookCommon = {
+export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): NotificationHookUnion {
+  const common: NotificationHook = {
     id: original.id,
     name: original.name,
     description: original.description,
@@ -407,7 +407,7 @@ export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): HookUn
   switch (original.hookType) {
     case "Email": {
       const orig1 = original as EmailHookInfo;
-      const result1: HookUnion = {
+      const result1: NotificationHookUnion = {
         ...common,
         hookType: "Email",
         hookParameter: orig1.hookParameter
@@ -416,7 +416,7 @@ export function fromServiceHookInfoUnion(original: ServiceHookInfoUnion): HookUn
     }
     case "Webhook": {
       const orig2 = original as WebhookHookInfo;
-      const result2: HookUnion = {
+      const result2: NotificationHookUnion = {
         ...common,
         hookType: "Webhook",
         hookParameter: orig2.hookParameter

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -69,9 +69,9 @@ describe("MetricsAdvisorClient", () => {
       new Date(Date.UTC(2020, 8, 5))
     );
     let result = await iterator.next();
-    assert.ok(result.value.seriesKey, "Expecting first incident");
+    assert.ok(result.value.rootDimensionKey, "Expecting first incident");
     result = await iterator.next();
-    assert.ok(result.value.seriesKey, "Expecting second incident");
+    assert.ok(result.value.rootDimensionKey, "Expecting second incident");
   });
 
   it("listIncidentsForDetectionConfiguration() by page", async function() {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -259,8 +259,8 @@ describe("MetricsAdvisorClient", () => {
       new Date(Date.UTC(2020, 7, 5)),
       new Date(Date.UTC(2020, 8, 5)),
       [
-        { Dim1: "Common Lime", Dim2: "Amphibian" },
-        { Dim1: "Common Beech", Dim2: "Ant" }
+        { dimension: { Dim1: "Common Lime", Dim2: "Amphibian" } },
+        { dimension: { Dim1: "Common Beech", Dim2: "Ant" } }
       ]
     );
     assert.ok(

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -43,9 +43,9 @@ describe("MetricsAdvisorClient", () => {
       new Date(Date.UTC(2020, 8, 5))
     );
     let result = await iterator.next();
-    assert.ok(result.value.dimension, "Expecting first anomaly");
+    assert.ok(result.value.seriesKey, "Expecting first anomaly");
     result = await iterator.next();
-    assert.ok(result.value.dimension, "Expecting second anomaly");
+    assert.ok(result.value.seriesKey, "Expecting second anomaly");
   });
 
   it("listAnomaliesForDetectionConfiguration() by page", async function() {
@@ -69,9 +69,9 @@ describe("MetricsAdvisorClient", () => {
       new Date(Date.UTC(2020, 8, 5))
     );
     let result = await iterator.next();
-    assert.ok(result.value.dimensionKey, "Expecting first incident");
+    assert.ok(result.value.seriesKey, "Expecting first incident");
     result = await iterator.next();
-    assert.ok(result.value.dimensionKey, "Expecting second incident");
+    assert.ok(result.value.seriesKey, "Expecting second incident");
   });
 
   it("listIncidentsForDetectionConfiguration() by page", async function() {
@@ -158,9 +158,9 @@ describe("MetricsAdvisorClient", () => {
       testEnv.METRICS_ADVISOR_ALERT_ID
     );
     let result = await iterator.next();
-    assert.ok(result.value.dimension, "Expecting first anomaly");
+    assert.ok(result.value.seriesKey, "Expecting first anomaly");
     result = await iterator.next();
-    assert.ok(result.value.dimension, "Expecting second anomaly");
+    assert.ok(result.value.seriesKey, "Expecting second anomaly");
   });
 
   it("lists anomalies for alert by page", async function() {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -277,10 +277,10 @@ describe("MetricsAdvisorClient", () => {
     });
 
     assert.ok(
-      data.metricSeriesDataList![0].timestampList &&
-        data.metricSeriesDataList![0].timestampList.length > 0 &&
-        data.metricSeriesDataList![0].valueList &&
-        data.metricSeriesDataList![0].valueList.length > 0,
+      data.metricSeriesDataList![0].timestamps &&
+        data.metricSeriesDataList![0].timestamps.length > 0 &&
+        data.metricSeriesDataList![0].values &&
+        data.metricSeriesDataList![0].values.length > 0,
       "Expecting data for the first time series"
     );
 
@@ -294,10 +294,10 @@ describe("MetricsAdvisorClient", () => {
     });
 
     assert.ok(
-      data.metricSeriesDataList![1].timestampList &&
-        data.metricSeriesDataList![1].timestampList.length > 0 &&
-        data.metricSeriesDataList![1].valueList &&
-        data.metricSeriesDataList![1].valueList.length > 0,
+      data.metricSeriesDataList![1].timestamps &&
+        data.metricSeriesDataList![1].timestamps.length > 0 &&
+        data.metricSeriesDataList![1].values &&
+        data.metricSeriesDataList![1].values.length > 0,
       "Expecting data for the second time series"
     );
   });
@@ -320,12 +320,12 @@ describe("MetricsAdvisorClient", () => {
     });
 
     assert.ok(
-      data.results![0].timestampList &&
-        data.results![0].timestampList.length > 0 &&
-        data.results![0].valueList &&
-        data.results![0].valueList.length > 0 &&
-        data.results![0].isAnomalyList &&
-        data.results![0].isAnomalyList.length > 0,
+      data.results![0].timestamps &&
+        data.results![0].timestamps.length > 0 &&
+        data.results![0].values &&
+        data.results![0].values.length > 0 &&
+        data.results![0].isAnomaly &&
+        data.results![0].isAnomaly.length > 0,
       "Expecting enriched data for the first time series"
     );
 
@@ -335,12 +335,12 @@ describe("MetricsAdvisorClient", () => {
     });
 
     assert.ok(
-      data.results![1].timestampList &&
-        data.results![1].timestampList.length > 0 &&
-        data.results![1].valueList &&
-        data.results![1].valueList.length > 0 &&
-        data.results![0].isAnomalyList &&
-        data.results![0].isAnomalyList.length > 0,
+      data.results![1].timestamps &&
+        data.results![1].timestamps.length > 0 &&
+        data.results![1].values &&
+        data.results![1].values.length > 0 &&
+        data.results![0].isAnomaly &&
+        data.results![0].isAnomaly.length > 0,
       "Expecting enriched data for the second time series"
     );
   });

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -309,7 +309,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
             fillType: "PreviousValue"
           },
           accessMode: "Public",
-          viewers: ["viewer1@example.com"],
+          viewerEmails: ["viewer1@example.com"],
           actionLinkTemplate: "Updated Azure Blob action link template"
         }
       };
@@ -329,7 +329,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       );
       assert.equal(updated.options!.missingDataPointFillSettings?.fillType, "PreviousValue");
       assert.equal(updated.options!.accessMode, "Public");
-      assert.deepStrictEqual(updated.options!.viewers, ["viewer1@example.com"]);
+      assert.deepStrictEqual(updated.options!.viewerEmails, ["viewer1@example.com"]);
       assert.equal(updated.options?.actionLinkTemplate, "Updated Azure Blob action link template");
     });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -13,8 +13,8 @@ import {
   DataFeedPatch,
   DataFeedSchema,
   DataFeedSource,
-  Dimension,
-  Metric,
+  DataFeedDimension,
+  DataFeedMetric,
   MetricsAdvisorAdministrationClient,
   MetricsAdvisorKeyCredential
 } from "../src";
@@ -98,7 +98,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
   let createdPostGreSqlId: string;
 
   describe("DataFeed", async () => {
-    const metric: Metric[] = [
+    const metric: DataFeedMetric[] = [
       {
         name: "Metric1",
         displayName: "Metric1",
@@ -110,7 +110,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         description: ""
       }
     ];
-    const dimension: Dimension[] = [
+    const dimension: DataFeedDimension[] = [
       { name: "Dim1", displayName: "Dim1 display" },
       { name: "Dim2", displayName: "Dim2 display" }
     ];

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
@@ -9,10 +9,10 @@ dotenv.config();
 import {
   MetricsAdvisorAdministrationClient,
   MetricsAdvisorKeyCredential,
-  WebhookHook,
-  EmailHook,
-  EmailHookPatch,
-  WebhookHookPatch
+  WebNotificationHook,
+  EmailNotificationHook,
+  EmailNotificationHookPatch,
+  WebNotificationHookPatch
 } from "../src";
 import { createRecordedAdminClient, testEnv } from "./util/recordedClients";
 import { Recorder } from "@azure/test-utils-recorder";
@@ -47,7 +47,7 @@ describe("MetricsAdvisorClient hooks", () => {
   });
 
   it("creates email Hook", async () => {
-    const hook: EmailHook = {
+    const hook: EmailNotificationHook = {
       hookType: "Email",
       name: emailHookName,
       description: "description",
@@ -61,7 +61,7 @@ describe("MetricsAdvisorClient hooks", () => {
   });
 
   it("creates web Hook", async () => {
-    const hook: WebhookHook = {
+    const hook: WebNotificationHook = {
       hookType: "Webhook",
       name: webHookName,
       description: "description",
@@ -77,7 +77,7 @@ describe("MetricsAdvisorClient hooks", () => {
   });
 
   it("updates email Hook", async () => {
-    const emailPatch: EmailHookPatch = {
+    const emailPatch: EmailNotificationHookPatch = {
       hookType: "Email",
       hookParameter: {
         toList: ["test2@example.com", "test3@example.com"]
@@ -85,12 +85,12 @@ describe("MetricsAdvisorClient hooks", () => {
     };
     const updated = await client.updateHook(createdEmailHookId, emailPatch);
     assert.equal(updated.hookType, emailPatch.hookType);
-    const emailHook = updated as EmailHook;
+    const emailHook = updated as EmailNotificationHook;
     assert.deepEqual(emailHook.hookParameter.toList, ["test2@example.com", "test3@example.com"]);
   });
 
   it("updates Web Hook", async () => {
-    const webPatch: WebhookHookPatch = {
+    const webPatch: WebNotificationHookPatch = {
       hookType: "Webhook",
       hookParameter: {
         endpoint: "https://httpbin.org/post",
@@ -100,7 +100,7 @@ describe("MetricsAdvisorClient hooks", () => {
     };
     const updated = await client.updateHook(createdWebHookId, webPatch);
     assert.equal(updated.hookType, webPatch.hookType);
-    const webHook = updated as WebhookHook;
+    const webHook = updated as WebNotificationHook;
     assert.equal(webHook.hookParameter.username, "user1");
     assert.equal(webHook.hookParameter.endpoint, "https://httpbin.org/post");
     assert.equal(webHook.hookParameter.password, "pass123");


### PR DESCRIPTION
- Rename names that are too generic

- Rename `admins` to `adminEmails` and `viewers` to `viewerEmails`

- Remove `-List` suffix from array property names

- Use DimensionKey where a dimension identification is needed

  This is more consistent with other APIs.  We might decide to remove
the wrapping `dimension` property around `Record<string, string>` in
the future but for all should have it.

  Also rename properties of `DimensionKey` type to `seriesKey`.