### PR TITLE
Prevent template run for sync builds, Update SetTestPipelineVersion

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -36,6 +36,8 @@ stages:
                         pwsh: true
                         workingDirectory: $(Build.SourcesDirectory)
                         filePath: eng/scripts/SetTestPipelineVersion.ps1
+                        arguments: >
+                          -PreviewVersionNumber $(build.buildid)
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}
@@ -205,6 +207,7 @@ stages:
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                          CloseAfterOpenForTesting: $(TestPipeline)
 
   - stage: Integration
     dependsOn: ${{parameters.DependsOn}}

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -10,6 +10,8 @@ steps:
       pwsh: true
       workingDirectory: $(Build.SourcesDirectory)
       filePath: eng/scripts/SetTestPipelineVersion.ps1
+      arguments: >
+        -PreviewVersionNumber $(build.buildid)
 
   - pwsh: |
       $folder = "${{parameters.ServiceDirectory}}"

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -9,7 +9,6 @@ trigger:
   paths:
     include:
       - sdk/template/
-      - eng/common/
 
 pr:
   branches:
@@ -21,6 +20,8 @@ pr:
   paths:
     include:
       - sdk/template/
+    exclude:
+      - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
Prevent template pipeline run triggered by eng/common changes.
Use BuildID as preview version in template runs.
Update SetTestPipelineVersion.ps1