### PR TITLE
Parallelize smoke test resource deployments. Improve script readability.

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -45,6 +45,8 @@ param (
   $RemainingArguments
 )
 
+$repoRoot = Resolve-Path -Path "$PSScriptRoot../../../"
+
 function OutputWarning {
   param([string] $Output)
 
@@ -57,17 +59,8 @@ function OutputWarning {
 
 }
 
-$previousEnvironmentVariables = @{ }
-
 function SetEnvironmentVariable {
-  param(
-    [string] $Name,
-    [string] $Value
-  )
-
-  if ($previousEnvironmentVariables.ContainsKey($Name) -and $previousEnvironmentVariables[$Name] -ne $Value) {
-    OutputWarning "Environment variable already set: $Name with different value"
-  }
+  param([string] $Name, [string] $Value)
 
   if ($CI) {
     Write-Host "##vso[task.setvariable variable=_$Name;issecret=true;]$($Value)"
@@ -79,94 +72,41 @@ function SetEnvironmentVariable {
   }
 }
 
-Write-Verbose "Setting AAD environment variables for Test Application..."
-SetEnvironmentVariable -Name AZURE_CLIENT_ID -Value $TestApplicationId
-SetEnvironmentVariable -Name AZURE_CLIENT_SECRET -Value $TestApplicationSecret
-SetEnvironmentVariable -Name AZURE_TENANT_ID -Value $TenantId
+function SetEnvironmentVariables {
+  Write-Verbose "Setting AAD environment variables for Test Application..."
+  SetEnvironmentVariable -Name AZURE_CLIENT_ID -Value $TestApplicationId
+  SetEnvironmentVariable -Name AZURE_CLIENT_SECRET -Value $TestApplicationSecret
+  SetEnvironmentVariable -Name AZURE_TENANT_ID -Value $TenantId
 
-Write-Verbose "Setting cloud-specific environment variables"
-$cloudEnvironment = Get-AzEnvironment -Name $Environment
-SetEnvironmentVariable -Name AZURE_AUTHORITY_HOST -Value $cloudEnvironment.ActiveDirectoryAuthority
-
-$repoRoot = Resolve-Path -Path "$PSScriptRoot../../../"
-
-Write-Verbose "Detecting samples..."
-$javascriptSamples = (Get-ChildItem -Path "$repoRoot/sdk/$ServiceDirectory/*/samples/javascript/" -Directory
-  | Where-Object { Test-Path "$_/package.json" })
-
-$manifest = $javascriptSamples | ForEach-Object {
-  # Example: C:\code\azure-sdk-for-js\sdk\appconfiguration\app-configuration\samples\javascript
-  @{
-    # Package name for example "app-configuration"
-    Name               = ((Join-Path $_ ../../) | Get-Item).Name;
-
-    # Path to "app-configuration" part from example
-    PackageDirectory   = ((Join-Path $_ ../../) | Get-Item).FullName;
-
-    # Service Directory for example "appconfiguration"
-    ResourcesDirectory = ((Join-Path $_ ../../../) | Get-Item).Name;
-  }
+  Write-Verbose "Setting cloud-specific environment variables"
+  $cloudEnvironment = Get-AzEnvironment -Name $Environment
+  SetEnvironmentVariable -Name AZURE_AUTHORITY_HOST -Value $cloudEnvironment.ActiveDirectoryAuthority
 }
 
-$deployedServiceDirectories = @{ }
-$runManifest = @()
-$dependencies = New-Object 'system.collections.generic.dictionary[string,string]'
-$baseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
-$resourceGroupName = "rg-smoke-$baseName"
+function GenerateDeployManifest {
+  Write-Verbose "Detecting samples..."
+  $javascriptSamples = (Get-ChildItem -Path "$repoRoot/sdk/$ServiceDirectory/*/samples/javascript/" -Directory
+    | Where-Object { Test-Path "$_/package.json" })
 
-# Use the same resource group name that New-TestResources.ps1 generates
-SetEnvironmentVariable -Name 'AZURE_RESOURCEGROUP_NAME' -Value $resourceGroupName
+  $manifest = $javascriptSamples | ForEach-Object {
+    # Example: azure-sdk-for-js/sdk/appconfiguration/app-configuration/samples/javascript
+    @{
+      # Package name for example "app-configuration"
+      Name               = ((Join-Path $_ ../../) | Get-Item).Name;
 
-foreach ($entry in $manifest) {
-  if (!(Get-ChildItem -Path "$repoRoot/sdk/$($entry.ResourcesDirectory)" -Filter test-resources.json -Recurse)) {
-    Write-Verbose "Skipping $($entry.ResourcesDirectory): could not find test-resources.json"
-    continue
-  }
+      # Path to "app-configuration" part from example
+      PackageDirectory   = ((Join-Path $_ ../../) | Get-Item).FullName;
 
-  try {
-    Write-Verbose "Deploying resources for $($entry.Name)..."
-    if ($deployedServiceDirectories.ContainsKey($entry.ResourcesDirectory) -ne $true) {
-
-      # Force -CI to false here. This is to have the script make use of
-      # -BaseName so that all resources are created within the same resource
-      # group for easier cleanup. All created environment variables are returned
-      # to $deployOutput so they can be set in the user's context or in CI.
-      $deployOutput = &"$repoRoot/eng/common/TestResources/New-TestResources.ps1" `
-        -BaseName  $baseName `
-        -ResourceGroupName $resourceGroupName `
-        -ServiceDirectory $entry.ResourcesDirectory `
-        -TestApplicationId $TestApplicationId `
-        -TestApplicationSecret $TestApplicationSecret `
-        -ProvisionerApplicationId $TestApplicationId `
-        -ProvisionerApplicationSecret $TestApplicationSecret `
-        -TestApplicationOid $TestApplicationOid `
-        -TenantId $TenantId `
-        -SubscriptionId $SubscriptionId `
-        -Location $Location `
-        -Environment $Environment `
-        -AdditionalParameters $AdditionalParameters `
-        -DeleteAfterHours 24 `
-        -Force `
-        -Verbose `
-        -CI:$CI
-
-      $deployedServiceDirectories[$entry.ResourcesDirectory] = $true;
-
-      foreach ($key in $deployOutput.Keys) {
-        SetEnvironmentVariable -Name $key -Value $deployOutput[$key]
-      }
+      # Service Directory for example "appconfiguration"
+      ResourcesDirectory = ((Join-Path $_ ../../../) | Get-Item).Name;
     }
-    else {
-      Write-Verbose "Skipping resource directory deployment (already deployed) for $($entry.ResourcesDirectory)"
-    }
+  }
 
-  }
-  catch {
-    OutputWarning "Failed to deploy $($entry.Name) $($_.Exception.Message)"
-    Write-Warning "Failed to deploy $($entry.Name)"
-    Write-Host $_.Exception.Message
-    continue
-  }
+  return $manifest
+}
+
+function UpdateSamplesForService {
+  Param([Parameter(Mandatory = $true)] $entry)
 
   Write-Verbose "Preparing samples for $($entry.Name)"
   dev-tool samples prep --directory $entry.PackageDirectory --use-packages
@@ -174,13 +114,17 @@ foreach ($entry in $manifest) {
   # Resolve full path for samples location. This has to be set after sample
   # prep because the directory will not resolve until the folder exists.
   $entry.SamplesDirectory = Join-Path -Path $entry.PackageDirectory -ChildPath 'dist-samples/javascript' -Resolve
+}
 
-  # Set outputs
-  $runManifest += $entry
+function UpdateSampleDependencies {
+  Param(
+    [Parameter(Mandatory = $true)] $sample,
+    [Parameter(Mandatory = $true)] $dependencies
+  )
 
   # Set sample's dependencies in all-up dependencies for smoke tests
-  Write-Verbose "Updating local package.json with dependencies from smoke test for $($entry.Name)"
-  $packageSpec = (Get-Content -Path "$($entry.SamplesDirectory)/package.json"
+  Write-Verbose "Updating local package.json with dependencies from smoke test for $($sample.Name)"
+  $packageSpec = (Get-Content -Path "$($sample.SamplesDirectory)/package.json"
     | ConvertFrom-Json -AsHashtable)
 
   foreach ($dep in $packageSpec.dependencies.Keys) {
@@ -191,30 +135,126 @@ foreach ($entry in $manifest) {
       $dependencies[$dep] = $packageSpec.dependencies[$dep]
     }
   }
-
-
 }
 
-Write-Verbose "Writing run-manifest.json"
-($runManifest | ConvertTo-Json -AsArray | Set-Content -Path "$repoRoot/common/smoke-test/run-manifest.json" -Force)
+function NewTestResources {
+  Param(
+    [Parameter(Mandatory = $true)] [System.Collections.Hashtable]$entry,
+    [Parameter(Mandatory = $true)] [string]$baseName,
+    [Parameter(Mandatory = $true)] [string]$resourceGroupName
+  )
 
-Write-Verbose "Writing dependencies into Smoke Test package.json"
-$runnerPackageSpec = Get-Content "$repoRoot/common/smoke-test/package.json" | ConvertFrom-Json -AsHashtable
-$runnerPackageSpec.dependencies = $dependencies
-($runnerPackageSpec | ConvertTo-Json | Set-Content "$repoRoot/common/smoke-test/package.json")
+  # Force -CI to false here. This is to have the script make use of
+  # -BaseName so that all resources are created within the same resource
+  # group for easier cleanup. All created environment variables are returned
+  # to $deployOutput so they can be set in the user's context or in CI.
+  $deployOutput = &"$repoRoot/eng/common/TestResources/New-TestResources.ps1" `
+    -BaseName  $baseName `
+    -ResourceGroupName $resourceGroupName `
+    -ServiceDirectory $entry.ResourcesDirectory `
+    -TestApplicationId $TestApplicationId `
+    -TestApplicationSecret $TestApplicationSecret `
+    -ProvisionerApplicationId $TestApplicationId `
+    -ProvisionerApplicationSecret $TestApplicationSecret `
+    -TestApplicationOid $TestApplicationOid `
+    -TenantId $TenantId `
+    -SubscriptionId $SubscriptionId `
+    -Location $Location `
+    -Environment $Environment `
+    -AdditionalParameters $AdditionalParameters `
+    -DeleteAfterHours 24 `
+    -Force `
+    -Verbose `
+    -CI:$CI
 
-SetEnvironmentVariable -Name "NODE_PATH" -Value "$PSScriptRoot/node_modules"
-
-if ($CI) {
-  # If in CI mark the task as successful even if there are warnings so the
-  # pipeline execution status shows up as red or green
-  Write-Host "##vso[task.complete result=Succeeded; ]DONE"
+  return $deployOutput
 }
 
+function DeployTestResources {
+  Param([Parameter(Mandatory = $true)] $deployManifest)
+
+  $deployedServiceDirectories = @{ }
+  $baseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
+  $resourceGroupName = "rg-smoke-$baseName"
+  $dependencies = New-Object 'System.Collections.Concurrent.ConcurrentDictionary[string,string]'
+  $runManifest = [System.Collections.ArrayList]::Synchronized((New-Object 'System.Collections.ArrayList'))
+
+  # Use the same resource group name that New-TestResources.ps1 generates
+  SetEnvironmentVariable -Name 'AZURE_RESOURCEGROUP_NAME' -Value $resourceGroupName
+
+  foreach ($entry in $deployManifest) {
+    if (!(Get-ChildItem -Path "$repoRoot/sdk/$($entry.ResourcesDirectory)" -Filter test-resources.json -Recurse)) {
+      Write-Verbose "Skipping $($entry.ResourcesDirectory): could not find test-resources.json"
+      continue
+    }
+
+    try {
+      if ($deployedServiceDirectories.ContainsKey($entry.ResourcesDirectory) -ne $true) {
+        $deployOutput = NewTestResources $entry $baseName $resourceGroupName
+        $deployedServiceDirectories[$entry.ResourcesDirectory] = $true;
+
+        foreach ($key in $deployOutput.Keys) {
+          SetEnvironmentVariable -Name $key -Value $deployOutput[$key]
+        }
+      }
+      else {
+        Write-Verbose "Skipping resource directory deployment (already deployed) for $($entry.ResourcesDirectory)"
+      }
+
+    }
+    catch {
+      OutputWarning "Failed to deploy $($entry.Name) $($_.Exception.Message)"
+      Write-Warning "Failed to deploy $($entry.Name)"
+      Write-Host $_.Exception.Message
+      continue
+    }
+
+    UpdateSamplesForService $entry
+    UpdateSampleDependencies $entry $dependencies
+    $runManifest.Add($entry)
+  }
+
+  return @{
+    Dependencies = $dependencies;
+    RunManifest = $runManifest
+  }
+}
+
+function WriteConfigs {
+  Param(
+    [Parameter(Mandatory = $true)] [System.Collections.Generic.Dictionary[string,string]]$dependencies,
+    [Parameter(Mandatory = $true)] [System.Object[]]$runManifest
+  )
+
+  Write-Verbose "Writing run-manifest.json"
+  ($runManifest | ConvertTo-Json -AsArray | Set-Content -Path "$repoRoot/common/smoke-test/run-manifest.json" -Force)
+
+  Write-Verbose "Writing dependencies into Smoke Test package.json"
+  $runnerPackageSpec = Get-Content "$repoRoot/common/smoke-test/package.json" | ConvertFrom-Json -AsHashtable
+  $runnerPackageSpec.dependencies = $dependencies
+  ($runnerPackageSpec | ConvertTo-Json | Set-Content "$repoRoot/common/smoke-test/package.json")
+}
+
+function InitializeSmokeTests {
+  SetEnvironmentVariables
+  $deployManifest = GenerateDeployManifest
+  $configs = DeployTestResources $deployManifest
+  WriteConfigs $configs.Dependencies $configs.RunManifest
+
+  SetEnvironmentVariable -Name "NODE_PATH" -Value "$PSScriptRoot/node_modules"
+
+  if ($CI) {
+    # If in CI mark the task as successful even if there are warnings so the
+    # pipeline execution status shows up as red or green
+    Write-Host "##vso[task.complete result=Succeeded; ]DONE"
+  }
+}
+
+InitializeSmokeTests
 
 <#
 .SYNOPSIS
-Deploys resources, prepares onboarded samples, and creates run manifest for Smoke Tests
+Deploys resources, discovers and generates samples, configures local dependencies, and creates run manifest for Smoke Tests
 
 .DESCRIPTION
 


### PR DESCRIPTION
This PR makes two changes:

1. Refactors `common/smoke-test/Initialize-SmokeTests.ps1` to be more readable, by moving all logic into functions.
2. Parallelizes the resource deployment logic. This reduces our total smoke test pipeline duration by 25-35 minutes, which is a roughly 50% reduction in total pipeline duration.

```
$ Measure-Command { ./Initialize-SmokeTests.ps1 -Verbose @subscriptionConfiguration }
...
Minutes           : 3
Seconds           : 31
...
```

Due to the refactoring, reviewing the parallelization logic may be annoying. All that logic can be reviewed in isolation in the [second commit](https://github.com/Azure/azure-sdk-for-js/commit/39ee0ae5bc1561b90a922bf0bf7e37810cacaea3)