### PR TITLE
Exclude eng directory from npm ci/pr gates

### DIFF
--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -3,7 +3,10 @@ trigger:
     include:
       - master
   paths:
+    include:
+      - eng/pipelines/mgmt-ci.yml
     exclude:
+      - eng/
       - sdk/anomalydetector/ai-anomaly-detector/
       - sdk/appconfiguration/app-configuration/
       - sdk/communication/communication-administration/

--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -3,10 +3,8 @@ trigger:
     include:
       - master
   paths:
-    include:
-      - eng/pipelines/mgmt-ci.yml
     exclude:
-      - eng/
+      - eng/common/
       - sdk/anomalydetector/ai-anomaly-detector/
       - sdk/appconfiguration/app-configuration/
       - sdk/communication/communication-administration/

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -3,7 +3,10 @@ pr:
     include:
       - '*'
   paths:
+    include:
+      - eng/pipelines/mgmt-pr.yml
     exclude:
+      - eng/
       - sdk/anomalydetector/ai-anomaly-detector/
       - sdk/appconfiguration/app-configuration/
       - sdk/communication/communication-administration/

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -3,10 +3,8 @@ pr:
     include:
       - '*'
   paths:
-    include:
-      - eng/pipelines/mgmt-pr.yml
     exclude:
-      - eng/
+      - eng/common/
       - sdk/anomalydetector/ai-anomaly-detector/
       - sdk/appconfiguration/app-configuration/
       - sdk/communication/communication-administration/


### PR DESCRIPTION
These pipelines only test npm related checks with no other pipeline template dependencies. Reduce the false negative rate by not running them for unrelated changes.