### PR TITLE
Include SharedAccessSignature in SB & EH connection string model

### DIFF
--- a/sdk/core/core-amqp/src/auth/sas.ts
+++ b/sdk/core/core-amqp/src/auth/sas.ts
@@ -79,7 +79,7 @@ export class SharedKeyCredential {
    */
   static fromConnectionString(connectionString: string): SharedKeyCredential {
     const parsed = parseConnectionString<
-      ServiceBusConnectionStringModel & { SharedAccessSignature: string }
+      ServiceBusConnectionStringModel
     >(connectionString);
 
     if (parsed.SharedAccessSignature == null) {

--- a/sdk/core/core-amqp/src/auth/sas.ts
+++ b/sdk/core/core-amqp/src/auth/sas.ts
@@ -78,9 +78,7 @@ export class SharedKeyCredential {
    * @param {string} connectionString - The EventHub/ServiceBus connection string
    */
   static fromConnectionString(connectionString: string): SharedKeyCredential {
-    const parsed = parseConnectionString<
-      ServiceBusConnectionStringModel
-    >(connectionString);
+    const parsed = parseConnectionString<ServiceBusConnectionStringModel>(connectionString);
 
     if (parsed.SharedAccessSignature == null) {
       return new SharedKeyCredential(parsed.SharedAccessKeyName, parsed.SharedAccessKey);

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -64,6 +64,7 @@ export interface ServiceBusConnectionStringModel {
   Endpoint: string;
   SharedAccessKeyName: string;
   SharedAccessKey: string;
+  SharedAccessSignature?: string
   EntityPath?: string;
   [x: string]: any;
 }
@@ -75,6 +76,7 @@ export interface EventHubConnectionStringModel {
   Endpoint: string;
   SharedAccessKeyName: string;
   SharedAccessKey: string;
+  SharedAccessSignature?: string
   EntityPath?: string;
   [x: string]: any;
 }

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -64,7 +64,7 @@ export interface ServiceBusConnectionStringModel {
   Endpoint: string;
   SharedAccessKeyName: string;
   SharedAccessKey: string;
-  SharedAccessSignature?: string
+  SharedAccessSignature?: string;
   EntityPath?: string;
   [x: string]: any;
 }
@@ -76,7 +76,7 @@ export interface EventHubConnectionStringModel {
   Endpoint: string;
   SharedAccessKeyName: string;
   SharedAccessKey: string;
-  SharedAccessSignature?: string
+  SharedAccessSignature?: string;
   EntityPath?: string;
   [x: string]: any;
 }


### PR DESCRIPTION
#11893 and #11894 are issues requesting a parser for Service Bus and Event Hubs connection strings.
We already have a method `parseConnectionString<T>(connectionString): T` exposed from `@azure/core-amqp` that does something like this. The differences are
-  This method uses a type variable. The user is expected to pass either `EventHubConnectionStringModel` or `ServiceBusConnectionStringModel` or any type of their choice. If a user does not pass any type variable, they get a json object representing all the key value pairs in the connection string, but no help on the names of the keys. 
- The models allow more than the restricted set of values listed in #11893 and #11894
- The models reflect the keys in the connection string as is and does not use the custom names like `FullyQualifiedNamespace` or `EventHubName`
- The method does not do any validation listed in #11893 and #11894


The main motivation behind the issues that were logged is to assist with transforming a connection string for use with credential-based client creation. With this PR, the parseConnectionString method along with the EH & SB connection string models are good enough for the time being, though not perfect.



@richardpark-msft, @HarshaNalluru, @bterlson, @jsquire, Thoughts?    