### PR TITLE
Switch from Testpipeline variable to parameter

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -29,13 +29,14 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - task: PowerShell@2
-                      displayName: Prep template pipeline for release
-                      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
-                      inputs:
-                        pwsh: true
-                        workingDirectory: $(Build.SourcesDirectory)
-                        filePath: eng/scripts/SetTestPipelineVersion.ps1
+                    - ${{if eq(parameters.TestPipeline, 'true')}}:
+                      - task: PowerShell@2
+                        displayName: Prep template pipeline for release
+                        condition: succeeded()
+                        inputs:
+                          pwsh: true
+                          workingDirectory: $(Build.SourcesDirectory)
+                          filePath: eng/scripts/SetTestPipelineVersion.ps1
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}
@@ -131,6 +132,7 @@ stages:
                           DocRepoDestinationPath: 'docs-ref-services/' 
                           GHReviewersVariable: 'OwningGHUser'
                           CIConfigs: $(CIConfigs)
+                          CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
           - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: PublishDocsGitHubIO
@@ -205,6 +207,7 @@ stages:
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                          CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
   - stage: Integration
     dependsOn: ${{parameters.DependsOn}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -2,6 +2,9 @@ parameters:
 - name: Artifacts
   type: object
   default: []
+- name: TestPipeline
+  type: boolean
+  default: false
 - name: ServiceDirectory
   type: string
   default: not-specified
@@ -23,17 +26,19 @@ stages:
   jobs:
   - template: ../jobs/archetype-sdk-client.yml
     parameters:
-      ServiceDirectory: ${{parameters.ServiceDirectory}}
-      Artifacts: ${{parameters.Artifacts}}
-      RunUnitTests: ${{parameters.RunUnitTests}}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      Artifacts: ${{ parameters.Artifacts }}
+      TestPipeline: ${{ parameters.TestPipeline }}
+      RunUnitTests: ${{ parameters.RunUnitTests }}
 
 # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
 - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq(parameters.IncludeRelease,true))}}:
   - template: archetype-js-release.yml
     parameters:
       DependsOn: Build
-      ServiceDirectory: ${{parameters.ServiceDirectory}}
-      Artifacts: ${{parameters.Artifacts}}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      Artifacts: ${{ parameters.Artifacts }}
+      TestPipeline: ${{ parameters.TestPipeline }}
       ArtifactName: packages
       TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
       TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -3,13 +3,14 @@ parameters:
   ServiceDirectory: not-specified
 
 steps:
-  - task: PowerShell@2
-    displayName: Prep template pipeline for release
-    condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
-    inputs:
-      pwsh: true
-      workingDirectory: $(Build.SourcesDirectory)
-      filePath: eng/scripts/SetTestPipelineVersion.ps1
+  - ${{if eq(parameters.TestPipeline, 'true')}}:
+    - task: PowerShell@2
+      displayName: Prep template pipeline for release
+      condition: succeeded()
+      inputs:
+        pwsh: true
+        workingDirectory: $(Build.SourcesDirectory)
+        filePath: eng/scripts/SetTestPipelineVersion.ps1
 
   - pwsh: |
       $folder = "${{parameters.ServiceDirectory}}"

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -9,7 +9,6 @@ trigger:
   paths:
     include:
       - sdk/template/
-      - eng/common/
 
 pr:
   branches:
@@ -26,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: template
+    TestPipeline: true
     Artifacts:
       - name: azure-template
         safeName: azuretemplate


### PR DESCRIPTION
Prevent template pipeline run triggered by eng/common changes.
Auto close update version Pull Requests for template pipelines.
Switch from TestPipeline variable to parameter

This includes some of the changes from https://github.com/Azure/azure-sdk-for-js/pull/11944 as other changes on that PR will take longer to complete.