### PR TITLE
Add Mgmt label to PRs for arm packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@
 /sdk/**/review/*api.md @bterlson @xirzec
 
 # Management Plane
+# PRLabel: %Mgmt
 /sdk/**/arm-*/ @qiaozha
 
 # PRLabel: %Monitor


### PR DESCRIPTION
This PR updates the CodeOwners file to add the `Mgmt` label to PRs for the management packages