### PR TITLE
Match connection string variable to test-resources override for communication samples

### DIFF
--- a/sdk/communication/communication-administration/samples/javascript/README.md
+++ b/sdk/communication/communication-administration/samples/javascript/README.md
@@ -47,7 +47,7 @@ node issueToken.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env CONNECTION_STRING="<connection string>" node issueToken.js
+npx cross-env COMMUNICATION_CONNECTION_STRING="<connection string>" node issueToken.js
 ```
 
 ## Next Steps

--- a/sdk/communication/communication-administration/samples/javascript/issueToken.js
+++ b/sdk/communication/communication-administration/samples/javascript/issueToken.js
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 async function main() {
   console.log("== Issue Token Sample ==");

--- a/sdk/communication/communication-administration/samples/javascript/revokeTokens.js
+++ b/sdk/communication/communication-administration/samples/javascript/revokeTokens.js
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 async function main() {
   console.log("== Issue Token Sample ==");

--- a/sdk/communication/communication-administration/samples/javascript/sample.env
+++ b/sdk/communication/communication-administration/samples/javascript/sample.env
@@ -1,3 +1,3 @@
 # Used in most samples. Retrieve these values from a Communication Service instance
 # in the Azure Portal.
-CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"
+COMMUNICATION_CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"

--- a/sdk/communication/communication-administration/samples/typescript/README.md
+++ b/sdk/communication/communication-administration/samples/typescript/README.md
@@ -53,7 +53,7 @@ node dist/issueToken.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env CONNECTION_STRING="<connection string>" node dist/issueToken.js
+npx cross-env COMMUNICATION_CONNECTION_STRING="<connection string>" node dist/issueToken.js
 ```
 
 ## Next Steps

--- a/sdk/communication/communication-administration/samples/typescript/sample.env
+++ b/sdk/communication/communication-administration/samples/typescript/sample.env
@@ -1,3 +1,3 @@
 # Used in most samples. Retrieve these values from a Communication Service instance
 # in the Azure Portal.
-CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"
+COMMUNICATION_CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"

--- a/sdk/communication/communication-administration/samples/typescript/src/issueToken.ts
+++ b/sdk/communication/communication-administration/samples/typescript/src/issueToken.ts
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 export const main = async () => {
   console.log("== Issue Token Sample ==");

--- a/sdk/communication/communication-administration/samples/typescript/src/revokeTokens.ts
+++ b/sdk/communication/communication-administration/samples/typescript/src/revokeTokens.ts
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 export const main = async () => {
   console.log("== Issue Token Sample ==");

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -117,5 +117,8 @@
     "sinon": "^9.0.2",
     "typescript": "~3.9.3",
     "util": "^0.12.1"
+  },
+  "//smokeTestConfiguration": {
+    "skipFolder": true
   }
 }

--- a/sdk/communication/communication-sms/samples/javascript/README.md
+++ b/sdk/communication/communication-sms/samples/javascript/README.md
@@ -46,7 +46,7 @@ node sendSms.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env CONNECTION_STRING="<connection string>" node sendSms.js
+npx cross-env COMMUNICATION_CONNECTION_STRING="<connection string>" node sendSms.js
 ```
 
 ## Next Steps

--- a/sdk/communication/communication-sms/samples/javascript/sample.env
+++ b/sdk/communication/communication-sms/samples/javascript/sample.env
@@ -1,3 +1,3 @@
 # Used in most samples. Retrieve these values from a Communication Service instance
 # in the Azure Portal.
-CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"
+COMMUNICATION_CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"

--- a/sdk/communication/communication-sms/samples/javascript/sendSms.js
+++ b/sdk/communication/communication-sms/samples/javascript/sendSms.js
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 async function main() {
   console.log("== Send SMS Message Sample ==");

--- a/sdk/communication/communication-sms/samples/typescript/README.md
+++ b/sdk/communication/communication-sms/samples/typescript/README.md
@@ -52,7 +52,7 @@ node dist/sendSms.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env CONNECTION_STRING="<connection string>" node dist/sendSms.js
+npx cross-env COMMUNICATION_CONNECTION_STRING="<connection string>" node dist/sendSms.js
 ```
 
 ## Next Steps

--- a/sdk/communication/communication-sms/samples/typescript/sample.env
+++ b/sdk/communication/communication-sms/samples/typescript/sample.env
@@ -1,3 +1,3 @@
 # Used in most samples. Retrieve these values from a Communication Service instance
 # in the Azure Portal.
-CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"
+COMMUNICATION_CONNECTION_STRING="endpoint=https://<resource name>.communication.azure.net/;accessKey=<key>"

--- a/sdk/communication/communication-sms/samples/typescript/src/sendSms.ts
+++ b/sdk/communication/communication-sms/samples/typescript/src/sendSms.ts
@@ -14,7 +14,7 @@ dotenv.config();
 
 // You will need to set this environment variables or edit the following values
 const connectionString =
-  process.env["CONNECTION_STRING"] || "<communication service connection string>";
+  process.env["COMMUNICATION_CONNECTION_STRING"] || "<communication service connection string>";
 
 export const main = async () => {
   console.log("== Send SMS Message Sample ==");


### PR DESCRIPTION
The smoke tests are failing because the env variable override in test-resources.json injects a value for COMMUNICATION_CONNECTION_STRING, but most of the samples call for `process.env["CONNECTION_STRING"]`. This PR updates all samples and README docs to reference the longer, scoped connection string environment variable.

https://github.com/azure/azure-sdk/issues/1934