### PR TITLE
[Identity] Interactive Browser Credential samples idea

### DIFF
--- a/sdk/identity/identity/samples/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/samples/interactiveBrowserCredential.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { InteractiveBrowserCredential } from "../src/credentials/interactiveBrowserCredential";
+
+/**
+ * The `InteractiveBrowserCredential` pops up a browser window where users
+ * are be able to safely authenticate with the Azure Active Directory.
+ * 
+ * This sample file uses the `InteractiveBrowserCredential` to retrieve a token.
+ */
+async function main() {
+  const credential = new InteractiveBrowserCredential();
+  const token = await credential.getToken('https://vault.azure.net/.default');
+  console.log({ token });
+}
+  
+main().then(console.log).catch((e) => console.error(e));
+  
+/** 
+ * As an example authenticating a specific Azure SDK client, here we can see how to
+ * authenticate the Key Vault Keys client to retrieve the properties of the existing keys:
+ *
+ * ```ts
+ * const identity = require("@azure/identity");
+ * const { KeyClient } = require("@azure/keyvault-keys");
+ * 
+ * async function main() {
+ *   // To specify a specific port, in case the port 80 is busy, you can do:
+ *   // const credential = new identity.InteractiveBrowserCredential({ redirectUri: "http://localhost:8080" });
+ *
+ *   const credential = new identity.InteractiveBrowserCredential();
+ *   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
+ *   const client = new KeyClient(keyVaultUrl, credential);
+ * 
+ *   // Retrieving the properties of the existing keys in that specific Key Vault.
+ *   console.log(await client.listPropertiesOfKeys().next());
+ * }
+ * 
+ * main().then(console.log).catch((e) => console.error(e));
+ * ```
+ */

--- a/sdk/identity/identity/samples/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/samples/interactiveBrowserCredential.ts
@@ -3,6 +3,10 @@
 
 import { InteractiveBrowserCredential } from "../src/credentials/interactiveBrowserCredential";
 
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
 /**
  * The `InteractiveBrowserCredential` pops up a browser window where users
  * are be able to safely authenticate with the Azure Active Directory.
@@ -10,7 +14,12 @@ import { InteractiveBrowserCredential } from "../src/credentials/interactiveBrow
  * This sample file uses the `InteractiveBrowserCredential` to retrieve a token.
  */
 async function main() {
-  const credential = new InteractiveBrowserCredential();
+  const credential = new InteractiveBrowserCredential({
+    // By default, tenantId will be "organizations". You might assign a specific tenant this way.
+    tenantId: process.env.AZURE_TENANT_ID,
+    // By default, clientId will be the same used by the Azure CLI. You might assign a specific client ID this way.
+    clientId: process.env.AZURE_CLIENT_ID
+  });
   const token = await credential.getToken('https://vault.azure.net/.default');
   console.log({ token });
 }

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -31,7 +31,27 @@ class AuthenticationRequired extends CredentialUnavailable {}
 /**
  * Enables authentication to Azure Active Directory inside of the web browser
  * using the interactive login flow, either via browser redirects or a popup
- * window.  This credential is not currently supported in Node.js.
+ * window.
+ *
+ * Example usage authenticating the Key Vault Keys client:
+ * ```ts
+ * const identity = require("@azure/identity");
+ * const { KeyClient } = require("@azure/keyvault-keys");
+ *
+ * async function main() {
+ *   // To specify a specific port, in case the port 80 is busy, you can do:
+ *   // const credential = new identity.InteractiveBrowserCredential({ redirectUri: "http://localhost:8080" });
+ *
+ *   const credential = new identity.InteractiveBrowserCredential();
+ *   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
+ *   const client = new KeyClient(keyVaultUrl, credential);
+ *
+ *   // Retrieving the properties of the existing keys in that specific Key Vault.
+ *   console.log(await client.listPropertiesOfKeys().next());
+ * }
+ *
+ * main().then(console.log).catch((e) => console.error(e));
+ * ```
  */
 export class InteractiveBrowserCredential implements TokenCredential {
   private identityClient: IdentityClient;


### PR DESCRIPTION
This is a concept PR to address #11852 by providing clear samples on how to use the interactive browser credential.

Is this what was expected? Feedback appreciated.

If everything goes well and this gets eventually merged, this:
Fixes #11852

**Important:**
This does not include all of the AAD gymnastics one has to do. What would be the most appropriate place to write about that? Do we already have something? That part is language agnostic.

**TODO:**
Do it also like how .Net does it in a Markdown file. [Example link](https://github.com/Azure/azure-sdk-for-net/blob/feature/identity/140/sdk/identity/Azure.Identity/samples/ClientSideUserAuthentication.md).