### PR TITLE
[core-http] Clean up event listener when streaming is done

### DIFF
--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -202,11 +202,11 @@ export abstract class FetchHttpClient implements HttpClient {
       // clean up event listener
       if (httpRequest.abortSignal && abortListener) {
         let uploadStreamDone = Promise.resolve();
-        if (httpRequest.abortSignal && isReadableStream(body)) {
+        if (isReadableStream(body)) {
           uploadStreamDone = isStreamComplete(body);
         }
         let downloadStreamDone = Promise.resolve();
-        if (httpRequest.abortSignal && isReadableStream(operationResponse?.readableStreamBody)) {
+        if (isReadableStream(operationResponse?.readableStreamBody)) {
           downloadStreamDone = isStreamComplete(operationResponse!.readableStreamBody);
         }
 

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -215,7 +215,7 @@ export abstract class FetchHttpClient implements HttpClient {
       };
 
       // it's super rare if not impossible that both download streaming and upload streaming happen
-      // at the same time so don't care about that case.
+      // at the same time so assume download stream (if any) will ends after upload stream (if any).
       if (operationResponse?.readableStreamBody) {
         // download stream
         cleanUpStreamListener(operationResponse!.readableStreamBody);

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -215,8 +215,8 @@ export abstract class FetchHttpClient implements HttpClient {
             httpRequest.abortSignal?.removeEventListener("abort", abortListener!);
             return;
           })
-          .catch((e) => {
-            throw e;
+          .catch(() => {
+            /* ignore errors */
           });
       }
     }

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -216,7 +216,7 @@ export abstract class FetchHttpClient implements HttpClient {
 
       // it's super rare if not impossible that both download streaming and upload streaming happen
       // at the same time so assume download stream (if any) will ends after upload stream (if any).
-      if (operationResponse?.readableStreamBody) {
+      if (isReadableStream(operationResponse?.readableStreamBody)) {
         // download stream
         cleanUpStreamListener(operationResponse!.readableStreamBody);
       } else if (isReadableStream(body)) {

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -10,6 +10,7 @@ import { HttpOperationResponse } from "./httpOperationResponse";
 import { HttpHeaders, HttpHeadersLike } from "./httpHeaders";
 import { RestError } from "./restError";
 import { Readable, Transform } from "stream";
+import { logger } from "./log";
 
 interface FetchError extends Error {
   code?: string;
@@ -215,8 +216,8 @@ export abstract class FetchHttpClient implements HttpClient {
             httpRequest.abortSignal?.removeEventListener("abort", abortListener!);
             return;
           })
-          .catch(() => {
-            /* ignore errors */
+          .catch((e) => {
+            logger.warning("Error when cleaning up abortListener", e);
           });
       }
     }
@@ -234,6 +235,8 @@ function isReadableStream(body: any): body is Readable {
 function isStreamComplete(stream: Readable): Promise<void> {
   return new Promise((resolve) => {
     stream.on("close", resolve);
+    stream.on("end", resolve);
+    stream.on("error", resolve);
   });
 }
 

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -210,9 +210,14 @@ export abstract class FetchHttpClient implements HttpClient {
           downloadStreamDone = isStreamComplete(operationResponse!.readableStreamBody);
         }
 
-        Promise.all([uploadStreamDone, downloadStreamDone]).then(() => {
-          httpRequest.abortSignal?.removeEventListener("abort", abortListener!);
-        });
+        Promise.all([uploadStreamDone, downloadStreamDone])
+          .then(() => {
+            httpRequest.abortSignal?.removeEventListener("abort", abortListener!);
+            return;
+          })
+          .catch((e) => {
+            throw e;
+          });
       }
     }
   }
@@ -228,7 +233,6 @@ function isReadableStream(body: any): body is Readable {
 
 function isStreamComplete(stream: Readable): Promise<void> {
   return new Promise((resolve) => {
-    stream.on("data", () => {});
     stream.on("close", resolve);
   });
 }

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -217,7 +217,7 @@ export abstract class FetchHttpClient implements HttpClient {
             return;
           })
           .catch((e) => {
-            logger.warning("Error when cleaning up abortListener", e);
+            logger.warning("Error when cleaning up abortListener on httpRequest", e);
           });
       }
     }

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -210,8 +210,9 @@ export abstract class FetchHttpClient implements HttpClient {
           downloadStreamDone = isStreamComplete(operationResponse!.readableStreamBody);
         }
 
-        await Promise.all([uploadStreamDone, downloadStreamDone]);
-        httpRequest.abortSignal?.removeEventListener("abort", abortListener);
+        Promise.all([uploadStreamDone, downloadStreamDone]).then(() => {
+          httpRequest.abortSignal?.removeEventListener("abort", abortListener!);
+        });
       }
     }
   }
@@ -227,9 +228,8 @@ function isReadableStream(body: any): body is Readable {
 
 function isStreamComplete(stream: Readable): Promise<void> {
   return new Promise((resolve) => {
+    stream.on("data", () => {});
     stream.on("close", resolve);
-    stream.on("end", resolve);
-    stream.on("error", resolve);
   });
 }
 

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -18,9 +18,18 @@ import { createHttpHeaders } from "./httpHeaders";
 import { RestError } from "./restError";
 import { URL } from "./util/url";
 import { IncomingMessage } from "http";
+import { logger } from "./log";
 
 function isReadableStream(body: any): body is NodeJS.ReadableStream {
   return body && typeof body.pipe === "function";
+}
+
+function isStreamComplete(stream: NodeJS.ReadableStream): Promise<void> {
+  return new Promise((resolve) => {
+    stream.on("close", resolve);
+    stream.on("end", resolve);
+    stream.on("error", resolve);
+  });
 }
 
 function isArrayBuffer(body: any): body is ArrayBuffer | ArrayBufferView {
@@ -92,6 +101,7 @@ export class NodeHttpsClient implements HttpsClient {
       }
     }
 
+    let responseStream: NodeJS.ReadableStream | undefined;
     try {
       const result = await new Promise<PipelineResponse>((resolve, reject) => {
         if (body && request.onUploadProgress) {
@@ -157,7 +167,23 @@ export class NodeHttpsClient implements HttpsClient {
     } finally {
       // clean up event listener
       if (request.abortSignal && abortListener) {
-        request.abortSignal.removeEventListener("abort", abortListener);
+        let uploadStreamDone = Promise.resolve();
+        if (isReadableStream(body)) {
+          uploadStreamDone = isStreamComplete(body as NodeJS.ReadableStream);
+        }
+        let downloadStreamDone = Promise.resolve();
+        if (isReadableStream(responseStream)) {
+          downloadStreamDone = isStreamComplete(responseStream);
+        }
+
+        Promise.all([uploadStreamDone, downloadStreamDone])
+          .then(() => {
+            request.abortSignal?.removeEventListener("abort", abortListener!);
+            return;
+          })
+          .catch((e) => {
+            logger.warning("Error when cleaning up abortListener", e);
+          });
       }
     }
   }

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -182,7 +182,7 @@ export class NodeHttpsClient implements HttpsClient {
             return;
           })
           .catch((e) => {
-            logger.warning("Error when cleaning up abortListener", e);
+            logger.warning("Error when cleaning up abortListener on httpRequest", e);
           });
       }
     }

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -734,7 +734,6 @@ describe("FileClient", () => {
       // tslint:disable-next-line:no-empty
     } catch (err) {
       assert.equal(err.name, "AbortError");
-      assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
     }
     assert.ok(eventTriggered);
   });


### PR DESCRIPTION
Currently our cleanup code removes the abort event listener when the response is
returned. In streaming case even the response is returned, the work is not done
yet. However, with the abort listener removed, we lost the ability to cancel the
streaming.

This change fixes the issue by unregistering the abort listener for
streaming when the stream ends or error happens.

This fixes #12029 