### PR TITLE
[Tables] Rename etag and timestamp system properties

### DIFF
--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -338,8 +338,8 @@ export class TableClient {
     delete(options?: DeleteTableOptions): Promise<DeleteTableResponse>;
     deleteEntity(partitionKey: string, rowKey: string, options?: DeleteTableEntityOptions): Promise<DeleteTableEntityResponse>;
     static fromConnectionString(connectionString: string, tableName: string, options?: TableServiceClientOptions): TableClient;
-    getEntity<T extends object>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<T>>;
-    listEntities<T extends object>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<T, ListEntitiesResponse<T>>;
+    getEntity<T extends object>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
+    listEntities<T extends object>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<TableEntityResult<T>, ListEntitiesResponse<TableEntityResult<T>>>;
     readonly tableName: string;
     updateEntity<T extends object>(entity: TableEntity<T>, mode: UpdateMode, options?: UpdateTableEntityOptions): Promise<UpdateEntityResponse>;
     upsertEntity<T extends object>(entity: TableEntity<T>, mode: UpdateMode, options?: UpsertTableEntityOptions): Promise<UpsertEntityResponse>;
@@ -398,6 +398,14 @@ export interface TableEntityQueryResponse {
         [propertyName: string]: any;
     }[];
 }
+
+// @public
+export type TableEntityResult<T> = T & {
+    etag: string;
+    partitionKey?: string;
+    rowKey?: string;
+    timestamp?: string;
+};
 
 // @public
 export interface TableGetAccessPolicyHeaders {

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -17,7 +17,8 @@ import {
   CreateTableOptions,
   CreateTableItemResponse,
   TableServiceClientOptions as TableClientOptions,
-  TableBatch
+  TableBatch,
+  TableEntityResult
 } from "./models";
 import {
   DeleteTableOptions,
@@ -212,7 +213,7 @@ export class TableClient {
     rowKey: string,
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: GetTableEntityOptions = {}
-  ): Promise<GetTableEntityResponse<T>> {
+  ): Promise<GetTableEntityResponse<TableEntityResult<T>>> {
     const { span, updatedOptions } = createSpan("TableClient-getEntity", options);
 
     try {
@@ -245,7 +246,7 @@ export class TableClient {
   public listEntities<T extends object>(
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: ListTableEntitiesOptions = {}
-  ): PagedAsyncIterableIterator<T, ListEntitiesResponse<T>> {
+  ): PagedAsyncIterableIterator<TableEntityResult<T>, ListEntitiesResponse<TableEntityResult<T>>> {
     const tableName = this.tableName;
     const iter = this.listEntitiesAll<T>(tableName, options);
 
@@ -269,7 +270,7 @@ export class TableClient {
   private async *listEntitiesAll<T extends object>(
     tableName: string,
     options?: ListTableEntitiesOptions
-  ): AsyncIterableIterator<T> {
+  ): AsyncIterableIterator<TableEntityResult<T>> {
     const firstPage = await this._listEntities<T>(tableName, options);
     const { nextPartitionKey, nextRowKey } = firstPage;
     yield* firstPage;
@@ -288,7 +289,7 @@ export class TableClient {
   private async *listEntitiesPage<T extends object>(
     tableName: string,
     options: InternalListTableEntitiesOptions = {}
-  ): AsyncIterableIterator<ListEntitiesResponse<T>> {
+  ): AsyncIterableIterator<ListEntitiesResponse<TableEntityResult<T>>> {
     const { span, updatedOptions } = createSpan("TableClient-listEntitiesPage", options);
 
     try {
@@ -319,7 +320,7 @@ export class TableClient {
   private async _listEntities<T extends object>(
     tableName: string,
     options?: ListTableEntitiesOptions
-  ): Promise<ListEntitiesResponse<T>> {
+  ): Promise<ListEntitiesResponse<TableEntityResult<T>>> {
     const queryOptions = this.convertQueryOptions(options?.queryOptions || {});
     const {
       xMsContinuationNextPartitionKey: nextPartitionKey,

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -232,6 +232,29 @@ export type ListTableItemsOptions = OperationOptions & {
 };
 
 /**
+ * Output type for query operations
+ */
+export type TableEntityResult<T> = T & {
+  /**
+   * etag property. Always returned by the service
+   */
+  etag: string;
+  /**
+   * Partition key property. Ommited if a select filter is set and this property is not requested
+   */
+  partitionKey?: string;
+  /**
+   * Row key property. Ommited if a select filter is set and this property is not requested
+   */
+  rowKey?: string;
+  /**
+   * Timestamp property. This property is assinged by the service on entity creation
+   * Ommited if a select filter is set and this property is not requested
+   */
+  timestamp?: string;
+};
+
+/**
  * List entities optional parameters.
  */
 export type ListTableEntitiesOptions = OperationOptions & {

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -5,7 +5,9 @@ import { EdmTypes } from "./models";
 
 const propertyCaseMap: Map<string, string> = new Map<string, string>([
   ["PartitionKey", "partitionKey"],
-  ["RowKey", "rowKey"]
+  ["RowKey", "rowKey"],
+  ["odata.etag", "etag"],
+  ["Timestamp", "timestamp"]
 ]);
 
 const Edm = {


### PR DESCRIPTION
When querying table entities the result includes 4 System properties:

- odata.etag: Always returned
- Timestamp: Can be omitted by setting a select query filter
- PartitionKey: Can be omitted by setting a select query filter
- RowKey: Can be omitted by setting a select query filter

This PR contains 2 changes to make the UX better when querying entities

1. Rename `odata.etag` -> `etag` and `Timestamp` -> `timestamp` we already do this for PartitionKey and RowKey
2. Add a return type for query operations to describe that a return type can contain the properties listed above