### PR TITLE
Remove receiver overloads meant to hide settlement methods when using ReceiveAndDelete mode

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Breaking changes
 
+- The methods to complete, abandon, defer and deadletter a message along with the method to renew message lock have been moved from the message to the receiver.
 - The `createBatch` method on the sender is renamed to `createMessageBatch`
 - The interface `CreateBatchOptions` followed by the options that are passed to the `createBatch` method is renamed to `CreateMessageBatchOptions`
 - The `tryAdd` method on the message batch object is renamed to `tryAddMessage`

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -24,9 +24,9 @@ import { WebSocketImpl } from 'rhea-promise';
 import { WebSocketOptions } from '@azure/core-amqp';
 
 // @public
-export interface AcceptSessionOptions<ReceiveModeT extends ReceiveMode> extends OperationOptionsBase {
+export interface AcceptSessionOptions extends OperationOptionsBase {
     maxAutoRenewLockDurationInMs?: number;
-    receiveMode?: ReceiveModeT;
+    receiveMode?: ReceiveMode;
 }
 
 // @public
@@ -127,9 +127,9 @@ export interface CreateQueueOptions extends OperationOptions {
 }
 
 // @public
-export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
+export interface CreateReceiverOptions {
     maxAutoLockRenewalDurationInMs?: number;
-    receiveMode?: ReceiveModeT;
+    receiveMode?: ReceiveMode;
     subQueue?: SubQueue;
 }
 
@@ -347,19 +347,13 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
     constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: ServiceBusClientOptions);
-    acceptNextSession(queueName: string, options?: AcceptSessionOptions<"peekLock">): Promise<ServiceBusSessionReceiver>;
-    acceptNextSession(queueName: string, options: AcceptSessionOptions<"receiveAndDelete">): Promise<ServiceBusSessionReceiver>;
-    acceptNextSession(topicName: string, subscriptionName: string, options?: AcceptSessionOptions<"peekLock">): Promise<ServiceBusSessionReceiver>;
-    acceptNextSession(topicName: string, subscriptionName: string, options: AcceptSessionOptions<"receiveAndDelete">): Promise<ServiceBusSessionReceiver>;
-    acceptSession(queueName: string, sessionId: string, options?: AcceptSessionOptions<"peekLock">): Promise<ServiceBusSessionReceiver>;
-    acceptSession(queueName: string, sessionId: string, options: AcceptSessionOptions<"receiveAndDelete">): Promise<ServiceBusSessionReceiver>;
-    acceptSession(topicName: string, subscriptionName: string, sessionId: string, options?: AcceptSessionOptions<"peekLock">): Promise<ServiceBusSessionReceiver>;
-    acceptSession(topicName: string, subscriptionName: string, sessionId: string, options: AcceptSessionOptions<"receiveAndDelete">): Promise<ServiceBusSessionReceiver>;
+    acceptNextSession(queueName: string, options?: AcceptSessionOptions): Promise<ServiceBusSessionReceiver>;
+    acceptNextSession(topicName: string, subscriptionName: string, options?: AcceptSessionOptions): Promise<ServiceBusSessionReceiver>;
+    acceptSession(queueName: string, sessionId: string, options?: AcceptSessionOptions): Promise<ServiceBusSessionReceiver>;
+    acceptSession(topicName: string, subscriptionName: string, sessionId: string, options?: AcceptSessionOptions): Promise<ServiceBusSessionReceiver>;
     close(): Promise<void>;
-    createReceiver(queueName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver;
-    createReceiver(queueName: string, options: CreateReceiverOptions<"receiveAndDelete">): ServiceBusReceiver;
-    createReceiver(topicName: string, subscriptionName: string, options?: CreateReceiverOptions<"peekLock">): ServiceBusReceiver;
-    createReceiver(topicName: string, subscriptionName: string, options: CreateReceiverOptions<"receiveAndDelete">): ServiceBusReceiver;
+    createReceiver(queueName: string, options?: CreateReceiverOptions): ServiceBusReceiver;
+    createReceiver(topicName: string, subscriptionName: string, options?: CreateReceiverOptions): ServiceBusReceiver;
     createSender(queueOrTopicName: string): ServiceBusSender;
     fullyQualifiedNamespace: string;
 }

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -78,12 +78,9 @@ export type ReceiveMode = "peekLock" | "receiveAndDelete";
 export type SubQueue = "deadLetter" | "transferDeadLetter";
 
 /**
- *
- *
- * @interface CreateReceiverOptions
- * @template ReceiveModeT
+ * Options to use when creating a receiver.
  */
-export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
+export interface CreateReceiverOptions {
   /**
    * Represents the receive mode for the receiver.
    *
@@ -103,7 +100,7 @@ export interface CreateReceiverOptions<ReceiveModeT extends ReceiveMode> {
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    */
-  receiveMode?: ReceiveModeT;
+  receiveMode?: ReceiveMode;
   /**
    * Represents the sub queue that is applicable for any queue or subscription.
    * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
@@ -186,8 +183,7 @@ export interface SubscribeOptions extends OperationOptionsBase {
  * @extends {OperationOptionsBase}
  * @template ReceiveModeT
  */
-export interface AcceptSessionOptions<ReceiveModeT extends ReceiveMode>
-  extends OperationOptionsBase {
+export interface AcceptSessionOptions extends OperationOptionsBase {
   /**
    * Represents the receive mode for the receiver.
    *
@@ -207,7 +203,7 @@ export interface AcceptSessionOptions<ReceiveModeT extends ReceiveMode>
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    */
-  receiveMode?: ReceiveModeT;
+  receiveMode?: ReceiveMode;
   /**
    * @property The maximum duration in milliseconds
    * until which, the lock on the session will be renewed automatically by the sdk.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -177,11 +177,6 @@ export interface SubscribeOptions extends OperationOptionsBase {
 /**
  * Describes the options passed to the `acceptSession` and `acceptNextSession` methods
  * when using a Queue/Subscription that has sessions enabled.
- *
- * @export
- * @interface AcceptSessionOptions
- * @extends {OperationOptionsBase}
- * @template ReceiveModeT
  */
 export interface AcceptSessionOptions extends OperationOptionsBase {
   /**

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -137,7 +137,7 @@ export class ServiceBusClient {
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the queue, after which they get sent to a separate dead letter
+   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
    * queue.
    *
    * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -103,7 +103,7 @@ export class ServiceBusClient {
    * `subQueue` in the options. To learn more about dead letter queues, see
    * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
@@ -131,7 +131,7 @@ export class ServiceBusClient {
    * `subQueue` in the options. To learn more about dead letter queues, see
    * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
@@ -203,7 +203,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for a session enabled Azure Service Bus queue.
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
@@ -227,7 +227,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for a session enabled Azure Service Bus subscription.
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
@@ -320,7 +320,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for the next available session in a session-enabled Azure Service Bus queue.
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
@@ -342,7 +342,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for the next available session in a session-enabled Azure Service Bus subscription.
    *
-   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * You can choose between two receive modes:  "peekLock" (default) and "receiveAndDelete".
    * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -96,115 +96,69 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue in peekLock mode. No connection is made
+   * Creates a receiver for an Azure Service Bus queue. No connection is made
    * to the service until one of the methods on the receiver is called.
    *
    * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
    * `subQueue` in the options. To learn more about dead letter queues, see
    * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * Messages that are not settled within the lock duration will be redelivered as many times as
    * the max delivery count set on the queue, after which they get sent to a separate dead letter
    * queue.
    *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
-  createReceiver(
-    queueName: string,
-    options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver;
+  createReceiver(queueName: string, options?: CreateReceiverOptions): ServiceBusReceiver;
   /**
-   * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode. No connection is made
+   * Creates a receiver for an Azure Service Bus subscription. No connection is made
    * to the service until one of the methods on the receiver is called.
    *
    * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
    * `subQueue` in the options. To learn more about dead letter queues, see
    * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  createReceiver(
-    queueName: string,
-    options: CreateReceiverOptions<"receiveAndDelete">
-  ): ServiceBusReceiver;
-  /**
-   * Creates a receiver for an Azure Service Bus subscription in peekLock mode. No connection is made
-   * to the service until one of the methods on the receiver is called.
-   *
-   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
-   * `subQueue` in the options. To learn more about dead letter queues, see
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * subscription.
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
+   * the max delivery count set on the queue, after which they get sent to a separate dead letter
    * queue.
    *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
+   * @param queueName The name of the queue to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
   createReceiver(
     topicName: string,
     subscriptionName: string,
-    options?: CreateReceiverOptions<"peekLock">
-  ): ServiceBusReceiver;
-  /**
-   * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode. No connection is made
-   * to the service until one of the methods on the receiver is called.
-   *
-   *
-   * To target sub queues like the dead letter queue or the transfer dead letter queue, provide the
-   * `subQueue` in the options. To learn more about dead letter queues, see
-   * https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
-   *
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options to pass the receiveMode, defaulted to receiveAndDelete.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  createReceiver(
-    topicName: string,
-    subscriptionName: string,
-    options: CreateReceiverOptions<"receiveAndDelete">
+    options?: CreateReceiverOptions
   ): ServiceBusReceiver;
   createReceiver(
     queueOrTopicName1: string,
-    optionsOrSubscriptionName2?:
-      | CreateReceiverOptions<"receiveAndDelete">
-      | CreateReceiverOptions<"peekLock">
-      | string,
-    options3?: CreateReceiverOptions<"receiveAndDelete"> | CreateReceiverOptions<"peekLock">
+    optionsOrSubscriptionName2?: CreateReceiverOptions | string,
+    options3?: CreateReceiverOptions
   ): ServiceBusReceiver {
     validateEntityPath(this._connectionContext.config, queueOrTopicName1);
 
@@ -237,38 +191,25 @@ export class ServiceBusClient {
         ? options.maxAutoLockRenewalDurationInMs
         : 5 * 60 * 1000;
 
-    if (receiveMode === "peekLock") {
-      return new ServiceBusReceiverImpl(
-        this._connectionContext,
-        entityPathWithSubQueue,
-        receiveMode,
-        maxLockAutoRenewDurationInMs,
-        this._clientOptions.retryOptions
-      );
-    } else {
-      return new ServiceBusReceiverImpl(
-        this._connectionContext,
-        entityPathWithSubQueue,
-        receiveMode,
-        maxLockAutoRenewDurationInMs,
-        this._clientOptions.retryOptions
-      );
-    }
+    return new ServiceBusReceiverImpl(
+      this._connectionContext,
+      entityPathWithSubQueue,
+      receiveMode,
+      maxLockAutoRenewDurationInMs,
+      this._clientOptions.retryOptions
+    );
   }
 
   /**
-   * Creates a receiver for a session enabled Azure Service Bus queue in peekLock mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
+   * Creates a receiver for a session enabled Azure Service Bus queue.
    *
-   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
-   * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the queue, after which they get sent to a separate dead letter
-   * queue.
-   *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
@@ -276,42 +217,23 @@ export class ServiceBusClient {
    * @param queueName The name of the queue to receive from.
    * @param sessionId The id of the session from which messages need to be received
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptSession(
     queueName: string,
     sessionId: string,
-    options?: AcceptSessionOptions<"peekLock">
+    options?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver>;
   /**
-   * Creates a receiver for a session enabled Azure Service Bus queue in receiveAndDelete mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
+   * Creates a receiver for a session enabled Azure Service Bus subscription.
    *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param queueName The name of the queue to receive from.
-   * @param sessionId The id of the session from which messages need to be received
-   * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  acceptSession(
-    queueName: string,
-    sessionId: string,
-    options: AcceptSessionOptions<"receiveAndDelete">
-  ): Promise<ServiceBusSessionReceiver>;
-  /**
-   * Creates a receiver for a session enabled Azure Service Bus subscription in peekLock mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
-   * subscription.
-   *
-   * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
@@ -320,53 +242,26 @@ export class ServiceBusClient {
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param sessionId The id of the session from which messages need to be received
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptSession(
     topicName: string,
     subscriptionName: string,
     sessionId: string,
-    options?: AcceptSessionOptions<"peekLock">
-  ): Promise<ServiceBusSessionReceiver>;
-  /**
-   * Creates a receiver for a session enabled Azure Service Bus subscription in receiveAndDelete mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param sessionId The id of the session from which messages need to be received
-   * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  acceptSession(
-    topicName: string,
-    subscriptionName: string,
-    sessionId: string,
-    options: AcceptSessionOptions<"receiveAndDelete">
+    options?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver>;
   async acceptSession(
     queueOrTopicName1: string,
-    optionsOrSubscriptionNameOrSessionId2?:
-      | AcceptSessionOptions<"peekLock">
-      | AcceptSessionOptions<"receiveAndDelete">
-      | string,
-    optionsOrSessionId3?:
-      | AcceptSessionOptions<"peekLock">
-      | AcceptSessionOptions<"receiveAndDelete">
-      | string,
-    options4?: AcceptSessionOptions<"peekLock"> | AcceptSessionOptions<"receiveAndDelete">
+    optionsOrSubscriptionNameOrSessionId2?: AcceptSessionOptions | string,
+    optionsOrSessionId3?: AcceptSessionOptions | string,
+    options4?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver> {
     validateEntityPath(this._connectionContext.config, queueOrTopicName1);
 
     let sessionId: string;
     let entityPath: string;
     let receiveMode: "peekLock" | "receiveAndDelete";
-    let options:
-      | AcceptSessionOptions<"peekLock">
-      | AcceptSessionOptions<"receiveAndDelete">
-      | undefined;
+    let options: AcceptSessionOptions | undefined;
 
     if (
       typeof queueOrTopicName1 === "string" &&
@@ -423,57 +318,37 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for the next available session in a session-enabled Azure Service Bus queue in peekLock mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
+   * Creates a receiver for the next available session in a session-enabled Azure Service Bus queue.
    *
-   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
-   * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the queue, after which they get sent to a separate dead letter
-   * queue.
-   *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptNextSession(
     queueName: string,
-    options?: AcceptSessionOptions<"peekLock">
+    options?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver>;
   /**
-   * Creates a receiver for the next available session in a session-enabled Azure Service Bus queue in receiveAndDelete mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
+   * Creates a receiver for the next available session in a session-enabled Azure Service Bus subscription.
    *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  acceptNextSession(
-    queueName: string,
-    options: AcceptSessionOptions<"receiveAndDelete">
-  ): Promise<ServiceBusSessionReceiver>;
-  /**
-   * Creates a receiver for the next available session in a session-enabled Azure Service Bus subscription in peekLock mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
-   * subscription.
-   *
-   * Messages that are not settled within the lock duration will be redelivered as many times as
-   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
+   * You can choose between "peekLock" (default) and "receiveAndDelete" modes.
+   * - In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
+   * - In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
-   * the message.
+   * You can settle a message by calling completeMessage(), abandonMessage(), deferMessage() or
+   * deadletterMessage() methods on the receiver.
    *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
@@ -481,36 +356,17 @@ export class ServiceBusClient {
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
+   * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptNextSession(
     topicName: string,
     subscriptionName: string,
-    options?: AcceptSessionOptions<"peekLock">
-  ): Promise<ServiceBusSessionReceiver>;
-  /**
-   * Creates a receiver for the next available session in a session-enabled Azure Service Bus subscription in receiveAndDelete mode.
-   * If the receiveMode is not provided in the options, it defaults to the "peekLock" mode.
-   *
-   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
-   *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options include receiveMode(defaulted to receiveAndDelete), options to create session receiver.
-   * @returns A receiver that can be used to receive messages of the form `ServiceBusReceivedMessage`
-   */
-  acceptNextSession(
-    topicName: string,
-    subscriptionName: string,
-    options: AcceptSessionOptions<"receiveAndDelete">
+    options?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver>;
   async acceptNextSession(
     queueOrTopicName1: string,
-    optionsOrSubscriptionName2?:
-      | AcceptSessionOptions<"peekLock">
-      | AcceptSessionOptions<"receiveAndDelete">
-      | string,
-    options3?: AcceptSessionOptions<"peekLock"> | AcceptSessionOptions<"receiveAndDelete">
+    optionsOrSubscriptionName2?: AcceptSessionOptions | string,
+    options3?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver> {
     validateEntityPath(this._connectionContext.config, queueOrTopicName1);
 

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -146,7 +146,8 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param queueName The name of the queue to receive from.
+   * @param topicName Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param options Options to pass the receiveMode, defaulted to peekLock.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -49,7 +49,7 @@ export interface CreateMessageSessionReceiverLinkOptions {
  * Describes all the options that can be set while instantiating a MessageSession object.
  */
 export type MessageSessionOptions = Pick<
-  AcceptSessionOptions<"receiveAndDelete">,
+  AcceptSessionOptions,
   "maxAutoRenewLockDurationInMs" | "abortSignal"
 > & {
   receiveMode?: ReceiveMode;

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -454,7 +454,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         logger.logError(
           sbError,
           "[%s] 'receiver_close' event occurred for receiver '%s' for sessionId '%s'. " +
-          "The associated error is: %O",
+            "The associated error is: %O",
           connectionId,
           this.name,
           this.sessionId,
@@ -466,7 +466,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       if (receiver && !receiver.isItselfClosed()) {
         logger.verbose(
           "%s 'receiver_close' event occurred on the receiver for sessionId '%s' " +
-          "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",
+            "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",
           this.logPrefix,
           this.sessionId
         );
@@ -483,7 +483,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       } else {
         logger.verbose(
           "%s 'receiver_close' event occurred on the receiver for sessionId '%s' " +
-          "because the sdk initiated it. Hence no need to gracefully close the receiver",
+            "because the sdk initiated it. Hence no need to gracefully close the receiver",
           this.logPrefix,
           this.sessionId
         );
@@ -498,7 +498,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         logger.logError(
           sbError,
           "%s 'session_close' event occurred for receiver for sessionId '%s'. " +
-          "The associated error is",
+            "The associated error is",
           this.logPrefix,
           this.sessionId
         );
@@ -509,7 +509,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       if (receiver && !receiver.isSessionItselfClosed()) {
         logger.verbose(
           "%s 'session_close' event occurred on the receiver for sessionId '%s' " +
-          "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",
+            "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",
           this.logPrefix,
           this.sessionId
         );
@@ -526,7 +526,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       } else {
         logger.verbose(
           "%s 'session_close' event occurred on the receiver for sessionId'%s' " +
-          "because the sdk initiated it. Hence no need to gracefully close the receiver",
+            "because the sdk initiated it. Hence no need to gracefully close the receiver",
           this.logPrefix,
           this.sessionId
         );
@@ -543,7 +543,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       if (this._sessionLockRenewalTimer) clearTimeout(this._sessionLockRenewalTimer);
       logger.verbose(
         "%s Cleared the timers for 'no new message received' task and " +
-        "'session lock renewal' task.",
+          "'session lock renewal' task.",
         this.logPrefix
       );
 
@@ -612,7 +612,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         if (this.receiveMode === "peekLock" && (!this.link || !this.link.isOpen())) {
           logger.verbose(
             "%s Not calling the user's message handler for the current message " +
-            "as the receiver is closed",
+              "as the receiver is closed",
             this.logPrefix
           );
           return;
@@ -633,7 +633,7 @@ export class MessageSession extends LinkEntity<Receiver> {
           logger.logError(
             err,
             "%s An error occurred while running user's message handler for the message " +
-            "with id '%s' on the receiver",
+              "with id '%s' on the receiver",
             this.logPrefix,
             bMessage.messageId
           );
@@ -664,7 +664,7 @@ export class MessageSession extends LinkEntity<Receiver> {
               logger.logError(
                 translatedError,
                 "%s An error occurred while abandoning the message with id '%s' on the " +
-                "receiver",
+                  "receiver",
                 this.logPrefix,
                 bMessage.messageId,
                 translatedError
@@ -789,7 +789,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         this._deliveryDispositionMap.delete(delivery.id);
         logger.verbose(
           "[%s] Disposition for delivery id: %d, did not complete in %d milliseconds. " +
-          "Hence rejecting the promise with timeout error",
+            "Hence rejecting the promise with timeout error",
           this._context.connectionId,
           delivery.id,
           Constants.defaultOperationTimeoutInMs

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -27,9 +27,7 @@ describe("serviceBusClient unit tests", () => {
   // we pass.
   // So if we add other options types there's no need to generate a whole
   // new set of tests for it. :)
-  const sessionReceiverOptions:
-    | AcceptSessionOptions<"peekLock">
-    | AcceptSessionOptions<"receiveAndDelete"> = {};
+  const sessionReceiverOptions: AcceptSessionOptions = {};
 
   const testEntities = [
     { queue: "thequeue", entityPath: "thequeue" },

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -325,7 +325,7 @@ export class ServiceBusTestHelpers {
    */
   async createPeekLockReceiver(
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned">,
-    options?: CreateReceiverOptions<"peekLock">
+    options?: CreateReceiverOptions
   ): Promise<ServiceBusReceiver> {
     if (entityNames.usesSessions) {
       // if you're creating a receiver this way then you'll just use the default
@@ -348,7 +348,7 @@ export class ServiceBusTestHelpers {
 
   async acceptNextSessionWithPeekLock(
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned">,
-    options?: AcceptSessionOptions<"peekLock">
+    options?: AcceptSessionOptions
   ) {
     if (!entityNames.usesSessions) {
       throw new TypeError(
@@ -370,7 +370,7 @@ export class ServiceBusTestHelpers {
   async acceptSessionWithPeekLock(
     entityNames: Omit<ReturnType<typeof getEntityNames>, "isPartitioned">,
     sessionId: string,
-    options?: AcceptSessionOptions<"peekLock">
+    options?: AcceptSessionOptions
   ): Promise<ServiceBusSessionReceiver> {
     if (!entityNames.usesSessions) {
       throw new TypeError(


### PR DESCRIPTION
This is a follow up for the changes in the PR #11962

In #11926 we decided not to have the overloads for `createReceiver`, `acceptSession` and `acceptNextSession` methods that would allow us to hide the message settlement methods if a TypeScript  user is using ReceiveAndDelete mode. This PR removes the said overloads that are remnants of #11962

