### PR TITLE
[Identity] Device Code Credential samples idea

### DIFF
--- a/sdk/identity/identity/samples/deviceCodeCredential.ts
+++ b/sdk/identity/identity/samples/deviceCodeCredential.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DeviceCodeCredential } from "../src/credentials/deviceCodeCredential";
+
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+/**
+ * The `DeviceCodeCredential` prints a URL and a code. The URL allows users to authenticate with the printed code.
+ * 
+ * This sample file uses the `DeviceCodeCredential` to retrieve a token.
+ */
+async function main() {
+  const credential = new DeviceCodeCredential(
+    // By default, tenantId will be "organizations". You might assign a specific tenant this way.
+    process.env.AZURE_TENANT_ID!,
+    // By default, clientId will be the same used by the Azure CLI. You might assign a specific client ID this way.
+    process.env.AZURE_CLIENT_ID!
+  );
+  const token = await credential.getToken('https://vault.azure.net/.default');
+  console.log({ token });
+}
+  
+main().then(console.log).catch((e) => console.error(e));
+  
+/** 
+ * As an example authenticating a specific Azure SDK client, here we can see how to
+ * authenticate the Key Vault Keys client to retrieve the properties of the existing keys:
+ *
+ * ```ts
+ * const identity = require("@azure/identity");
+ * const { KeyClient } = require("@azure/keyvault-keys");
+ * 
+ * async function main() {
+ *   const credential = new identity.DeviceCodeCredential();
+ *   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
+ *   const client = new KeyClient(keyVaultUrl, credential);
+ * 
+ *   // Retrieving the properties of the existing keys in that specific Key Vault.
+ *   console.log(await client.listPropertiesOfKeys().next());
+ * }
+ * 
+ * main().then(console.log).catch((e) => console.error(e));
+ * ```
+ */

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -53,6 +53,24 @@ export function defaultDeviceCodePromptCallback(deviceCodeInfo: DeviceCodeInfo):
 /**
  * Enables authentication to Azure Active Directory using a device code
  * that the user can enter into https://microsoft.com/devicelogin.
+ *
+ * As an example authenticating a specific Azure SDK client, here we can see how to
+ * authenticate the Key Vault Keys client to retrieve the properties of the existing keys:
+ * ```ts
+ * const identity = require("@azure/identity");
+ * const { KeyClient } = require("@azure/keyvault-keys");
+ *
+ * async function main() {
+ *   const credential = new identity.DeviceCodeCredential();
+ *   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
+ *   const client = new KeyClient(keyVaultUrl, credential);
+ *
+ *   // Retrieving the properties of the existing keys in that specific Key Vault.
+ *   console.log(await client.listPropertiesOfKeys().next());
+ * }
+ *
+ * main().then(console.log).catch((e) => console.error(e));
+ * ```
  */
 export class DeviceCodeCredential implements TokenCredential {
   private pca: PublicClientApplication;


### PR DESCRIPTION
This is a concept PR to address #11851 by providing clear samples on how to use the device code credential.

Is this what was expected? Feedback appreciated.

If everything goes well and this gets eventually merged, this:
Fixes #11851

**Important:**
This does not include all of the AAD gymnastics one has to do. What would be the most appropriate place to write about that? Do we already have something? That part is language agnostic.

**TODO:**
Do it also like how .Net does it in a Markdown file. [Example link](https://github.com/Azure/azure-sdk-for-net/blob/feature/identity/140/sdk/identity/Azure.Identity/samples/ClientSideUserAuthentication.md).