### PR TITLE
[MetricsAdvisor] Use PerMinute and PerSecond in granularity type

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Breaking] `IncidentRootCause` property `dimensionKey` is renamed to `seriesKey`. `AnomalyIncident.dimensionKey` is renamed to `rootDimensionKey`
 - [Breaking] The `-List` suffix is removed from Array properties in `MetricSeriesData` and `MetricsEnrichedSeriesData`. Plural form is used instead.
 - [Breaking] `*PageResponse` types now extends from `Array<ItemType>` instead of wrapping an array of `ItemType`. Their types names are also shortened.
+- [Breaking] Data feed ingestion granularity now has `"PerMinute"` and `"PerSecond"` instead of `"Minutely"` and `"Secondly"`.
 - Parameters of `Date` type now also accept strings. No validation is done for the strings. The SDK calls `new Date()` to convert them to `Date`.
 
 ## 1.0.0-beta.1 (2020-10-07)

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -222,7 +222,7 @@ export interface DataFeedDimension {
 
 // @public
 export type DataFeedGranularity = {
-    granularityType: "Yearly" | "Monthly" | "Weekly" | "Daily" | "Hourly" | "Minutely" | "Secondly";
+    granularityType: "Yearly" | "Monthly" | "Weekly" | "Daily" | "Hourly" | "PerMinute" | "PerSecond";
 } | {
     granularityType: "Custom";
     customGranularityValue: number;

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -58,7 +58,8 @@ import {
   toServiceAnomalyDetectionConfiguration,
   toServiceAnomalyDetectionConfigurationPatch,
   toServiceAlertConfiguration,
-  toServiceAlertConfigurationPatch
+  toServiceAlertConfigurationPatch,
+  toServiceGranularity
 } from "./transforms";
 
 /**
@@ -213,9 +214,7 @@ export class MetricsAdvisorAdministrationClient {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       const body = {
         dataFeedName: name,
-        granularityName: granularity.granularityType,
-        granularityAmount:
-          granularity.granularityType === "Custom" ? granularity.customGranularityValue : undefined,
+        ...toServiceGranularity(granularity),
         ...source,
         metrics: schema.metrics,
         dimension: schema.dimensions,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -249,8 +249,8 @@ export type DataFeedGranularity =
         | "Weekly"
         | "Daily"
         | "Hourly"
-        | "Minutely"
-        | "Secondly";
+        | "PerMinute"
+        | "PerSecond";
     }
   | {
       granularityType: "Custom";

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/transforms.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/transforms.spec.ts
@@ -7,15 +7,19 @@ import { assert } from "chai";
 import {
   AnomalyDetectionConfiguration as ServiceAnomalyDetectionConfiguration,
   AnomalyFeedback as ServiceAnomalyFeedback,
+  DataFeedDetailUnion as ServiceDataFeedDetailUnion,
+  Granularity as ServiceGranularity,
   ChangePointFeedback as ServiceChangePointFeedback,
   CommentFeedback as ServiceCommentFeedback,
   PeriodFeedback as ServicePeriodFeedback,
   WholeMetricConfiguration as ServiceWholeMetricConfiguration
 } from "../src/generated/models";
-import { MetricDetectionCondition } from "../src/models";
+import { DataFeedGranularity, MetricDetectionCondition } from "../src/models";
 import {
   fromServiceAnomalyDetectionConfiguration,
-  fromServiceMetricFeedbackUnion
+  fromServiceDataFeedDetailUnion,
+  fromServiceMetricFeedbackUnion,
+  toServiceGranularity
 } from "../src/transforms";
 
 describe("Transforms", () => {
@@ -159,5 +163,63 @@ describe("Transforms", () => {
       assert.equal(actual.periodValue, feedback.value.periodValue);
       assert.equal(actual.metricId, feedback.metricId);
     }
+  });
+
+  it("fromServiceDataFeedDetailUnion()", () => {
+    const serviceDataFeed: ServiceDataFeedDetailUnion = {
+      dataSourceType: "AzureBlob",
+      dataFeedName: "name",
+      metrics: [{ name: "m1", id: "m-id1", displayName: "m1 display" }],
+      dimension: [{ name: "d1", displayName: "d1 display" }],
+      granularityName: "Daily",
+      dataStartFrom: new Date(Date.UTC(2020, 9, 1))
+    };
+
+    const actual = fromServiceDataFeedDetailUnion(serviceDataFeed);
+
+    assert.strictEqual(actual.name, serviceDataFeed.dataFeedName);
+    assert.deepStrictEqual(actual.schema.dimensions, serviceDataFeed.dimension);
+    assert.deepStrictEqual(actual.schema.metrics, serviceDataFeed.metrics);
+    assert.strictEqual(actual.source.dataSourceType, serviceDataFeed.dataSourceType);
+  });
+
+  [
+    { original: "Yearly", expected: "Yearly" },
+    { original: "Daily", expected: "Daily" },
+    { original: "Secondly", expected: "PerSecond" },
+    { original: "Minutely", expected: "PerMinute" }
+  ].forEach((granularity) => {
+    it(`fromServiceDataFeedDetailUnion() on granularity ${granularity.original}`, () => {
+      const serviceDataFeed: ServiceDataFeedDetailUnion = {
+        dataSourceType: "AzureBlob",
+        dataFeedName: "name",
+        metrics: [{ name: "m1", id: "m-id1", displayName: "m1 display" }],
+        dimension: [{ name: "d1", displayName: "d1 display" }],
+        granularityName: granularity.original as ServiceGranularity,
+        dataStartFrom: new Date(Date.UTC(2020, 9, 1))
+      };
+
+      const actual = fromServiceDataFeedDetailUnion(serviceDataFeed);
+      assert.deepStrictEqual(actual.granularity, {
+        granularityType: granularity.expected
+      } as DataFeedGranularity);
+    });
+  });
+
+  [
+    { original: "Yearly", expected: "Yearly" },
+    { original: "Daily", expected: "Daily" },
+    { original: "PerSecond", expected: "Secondly" },
+    { original: "PerMinute", expected: "Minutely" }
+  ].forEach((granularity) => {
+    it(`toServiceGranularity() on granularity ${granularity.original}`, () => {
+      const from = {
+        granularityType: granularity.original
+      } as DataFeedGranularity;
+
+      const actual = toServiceGranularity(from);
+
+      assert.strictEqual(actual.granularityName, granularity.expected);
+    });
   });
 });


### PR DESCRIPTION
instead of Minutely and Secondly