### PR TITLE
Add canary region and node LTS coverage to smoke test matrix

### DIFF
--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -6,45 +6,43 @@ jobs:
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+          SmokeTestNodeVersion: "8.x"
         Linux (AzureCloud Canary):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          Location: 'eastus2euap'
+          Location: "eastus2euap"
+          SmokeTestNodeVersion: "14.x"
         Windows (AzureCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-        Windows (AzureCloud Canary):
-          OSVmImage: "windows-2019"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          Location: 'eastus2euap'
+          SmokeTestNodeVersion: "12.x"
         Mac (AzureCloud):
           OSVmImage: "macOS-10.14"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-        Mac (AzureCloud Canary):
-          OSVmImage: "macOS-10.14"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          Location: 'eastus2euap'
+          SmokeTestNodeVersion: "10.x"
         Linux (AzureUSGovernment):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
+          SmokeTestNodeVersion: "10.x"
         Windows (AzureUSGovernment):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
+          SmokeTestNodeVersion: "14.x"
         Linux (AzureChinaCloud):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
+          SmokeTestNodeVersion: "12.x"
         Windows (AzureChinaCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
+          SmokeTestNodeVersion: "10.x"
 
     pool:
       vmImage: $(OSVmImage)
@@ -64,9 +62,9 @@ jobs:
       - template: ../../eng/pipelines/templates/steps/common.yml
 
       - task: NodeTool@0
-        displayName: Use Node $(NodeVersion)
+        displayName: Use Node $(SmokeTestNodeVersion)
         inputs:
-          versionSpec: $(NodeVersion)
+          versionSpec: $(SmokeTestNodeVersion)
 
       - pwsh: npm install -g
         workingDirectory: $(Build.SourcesDirectory)/common/tools/dev-tool

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -9,7 +9,7 @@ jobs:
           NodeTestVersion: "8.x"
         Linux (AzureCloud Canary):
           OSVmImage: "ubuntu-18.04"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           Location: "eastus2euap"
           NodeTestVersion: "14.x"

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -6,14 +6,29 @@ jobs:
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+        Linux (AzureCloud Canary):
+          OSVmImage: "ubuntu-18.04"
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+          Location: 'eastus2euap'
         Windows (AzureCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+        Windows (AzureCloud Canary):
+          OSVmImage: "windows-2019"
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+          Location: 'eastus2euap'
         Mac (AzureCloud):
           OSVmImage: "macOS-10.14"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+        Mac (AzureCloud Canary):
+          OSVmImage: "macOS-10.14"
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
+          Location: 'eastus2euap'
         Linux (AzureUSGovernment):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
@@ -69,6 +84,7 @@ jobs:
           ./Initialize-SmokeTests.ps1 `
             -CI `
             -Verbose `
+            -Location '$(Location)' `
             @subscriptionConfiguration `
             -AdditionalParameters $(ArmTemplateParameters)
         workingDirectory: $(Build.SourcesDirectory)/common/smoke-test

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -6,43 +6,43 @@ jobs:
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          SmokeTestNodeVersion: "8.x"
+          NodeTestVersion: "8.x"
         Linux (AzureCloud Canary):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           Location: "eastus2euap"
-          SmokeTestNodeVersion: "14.x"
+          NodeTestVersion: "14.x"
         Windows (AzureCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          SmokeTestNodeVersion: "12.x"
+          NodeTestVersion: "12.x"
         Mac (AzureCloud):
           OSVmImage: "macOS-10.14"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          SmokeTestNodeVersion: "10.x"
+          NodeTestVersion: "10.x"
         Linux (AzureUSGovernment):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-          SmokeTestNodeVersion: "10.x"
+          NodeTestVersion: "10.x"
         Windows (AzureUSGovernment):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-          SmokeTestNodeVersion: "14.x"
+          NodeTestVersion: "14.x"
         Linux (AzureChinaCloud):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-          SmokeTestNodeVersion: "12.x"
+          NodeTestVersion: "12.x"
         Windows (AzureChinaCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-          SmokeTestNodeVersion: "10.x"
+          NodeTestVersion: "10.x"
 
     pool:
       vmImage: $(OSVmImage)
@@ -61,10 +61,7 @@ jobs:
     steps:
       - template: ../../eng/pipelines/templates/steps/common.yml
 
-      - task: NodeTool@0
-        displayName: Use Node $(SmokeTestNodeVersion)
-        inputs:
-          versionSpec: $(SmokeTestNodeVersion)
+      - template: ../../eng/pipelines/templates/steps/use-node-test-version.yml
 
       - pwsh: npm install -g
         workingDirectory: $(Build.SourcesDirectory)/common/tools/dev-tool

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -61,7 +61,9 @@ jobs:
     steps:
       - template: ../../eng/pipelines/templates/steps/common.yml
 
-      - template: ../../eng/pipelines/templates/steps/use-node-test-version.yml
+      - template: ../../eng/pipelines/templates/steps/use-node-version.yml
+        parameters:
+          NodeVersion: $(NodeTestVersion)
 
       - pwsh: npm install -g
         workingDirectory: $(Build.SourcesDirectory)/common/tools/dev-tool

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -2,43 +2,37 @@ jobs:
   - job: SmokeTest
     strategy:
       matrix:
-        Linux (AzureCloud):
+        Linux Node14 (AzureCloud):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "8.x"
-        Linux (AzureCloud Canary):
-          OSVmImage: "ubuntu-18.04"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          Location: "eastus2euap"
           NodeTestVersion: "14.x"
-        Windows (AzureCloud):
+        Windows Node12 (AzureCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "12.x"
-        Mac (AzureCloud):
+        Mac Node10 (AzureCloud):
           OSVmImage: "macOS-10.14"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "10.x"
-        Linux (AzureUSGovernment):
+        Linux Node10 (AzureUSGovernment):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
           NodeTestVersion: "10.x"
-        Windows (AzureUSGovernment):
+        Windows Node14 (AzureUSGovernment):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
           NodeTestVersion: "14.x"
-        Linux (AzureChinaCloud):
+        Linux Node12 (AzureChinaCloud):
           OSVmImage: "ubuntu-18.04"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
           NodeTestVersion: "12.x"
-        Windows (AzureChinaCloud):
+        Windows Node10 (AzureChinaCloud):
           OSVmImage: "windows-2019"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)

--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -9,7 +9,7 @@ jobs:
           NodeTestVersion: "8.x"
         Linux (AzureCloud Canary):
           OSVmImage: "ubuntu-18.04"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           Location: "eastus2euap"
           NodeTestVersion: "14.x"


### PR DESCRIPTION
This PR adds a new entry to the smoke test matrix to add a public cloud test against a Canary/EUAP region (specifically eastus2euap), and to cover multiple node versions across the matrix.

Version coverage across the matrix taken from [here](https://github.com/Azure/azure-sdk-for-js/issues/9462)

Azure/azure-sdk#1879