### PR TITLE
Elaborate on smoke test initialize logic in docs and script. Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ child.conf.json
 
 # temporary test artifacts
 test/tmp/*
+common/smoke-test/run-manifest.json
 
 # build artifacts
 dist

--- a/common/smoke-test/.gitignore
+++ b/common/smoke-test/.gitignore
@@ -1,5 +1,0 @@
-package-lock.json
-run-manifest.json
-
-*.js
-*.js.map

--- a/common/smoke-test/.gitignore
+++ b/common/smoke-test/.gitignore
@@ -1,4 +1,5 @@
-!package-lock.json
+package-lock.json
+run-manifest.json
 
 *.js
 *.js.map

--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -179,6 +179,7 @@ foreach ($entry in $manifest) {
   $runManifest += $entry
 
   # Set sample's dependencies in all-up dependencies for smoke tests
+  Write-Verbose "Updating local package.json with dependencies from smoke test for $($entry.Name)"
   $packageSpec = (Get-Content -Path "$($entry.SamplesDirectory)/package.json"
     | ConvertFrom-Json -AsHashtable)
 

--- a/common/smoke-test/README.md
+++ b/common/smoke-test/README.md
@@ -101,3 +101,7 @@ npm i
 # Run smoke tests defined in run-manifest.json
 node run.js
 ```
+
+NOTE: `node run.js` must be run from within the same powershell session that Initialize-SmokeTests.ps1 was run, 
+since that script sets the NODE_PATH variable to the current directory (so that module imports from the samples will be redirected).
+To run `node run.js` from a separate session, set/export the NODE_PATH variable to the `<current directory>/node_modules`.

--- a/common/smoke-test/README.md
+++ b/common/smoke-test/README.md
@@ -22,6 +22,7 @@ package.
 
 - AAD Application with `Owner` permissions to an Azure subscription
 - PowerShell 7
+- [Azure Powershell cmdlets](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-4.7.0)
 - Node 12.x
 - Azure SDK for JS [`dev-tool`](https://github.com/Azure/azure-sdk-for-js/blob/master/common/tools/dev-tool)
 
@@ -63,9 +64,13 @@ not skipped will be included in smoke tests):
 ### Initialize Smoke Tests
 
 Run `Initialize-SmokeTests.ps1` to deploy resources and prepare samples. The
-deploy script will search for packages that have samples, deploy resources
-specified in `test-resources.json`, prep samples to execute in the JS Smoke Test
-harness, and build the Smoke Test run manifest.
+deploy script performs the following actions:
+
+1. Searches for packages that have samples.
+1. Deploys resource definitions specified in `test-resources.json` via Azure Resource Manager (via `/eng/common/TestResources/New-TestResources.ps1`).
+1. Preps samples to execute in the JS Smoke Test harness. This will take the form of `dist-samples` directories for included projects in `sdk/`.
+1. Updates the local directory package.json to include dependencies required by smoke tests.
+1. Generates the Smoke Test run manifest used by `run.js`, containing a list of smoke test directories to execute.
 
 Omit the `-CI` flag when running locally to have environment variables set in
 the context of your current PowerShell session.
@@ -87,12 +92,12 @@ In the folder `common/smoke-tests/`
 
 ### Run tests
 
-In the folder `common/smoke-tests/`
+In the folder `common/smoke-test/`
 
 ```powershell
-# Install collected dependencies
+# Install generated dependencies for smoke-tests in run-manifest.json
 npm i
 
-# Run smoke tests
+# Run smoke tests defined in run-manifest.json
 node run.js
 ```


### PR DESCRIPTION
This PR contains some quick doc updates that aim to clarify a few things I was initially confused by when trying to execute and understand how the smoke test initialization/run process worked.

I've also updated the .gitignore to ignore changes to the auto-generated files. I've also considered the possibility of using `git update-index --assume-unchanged` for auto-gen changes to package.json, but I'm thinking it's not worth adding the git dependency to Initialize-SmokeTests.ps1.

https://github.com/Azure/azure-sdk/issues/1879