### PR TITLE
[Recorder] Fixing the missed await for `recorder.stop()` in the tests in all the packages 📝

### DIFF
--- a/sdk/eventgrid/eventgrid/test/eventGridClient.spec.ts
+++ b/sdk/eventgrid/eventgrid/test/eventGridClient.spec.ts
@@ -32,8 +32,8 @@ describe("EventGridPublisherClient", function() {
       ));
     });
 
-    afterEach(function() {
-      recorder.stop();
+    afterEach(async function() {
+      await recorder.stop();
     });
 
     it("sends a single event", async () => {
@@ -90,8 +90,8 @@ describe("EventGridPublisherClient", function() {
       ));
     });
 
-    afterEach(function() {
-      recorder.stop();
+    afterEach(async function() {
+      await recorder.stop();
     });
 
     it("sends a single event", async () => {
@@ -189,8 +189,8 @@ describe("EventGridPublisherClient", function() {
       ));
     });
 
-    afterEach(function() {
-      recorder.stop();
+    afterEach(async function() {
+      await recorder.stop();
     });
 
     it("sends a single event", async () => {

--- a/sdk/formrecognizer/ai-form-recognizer/test/public/node/formrecognizerclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/public/node/formrecognizerclient.spec.ts
@@ -26,7 +26,7 @@ describe("FormRecognizerClient NodeJS only", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 
@@ -185,7 +185,7 @@ describe("[AAD] FormRecognizerClient NodeJS only", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -41,7 +41,7 @@ describe("Local cryptography public tests", () => {
   });
 
   afterEach(async function() {
-    recorder.stop();
+    await recorder.stop();
   });
 
   it("encrypt & decrypt RSA1_5", async function() {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -32,7 +32,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -32,7 +32,7 @@ describe("MetricsAdvisorClient", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -81,7 +81,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/hookTests.spec.ts
@@ -42,7 +42,7 @@ describe("MetricsAdvisorClient hooks", () => {
 
   afterEach(async function() {
     if (recorder) {
-      recorder.stop();
+      await recorder.stop();
     }
   });
 

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -393,7 +393,7 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
 
   afterEach(async function() {
     await fileSystemClient.delete();
-    recorder.stop();
+    await recorder.stop();
   });
 
   it("setAccessControlRecursive should work", async () => {

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -10,7 +10,7 @@ import {
   DataLakeFileSystemClient,
   DataLakeServiceClient,
   PathAccessControlItem,
-  PathPermissions,
+  PathPermissions
 } from "../../src";
 import { toAcl, toRemoveAcl } from "../../src/transforms";
 import { bodyToString, getDataLakeServiceClient, recorderEnvSetup } from "../utils";
@@ -603,7 +603,11 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
     } catch (err) {
       assert.equal(err.name, "DataLakeAclChangeFailedError");
       assert.equal(err.innerError.name, "AbortError");
-      assert.equal(err.innerError.message, "The operation was aborted.", "Unexpected error caught: " + err);
+      assert.equal(
+        err.innerError.message,
+        "The operation was aborted.",
+        "Unexpected error caught: " + err
+      );
     }
 
     const result = await directoryClient.setAccessControlRecursive(
@@ -725,7 +729,6 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
     // TODO: Cannot set up environment to reproduce progress failure due to service change
     // Blob Data Contributor unexpectedly doesn't have permission for setRecursiveAcl API
     // Check with feature team
-    
     // /directory
     // /directory/subdirectory1
     // /directory/subdirectory1/fileName1
@@ -735,7 +738,6 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
     // Service client with SharedKey authentication creates following directories and files
     // /directory/subdirectory1/fileName5
     // /directory/subdirectory2/fileName6
-
     /*
 
     const token = "";

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## 2020-07-10
 
-- [Bug Fix] Fixed an issue where the browser-recording file is saved before all the recorded requests are pushed to the array of recordings(request-response pairs).
+- [Bug Fix] Fixed an issue where the browser-recording file is saved before all the recorded requests are pushed to the array of recordings(request-response pairs). `await recorder.stop()` - stop() call is expected to be await-ed from now on.
 
 ## 2020-04-30
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## 2020-07-10
 
 - [Bug Fix] Fixed an issue where the browser-recording file is saved before all the recorded requests are pushed to the array of recordings(request-response pairs). `await recorder.stop()` - stop() call is expected to be await-ed from now on.
+  [#10013](https://github.com/Azure/azure-sdk-for-js/pull/10013)
 
 ## 2020-04-30
 

--- a/sdk/test-utils/recorder/GUIDELINES.md
+++ b/sdk/test-utils/recorder/GUIDELINES.md
@@ -29,7 +29,7 @@ Add `@azure/test-utils-recorder` as a devDependency of your sdk.
 
 ### Recording the tests
 
-- `recorder = record(this, recorderEnvSetup);` initiates recording the HTTP requests and when `recorder.stop();` is called, the recording stops
+- `recorder = record(this, recorderEnvSetup);` initiates recording the HTTP requests and when `await recorder.stop();` is called, the recording stops
   and all the HTTP requests recorded in between the two calls are saved as part of the recording in the `"record"` mode.
   In the same way, existing recordings are leveraged and played back in the `"playback"` mode when `recorder = record(this, recorderEnvSetup);` is invoked.
   [Has no effect if the `TEST_MODE` is `"live"`, tests hit the live-service, we don't record the requests/responses]
@@ -47,7 +47,7 @@ Add `@azure/test-utils-recorder` as a devDependency of your sdk.
 
     afterEach(async () => {
       /*Place your code here*/
-      recorder.stop();
+      await recorder.stop();
     });
 
     it("<test-title>", async () => {
@@ -58,7 +58,7 @@ Add `@azure/test-utils-recorder` as a devDependency of your sdk.
 
 - Consider the `beforeEach`, `afterEach` and `it` blocks in the above test-suite.
 
-  - `recorder = record(this, recorderEnvSetup);` is invoked in the `beforeEach` section and `recorder.stop();` in the `afterEach` section.
+  - `recorder = record(this, recorderEnvSetup);` is invoked in the `beforeEach` section and `await recorder.stop();` in the `afterEach` section.
   - All the HTTP requests recorded in between the two calls are saved as part of the test(`it` block) recording in the `"record"` mode.
   - Existing test recording is played back when invoked `recorder = record(this, recorderEnvSetup);` in the `"playback"` mode.=
   - Any function call that affects http requests and is not in the `it`-block and belongs to a `describe`-block must go in one of the `beforeEach` or `afterEach` sections.
@@ -122,7 +122,7 @@ Add `@azure/test-utils-recorder` as a devDependency of your sdk.
   const tmr = recorder.newDate("tmr");
   ```
 
-- When `recorder.stop()` is called for a test, we save that unique information corresponding to the test run along with the test recording in the `record` mode.
+- When `await recorder.stop()` is called for a test, we save that unique information corresponding to the test run along with the test recording in the `record` mode.
 
 - In `playback` mode, the saved unique information is pulled out from the existing recording in order to replay the http requests.
 
@@ -197,7 +197,7 @@ Add `@azure/test-utils-recorder` as a devDependency of your sdk.
 
     afterEach(async () => {
       /*Place your code here*/
-      recorder.stop();
+      await recorder.stop();
     });
 
     it("should abort when abort() is called", async () => {

--- a/sdk/test-utils/recorder/README.md
+++ b/sdk/test-utils/recorder/README.md
@@ -327,8 +327,8 @@ describe("My test", () => {
     client = new KeysClient(keyVaultUrl, credential);
   });
 
-  afterEach(function () {
-    recorder.stop();
+  afterEach(async function () {
+    await recorder.stop();
   });
 });
 ```
@@ -367,8 +367,8 @@ recordings.
     client = new KeysClient(keyVaultUrl, credential);
   });
 
-  afterEach(function () {
-    recorder.stop();
+  afterEach(async function () {
+    await recorder.stop();
   });
 
   it("my first test", async function() {

--- a/sdk/test-utils/recorder/README.md
+++ b/sdk/test-utils/recorder/README.md
@@ -28,8 +28,8 @@ tests of an sdk.
 
 - [Key concepts](#key-concepts).
 - [Getting started](#getting-started).
-    - [Installing the package](#installing-the-package).
-    - [Configuring your project](#configuring-your-project).
+  - [Installing the package](#installing-the-package).
+  - [Configuring your project](#configuring-your-project).
 - [Examples](#examples).
   - [How to record](#how-to-record).
   - [How to playback](#how-to-playback).
@@ -139,7 +139,7 @@ Or, if you know what functions you want to import, you can also do the following
 ```typescript
 import { record, env, delay } from "@azure/test-utils-recorder";
 ```
- 
+
 The common recorder provides the following public methods and properties:
 
 - `record()`: Which deals with recording and playing back the network requests,
@@ -203,7 +203,7 @@ make it easier to switch from record mode to playback mode, on a meaningful cont
   // ... your package.json properties
   "integration-test:node": "mocha myNodeTests.js",
   "unit-test:node": "TEST_MODE=playback npm run integration-test:node",
-  "test:node:record": "TEST_MODE=record npm run integration-test:node",
+  "test:node:record": "TEST_MODE=record npm run integration-test:node"
   // ... more of your package.json properties
 }
 ```
@@ -216,7 +216,7 @@ add a way to clear the recordings on your `package.json`, like the following one
 ```json
 {
   // ... your package.json properties
-  "clear-recordings": "rm -fr recordings",
+  "clear-recordings": "rm -fr recordings"
   // ... more of your package.json properties
 }
 ```
@@ -245,7 +245,7 @@ config.set({
   files: [
     // ... you might have other things here. Keep them.
     "recordings/browsers/**/*.json"
-  ],
+  ]
   // ... more configuration properties here
 });
 ```
@@ -258,7 +258,7 @@ config.set({
   preprocessors: {
     // ... you might have other things here. Keep them.
     "recordings/browsers/**/*.json": ["json"]
-  },
+  }
   // ... more configuration properties here
 });
 ```
@@ -272,7 +272,7 @@ config.set({
   envPreprocessor: [
     // ... you might have other things here. Keep them.
     "TEST_MODE"
-  ],
+  ]
   // ... more configuration properties here
 });
 ```
@@ -285,7 +285,7 @@ config.set({
   // ... more configuration properties here
   browserConsoleLogOptions: {
     terminal: process.env.TEST_MODE !== "record"
-  },
+  }
   // ... more configuration properties here
 });
 ```
@@ -327,7 +327,7 @@ describe("My test", () => {
     client = new KeysClient(keyVaultUrl, credential);
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await recorder.stop();
   });
 });
@@ -388,7 +388,7 @@ recordings.
 ### How to playback
 
 Once you have recorded something, you can run your tests again with `TEST_MODE`
-set to `playback`.  You'll notice how they pass much faster. This time, they
+set to `playback`. You'll notice how they pass much faster. This time, they
 will not reach out to the remote address, but instead they will respond every
 request according to their matching copy stored in the recordings.
 
@@ -411,9 +411,9 @@ Writing live tests can take considerable time, specially since each time you
 want to check that everything works fine, you potentially need to run again
 every test. With the common recorder, you can specify what test to run by following Mocha's
 approach of setting certain tests to `it.only`, and also to skip specific tests
-with `it.skip`.  If you launch the recorder in record mode with some of these
+with `it.skip`. If you launch the recorder in record mode with some of these
 changes (and given that you activate the recorder on `beforeEach`), only the
-files that relate to the changed tests will be updated.  Skipped tests won't
+files that relate to the changed tests will be updated. Skipped tests won't
 update their recordings. This way, you can focus on fixing a specific set of
 test with `.only`, then remove all the `.only` calls and trust that the playback will
 keep confirming that the unaffected tests are fine and green.
@@ -474,10 +474,7 @@ the recorded string and return a string.
 Let's say your project can't include the word `mango`. You will be able to get rid of it with the following code inside your `beforeEach`:
 
 ```typescript
-setReplacements([
-  (recording: string): string =>
-    recording.replace(/mango/g, "bananas"),
-]);
+setReplacements([(recording: string): string => recording.replace(/mango/g, "bananas")]);
 ```
 
 This lets you have control over the generated recordings and filter any
@@ -494,7 +491,7 @@ For example, given that we find this query parameters in our recordings:
 if we don't want the parameters "sr", "sig" and "sp" to appear in these files, we can do the following:
 
 ```typescript
-skipQueryParams(["sr", "sig", "sp"])
+skipQueryParams(["sr", "sig", "sp"]);
 ```
 
 ### Ever-changing tests
@@ -514,13 +511,13 @@ understand, and we might be able to help by providing you with the following
 suggestions:
 
 1. Use randomly generated strings as prefixes or suffixes for the resources you
-create.  This will help you, but it will also only work so far, since new
-resources are likely to get accumulated, even if you set code to delete them in
-between tests, since some tests will eventually fail and crash your program.
+   create. This will help you, but it will also only work so far, since new
+   resources are likely to get accumulated, even if you set code to delete them in
+   between tests, since some tests will eventually fail and crash your program.
 2. Set up a separate program as part of your CI to automatically create and
-destroy new resources each time you run a test. It doesn't sound easy, but it
-might be a better solution.  You'll need to make sure to clear resources in
-case this program fails.
+   destroy new resources each time you run a test. It doesn't sound easy, but it
+   might be a better solution. You'll need to make sure to clear resources in
+   case this program fails.
 
 These ideas come with their own issue and things to consider, so please take them
 as ideas. We understand that might not be an easy problem to fix.
@@ -542,7 +539,7 @@ make sure to handle it as soon as we find the time.
 ## Next steps
 
 The common recorder might not be used yet in each one of the libraries in the
-azure-sdk-for-js repository (we're working on it).  In the mean time, an easy
+azure-sdk-for-js repository (we're working on it). In the mean time, an easy
 way to find where we're using this package is by going through the following
 search link:
 <https://github.com/Azure/azure-sdk-for-js/search?q=test-utils-recorder>


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/10013 updated the stop() method that is exported with the recorder to return a promise to make sure certain heavy recordings were recorded properly in the browser, @jeremymeng had updated all the packages to `await recorder.stop()`. 
However, some of the tests missed this update. This PR attempts to fix the rest of the tests and any of the `md` files that are outdated w.r.t this change.

Please make sure the call is awaited from now on. Thanks to @willmtemple for pointing out!