### PR TITLE
[core-http] Allow defining multiple error responses for Operations

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -230,6 +230,7 @@ export interface OperationResponse {
 export interface OperationResponseMap {
     bodyMapper?: Mapper;
     headersMapper?: Mapper;
+    isError?: boolean;
 }
 
 // @public

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -175,10 +175,12 @@ async function deserializeResponseBody(
   return parsedResponse;
 }
 
-function isOperationSpecEmpty(operationSpec: OperationSpec):boolean {
+function isOperationSpecEmpty(operationSpec: OperationSpec): boolean {
   const expectedStatusCodes = Object.keys(operationSpec.responses);
-  return (expectedStatusCodes.length === 0 ||
-      (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default"));
+  return (
+    expectedStatusCodes.length === 0 ||
+    (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default")
+  );
 }
 
 function handleErrorResponse(
@@ -188,10 +190,11 @@ function handleErrorResponse(
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const responseSpec = operationSpec.responses[String(parsedResponse.status)];
 
-  if((responseSpec && !responseSpec.isError)
-   || (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
-   ) {
-    return { error: null, shouldReturnResponse: false};
+  if (
+    (responseSpec && !responseSpec.isError) ||
+    (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
+  ) {
+    return { error: null, shouldReturnResponse: false };
   }
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -123,7 +123,11 @@ async function deserializeResponseBody(
   }
 
   const responseSpec = getOperationResponseMap(parsedResponse);
-  const { error, shouldReturnResponse } = handleErrorResponse(parsedResponse, operationSpec,responseSpec);
+  const { error, shouldReturnResponse } = handleErrorResponse(
+    parsedResponse,
+    operationSpec,
+    responseSpec
+  );
   if (error) {
     throw error;
   } else if (shouldReturnResponse) {
@@ -190,12 +194,12 @@ function handleErrorResponse(
 ): { error: RestError | null; shouldReturnResponse: boolean } {
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const isExpectedStatusCode: boolean = isOperationSpecEmpty(operationSpec)
-      ? isSuccessByStatus
-      : !!responseSpec;
+    ? isSuccessByStatus
+    : !!responseSpec;
 
-  if(isExpectedStatusCode) {
+  if (isExpectedStatusCode) {
     if (responseSpec) {
-      if(!responseSpec.isError) {
+      if (!responseSpec.isError) {
         return { error: null, shouldReturnResponse: false };
       }
     } else {

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -123,14 +123,12 @@ async function deserializeResponseBody(
   }
 
   const responseSpec = getOperationResponseMap(parsedResponse);
-  const errorResponse = handleErrorResponse(parsedResponse, operationSpec);
-  if (errorResponse) {
-    // There is no error spec. So, return it
-    return errorResponse;
+  const { error, shouldReturnResponse } = handleErrorResponse(parsedResponse, operationSpec);
+  if (error) {
+    throw error;
+  } else if (shouldReturnResponse) {
+    return parsedResponse;
   }
-
-  // There is no operation response spec for current status code.
-  // So, treat it as an error case and use the default response spec to deserialize the response.
 
   // An operation response spec does exist for current status code, so
   // use it to deserialize the response.
@@ -180,111 +178,78 @@ async function deserializeResponseBody(
 function handleErrorResponse(
   parsedResponse: FullOperationResponse,
   operationSpec: OperationSpec
-): FullOperationResponse | undefined {
-  enum RESPONSE_STATUS {
-    NONERROR,
-    ERRORNONDEFAULT,
-    ERRORDEFAULT
-  }
-  let parsedResponseStatus: RESPONSE_STATUS;
-  const statusCodes: string[] = Object.keys(operationSpec.responses);
-  const errorResponseCodes: string[] = [],
-    nonErrorResponseCodes: string[] = [];
+): { error: RestError | null; shouldReturnResponse: boolean } {
+  const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
+  const responseSpec = operationSpec.responses[String(parsedResponse.status)];
 
-  for (const statusCode of statusCodes) {
-    if (statusCode !== "default" && operationSpec.responses[statusCode].isError) {
-      errorResponseCodes.push(statusCode);
-    } else {
-      nonErrorResponseCodes.push(statusCode);
-    }
+  if ((responseSpec && !responseSpec.isError) || (!responseSpec && isSuccessByStatus)) {
+    return { error: null, shouldReturnResponse: false };
   }
 
-  if (
-    nonErrorResponseCodes.includes(parsedResponse.status + "") ||
-    (200 <= parsedResponse.status && parsedResponse.status < 300)
-  ) {
-    parsedResponseStatus = RESPONSE_STATUS.NONERROR;
-  } else {
-    if (errorResponseCodes.includes(parsedResponse.status + "")) {
-      parsedResponseStatus = RESPONSE_STATUS.ERRORNONDEFAULT;
-    } else {
-      parsedResponseStatus = RESPONSE_STATUS.ERRORDEFAULT;
-    }
+  const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
+
+  if (!errorResponseSpec) {
+    return { error: null, shouldReturnResponse: true };
   }
 
-  if (
-    parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT ||
-    parsedResponseStatus === RESPONSE_STATUS.ERRORNONDEFAULT
-  ) {
-    const errorResponseSpec =
-      parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT
-        ? operationSpec.responses.default
-        : operationSpec.responses[parsedResponse.status];
+  const defaultBodyMapper = errorResponseSpec.bodyMapper;
+  const defaultHeadersMapper = errorResponseSpec.headersMapper;
 
-    if (!errorResponseSpec) {
-      return parsedResponse;
-    }
+  const initialErrorMessage = isStreamOperation(operationSpec)
+    ? `Unexpected status code: ${parsedResponse.status}`
+    : (parsedResponse.bodyAsText as string);
 
-    const defaultBodyMapper = errorResponseSpec.bodyMapper;
-    const defaultHeadersMapper = errorResponseSpec.headersMapper;
+  const error = new RestError(initialErrorMessage, {
+    statusCode: parsedResponse.status,
+    request: parsedResponse.request,
+    response: parsedResponse
+  });
 
-    const initialErrorMessage = isStreamOperation(operationSpec)
-      ? `Unexpected status code: ${parsedResponse.status}`
-      : (parsedResponse.bodyAsText as string);
-
-    const error = new RestError(initialErrorMessage, {
-      statusCode: parsedResponse.status,
-      request: parsedResponse.request,
-      response: parsedResponse
-    });
-
-    try {
-      // If error response has a body, try to extract error code & message from it
-      // Then try to deserialize it using default body mapper
-      if (parsedResponse.parsedBody) {
-        const parsedBody = parsedResponse.parsedBody;
-        const internalError: any = parsedBody.error || parsedBody;
-        error.code = internalError.code;
-        if (internalError.message) {
-          error.message = internalError.message;
-        }
-
-        if (defaultBodyMapper) {
-          let valueToDeserialize: any = parsedBody;
-          if (operationSpec.isXML && defaultBodyMapper.type.name === MapperTypeNames.Sequence) {
-            valueToDeserialize = [];
-            const elementName = defaultBodyMapper.xmlElementName;
-            if (typeof parsedBody === "object" && elementName) {
-              valueToDeserialize = parsedBody[elementName];
-            }
-          }
-          if (error.response) {
-            const errorResponse: FullOperationResponse = error.response;
-            errorResponse.parsedBody = operationSpec.serializer.deserialize(
-              defaultBodyMapper,
-              valueToDeserialize,
-              "error.response.parsedBody"
-            );
-          }
-        }
+  try {
+    // If error response has a body, try to extract error code & message from it
+    // Then try to deserialize it using default body mapper
+    if (parsedResponse.parsedBody) {
+      const parsedBody = parsedResponse.parsedBody;
+      const internalError: any = parsedBody.error || parsedBody;
+      error.code = internalError.code;
+      if (internalError.message) {
+        error.message = internalError.message;
       }
 
-      // If error response has headers, try to deserialize it using default header mapper
-      if (parsedResponse.headers && defaultHeadersMapper && error.response) {
-        const errorResponse: FullOperationResponse = error.response;
-        errorResponse.parsedHeaders = operationSpec.serializer.deserialize(
-          defaultHeadersMapper,
-          parsedResponse.headers.toJSON(),
-          "operationRes.parsedHeaders"
-        );
+      if (defaultBodyMapper) {
+        let valueToDeserialize: any = parsedBody;
+        if (operationSpec.isXML && defaultBodyMapper.type.name === MapperTypeNames.Sequence) {
+          valueToDeserialize = [];
+          const elementName = defaultBodyMapper.xmlElementName;
+          if (typeof parsedBody === "object" && elementName) {
+            valueToDeserialize = parsedBody[elementName];
+          }
+        }
+        if (error.response) {
+          const errorResponse: FullOperationResponse = error.response;
+          errorResponse.parsedBody = operationSpec.serializer.deserialize(
+            defaultBodyMapper,
+            valueToDeserialize,
+            "error.response.parsedBody"
+          );
+        }
       }
-    } catch (defaultError) {
-      error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody - "${parsedResponse.bodyAsText}" for the default response.`;
     }
-    throw error;
+
+    // If error response has headers, try to deserialize it using default header mapper
+    if (parsedResponse.headers && defaultHeadersMapper && error.response) {
+      const errorResponse: FullOperationResponse = error.response;
+      errorResponse.parsedHeaders = operationSpec.serializer.deserialize(
+        defaultHeadersMapper,
+        parsedResponse.headers.toJSON(),
+        "operationRes.parsedHeaders"
+      );
+    }
+  } catch (defaultError) {
+    error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody - "${parsedResponse.bodyAsText}" for the default response.`;
   }
 
-  return undefined;
+  return { error, shouldReturnResponse: false };
 }
 
 async function parse(

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -175,6 +175,12 @@ async function deserializeResponseBody(
   return parsedResponse;
 }
 
+function isOperationSpecEmpty(operationSpec: OperationSpec):boolean {
+  const expectedStatusCodes = Object.keys(operationSpec.responses);
+  return (expectedStatusCodes.length === 0 ||
+      (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default"));
+}
+
 function handleErrorResponse(
   parsedResponse: FullOperationResponse,
   operationSpec: OperationSpec
@@ -182,8 +188,10 @@ function handleErrorResponse(
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const responseSpec = operationSpec.responses[String(parsedResponse.status)];
 
-  if ((responseSpec && !responseSpec.isError) || (!responseSpec && isSuccessByStatus)) {
-    return { error: null, shouldReturnResponse: false };
+  if((responseSpec && !responseSpec.isError)
+   || (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
+   ) {
+    return { error: null, shouldReturnResponse: false};
   }
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -171,6 +171,11 @@ export interface OperationResponseMap {
    * The mapper that will be used to deserialize the response body.
    */
   bodyMapper?: Mapper;
+
+  /**
+   * Indicates if this is an error response
+   */
+  isError?: boolean;
 }
 
 /**

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -431,6 +431,141 @@ describe("deserializationPolicy", function() {
         assert.strictEqual(e.response.parsedBody.message, "InvalidResourceNameBody");
       }
     });
+
+    it(`with non default error response headers`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = createSerializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          500: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+            isError: true
+          }
+        },
+        serializer
+      };
+
+      try {
+        await getDeserializedResponse({
+          operationSpec,
+          headers: { "x-ms-error-code": "InvalidResourceNameHeader" },
+          bodyAsText: '{"message": "InvalidResourceNameBody"}',
+          status: 500
+        });
+        assert.fail();
+      } catch (e) {
+        assert.exists(e);
+        assert.strictEqual(e.response.parsedHeaders.errorCode, "InvalidResourceNameHeader");
+        assert.strictEqual(e.response.parsedBody.message, "InvalidResourceNameBody");
+      }
+    });
+
+    it(`with non default complex error response`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message1: {
+              type: {
+                name: "String"
+              }
+            },
+            message2: {
+              type: {
+                name: "String"
+              }
+            },
+            message3: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = createSerializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          503: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+            isError: true
+          }
+        },
+        serializer
+      };
+
+      try {
+        await getDeserializedResponse({
+          operationSpec,
+          headers: { "x-ms-error-code": "InvalidResourceNameHeader" },
+          bodyAsText:
+            '{"message1": "InvalidResourceNameBody1", "message2": "InvalidResourceNameBody2", "message3": "InvalidResourceNameBody3"}',
+          status: 503
+        });
+        assert.fail();
+      } catch (e) {
+        assert.exists(e);
+        assert.strictEqual(e.response.parsedHeaders.errorCode, "InvalidResourceNameHeader");
+        assert.strictEqual(e.response.parsedBody.message1, "InvalidResourceNameBody1");
+        assert.strictEqual(e.response.parsedBody.message2, "InvalidResourceNameBody2");
+        assert.strictEqual(e.response.parsedBody.message3, "InvalidResourceNameBody3");
+      }
+    });
   });
 });
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (2020-10-16)
+## 1.2.0 (2020-10-19)
 
 - Add support for multiple error response codes.[PR 11841](https://github.com/Azure/azure-sdk-for-js/pull/11841)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.1.10 (Unreleased)
+## 1.2.0 (2020-10-16)
 
+- Add support for multiple error response codes.[PR 11841](https://github.com/Azure/azure-sdk-for-js/pull/11841)
 
 ## 1.1.9 (2020-09-30)
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -471,6 +471,7 @@ export interface OperationRequestOptions {
 export interface OperationResponse {
     bodyMapper?: Mapper;
     headersMapper?: Mapper;
+    isError?: boolean;
 }
 
 // @public

--- a/sdk/core/core-http/src/operationResponse.ts
+++ b/sdk/core/core-http/src/operationResponse.ts
@@ -16,4 +16,9 @@ export interface OperationResponse {
    * The mapper that will be used to deserialize the response body.
    */
   bodyMapper?: Mapper;
+
+  /**
+   * Indicates if this is an error response
+   */
+  isError?: boolean;
 }

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -151,104 +151,11 @@ export function deserializeResponseBody(
 
     const responseSpec = getOperationResponse(parsedResponse);
 
-    const statusCodes: string[] = Object.keys(operationSpec.responses);
-    const errorResponseCodes: string[] = [],
-      nonErrorResponseCodes: string[] = [];
+    const errorResponse = handleErrorResponse(parsedResponse, operationSpec);
 
-    for (const statusCode of statusCodes) {
-      if (statusCode !== "default" && operationSpec.responses[statusCode].isError) {
-        errorResponseCodes.push(statusCode);
-      } else {
-        nonErrorResponseCodes.push(statusCode);
-      }
-    }
-
-    enum RESPONSE_STATUS {
-      NONERROR,
-      ERRORNONDEFAULT,
-      ERRORDEFAULT
-    }
-
-    let parsedResponseStatus: RESPONSE_STATUS;
-
-    if (
-      nonErrorResponseCodes.includes(parsedResponse.status + "") ||
-      (200 <= parsedResponse.status && parsedResponse.status < 300)
-    ) {
-      parsedResponseStatus = RESPONSE_STATUS.NONERROR;
-    } else {
-      if (errorResponseCodes.includes(parsedResponse.status + "")) {
-        parsedResponseStatus = RESPONSE_STATUS.ERRORNONDEFAULT;
-      } else {
-        parsedResponseStatus = RESPONSE_STATUS.ERRORDEFAULT;
-      }
-    }
-
-    if (
-      parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT ||
-      parsedResponseStatus === RESPONSE_STATUS.ERRORNONDEFAULT
-    ) {
-      const errorResponseSpec =
-        parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT
-          ? operationSpec.responses.default
-          : operationSpec.responses[parsedResponse.status];
-
-      if (!errorResponseSpec) {
-        return parsedResponse;
-      }
-
-      const defaultBodyMapper = errorResponseSpec.bodyMapper;
-      const defaultHeadersMapper = errorResponseSpec.headersMapper;
-
-      const initialErrorMessage = isStreamOperation(operationSpec)
-        ? `Unexpected status code: ${parsedResponse.status}`
-        : (parsedResponse.bodyAsText as string);
-
-      const error = new RestError(
-        initialErrorMessage,
-        undefined,
-        parsedResponse.status,
-        parsedResponse.request,
-        parsedResponse
-      );
-
-      try {
-        // If error response has a body, try to extract error code & message from it
-        // Then try to deserialize it using default body mapper
-        if (parsedResponse.parsedBody) {
-          const parsedBody = parsedResponse.parsedBody;
-          const internalError: any = parsedBody.error || parsedBody;
-          error.code = internalError.code;
-          if (internalError.message) {
-            error.message = internalError.message;
-          }
-
-          if (defaultBodyMapper) {
-            let valueToDeserialize: any = parsedBody;
-            if (operationSpec.isXML && defaultBodyMapper.type.name === MapperType.Sequence) {
-              valueToDeserialize =
-                typeof parsedBody === "object" ? parsedBody[defaultBodyMapper.xmlElementName!] : [];
-            }
-            error.response!.parsedBody = operationSpec.serializer.deserialize(
-              defaultBodyMapper,
-              valueToDeserialize,
-              "error.response.parsedBody"
-            );
-          }
-        }
-
-        // If error response has headers, try to deserialize it using default header mapper
-        if (parsedResponse.headers && defaultHeadersMapper) {
-          error.response!.parsedHeaders = operationSpec.serializer.deserialize(
-            defaultHeadersMapper,
-            parsedResponse.headers.rawHeaders(),
-            "operationRes.parsedHeaders"
-          );
-        }
-      } catch (defaultError) {
-        error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody - "${parsedResponse.bodyAsText}" for the default response.`;
-      }
-      throw error;
+    if (errorResponse) {
+      // There is no error spec. So, return it
+      return errorResponse;
     }
 
     // An operation response spec does exist for current status code, so
@@ -294,6 +201,111 @@ export function deserializeResponseBody(
 
     return parsedResponse;
   });
+}
+
+function handleErrorResponse(
+  parsedResponse: HttpOperationResponse,
+  operationSpec: OperationSpec
+): HttpOperationResponse | undefined {
+  enum RESPONSE_STATUS {
+    NONERROR,
+    ERRORNONDEFAULT,
+    ERRORDEFAULT
+  }
+  let parsedResponseStatus: RESPONSE_STATUS;
+  const statusCodes: string[] = Object.keys(operationSpec.responses);
+  const errorResponseCodes: string[] = [],
+    nonErrorResponseCodes: string[] = [];
+
+  for (const statusCode of statusCodes) {
+    if (statusCode !== "default" && operationSpec.responses[statusCode].isError) {
+      errorResponseCodes.push(statusCode);
+    } else {
+      nonErrorResponseCodes.push(statusCode);
+    }
+  }
+
+  if (
+    nonErrorResponseCodes.includes(parsedResponse.status + "") ||
+    (200 <= parsedResponse.status && parsedResponse.status < 300)
+  ) {
+    parsedResponseStatus = RESPONSE_STATUS.NONERROR;
+  } else {
+    if (errorResponseCodes.includes(parsedResponse.status + "")) {
+      parsedResponseStatus = RESPONSE_STATUS.ERRORNONDEFAULT;
+    } else {
+      parsedResponseStatus = RESPONSE_STATUS.ERRORDEFAULT;
+    }
+  }
+
+  if (
+    parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT ||
+    parsedResponseStatus === RESPONSE_STATUS.ERRORNONDEFAULT
+  ) {
+    const errorResponseSpec =
+      parsedResponseStatus === RESPONSE_STATUS.ERRORDEFAULT
+        ? operationSpec.responses.default
+        : operationSpec.responses[parsedResponse.status];
+
+    if (!errorResponseSpec) {
+      return parsedResponse;
+    }
+
+    const defaultBodyMapper = errorResponseSpec.bodyMapper;
+    const defaultHeadersMapper = errorResponseSpec.headersMapper;
+
+    const initialErrorMessage = isStreamOperation(operationSpec)
+      ? `Unexpected status code: ${parsedResponse.status}`
+      : (parsedResponse.bodyAsText as string);
+
+    const error = new RestError(
+      initialErrorMessage,
+      undefined,
+      parsedResponse.status,
+      parsedResponse.request,
+      parsedResponse
+    );
+
+    try {
+      // If error response has a body, try to extract error code & message from it
+      // Then try to deserialize it using default body mapper
+      if (parsedResponse.parsedBody) {
+        const parsedBody = parsedResponse.parsedBody;
+        const internalError: any = parsedBody.error || parsedBody;
+        error.code = internalError.code;
+        if (internalError.message) {
+          error.message = internalError.message;
+        }
+
+        if (defaultBodyMapper) {
+          let valueToDeserialize: any = parsedBody;
+          if (operationSpec.isXML && defaultBodyMapper.type.name === MapperType.Sequence) {
+            valueToDeserialize =
+              typeof parsedBody === "object" ? parsedBody[defaultBodyMapper.xmlElementName!] : [];
+          }
+          error.response!.parsedBody = operationSpec.serializer.deserialize(
+            defaultBodyMapper,
+            valueToDeserialize,
+            "error.response.parsedBody"
+          );
+        }
+      }
+
+      // If error response has headers, try to deserialize it using default header mapper
+      if (parsedResponse.headers && defaultHeadersMapper) {
+        error.response!.parsedHeaders = operationSpec.serializer.deserialize(
+          defaultHeadersMapper,
+          parsedResponse.headers.rawHeaders(),
+          "operationRes.parsedHeaders"
+        );
+      }
+    } catch (defaultError) {
+      error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody - "${parsedResponse.bodyAsText}" for the default response.`;
+    }
+    throw error;
+  }
+
+  return undefined;
 }
 
 function parse(

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -151,7 +151,11 @@ export function deserializeResponseBody(
 
     const responseSpec = getOperationResponse(parsedResponse);
 
-    const { error, shouldReturnResponse } = handleErrorResponse(parsedResponse, operationSpec, responseSpec);
+    const { error, shouldReturnResponse } = handleErrorResponse(
+      parsedResponse,
+      operationSpec,
+      responseSpec
+    );
     if (error) {
       throw error;
     } else if (shouldReturnResponse) {
@@ -218,19 +222,19 @@ function handleErrorResponse(
 ): { error: RestError | null; shouldReturnResponse: boolean } {
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const isExpectedStatusCode: boolean = isOperationSpecEmpty(operationSpec)
-      ? isSuccessByStatus
-      : !!responseSpec;
+    ? isSuccessByStatus
+    : !!responseSpec;
 
-  if(isExpectedStatusCode) {
+  if (isExpectedStatusCode) {
     if (responseSpec) {
-      if(!responseSpec.isError) {
+      if (!responseSpec.isError) {
         return { error: null, shouldReturnResponse: false };
       }
     } else {
       return { error: null, shouldReturnResponse: false };
     }
   }
-  
+
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 
   // If the item failed but there's no error spec or default spec, just return it as-is.

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -203,6 +203,12 @@ export function deserializeResponseBody(
   });
 }
 
+function isOperationSpecEmpty(operationSpec: OperationSpec):boolean {
+  const expectedStatusCodes = Object.keys(operationSpec.responses);
+  return (expectedStatusCodes.length === 0 ||
+      (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default"));
+}
+
 function handleErrorResponse(
   parsedResponse: HttpOperationResponse,
   operationSpec: OperationSpec
@@ -210,9 +216,11 @@ function handleErrorResponse(
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const responseSpec = operationSpec.responses[String(parsedResponse.status)];
   // Either we found a non-error response or the status is success.
-  if ((responseSpec && !responseSpec.isError) || (!responseSpec && isSuccessByStatus)) {
-    return { error: null, shouldReturnResponse: false };
-  }
+  if((responseSpec && !responseSpec.isError)
+   || (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
+   ) {
+    return { error: null, shouldReturnResponse: false};
+  }  
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -171,7 +171,10 @@ export function deserializeResponseBody(
 
     let parsedResponseStatus: RESPONSE_STATUS;
 
-    if (nonErrorResponseCodes.includes(parsedResponse.status + "")) {
+    if (
+      nonErrorResponseCodes.includes(parsedResponse.status + "") ||
+      (200 <= parsedResponse.status && parsedResponse.status < 300)
+    ) {
       parsedResponseStatus = RESPONSE_STATUS.NONERROR;
     } else {
       if (errorResponseCodes.includes(parsedResponse.status + "")) {

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -203,10 +203,12 @@ export function deserializeResponseBody(
   });
 }
 
-function isOperationSpecEmpty(operationSpec: OperationSpec):boolean {
+function isOperationSpecEmpty(operationSpec: OperationSpec): boolean {
   const expectedStatusCodes = Object.keys(operationSpec.responses);
-  return (expectedStatusCodes.length === 0 ||
-      (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default"));
+  return (
+    expectedStatusCodes.length === 0 ||
+    (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default")
+  );
 }
 
 function handleErrorResponse(
@@ -216,11 +218,12 @@ function handleErrorResponse(
   const isSuccessByStatus = 200 <= parsedResponse.status && parsedResponse.status < 300;
   const responseSpec = operationSpec.responses[String(parsedResponse.status)];
   // Either we found a non-error response or the status is success.
-  if((responseSpec && !responseSpec.isError)
-   || (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
-   ) {
-    return { error: null, shouldReturnResponse: false};
-  }  
+  if (
+    (responseSpec && !responseSpec.isError) ||
+    (!responseSpec && isOperationSpecEmpty(operationSpec) && isSuccessByStatus)
+  ) {
+    return { error: null, shouldReturnResponse: false };
+  }
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  coreHttpVersion: "1.1.10",
+  coreHttpVersion: "1.2.0",
 
   /**
    * Specifies HTTP.

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -742,6 +742,149 @@ describe("deserializationPolicy", function() {
         assert.strictEqual(e.response.parsedBody.message, "InvalidResourceNameBody");
       }
     });
+
+    it(`with non default error response headers`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = new Serializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          500: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+            isError: true
+          }
+        },
+        serializer
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 500,
+        headers: new HttpHeaders({
+          "x-ms-error-code": "InvalidResourceNameHeader"
+        }),
+        bodyAsText: '{"message": "InvalidResourceNameBody"}'
+      };
+
+      try {
+        await deserializeResponse(response);
+        assert.fail();
+      } catch (e) {
+        assert(e);
+        assert.strictEqual(e.response.parsedHeaders.errorCode, "InvalidResourceNameHeader");
+        assert.strictEqual(e.response.parsedBody.message, "InvalidResourceNameBody");
+      }
+    });
+
+    it(`with non default complex error response`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message1: {
+              type: {
+                name: "String"
+              }
+            },
+            message2: {
+              type: {
+                name: "String"
+              }
+            },
+            message3: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            errorCode: {
+              serializedName: "x-ms-error-code",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = new Serializer(HeadersMapper, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          503: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+            isError: true
+          }
+        },
+        serializer
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 503,
+        headers: new HttpHeaders({
+          "x-ms-error-code": "InvalidResourceNameHeader"
+        }),
+        bodyAsText:
+          '{"message1": "InvalidResourceNameBody1", "message2": "InvalidResourceNameBody2", "message3": "InvalidResourceNameBody3"}'
+      };
+
+      try {
+        await deserializeResponse(response);
+        assert.fail();
+      } catch (e) {
+        assert(e);
+        assert.strictEqual(e.response.parsedHeaders.errorCode, "InvalidResourceNameHeader");
+        assert.strictEqual(e.response.parsedBody.message1, "InvalidResourceNameBody1");
+        assert.strictEqual(e.response.parsedBody.message2, "InvalidResourceNameBody2");
+        assert.strictEqual(e.response.parsedBody.message3, "InvalidResourceNameBody3");
+      }
+    });
   });
 });
 


### PR DESCRIPTION
This PR is to address the issue https://github.com/Azure/azure-sdk-for-js/issues/8881

@joheredi Please review and approve

Note: I have set the release date for 2020-10-16. Let me know of I need to change it.  