### PR TITLE
[core-http] Redirect pipeline

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.10 (Unreleased)
 
+- Explicitly set `manual` redirect handling for node fetch. And fixing redirectPipeline [PR 11863](https://github.com/Azure/azure-sdk-for-js/pull/11863)
 
 ## 1.1.9 (2020-09-30)
 

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -142,6 +142,7 @@ export abstract class FetchHttpClient implements HttpClient {
       headers: httpRequest.headers.rawHeaders(),
       method: httpRequest.method,
       signal: abortController.signal,
+      redirect: "manual",
       ...platformSpecificRequestInit
     };
 

--- a/sdk/core/core-http/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-http/src/policies/redirectPolicy.ts
@@ -61,7 +61,11 @@ function handleRedirect(
   const locationHeader = response.headers.get("location");
   if (
     locationHeader &&
-    (status === 300 || status === 307 || (status === 303 && request.method === "POST")) &&
+    (status === 300 ||
+      (status === 301 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 302 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 303 && request.method === "POST") ||
+      status === 307) &&
     (!policy.maxRetries || currentRetries < policy.maxRetries)
   ) {
     const builder = URLBuilder.parse(request.url);
@@ -72,6 +76,7 @@ function handleRedirect(
     // redirected GET request if the redirect url is present in the location header
     if (status === 303) {
       request.method = "GET";
+      delete request.body;
     }
 
     return policy._nextPolicy

--- a/sdk/core/core-http/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-http/src/policies/redirectPolicy.ts
@@ -12,6 +12,11 @@ import {
 } from "./requestPolicy";
 
 /**
+ * Methods that are allowed to follow redirects 301 and 302
+ */
+const allowedRedirect = ["GET", "HEAD"];
+
+/**
  * Options for how redirect responses are handled.
  */
 export interface RedirectOptions {
@@ -62,8 +67,8 @@ function handleRedirect(
   if (
     locationHeader &&
     (status === 300 ||
-      (status === 301 && ["GET", "HEAD"].includes(request.method)) ||
-      (status === 302 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 301 && allowedRedirect.includes(request.method)) ||
+      (status === 302 && allowedRedirect.includes(request.method)) ||
       (status === 303 && request.method === "POST") ||
       status === 307) &&
     (!policy.maxRetries || currentRetries < policy.maxRetries)

--- a/sdk/core/core-http/test/policies/redirectPolicy.spec.ts
+++ b/sdk/core/core-http/test/policies/redirectPolicy.spec.ts
@@ -1,0 +1,273 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { RedirectPolicy } from "../../src/policies/redirectPolicy";
+import { WebResource } from "../../src/webResource";
+import { HttpOperationResponse } from "../../src/httpOperationResponse";
+import { HttpHeaders, RequestPolicyOptions } from "../../src/coreHttp";
+
+describe("RedirectPolicy", () => {
+  it("should not follow redirect if no location header", async () => {
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders()
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, 301);
+  });
+
+  it("should not follow POST 301 redirect", async function() {
+    const expectedStatusCode = 301;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 301 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 301 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "HEAD");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should not follow POST 302 redirect", async function() {
+    const expectedStatusCode = 302;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 302 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 302 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "HEAD");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow POST 303 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [303];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        if (!responseCodes.length) {
+          assert.strictEqual(_requestToSend.method, "GET", "Expected second request to be GET");
+        }
+
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should not follow GET 303 redirect", async function() {
+    const expectedStatusCode = 303;
+    const responseCodes = [303];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 307 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [307];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 300 redirect", async function() {
+    const expectedStatusCode = 200;
+    const responseCodes = [300];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {})
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should only try maxretries", async function() {
+    const expectedStatusCode = 300;
+    const maxretries = 1;
+    const responseCodes = [300, 300, 200];
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders({ location: "https://example.com/new" })
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions(), maxretries);
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should try to redirect 3 times by default", async function() {
+    const expectedStatusCode = 300;
+    let callCount = 0;
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        callCount++;
+        return Promise.resolve({
+          status: 300,
+          request: _requestToSend,
+          headers: new HttpHeaders({ location: "https://example.com/new" })
+        });
+      }
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+    assert.strictEqual(callCount, 21);
+  });
+});

--- a/sdk/core/core-https/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-https/src/policies/redirectPolicy.ts
@@ -11,6 +11,11 @@ import { URL } from "../util/url";
 export const redirectPolicyName = "redirectPolicy";
 
 /**
+ * Methods that are allowed to follow redirects 301 and 302
+ */
+const allowedRedirect = ["GET", "HEAD"];
+
+/**
  * Options for how redirect responses are handled.
  */
 export interface RedirectPolicyOptions {
@@ -48,8 +53,8 @@ async function handleRedirect(
   if (
     locationHeader &&
     (status === 300 ||
-      (status === 301 && ["GET", "HEAD"].includes(request.method)) ||
-      (status === 302 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 301 && allowedRedirect.includes(request.method)) ||
+      (status === 302 && allowedRedirect.includes(request.method)) ||
       (status === 303 && request.method === "POST") ||
       status === 307) &&
     currentRetries < maxRetries

--- a/sdk/core/core-https/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-https/src/policies/redirectPolicy.ts
@@ -47,7 +47,11 @@ async function handleRedirect(
   const locationHeader = headers.get("location");
   if (
     locationHeader &&
-    (status === 300 || status === 307 || (status === 303 && request.method === "POST")) &&
+    (status === 300 ||
+      (status === 301 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 302 && ["GET", "HEAD"].includes(request.method)) ||
+      (status === 303 && request.method === "POST") ||
+      status === 307) &&
     currentRetries < maxRetries
   ) {
     const url = new URL(locationHeader, request.url);
@@ -58,6 +62,7 @@ async function handleRedirect(
     // redirected GET request if the redirect url is present in the location header
     if (status === 303) {
       req.method = "GET";
+      delete req.body;
     }
 
     const res = await next(req);

--- a/sdk/core/core-https/test/redirectPolicy.spec.ts
+++ b/sdk/core/core-https/test/redirectPolicy.spec.ts
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { redirectPolicy } from "../src/policies/redirectPolicy";
+import * as sinon from "sinon";
+import { createHttpHeaders, createPipelineRequest, PipelineResponse, SendRequest } from "../src";
+
+describe("RedirectPolicy", () => {
+  it("should not follow redirect if no location header", async () => {
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 301
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+    const result = await policy.sendRequest(request, next);
+
+    assert.strictEqual(result.status, 301);
+  });
+
+  it("should not follow POST 301 redirect", async function() {
+    const expectedStatusCode = 301;
+    const request = createPipelineRequest({ url: "https://example.com", method: "POST" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 301
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+    const result = await policy.sendRequest(request, next);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 301 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 301
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 301 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "HEAD" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 301
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should not follow POST 302 redirect", async function() {
+    const expectedStatusCode = 302;
+    const request = createPipelineRequest({ url: "https://example.com", method: "POST" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 302
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+    const result = await policy.sendRequest(request, next);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 302 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 302
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 302 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "HEAD" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 302
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow POST 303 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "POST" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 303
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(next.lastCall.args[0].method, "GET");
+    assert.isUndefined(next.lastCall.args[0].body);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should not follow GET 303 redirect", async function() {
+    const expectedStatusCode = 303;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 303
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 307 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 307
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 300 redirect", async function() {
+    const expectedStatusCode = 200;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 300
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should only try maxretries", async function() {
+    const expectedStatusCode = 300;
+    const maxRetries = 1;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 300
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    const policy = redirectPolicy({ maxRetries });
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.onFirstCall().resolves(redirectResponse);
+    next.onSecondCall().resolves(redirectResponse);
+    next.onThirdCall().resolves(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should try to redirect 20 times by default", async function() {
+    const expectedStatusCode = 300;
+    const request = createPipelineRequest({ url: "https://example.com", method: "GET" });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({ location: "https://example.com/redirect" }),
+      request,
+      status: 300
+    };
+
+    const policy = redirectPolicy();
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(redirectResponse);
+
+    const result = await policy.sendRequest(request, next);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+    assert.strictEqual(next.callCount, 21);
+  });
+});


### PR DESCRIPTION
`core-http` has been using fetch without explicitly specifying a redirect behavior which defaults to `follow`. This caused our `redirectPipeline` to never actually execute.

In this PR I'm setting redirect to `manual` so that our pipeline handles redirects. Unfortunately there doesn't seem to be a way to set manual redirect handling for `XMLHttpRequest`, so browsers will keep the default behavior.


I'm also fixing the redirect logic to align with the [tests in Autorest Test Server ](https://github.com/Azure/autorest.testserver/blob/5eba43116b366969466663be449efc017c9f5a34/legacy/routes/httpResponses.js#L470)and be consistent with the other languages

Fixes #10103

