### PR TITLE
Updated regex to pick correct package artifact

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -45,7 +45,7 @@ stages:
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}}
                         TargetFolder: ${{artifact.safeName}}
-                        PackageName: ${{artifact.name}}-*.tgz
+                        PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                       workingDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -74,7 +74,7 @@ stages:
                     steps:
                       - checkout: self
                       - script: |
-                          export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*.tgz`
+                          export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz`
                           echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
                         displayName: Detecting package archive
 
@@ -107,7 +107,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}
                           TargetFolder: ${{artifact.safeName}}
-                          PackageName: ${{artifact.name}}-*.tgz
+                          PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
                       - pwsh: |
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
@@ -155,7 +155,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}
                           TargetFolder: ${{artifact.safeName}}
-                          PackageName: ${{artifact.name}}-*.tgz
+                          PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml
                         parameters:
                           SourceFolder: ${{parameters.DocArtifact}}
@@ -224,7 +224,7 @@ stages:
         - ${{ each artifact in parameters.Artifacts }}:
           - ${{if ne(artifact.skipPublishDevFeed, 'true')}}:
             - pwsh: |
-                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*-alpha*.tgz
+                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+-alpha.*.tgz
                 echo "##vso[task.setvariable variable=Package.Archive]$detectedPackageName"
                 if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-js') {
                   $npmToken="$(azure-sdk-npm-token)"

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -45,7 +45,7 @@ stages:
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}}
                         TargetFolder: ${{artifact.safeName}}
-                        PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
+                        PackageName: ${{artifact.name}}-[0-9]*.[0-9]*.[0-9]*.*.tgz
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                       workingDirectory: $(Pipeline.Workspace)
@@ -74,7 +74,7 @@ stages:
                     steps:
                       - checkout: self
                       - script: |
-                          export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz`
+                          export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]*[0-9]*.[0-9]*.*.tgz`
                           echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
                         displayName: Detecting package archive
 
@@ -107,7 +107,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}
                           TargetFolder: ${{artifact.safeName}}
-                          PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
+                          PackageName: ${{artifact.name}}-[0-9]*.[0-9]*.[0-9]*.*.tgz
                       - pwsh: |
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
@@ -155,7 +155,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}
                           TargetFolder: ${{artifact.safeName}}
-                          PackageName: ${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+.*.tgz
+                          PackageName: ${{artifact.name}}-[0-9]*.[0-9]*.[0-9]*.*.tgz
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml
                         parameters:
                           SourceFolder: ${{parameters.DocArtifact}}
@@ -224,7 +224,7 @@ stages:
         - ${{ each artifact in parameters.Artifacts }}:
           - ${{if ne(artifact.skipPublishDevFeed, 'true')}}:
             - pwsh: |
-                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]+.[0-9]+.[0-9]+-alpha.*.tgz
+                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]*.[0-9]*.[0-9]*-alpha*.tgz
                 echo "##vso[task.setvariable variable=Package.Archive]$detectedPackageName"
                 if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-js') {
                   $npmToken="$(azure-sdk-npm-token)"

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
-## 1.0.9-beta.3 (Unreleased)
+## 1.0.9-beta.13 (2020-10-13)
+- Test Release Pipeline
 
+## 1.0.9-beta.3 (2020-09-05)
+- Test Release Pipeline
 
 ## 1.0.9-beta.2 (2020-09-04)
 - Testing release tag replacement

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.9-beta.3",
+  "version": "1.0.9-beta.13",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Copy artifact step in release stage is using pattern <artifact-name>-*.tgz to copy artifact into publish folder. This is causing issue when two packages has same prefix. for e.g. storage-blob and storage-blob-changefeed.

Fix here is to ensure we are looking for package with artifact name followed by version format to ensure we pick only required artifact.