### PR TITLE
[service-bus] Pass in ProcessErrorArgs to subscribe({ processError }) for extra diagnostics

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,8 +8,8 @@
   [PR 11651](https://github.com/Azure/azure-sdk-for-js/pull/11651)
   and
   [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
-- The `processError` passed to `Receiver.subscribe` has an new additional parameter - `ProcessErrorContext`. This parameter provides additional context that can make it simpler to distinguish
-  errors that were thrown from your callback (via the `errorSource` member of `ProcessErrorContext`) as well as giving you some information about the entity that generated the error.
+- The `processError` passed to `Receiver.subscribe` now receives a `ProcessErrorArgs` instead of just an error. This parameter provides additional context that can make it simpler to distinguish
+  errors that were thrown from your callback (via the `errorSource` member of `ProcessErrorArgs`) as well as giving you some information about the entity that generated the error.
   [PR 11927](https://github.com/Azure/azure-sdk-for-js/pull/11927)
 
 ## 7.0.0-preview.7 (2020-10-07)

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,9 @@
   [PR 11651](https://github.com/Azure/azure-sdk-for-js/pull/11651)
   and
   [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
+- The `processError` passed to `Receiver.subscribe` has an new additional parameter - `ProcessErrorContext`. This parameter provides additional context that can make it simpler to distinguish
+  errors that were thrown from your callback (via the `errorSource` member of `ProcessErrorContext`) as well as giving you some information about the entity that generated the error.
+  [PR 11927](https://github.com/Azure/azure-sdk-for-js/pull/11927)
 
 ## 7.0.0-preview.7 (2020-10-07)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -35,6 +35,7 @@
   - `acceptSession`, which opens a session by name
   - `acceptNextSession`, which opens the next available session, determined by Service Bus.
   - as part of this `CreateSessionReceiverOptions` has been renamed to `AcceptSessionReceiverOptions` to conform to guidelines.
+- The `processError` handler passed to `Receiver.subscribe` now takes a `ProcessErrorArgs` instead of just an error.
 
 ## 7.0.0-preview.6 (2020-09-10)
 

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -194,10 +194,10 @@ const myMessageHandler = async (message) => {
   // your code here
   console.log(`message.body: ${message.body}`);
 };
-const myErrorHandler = async (error, context) => {
+const myErrorHandler = async (args) => {
   console.log(
-    `Error occurred with ${context.entityPath} within ${context.fullyQualifiedNamespace}: `,
-    error
+    `Error occurred with ${args.entityPath} within ${args.fullyQualifiedNamespace}: `,
+    args.error
   );
 };
 receiver.subscribe({

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -133,7 +133,7 @@ The following sections provide code snippets that cover some of the common tasks
 Once you have created an instance of a `ServiceBusClient` class, you can get a `Sender`
 using the [createSender][sbclient_createsender] method.
 
-This gives you a sender which you can use to [send][sender_send] messages.
+This gives you a sender which you can use to [send][sender_sendmessages] messages.
 
 ```javascript
 const sender = serviceBusClient.createSender("my-queue");
@@ -175,7 +175,7 @@ You can use this receiver in one of 3 ways to receive messages:
 
 #### Get an array of messages
 
-Use the [receiveMessages][receiverreceivebatch] function which returns a promise that
+Use the [receiveMessages][receiver_receivemessages] function which returns a promise that
 resolves to an array of messages.
 
 ```javascript
@@ -229,7 +229,7 @@ To learn more, please read [Settling Received Messages](https://docs.microsoft.c
 > read more about how to configure this feature in the portal [here][docsms_messagesessions_fifo].
 
 In order to send messages to a session, use the `ServiceBusClient` to create a sender using
-[createSender][sbclient_createsender]. This gives you a sender which you can use to [send][sender_send] messages.
+[createSender][sbclient_createsender]. This gives you a sender which you can use to [send][sender_sendmessages] messages.
 
 When sending the message, set the `sessionId` property in the message to ensure
 your message lands in the right session.
@@ -378,19 +378,19 @@ If you'd like to contribute to this library, please read the [contributing guide
 [azure_identity]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md
 [defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential
 [sbclient]: https://docs.microsoft.com/javascript/api/%40azure/service-bus/servicebusclient?view=azure-node-preview
-[sbclient_constructor]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#servicebusclient-string--servicebusclientoptions-
-[sbclient_tokencred_overload]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#servicebusclient-string--tokencredential--servicebusclientoptions-
-[sbclient_createsender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createsender-string-
-[sbclient_createreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createreceiver-string--createreceiveroptions--peeklock---
+[sbclient_constructor]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#ServiceBusClient_string__ServiceBusClientOptions_
+[sbclient_tokencred_overload]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#ServiceBusClient_string__TokenCredential__ServiceBusClientOptions_
+[sbclient_createsender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createSender_string_
+[sbclient_createreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createReceiver_string__CreateReceiverOptions__peekLock___
 [sbclient_acceptsession]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#acceptSession_string__string__AcceptSessionOptions__peekLock___
-[sender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/sender?view=azure-node-preview
-[sender_send]: https://docs.microsoft.com/javascript/api/@azure/service-bus/sender?view=azure-node-preview#sendmessages-servicebusmessage---servicebusmessage-----servicebusmessagebatch--operationoptionsbase-
-[receiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/receiver?view=azure-node-preview
-[receiverreceivebatch]: https://docs.microsoft.com/javascript/api/@azure/service-bus/receiver?view=azure-node-preview#receivemessages-number--receivemessagesoptions-
-[receiver_subscribe]: https://docs.microsoft.com/javascript/api/@azure/service-bus/receiver?view=azure-node-preview#subscribe-messagehandlers-receivedmessaget---subscribeoptions-
-[receiver_getmessageiterator]: https://docs.microsoft.com/javascript/api/@azure/service-bus/receiver?view=azure-node-preview#getmessageiterator-getmessageiteratoroptions-
-[sessionreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/sessionreceiver?view=azure-node-preview
-[migrationguide]: https://github.com/Azure/azure-sdk-for-js/blob/fb53a838e702a075c4db6f1d4a17849a271342df/sdk/servicebus/service-bus/migrationguide.md
+[sender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebussender?view=azure-node-preview
+[sender_sendmessages]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebussender?view=azure-node-preview#sendMessages_ServiceBusMessage___ServiceBusMessage_____ServiceBusMessageBatch__OperationOptionsBase_
+[receiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusreceiver?view=azure-node-preview
+[receiver_receivemessages]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusreceiver?view=azure-node-preview#receiveMessages_number__ReceiveMessagesOptions_
+[receiver_subscribe]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusreceiver?view=azure-node-preview#subscribe_MessageHandlers_ReceivedMessageT___SubscribeOptions_
+[receiver_getmessageiterator]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusreceiver?view=azure-node-preview#getMessageIterator_GetMessageIteratorOptions_
+[sessionreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebussessionreceiver?view=azure-node-preview
+[migrationguide]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/migrationguide.md
 [docsms_messagesessions]: https://docs.microsoft.com/azure/service-bus-messaging/message-sessions
 [docsms_messagesessions_fifo]: https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#first-in-first-out-fifo-pattern
 [queue_concept]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview#queues

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -112,7 +112,7 @@ To interact with these resources, one should be familiar with the following SDK 
 
 - Send messages, to a queue or topic, using a [`Sender`][sender] created using [`ServiceBusClient.createSender()`][sbclient_createsender].
 - Receive messages, from either a queue or a subscription, using a [`Receiver`][receiver] created using [`ServiceBusClient.createReceiver()`][sbclient_createreceiver].
-- Receive messages, from session enabled queues or subscriptions, using a [`SessionReceiver`][sessionreceiver] created using [`ServiceBusClient.acceptSession()`][sbclient_createsessionreceiver].
+- Receive messages, from session enabled queues or subscriptions, using a [`SessionReceiver`][sessionreceiver] created using [`ServiceBusClient.acceptSession()`][sbclient_acceptsession].
 
 Please note that the Queues, Topics and Subscriptions should be created prior to using this library.
 
@@ -382,7 +382,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 [sbclient_tokencred_overload]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#servicebusclient-string--tokencredential--servicebusclientoptions-
 [sbclient_createsender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createsender-string-
 [sbclient_createreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createreceiver-string--createreceiveroptions--peeklock---
-[sbclient_createsessionreceiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#createsessionreceiver-string--createsessionreceiveroptions--peeklock---
+[sbclient_acceptsession]: https://docs.microsoft.com/javascript/api/@azure/service-bus/servicebusclient?view=azure-node-preview#acceptSession_string__string__AcceptSessionOptions__peekLock___
 [sender]: https://docs.microsoft.com/javascript/api/@azure/service-bus/sender?view=azure-node-preview
 [sender_send]: https://docs.microsoft.com/javascript/api/@azure/service-bus/sender?view=azure-node-preview#sendmessages-servicebusmessage---servicebusmessage-----servicebusmessagebatch--operationoptionsbase-
 [receiver]: https://docs.microsoft.com/javascript/api/@azure/service-bus/receiver?view=azure-node-preview

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -192,9 +192,13 @@ When you are done, call `receiver.close()` to stop receiving any more messages.
 ```javascript
 const myMessageHandler = async (message) => {
   // your code here
+  console.log(`message.body: ${message.body}`);
 };
-const myErrorHandler = async (error) => {
-  console.log(error);
+const myErrorHandler = async (error, context) => {
+  console.log(
+    `Error occurred with ${context.entityPath} within ${context.fullyQualifiedNamespace}: `,
+    error
+  );
 };
 receiver.subscribe({
   processMessage: myMessageHandler,

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -101,8 +101,9 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   queueOrSubscriptionReceiver.subscribe({
     processMessage: onMessageFn,
     // `processError` is now declared as async and should return a promise.
-    processError: async (err) => {
-      onErrorFn(err);
+    processError: async (args: ProcessErrorArgs) => {
+      // additional information is in 'args' to provide context for the error.
+      onErrorFn(args.error);
     }
   });
   ```

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -234,7 +234,7 @@ export interface ProcessErrorContext {
     /**
      * Errors thrown from the user's `processMessage` callback passed to `subscribe`
      */
-     | "userCallback"
+     | "processMessageCallback"
     /**
      * Errors thrown when receiving messages.
      */
@@ -249,15 +249,7 @@ export interface ProcessErrorContext {
      * Broadly covers a series of phases - the actual initialization that occurs when an operation
      * is first started as well as errors that occur when reconnecting.
      */
-     | "initialize"
-    /**
-     * Errors thrown when accepting a session.
-     */
-     | "acceptSession"
-    /**
-     * Errors thrown when closing a session.
-     */
-     | "closeSession";
+     | "initialize";
     fullyQualifiedNamespace: string;
 }
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -193,7 +193,7 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {
 
 // @public
 export interface MessageHandlers<ReceivedMessageT> {
-    processError(err: Error, context: ProcessErrorContext): Promise<void>;
+    processError(args: ProcessErrorArgs): Promise<void>;
     processMessage(message: ReceivedMessageT): Promise<void>;
 }
 
@@ -224,27 +224,10 @@ export interface PeekMessagesOptions extends OperationOptionsBase {
 }
 
 // @public
-export interface ProcessErrorContext {
+export interface ProcessErrorArgs {
     entityPath: string;
-    errorSource: "complete"
-    /**
-     * Covers errors that occur when the user (or autoComplete) abandons a message.
-     */
-     | "abandon"
-    /**
-     * Errors thrown from the user's `processMessage` callback passed to `subscribe`
-     */
-     | "processMessageCallback"
-    /**
-     * Errors thrown when receiving messages.
-     */
-     | "receive"
-    /**
-     * Errors thrown when the user calls renewLock or when the internal lock renewer calls renewLock.
-     * Automatic lock renewal can be enabled via the `CreateReceiverOptions.maxAutoLockRenewalDurationInMs`
-     * property passed when calling `ServiceBusClient.createReceiver()`
-     */
-     | "renewLock";
+    error: Error | MessagingError;
+    errorSource: "abandon" | "complete" | "processMessageCallback" | "receive" | "renewLock";
     fullyQualifiedNamespace: string;
 }
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -244,12 +244,7 @@ export interface ProcessErrorContext {
      * Automatic lock renewal can be enabled via the `CreateReceiverOptions.maxAutoLockRenewalDurationInMs`
      * property passed when calling `ServiceBusClient.createReceiver()`
      */
-     | "renewLock"
-    /**
-     * Broadly covers a series of phases - the actual initialization that occurs when an operation
-     * is first started as well as errors that occur when reconnecting.
-     */
-     | "initialize";
+     | "renewLock";
     fullyQualifiedNamespace: string;
 }
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -193,7 +193,7 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {
 
 // @public
 export interface MessageHandlers<ReceivedMessageT> {
-    processError(err: Error): Promise<void>;
+    processError(err: Error, context: ProcessErrorContext): Promise<void>;
     processMessage(message: ReceivedMessageT): Promise<void>;
 }
 
@@ -221,6 +221,44 @@ export type OperationOptionsBase = Pick<OperationOptions, "abortSignal" | "traci
 // @public
 export interface PeekMessagesOptions extends OperationOptionsBase {
     fromSequenceNumber?: Long;
+}
+
+// @public
+export interface ProcessErrorContext {
+    entityPath: string;
+    errorSource: "complete"
+    /**
+     * Covers errors that occur when the user (or autoComplete) abandons a message.
+     */
+     | "abandon"
+    /**
+     * Errors thrown from the user's `processMessage` callback passed to `subscribe`
+     */
+     | "userCallback"
+    /**
+     * Errors thrown when receiving messages.
+     */
+     | "receive"
+    /**
+     * Errors thrown when the user calls renewLock or when the internal lock renewer calls renewLock.
+     * Automatic lock renewal can be enabled via the `CreateReceiverOptions.maxAutoLockRenewalDurationInMs`
+     * property passed when calling `ServiceBusClient.createReceiver()`
+     */
+     | "renewLock"
+    /**
+     * Broadly covers a series of phases - the actual initialization that occurs when an operation
+     * is first started as well as errors that occur when reconnecting.
+     */
+     | "initialize"
+    /**
+     * Errors thrown when accepting a session.
+     */
+     | "acceptSession"
+    /**
+     * Errors thrown when closing a session.
+     */
+     | "closeSession";
+    fullyQualifiedNamespace: string;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -104,7 +104,7 @@ async function receiveMessage() {
       }
     };
     const processError = async (err) => {
-      console.log(">>>>> Error occurred: ", err);
+      console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
     };
     receiver.subscribe(
       { processMessage, processError },

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -103,8 +103,8 @@ async function receiveMessage() {
         await brokeredMessage.deadLetter();
       }
     };
-    const processError = async (err) => {
-      console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
+    const processError = async (args) => {
+      console.log(`>>>>> Error from error source ${args.errorSource} occurred: `, args.error);
     };
     receiver.subscribe(
       { processMessage, processError },

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -103,8 +103,8 @@ async function receiveFromNextSession(serviceBusClient) {
           refreshTimer();
           await processMessage(msg);
         },
-        async processError(err, context) {
-          rejectSessionWithError(err);
+        async processError(args) {
+          rejectSessionWithError(args.error);
         }
       },
       {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -103,7 +103,7 @@ async function receiveFromNextSession(serviceBusClient) {
           refreshTimer();
           await processMessage(msg);
         },
-        async processError(err) {
+        async processError(err, context) {
           rejectSessionWithError(err);
         }
       },

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -30,8 +30,8 @@ async function main() {
     await brokeredMessage.complete();
   };
 
-  const processError = async (err, context) => {
-    console.log(`Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`Error from error source ${args.errorSource} occurred: `, args.error);
   };
 
   try {

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -30,8 +30,8 @@ async function main() {
     await brokeredMessage.complete();
   };
 
-  const processError = async (err) => {
-    console.log("Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`Error from error source ${context.errorSource} occurred: `, err);
   };
 
   try {

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -75,8 +75,8 @@ async function receiveMessages(sbClient) {
     console.log(`Received message: ${brokeredMessage.body} - ${brokeredMessage.label}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err) => {
-    console.log("Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`Error from error source ${context.errorSource} occurred: `, err);
   };
 
   console.log(`\nStarting receiver immediately at ${new Date(Date.now())}`);

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -75,8 +75,8 @@ async function receiveMessages(sbClient) {
     console.log(`Received message: ${brokeredMessage.body} - ${brokeredMessage.label}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err, context) => {
-    console.log(`Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`Error from error source ${args.errorSource} occurred: `, args.error);
   };
 
   console.log(`\nStarting receiver immediately at ${new Date(Date.now())}`);

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -81,8 +81,8 @@ async function receiveMessages(sbClient, sessionId) {
   const processMessage = async (message) => {
     console.log(`Received: ${message.sessionId} - ${message.body} `);
   };
-  const processError = async (err) => {
-    console.log(">>>>> Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
   };
 
   receiver.subscribe({

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -81,8 +81,8 @@ async function receiveMessages(sbClient, sessionId) {
   const processMessage = async (message) => {
     console.log(`Received: ${message.sessionId} - ${message.body} `);
   };
-  const processError = async (err, context) => {
-    console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`>>>>> Error from error source ${args.errorSource} occurred: `, args.error);
   };
 
   receiver.subscribe({

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -105,8 +105,8 @@ async function receiveMessage() {
         await brokeredMessage.deadLetter();
       }
     };
-    const processError = async (err) => {
-      console.log(">>>>> Error occurred: ", err);
+    const processError = async (err, context) => {
+      console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
     };
 
     receiver.subscribe(

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -105,8 +105,8 @@ async function receiveMessage() {
         await brokeredMessage.deadLetter();
       }
     };
-    const processError = async (err, context) => {
-      console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
+    const processError = async (args) => {
+      console.log(`>>>>> Error from error source ${args.errorSource} occurred: `, args.error);
     };
 
     receiver.subscribe(

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -112,7 +112,7 @@ async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promi
           refreshTimer();
           await processMessage(msg);
         },
-        async processError(err) {
+        async processError(err, context) {
           rejectSessionWithError(err);
         }
       },

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -112,8 +112,8 @@ async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promi
           refreshTimer();
           await processMessage(msg);
         },
-        async processError(err, context) {
-          rejectSessionWithError(err);
+        async processError(args) {
+          rejectSessionWithError(args.error);
         }
       },
       {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -34,8 +34,8 @@ export async function main() {
     console.log(`Received message: ${brokeredMessage.body}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err, context) => {
-    console.log(`Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`Error from error source ${args.errorSource} occurred: `, args.error);
   };
 
   try {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -34,8 +34,8 @@ export async function main() {
     console.log(`Received message: ${brokeredMessage.body}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err) => {
-    console.log("Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`Error from error source ${context.errorSource} occurred: `, err);
   };
 
   try {

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -78,8 +78,8 @@ async function receiveMessages(sbClient: ServiceBusClient) {
     console.log(`Received message: ${brokeredMessage.body} - ${brokeredMessage.label}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err) => {
-    console.log("Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`Error from error source ${context.errorSource} occurred: `, err);
   };
 
   console.log(`\nStarting receiver immediately at ${new Date(Date.now())}`);

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -78,8 +78,8 @@ async function receiveMessages(sbClient: ServiceBusClient) {
     console.log(`Received message: ${brokeredMessage.body} - ${brokeredMessage.label}`);
     await brokeredMessage.complete();
   };
-  const processError = async (err, context) => {
-    console.log(`Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`Error from error source ${args.errorSource} occurred: `, args.error);
   };
 
   console.log(`\nStarting receiver immediately at ${new Date(Date.now())}`);

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -85,8 +85,8 @@ async function receiveMessages(sbClient: ServiceBusClient, sessionId: string) {
   const processMessage = async (message: ServiceBusMessage) => {
     console.log(`Received: ${message.sessionId} - ${message.body} `);
   };
-  const processError = async (err, context) => {
-    console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
+  const processError = async (args) => {
+    console.log(`>>>>> Error from error source ${args.errorSource} occurred: `, args.error);
   };
   receiver.subscribe({
     processMessage,

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -85,8 +85,8 @@ async function receiveMessages(sbClient: ServiceBusClient, sessionId: string) {
   const processMessage = async (message: ServiceBusMessage) => {
     console.log(`Received: ${message.sessionId} - ${message.body} `);
   };
-  const processError = async (err) => {
-    console.log(">>>>> Error occurred: ", err);
+  const processError = async (err, context) => {
+    console.log(`>>>>> Error from error source ${context.errorSource} occurred: `, err);
   };
   receiver.subscribe({
     processMessage,

--- a/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
+++ b/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
@@ -6,7 +6,7 @@ import { receiverLogger as logger } from "../log";
 import { ServiceBusMessageImpl } from "../serviceBusMessage";
 import { calculateRenewAfterDuration } from "../util/utils";
 import { LinkEntity } from "./linkEntity";
-import { OnError } from "./messageReceiver";
+import { OnErrorNoContext } from "./messageReceiver";
 
 /**
  * @internal
@@ -118,7 +118,7 @@ export class LockRenewer {
    *
    * @param bMessage The message whose lock renewal we will start.
    */
-  start(linkEntity: MinimalLink, bMessage: RenewableMessageProperties, onError: OnError) {
+  start(linkEntity: MinimalLink, bMessage: RenewableMessageProperties, onError: OnErrorNoContext) {
     try {
       const logPrefix = linkEntity.logPrefix;
 

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -14,7 +14,7 @@ import { LinkEntity, ReceiverType } from "./linkEntity";
 import { ConnectionContext } from "../connectionContext";
 import { DispositionType, ServiceBusMessageImpl } from "../serviceBusMessage";
 import { getUniqueName } from "../util/utils";
-import { ProcessErrorContext, ReceiveMode, SubscribeOptions } from "../models";
+import { ProcessErrorArgs, ReceiveMode, SubscribeOptions } from "../models";
 import { DispositionStatusOptions } from "./managementClient";
 import { AbortSignalLike } from "@azure/core-http";
 import { onMessageSettled, DeferredPromiseAndTimer } from "./shared";
@@ -84,7 +84,7 @@ export interface OnError {
    * NOTE: if this signature changes make sure you reflect those same changes in the
    * `OnErrorNoContext` definition below.
    */
-  (error: MessagingError | Error, context: ProcessErrorContext): void;
+  (args: ProcessErrorArgs): void;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -14,7 +14,7 @@ import { LinkEntity, ReceiverType } from "./linkEntity";
 import { ConnectionContext } from "../connectionContext";
 import { DispositionType, ServiceBusMessageImpl } from "../serviceBusMessage";
 import { getUniqueName } from "../util/utils";
-import { ReceiveMode, SubscribeOptions } from "../models";
+import { ProcessErrorContext, ReceiveMode, SubscribeOptions } from "../models";
 import { DispositionStatusOptions } from "./managementClient";
 import { AbortSignalLike } from "@azure/core-http";
 import { onMessageSettled, DeferredPromiseAndTimer } from "./shared";
@@ -80,7 +80,21 @@ export interface OnMessage {
 export interface OnError {
   /**
    * Handler for any error that occurs while receiving or processing messages.
+   *
+   * NOTE: if this signature changes make sure you reflect those same changes in the
+   * `OnErrorNoContext` definition below.
    */
+  (error: MessagingError | Error, context: ProcessErrorContext): void;
+}
+
+/**
+ * An onError method but without the context property. Used when wrapping OnError
+ * with an implicit ProcessErrorContext. Used by LockRenewer.
+ *
+ * @internal
+ * @ignore
+ */
+export interface OnErrorNoContext {
   (error: MessagingError | Error): void;
 }
 

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -25,7 +25,7 @@ import {
 } from "@azure/core-amqp";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
 import { receiverLogger as logger } from "../log";
-import { AmqpError, EventContext, isAmqpError, OnAmqpEvent } from "rhea-promise";
+import { AmqpError, EventContext, OnAmqpEvent } from "rhea-promise";
 import { ServiceBusMessageImpl } from "../serviceBusMessage";
 import { AbortSignalLike } from "@azure/abort-controller";
 
@@ -281,22 +281,19 @@ export class StreamingReceiver extends MessageReceiver {
       try {
         await this._onMessage(bMessage);
       } catch (err) {
-        // This ensures we call users' error handler when users' message handler throws.
-        if (!isAmqpError(err)) {
-          logger.logError(
-            err,
-            "%s An error occurred while running user's message handler for the message " +
-              "with id '%s' on the receiver '%s'",
-            this.logPrefix,
-            bMessage.messageId,
-            this.name
-          );
-          this._onError!(err, {
-            errorSource: "processMessageCallback",
-            entityPath: this.entityPath,
-            fullyQualifiedNamespace: this._context.config.host
-          });
-        }
+        logger.logError(
+          err,
+          "%s An error occurred while running user's message handler for the message " +
+            "with id '%s' on the receiver '%s'",
+          this.logPrefix,
+          bMessage.messageId,
+          this.name
+        );
+        this._onError!(err, {
+          errorSource: "processMessageCallback",
+          entityPath: this.entityPath,
+          fullyQualifiedNamespace: this._context.config.host
+        });
 
         // Do not want renewLock to happen unnecessarily, while abandoning the message. Hence,
         // doing this here. Otherwise, this should be done in finally.

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -292,7 +292,7 @@ export class StreamingReceiver extends MessageReceiver {
             this.name
           );
           this._onError!(err, {
-            errorSource: "userCallback",
+            errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
           });

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -199,7 +199,11 @@ export class StreamingReceiver extends MessageReceiver {
                 "retryable, we let the user know about it by calling the user's error handler.",
               this.logPrefix
             );
-            this._onError!(sbError);
+            this._onError!(sbError, {
+              errorSource: "receive",
+              entityPath: this.entityPath,
+              fullyQualifiedNamespace: this._context.config.host
+            });
           } else {
             logger.verbose(
               "%s The received error is not retryable. However, the receiver was " +
@@ -234,7 +238,11 @@ export class StreamingReceiver extends MessageReceiver {
               "retryable, we let the user know about it by calling the user's error handler.",
             this.logPrefix
           );
-          this._onError!(sbError);
+          this._onError!(sbError, {
+            errorSource: "receive",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         }
       }
     };
@@ -262,7 +270,11 @@ export class StreamingReceiver extends MessageReceiver {
 
       this._lockRenewer?.start(this, bMessage, (err) => {
         if (this._onError) {
-          this._onError(err);
+          this._onError(err, {
+            errorSource: "renewLock",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         }
       });
 
@@ -279,7 +291,11 @@ export class StreamingReceiver extends MessageReceiver {
             bMessage.messageId,
             this.name
           );
-          this._onError!(err);
+          this._onError!(err, {
+            errorSource: "userCallback",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         }
 
         // Do not want renewLock to happen unnecessarily, while abandoning the message. Hence,
@@ -314,7 +330,11 @@ export class StreamingReceiver extends MessageReceiver {
               bMessage.messageId,
               this.name
             );
-            this._onError!(translatedError);
+            this._onError!(translatedError, {
+              errorSource: "abandon",
+              entityPath: this.entityPath,
+              fullyQualifiedNamespace: this._context.config.host
+            });
           }
         }
         return;
@@ -346,7 +366,11 @@ export class StreamingReceiver extends MessageReceiver {
             bMessage.messageId,
             this.name
           );
-          this._onError!(translatedError);
+          this._onError!(translatedError, {
+            errorSource: "complete",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         }
       }
     };
@@ -513,7 +537,11 @@ export class StreamingReceiver extends MessageReceiver {
       if (typeof this._onError === "function") {
         logger.verbose(`${this.logPrefix} Unable to automatically reconnect`);
         try {
-          this._onError(err);
+          this._onError(err, {
+            errorSource: "initialize",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         } catch (err) {
           logger.logError(
             err,

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -199,7 +199,8 @@ export class StreamingReceiver extends MessageReceiver {
                 "retryable, we let the user know about it by calling the user's error handler.",
               this.logPrefix
             );
-            this._onError!(sbError, {
+            this._onError!({
+              error: sbError,
               errorSource: "receive",
               entityPath: this.entityPath,
               fullyQualifiedNamespace: this._context.config.host
@@ -238,7 +239,8 @@ export class StreamingReceiver extends MessageReceiver {
               "retryable, we let the user know about it by calling the user's error handler.",
             this.logPrefix
           );
-          this._onError!(sbError, {
+          this._onError!({
+            error: sbError,
             errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
@@ -270,7 +272,8 @@ export class StreamingReceiver extends MessageReceiver {
 
       this._lockRenewer?.start(this, bMessage, (err) => {
         if (this._onError) {
-          this._onError(err, {
+          this._onError({
+            error: err,
             errorSource: "renewLock",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
@@ -289,7 +292,8 @@ export class StreamingReceiver extends MessageReceiver {
           bMessage.messageId,
           this.name
         );
-        this._onError!(err, {
+        this._onError!({
+          error: err,
           errorSource: "processMessageCallback",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host
@@ -327,7 +331,8 @@ export class StreamingReceiver extends MessageReceiver {
               bMessage.messageId,
               this.name
             );
-            this._onError!(translatedError, {
+            this._onError!({
+              error: translatedError,
               errorSource: "abandon",
               entityPath: this.entityPath,
               fullyQualifiedNamespace: this._context.config.host
@@ -363,7 +368,8 @@ export class StreamingReceiver extends MessageReceiver {
             bMessage.messageId,
             this.name
           );
-          this._onError!(translatedError, {
+          this._onError!({
+            error: translatedError,
             errorSource: "complete",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
@@ -534,7 +540,8 @@ export class StreamingReceiver extends MessageReceiver {
       if (typeof this._onError === "function") {
         logger.verbose(`${this.logPrefix} Unable to automatically reconnect`);
         try {
-          this._onError(err, {
+          this._onError({
+            error: err,
             errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -538,7 +538,7 @@ export class StreamingReceiver extends MessageReceiver {
         logger.verbose(`${this.logPrefix} Unable to automatically reconnect`);
         try {
           this._onError(err, {
-            errorSource: "initialize",
+            errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
           });

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -22,7 +22,7 @@ export {
   AcceptSessionOptions,
   GetMessageIteratorOptions,
   MessageHandlers,
-  ProcessErrorContext,
+  ProcessErrorArgs,
   PeekMessagesOptions,
   ReceiveMessagesOptions,
   ReceiveMode,

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -10,7 +10,7 @@ export {
   RetryOptions,
   TokenCredential,
   TokenType,
-  WebSocketOptions
+  WebSocketOptions,
 } from "@azure/core-amqp";
 export { OperationOptions } from "@azure/core-http";
 export { Delivery, WebSocketImpl } from "rhea-promise";
@@ -22,11 +22,12 @@ export {
   AcceptSessionOptions,
   GetMessageIteratorOptions,
   MessageHandlers,
+  ProcessErrorContext,
   PeekMessagesOptions,
   ReceiveMessagesOptions,
   ReceiveMode,
   SubQueue,
-  SubscribeOptions
+  SubscribeOptions,
 } from "./models";
 export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEventHubs";
 export { ServiceBusReceiver } from "./receivers/receiver";
@@ -36,18 +37,18 @@ export { NamespaceProperties } from "./serializers/namespaceResourceSerializer";
 export {
   CreateQueueOptions,
   QueueProperties,
-  QueueRuntimeProperties
+  QueueRuntimeProperties,
 } from "./serializers/queueResourceSerializer";
 export { RuleProperties, SqlRuleAction, SqlRuleFilter } from "./serializers/ruleResourceSerializer";
 export {
   CreateSubscriptionOptions,
   SubscriptionProperties,
-  SubscriptionRuntimeProperties
+  SubscriptionRuntimeProperties,
 } from "./serializers/subscriptionResourceSerializer";
 export {
   CreateTopicOptions,
   TopicProperties,
-  TopicRuntimeProperties
+  TopicRuntimeProperties,
 } from "./serializers/topicResourceSerializer";
 export {
   EntitiesResponse,
@@ -60,7 +61,7 @@ export {
   SubscriptionResponse,
   SubscriptionRuntimePropertiesResponse,
   TopicResponse,
-  TopicRuntimePropertiesResponse
+  TopicRuntimePropertiesResponse,
 } from "./serviceBusAtomManagementClient";
 export { ServiceBusClient } from "./serviceBusClient";
 export {
@@ -70,7 +71,7 @@ export {
   DeadLetterOptions,
   ServiceBusReceivedMessage,
   ServiceBusReceivedMessageWithLock,
-  ServiceBusMessage
+  ServiceBusMessage,
 } from "./serviceBusMessage";
 export { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
 export { AuthorizationRule, EntityStatus, EntityAvailabilityStatus } from "./util/utils";

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -10,7 +10,7 @@ export {
   RetryOptions,
   TokenCredential,
   TokenType,
-  WebSocketOptions,
+  WebSocketOptions
 } from "@azure/core-amqp";
 export { OperationOptions } from "@azure/core-http";
 export { Delivery, WebSocketImpl } from "rhea-promise";
@@ -27,7 +27,7 @@ export {
   ReceiveMessagesOptions,
   ReceiveMode,
   SubQueue,
-  SubscribeOptions,
+  SubscribeOptions
 } from "./models";
 export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEventHubs";
 export { ServiceBusReceiver } from "./receivers/receiver";
@@ -37,18 +37,18 @@ export { NamespaceProperties } from "./serializers/namespaceResourceSerializer";
 export {
   CreateQueueOptions,
   QueueProperties,
-  QueueRuntimeProperties,
+  QueueRuntimeProperties
 } from "./serializers/queueResourceSerializer";
 export { RuleProperties, SqlRuleAction, SqlRuleFilter } from "./serializers/ruleResourceSerializer";
 export {
   CreateSubscriptionOptions,
   SubscriptionProperties,
-  SubscriptionRuntimeProperties,
+  SubscriptionRuntimeProperties
 } from "./serializers/subscriptionResourceSerializer";
 export {
   CreateTopicOptions,
   TopicProperties,
-  TopicRuntimeProperties,
+  TopicRuntimeProperties
 } from "./serializers/topicResourceSerializer";
 export {
   EntitiesResponse,
@@ -61,7 +61,7 @@ export {
   SubscriptionResponse,
   SubscriptionRuntimePropertiesResponse,
   TopicResponse,
-  TopicRuntimePropertiesResponse,
+  TopicRuntimePropertiesResponse
 } from "./serviceBusAtomManagementClient";
 export { ServiceBusClient } from "./serviceBusClient";
 export {
@@ -71,7 +71,7 @@ export {
   DeadLetterOptions,
   ServiceBusReceivedMessage,
   ServiceBusReceivedMessageWithLock,
-  ServiceBusMessage,
+  ServiceBusMessage
 } from "./serviceBusMessage";
 export { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
 export { AuthorizationRule, EntityStatus, EntityAvailabilityStatus } from "./util/utils";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -12,12 +12,12 @@ export interface ProcessErrorContext {
    * The operation where the error originated.
    */
   errorSource: /**
-   * Covers errors that occur when autoComplete completes a message.
+   * Errors that occur when autoComplete completes a message.
    */
   | "complete"
     /**
-     * Covers errors that occur when an error thrown from the user's processMessage callback
-     * causes a message to be abandoned.
+     * Errors that occur when automatic message `abandon` fails. Automatic
+     * message abandon'ing occurs when the `processMessage` handler throws an error.
      */
     | "abandon"
     /**

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -16,7 +16,7 @@ export interface ProcessErrorContext {
    */
   | "complete"
     /**
-     * Covers errors that occur when autoComplete or (failure from the user's processMessage callback)
+     * Covers errors that occur when an error thrown from the user's processMessage callback
      * causes a message to be abandoned.
      */
     | "abandon"

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -5,6 +5,59 @@ import { OperationOptionsBase } from "./modelsToBeSharedWithEventHubs";
 import Long from "long";
 
 /**
+ * Context for the error given in processError.
+ */
+export interface ProcessErrorContext {
+  /**
+   * The operation where the error originated.
+   */
+  errorSource: /**
+   * Covers errors that occur when the user (or autoComplete) completes a message.
+   */
+  | "complete"
+    /**
+     * Covers errors that occur when the user (or autoComplete) abandons a message.
+     */
+    | "abandon"
+    /**
+     * Errors thrown from the user's `processMessage` callback passed to `subscribe`
+     */
+    | "userCallback"
+    /**
+     * Errors thrown when receiving messages.
+     */
+    | "receive"
+    /**
+     * Errors thrown when the user calls renewLock or when the internal lock renewer calls renewLock.
+     * Automatic lock renewal can be enabled via the `CreateReceiverOptions.maxAutoLockRenewalDurationInMs`
+     * property passed when calling `ServiceBusClient.createReceiver()`
+     */
+    | "renewLock"
+    /**
+     * Broadly covers a series of phases - the actual initialization that occurs when an operation
+     * is first started as well as errors that occur when reconnecting.
+     */
+    | "initialize"
+    /**
+     * Errors thrown when accepting a session.
+     */
+    | "acceptSession"
+    /**
+     * Errors thrown when closing a session.
+     */
+    | "closeSession";
+
+  /**
+   * The entity path for the current receiver.
+   */
+  entityPath: string;
+  /**
+   * The fully qualified namespace for the Service Bus.
+   */
+  fullyQualifiedNamespace: string;
+}
+
+/**
  * The general message handler interface (used for streamMessages).
  */
 export interface MessageHandlers<ReceivedMessageT> {
@@ -18,7 +71,7 @@ export interface MessageHandlers<ReceivedMessageT> {
    * Handler that processes errors that occur during receiving.
    * @param err An error from Service Bus.
    */
-  processError(err: Error): Promise<void>;
+  processError(err: Error, context: ProcessErrorContext): Promise<void>;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -12,11 +12,12 @@ export interface ProcessErrorContext {
    * The operation where the error originated.
    */
   errorSource: /**
-   * Covers errors that occur when the user (or autoComplete) completes a message.
+   * Covers errors that occur when autoComplete completes a message.
    */
   | "complete"
     /**
-     * Covers errors that occur when the user (or autoComplete) abandons a message.
+     * Covers errors that occur when autoComplete or (failure from the user's processMessage callback)
+     * causes a message to be abandoned.
      */
     | "abandon"
     /**

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -22,7 +22,7 @@ export interface ProcessErrorContext {
     /**
      * Errors thrown from the user's `processMessage` callback passed to `subscribe`
      */
-    | "userCallback"
+    | "processMessageCallback"
     /**
      * Errors thrown when receiving messages.
      */
@@ -37,15 +37,7 @@ export interface ProcessErrorContext {
      * Broadly covers a series of phases - the actual initialization that occurs when an operation
      * is first started as well as errors that occur when reconnecting.
      */
-    | "initialize"
-    /**
-     * Errors thrown when accepting a session.
-     */
-    | "acceptSession"
-    /**
-     * Errors thrown when closing a session.
-     */
-    | "closeSession";
+    | "initialize";
 
   /**
    * The entity path for the current receiver.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -32,12 +32,7 @@ export interface ProcessErrorContext {
      * Automatic lock renewal can be enabled via the `CreateReceiverOptions.maxAutoLockRenewalDurationInMs`
      * property passed when calling `ServiceBusClient.createReceiver()`
      */
-    | "renewLock"
-    /**
-     * Broadly covers a series of phases - the actual initialization that occurs when an operation
-     * is first started as well as errors that occur when reconnecting.
-     */
-    | "initialize";
+    | "renewLock";
 
   /**
    * The entity path for the current receiver.

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -270,9 +270,7 @@ export class ServiceBusReceiverImpl<
         }
 
         if (!this.isClosed) {
-          sReceiver.subscribe(async (message) => {
-            await onMessage(message);
-          }, onError);
+          sReceiver.subscribe(onMessage, onError);
         } else {
           await sReceiver.close();
         }

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -282,7 +282,7 @@ export class ServiceBusReceiverImpl<
         // TODO: being a bit broad here but the only errors that should filter out this
         // far are going to be bootstrapping the subscription.
         onError(err, {
-          errorSource: "initialize",
+          errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host
         });

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -263,7 +263,7 @@ export class ServiceBusReceiverImpl<
           await onInitialize();
         } catch (err) {
           onError(err, {
-            errorSource: "userCallback",
+            errorSource: "processMessageCallback",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
           });

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -262,7 +262,8 @@ export class ServiceBusReceiverImpl<
         try {
           await onInitialize();
         } catch (err) {
-          onError(err, {
+          onError({
+            error: err,
             errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
@@ -279,7 +280,8 @@ export class ServiceBusReceiverImpl<
       .catch((err) => {
         // TODO: being a bit broad here but the only errors that should filter out this
         // far are going to be bootstrapping the subscription.
-        onError(err, {
+        onError({
+          error: err,
           errorSource: "receive",
           entityPath: this.entityPath,
           fullyQualifiedNamespace: this._context.config.host

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -10,7 +10,7 @@ import {
   InternalMessageHandlers
 } from "../models";
 import { OperationOptionsBase, trace } from "../modelsToBeSharedWithEventHubs";
-import { ServiceBusReceivedMessage } from "..";
+import { ServiceBusReceivedMessage } from "../serviceBusMessage";
 import { ConnectionContext } from "../connectionContext";
 import {
   getAlreadyReceivingErrorMsg,
@@ -262,7 +262,11 @@ export class ServiceBusReceiverImpl<
         try {
           await onInitialize();
         } catch (err) {
-          onError(err);
+          onError(err, {
+            errorSource: "userCallback",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
         }
 
         if (!this.isClosed) {
@@ -275,7 +279,13 @@ export class ServiceBusReceiverImpl<
         return;
       })
       .catch((err) => {
-        onError(err);
+        // TODO: being a bit broad here but the only errors that should filter out this
+        // far are going to be bootstrapping the subscription.
+        onError(err, {
+          errorSource: "initialize",
+          entityPath: this.entityPath,
+          fullyQualifiedNamespace: this._context.config.host
+        });
       });
   }
 

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -263,7 +263,7 @@ export class ServiceBusReceiverImpl<
           await onInitialize();
         } catch (err) {
           onError(err, {
-            errorSource: "processMessageCallback",
+            errorSource: "receive",
             entityPath: this.entityPath,
             fullyQualifiedNamespace: this._context.config.host
           });

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -472,7 +472,11 @@ export class ServiceBusSessionReceiverImpl<
     try {
       this._messageSession.subscribe(onMessage, onError, options);
     } catch (err) {
-      onError(err);
+      onError(err, {
+        errorSource: "initialize",
+        entityPath: this.entityPath,
+        fullyQualifiedNamespace: this._context.config.host
+      });
     }
   }
 

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -473,7 +473,7 @@ export class ServiceBusSessionReceiverImpl<
       this._messageSession.subscribe(onMessage, onError, options);
     } catch (err) {
       onError(err, {
-        errorSource: "initialize",
+        errorSource: "receive",
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host
       });

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -472,7 +472,8 @@ export class ServiceBusSessionReceiverImpl<
     try {
       this._messageSession.subscribe(onMessage, onError, options);
     } catch (err) {
-      onError(err, {
+      onError({
+        error: err,
         errorSource: "receive",
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { MessageHandlers } from "../models";
+import { MessageHandlers, ProcessErrorContext } from "../models";
 import { ServiceBusReceiver } from "./receiver";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
 import { receiverLogger, ServiceBusLogger } from "../log";
@@ -49,9 +49,9 @@ export function wrapProcessErrorHandler(
   handlers: Pick<MessageHandlers<unknown>, "processError">,
   logger: ServiceBusLogger = receiverLogger
 ): MessageHandlers<unknown>["processError"] {
-  return async (err: Error) => {
+  return async (err: Error, context: ProcessErrorContext) => {
     try {
-      await handlers.processError(err);
+      await handlers.processError(err, context);
     } catch (err) {
       logger.logError(err, `An error was thrown from the user's processError handler`);
     }

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { MessageHandlers, ProcessErrorContext } from "../models";
+import { MessageHandlers, ProcessErrorArgs } from "../models";
 import { ServiceBusReceiver } from "./receiver";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
 import { receiverLogger, ServiceBusLogger } from "../log";
@@ -49,9 +49,9 @@ export function wrapProcessErrorHandler(
   handlers: Pick<MessageHandlers<unknown>, "processError">,
   logger: ServiceBusLogger = receiverLogger
 ): MessageHandlers<unknown>["processError"] {
-  return async (err: Error, context: ProcessErrorContext) => {
+  return async (args: ProcessErrorArgs) => {
     try {
-      await handlers.processError(err, context);
+      await handlers.processError(args);
     } catch (err) {
       logger.logError(err, `An error was thrown from the user's processError handler`);
     }

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -639,7 +639,7 @@ export class MessageSession extends LinkEntity<Receiver> {
               bMessage.messageId
             );
             this._onError!(err, {
-              errorSource: "userCallback",
+              errorSource: "processMessageCallback",
               entityPath: this.entityPath,
               fullyQualifiedNamespace: this._context.config.host
             });
@@ -731,7 +731,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         // 2. the connection was broken (we don't reconnect)
         //
         // If any of these becomes untrue you'll probably want to re-evaluate this classification.
-        errorSource: "acceptSession",
+        errorSource: "receive",
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host
       });

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -5,7 +5,6 @@ import { Constants, ErrorNameConditionMapper, MessagingError, translate } from "
 import {
   AmqpError,
   EventContext,
-  isAmqpError,
   OnAmqpEvent,
   Receiver,
   ReceiverEvents,
@@ -629,21 +628,18 @@ export class MessageSession extends LinkEntity<Receiver> {
         try {
           await this._onMessage(bMessage);
         } catch (err) {
-          // This ensures we call users' error handler when users' message handler throws.
-          if (!isAmqpError(err)) {
-            logger.logError(
-              err,
-              "%s An error occurred while running user's message handler for the message " +
-                "with id '%s' on the receiver",
-              this.logPrefix,
-              bMessage.messageId
-            );
-            this._onError!(err, {
-              errorSource: "processMessageCallback",
-              entityPath: this.entityPath,
-              fullyQualifiedNamespace: this._context.config.host
-            });
-          }
+          logger.logError(
+            err,
+            "%s An error occurred while running user's message handler for the message " +
+              "with id '%s' on the receiver",
+            this.logPrefix,
+            bMessage.messageId
+          );
+          this._onError!(err, {
+            errorSource: "processMessageCallback",
+            entityPath: this.entityPath,
+            fullyQualifiedNamespace: this._context.config.host
+          });
 
           const error = translate(err);
           // Nothing much to do if user's message handler throws. Let us try abandoning the message.

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -4,7 +4,7 @@
 import chai from "chai";
 import Long from "long";
 import chaiAsPromised from "chai-as-promised";
-import { ServiceBusMessage, delay } from "../src";
+import { ServiceBusMessage, delay, ProcessErrorArgs } from "../src";
 import { getAlreadyReceivingErrorMsg } from "../src/util/errors";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusReceiver, ServiceBusReceiverImpl } from "../src/receivers/receiver";
@@ -595,8 +595,8 @@ describe("Batching Receiver", () => {
           async processMessage(): Promise<void> {
             // process message here - it's basically a ServiceBusMessage minus any settlement related methods
           },
-          async processError(err: Error): Promise<void> {
-            unexpectedError = err;
+          async processError(args: ProcessErrorArgs): Promise<void> {
+            unexpectedError = args.error;
           }
         });
       } catch (err) {

--- a/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
@@ -24,7 +24,7 @@ import { isLinkLocked } from "../utils/misc";
 import { ServiceBusSessionReceiverImpl } from "../../src/receivers/sessionReceiver";
 import { ServiceBusReceiverImpl } from "../../src/receivers/receiver";
 import { MessageSession } from "../../src/session/messageSession";
-import { ReceiveMode } from "../../src";
+import { ProcessErrorArgs, ReceiveMode } from "../../src";
 
 describe("AbortSignal", () => {
   const defaultOptions = {
@@ -354,8 +354,8 @@ describe("AbortSignal", () => {
         session.subscribe(
           {
             processMessage: async (_msg) => {},
-            processError: async (err) => {
-              receivedErrors.push(err);
+            processError: async (args) => {
+              receivedErrors.push(args.error);
             }
           },
           {
@@ -386,9 +386,9 @@ describe("AbortSignal", () => {
           receiver.subscribe(
             {
               processMessage: async (_msg: any) => {},
-              processError: async (err: Error) => {
+              processError: async (args: ProcessErrorArgs) => {
                 resolve();
-                receivedErrors.push(err);
+                receivedErrors.push(args.error);
               }
             },
             {

--- a/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
@@ -256,7 +256,7 @@ describe("Receiver unit tests", () => {
 
       assert.equal(processErrorParams.err.message, "Failed to initialize!");
       assert.deepEqual(processErrorParams.context, {
-        errorSource: "initialize",
+        errorSource: "receive",
         entityPath: "fakeEntityPath",
         fullyQualifiedNamespace: "fakeHost"
       });

--- a/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiver.spec.ts
@@ -230,7 +230,7 @@ describe("Receiver unit tests", () => {
       await receiverImpl.close();
     });
 
-    it("errors thrown when initializing a connection are reported as 'initialize' errors", async () => {
+    it("errors thrown when initializing a connection are reported as 'receive' errors", async () => {
       const receiverImpl = new ServiceBusReceiverImpl(
         createConnectionContextForTests({
           onCreateReceiverCalled: () => {

--- a/sdk/servicebus/service-bus/test/internal/shared.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/shared.spec.ts
@@ -5,6 +5,7 @@ import { getMessageIterator, wrapProcessErrorHandler } from "../../src/receivers
 import chai from "chai";
 import { ServiceBusReceiver } from "../../src/receivers/receiver";
 import { ServiceBusLogger } from "../../src/log";
+import { ProcessErrorContext } from "../../src/models";
 const assert = chai.assert;
 
 describe("shared", () => {
@@ -13,8 +14,15 @@ describe("shared", () => {
 
     const wrappedProcessError = wrapProcessErrorHandler(
       {
-        processError: (err) => {
+        processError: (err: Error, context: ProcessErrorContext) => {
           assert.equal(err.message, "Actual error that was passed in from service bus to the user");
+
+          assert.deepEqual(context, {
+            fullyQualifiedNamespace: "fully qualified namespace",
+            entityPath: "entity path",
+            errorSource: "renewLock"
+          });
+
           throw new Error("Whoops!");
         }
       },
@@ -29,7 +37,11 @@ describe("shared", () => {
       } as ServiceBusLogger
     );
 
-    wrappedProcessError(new Error("Actual error that was passed in from service bus to the user"));
+    wrappedProcessError(new Error("Actual error that was passed in from service bus to the user"), {
+      entityPath: "entity path",
+      errorSource: "renewLock",
+      fullyQualifiedNamespace: "fully qualified namespace"
+    });
 
     assert.isTrue(logErrorCalled, "log error should have been called");
   });

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -6,7 +6,12 @@ const should = chai.should();
 const expect = chai.expect;
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ServiceBusReceivedMessage, ServiceBusMessage, ServiceBusReceiver } from "../src";
+import {
+  ServiceBusReceivedMessage,
+  ServiceBusMessage,
+  ServiceBusReceiver,
+  ProcessErrorArgs
+} from "../src";
 
 import { TestClientType, TestMessage, checkWithTimeout } from "./utils/testUtils";
 
@@ -130,8 +135,8 @@ describe("receive and delete", () => {
           async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
             receivedMsgs.push(message);
           },
-          async processError(err: Error): Promise<void> {
-            errors.push(err.message);
+          async processError(args: ProcessErrorArgs): Promise<void> {
+            errors.push(args.error.message);
           }
         },
         { autoComplete: autoCompleteFlag }

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -16,6 +16,7 @@ import {
 import { ServiceBusReceiver } from "../src/receivers/receiver";
 import { ServiceBusSender } from "../src/sender";
 import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ProcessErrorArgs } from "../src/models";
 
 describe("Message Lock Renewal", () => {
   let serviceBusClient: ServiceBusClientForTests;
@@ -125,8 +126,8 @@ describe("Message Lock Renewal", () => {
 
   let uncaughtErrorFromHandlers: Error | undefined;
 
-  async function processError(err: Error): Promise<void> {
-    uncaughtErrorFromHandlers = err;
+  async function processError(args: ProcessErrorArgs): Promise<void> {
+    uncaughtErrorFromHandlers = args.error;
   }
 
   /**

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { MessagingError, ServiceBusMessage, delay } from "../src";
+import { ServiceBusMessage, delay, ProcessErrorArgs } from "../src";
 import { TestClientType, TestMessage, isMessagingError } from "./utils/testUtils";
 import {
   ServiceBusClientForTests,
@@ -124,8 +124,8 @@ describe("Session Lock Renewal", () => {
   // const maxAutoRenewLockDurationInMs = 300*1000;
   let uncaughtErrorFromHandlers: Error | undefined;
 
-  async function processError(err: MessagingError | Error) {
-    uncaughtErrorFromHandlers = err;
+  async function processError(args: ProcessErrorArgs) {
+    uncaughtErrorFromHandlers = args.error;
   }
 
   /**
@@ -334,11 +334,11 @@ describe("Session Lock Renewal", () => {
     receiver.subscribe(
       {
         processMessage,
-        async processError(err: MessagingError | Error) {
-          if (isMessagingError(err) && err.code === "SessionLockLostError") {
+        async processError(args: ProcessErrorArgs) {
+          if (isMessagingError(args.error) && args.error.code === "SessionLockLostError") {
             sessionLockLostErrorThrown = true;
           } else {
-            uncaughtErrorFromHandlers = err;
+            uncaughtErrorFromHandlers = args.error;
           }
         }
       },

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -144,13 +144,20 @@ describe("Errors with non existing Namespace", function(): void {
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err, context) {
-        context.should.deep.equal({
+      async processError(args) {
+        const actual = {
+          errorSource: args.errorSource,
+          entityPath: args.entityPath,
+          fullyQualifiedNamespace: args.fullyQualifiedNamespace
+        };
+
+        actual.should.deep.equal({
           errorSource: "initialize",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
         });
-        testError(err);
+
+        testError(args.error);
       }
     });
 
@@ -222,14 +229,20 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err, context) {
-        context.should.deep.equal({
+      async processError(args) {
+        const actual = {
+          errorSource: args.errorSource,
+          entityPath: args.entityPath,
+          fullyQualifiedNamespace: args.fullyQualifiedNamespace
+        };
+
+        actual.should.deep.equal({
           errorSource: "initialize",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
         });
 
-        testError(err, "some-name");
+        testError(args.error, "some-name");
       }
     });
 
@@ -249,14 +262,20 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err, context) {
-        context.should.deep.equal({
+      async processError(args) {
+        const expected = {
+          errorSource: args.errorSource,
+          entityPath: args.entityPath,
+          fullyQualifiedNamespace: args.fullyQualifiedNamespace
+        };
+
+        expected.should.deep.equal({
           errorSource: "initialize",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
         });
 
-        testError(err, "some-topic-name/Subscriptions/some-subscription-name");
+        testError(args.error, "some-topic-name/Subscriptions/some-subscription-name");
       }
     });
 

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -6,7 +6,12 @@ import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import * as dotenv from "dotenv";
 import Long from "long";
-import { MessagingError, ServiceBusClient, ServiceBusSessionReceiver } from "../src";
+import {
+  MessagingError,
+  ProcessErrorArgs,
+  ServiceBusClient,
+  ServiceBusSessionReceiver
+} from "../src";
 import { ServiceBusSender } from "../src/sender";
 import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
 import { getReceiverClosedErrorMsg, getSenderClosedErrorMsg } from "../src/util/errors";
@@ -145,17 +150,17 @@ describe("Errors with non existing Namespace", function(): void {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
       async processError(args) {
-        const actual = {
+        const actual: Omit<ProcessErrorArgs, "error"> = {
           errorSource: args.errorSource,
           entityPath: args.entityPath,
           fullyQualifiedNamespace: args.fullyQualifiedNamespace
         };
 
         actual.should.deep.equal({
-          errorSource: "initialize",
+          errorSource: "receive",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
-        });
+        } as Omit<ProcessErrorArgs, "error">);
 
         testError(args.error);
       }
@@ -230,17 +235,17 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
       async processError(args) {
-        const actual = {
+        const actual: Omit<ProcessErrorArgs, "error"> = {
           errorSource: args.errorSource,
           entityPath: args.entityPath,
           fullyQualifiedNamespace: args.fullyQualifiedNamespace
         };
 
         actual.should.deep.equal({
-          errorSource: "initialize",
+          errorSource: "receive",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
-        });
+        } as Omit<ProcessErrorArgs, "error">);
 
         testError(args.error, "some-name");
       }
@@ -263,17 +268,17 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
       async processError(args) {
-        const expected = {
+        const expected: Omit<ProcessErrorArgs, "error"> = {
           errorSource: args.errorSource,
           entityPath: args.entityPath,
           fullyQualifiedNamespace: args.fullyQualifiedNamespace
         };
 
         expected.should.deep.equal({
-          errorSource: "initialize",
+          errorSource: "receive",
           entityPath: receiver.entityPath,
           fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
-        });
+        } as Omit<ProcessErrorArgs, "error">);
 
         testError(args.error, "some-topic-name/Subscriptions/some-subscription-name");
       }

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -30,7 +30,7 @@ dotenv.config();
 const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
 const withSessionTestClientType = getRandomTestClientTypeWithSessions();
 
-describe("Create ServiceBusClient", function(): void {
+describe.only("Create ServiceBusClient", function(): void {
   let sbClient: ServiceBusClient;
 
   afterEach(async () => {
@@ -144,7 +144,12 @@ describe("Errors with non existing Namespace", function(): void {
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err) {
+      async processError(err, context) {
+        context.should.deep.equal({
+          errorSource: "initialize",
+          entityPath: receiver.entityPath,
+          fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
+        });
         testError(err);
       }
     });
@@ -217,7 +222,13 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err) {
+      async processError(err, context) {
+        context.should.deep.equal({
+          errorSource: "initialize",
+          entityPath: receiver.entityPath,
+          fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
+        });
+
         testError(err, "some-name");
       }
     });
@@ -238,7 +249,13 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
       async processMessage() {
         throw "processMessage should not have been called when receive call is made from a non existing namespace";
       },
-      async processError(err) {
+      async processError(err, context) {
+        context.should.deep.equal({
+          errorSource: "initialize",
+          entityPath: receiver.entityPath,
+          fullyQualifiedNamespace: sbClient.fullyQualifiedNamespace
+        });
+
         testError(err, "some-topic-name/Subscriptions/some-subscription-name");
       }
     });

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -30,7 +30,7 @@ dotenv.config();
 const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
 const withSessionTestClientType = getRandomTestClientTypeWithSessions();
 
-describe.only("Create ServiceBusClient", function(): void {
+describe("Create ServiceBusClient", function(): void {
   let sbClient: ServiceBusClient;
 
   afterEach(async () => {

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -6,7 +6,7 @@ import Long from "long";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ServiceBusReceivedMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, delay, ProcessErrorArgs } from "../src";
 
 import { TestClientType, TestMessage, checkWithTimeout, isMessagingError } from "./utils/testUtils";
 import { ServiceBusSender } from "../src/sender";
@@ -23,10 +23,8 @@ import { AbortController } from "@azure/abort-controller";
 
 let unexpectedError: Error | undefined;
 
-async function processError(err: Error): Promise<void> {
-  if (err) {
-    unexpectedError = err;
-  }
+async function processError(args: ProcessErrorArgs): Promise<void> {
+  unexpectedError = args.error;
 }
 
 describe("session tests", () => {

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -9,6 +9,7 @@ import { getEntityNameFromConnectionString } from "../src/constructorHelpers";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
 import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { ProcessErrorContext } from "../src/models";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
@@ -57,7 +58,7 @@ describe("Sample scenarios for track 2", () => {
           await message.complete();
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
+        async processError(err: Error, _context: ProcessErrorContext): Promise<void> {
           errors.push(err.message);
         }
       });

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -9,7 +9,7 @@ import { getEntityNameFromConnectionString } from "../src/constructorHelpers";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
 import { ServiceBusSender } from "../src/sender";
 import { ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
-import { ProcessErrorContext } from "../src/models";
+import { ProcessErrorArgs } from "../src/models";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
@@ -58,8 +58,8 @@ describe("Sample scenarios for track 2", () => {
           await message.complete();
           receivedBodies.push(message.body);
         },
-        async processError(err: Error, _context: ProcessErrorContext): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 
@@ -130,8 +130,8 @@ describe("Sample scenarios for track 2", () => {
         async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 
@@ -213,8 +213,8 @@ describe("Sample scenarios for track 2", () => {
           await message.complete();
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 
@@ -237,8 +237,8 @@ describe("Sample scenarios for track 2", () => {
         async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 
@@ -350,8 +350,8 @@ describe("Sample scenarios for track 2", () => {
         async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 
@@ -386,8 +386,8 @@ describe("Sample scenarios for track 2", () => {
         async processMessage(message: ServiceBusReceivedMessage): Promise<void> {
           receivedBodies.push(message.body);
         },
-        async processError(err: Error): Promise<void> {
-          errors.push(err.message);
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          errors.push(args.error.message);
         }
       });
 

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -3,7 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ServiceBusReceivedMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, delay, ProcessErrorArgs } from "../src";
 import { getAlreadyReceivingErrorMsg } from "../src/util/errors";
 import { TestMessage, checkWithTimeout, TestClientType } from "./utils/testUtils";
 import { StreamingReceiver } from "../src/core/streamingReceiver";
@@ -35,10 +35,8 @@ let unexpectedError: Error | undefined;
 const maxDeliveryCount = 10;
 const testClientType = getRandomTestClientTypeWithNoSessions();
 
-async function processError(err: Error): Promise<void> {
-  if (err) {
-    unexpectedError = err;
-  }
+async function processError(args: ProcessErrorArgs): Promise<void> {
+  unexpectedError = args.error;
 }
 
 describe("Streaming Receiver Tests", () => {
@@ -177,8 +175,8 @@ describe("Streaming Receiver Tests", () => {
 
         streamingReceiver.subscribe(
           async () => {},
-          (err) => {
-            actualError = err;
+          (args) => {
+            actualError = args.error;
           }
         );
 

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -3,7 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ServiceBusReceivedMessage, delay } from "../src";
+import { ServiceBusReceivedMessage, delay, ProcessErrorArgs } from "../src";
 import { getAlreadyReceivingErrorMsg } from "../src/util/errors";
 import { TestClientType, TestMessage, checkWithTimeout } from "./utils/testUtils";
 import { DispositionType, ServiceBusReceivedMessageWithLock } from "../src/serviceBusMessage";
@@ -44,10 +44,8 @@ describe("Streaming with sessions", () => {
     await serviceBusClient.test.after();
   });
 
-  async function processError(err: Error): Promise<void> {
-    if (err) {
-      unexpectedError = err;
-    }
+  async function processError(args: ProcessErrorArgs): Promise<void> {
+    unexpectedError = args.error;
   }
 
   async function afterEachTest(): Promise<void> {


### PR DESCRIPTION
Changes the `processError` callback passed to `Receiver.subscribe` to take a `ProcessErrorArgs` which gives the user some extra context about where the error originated from (`errorSource`) and the host and entity path.

Near term future work - adding in additional information like the message ID (helpful when trying to correlate settlement failures) and the session ID.

Work remaining:
- [x] Update samples
- [x] Docs (if any)

Fixes #11869