### PR TITLE
[core-http] Support overriding xml parser char key via options

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.2.0 (2020-10-19)
 
 - Explicitly set `manual` redirect handling for node fetch. And fixing redirectPipeline [PR 11863](https://github.com/Azure/azure-sdk-for-js/pull/11863)
-- Add support for multiple error response codes.[PR 11841](https://github.com/Azure/azure-sdk-for-js/)
+- Add support for multiple error response codes. [PR 11841](https://github.com/Azure/azure-sdk-for-js/)
+- Allow customizing serializer behavior via optional `SerialzierOptions` parameters. Particularly allow using a different `XML_CHARKEY` than the default `_` when parsing XML [PR 12065](https://github.com/Azure/azure-sdk-for-js/pull/12065)
 
 ## 1.1.9 (2020-09-30)
 

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -187,14 +187,10 @@ export interface DeserializationOptions {
 }
 
 // @public
-export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes, parsingOptions?: {
-    xmlCharKey?: string;
-}): RequestPolicyFactory;
+export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes, parsingOptions?: XmlOptions): RequestPolicyFactory;
 
 // @public (undocumented)
-export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse, options?: {
-    xmlCharKey?: string;
-}): Promise<HttpOperationResponse>;
+export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse, options?: XmlOptions): Promise<HttpOperationResponse>;
 
 // @public (undocumented)
 export interface DictionaryMapper extends BaseMapper {
@@ -518,10 +514,7 @@ export interface ParameterValue {
 }
 
 // @public
-export function parseXML(str: string, opts?: {
-    includeRoot?: boolean;
-    xmlCharKey?: string;
-}): Promise<any>;
+export function parseXML(str: string, opts?: XmlOptions): Promise<any>;
 
 // @public
 export interface PipelineOptions {
@@ -604,12 +597,10 @@ export interface RequestOptionsBase {
     };
     onDownloadProgress?: (progress: TransferProgressEvent) => void;
     onUploadProgress?: (progress: TransferProgressEvent) => void;
-    parsingOptions?: {
-        xmlCharKey?: string;
-    };
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
     spanOptions?: SpanOptions;
     timeout?: number;
+    xmlOptions?: XmlOptions;
 }
 
 // @public (undocumented)
@@ -736,18 +727,14 @@ export class Serializer {
     constructor(modelMappers?: {
         [key: string]: any;
     }, isXML?: boolean | undefined);
-    deserialize(mapper: Mapper, responseBody: any, objectName: string, options?: {
-        xmlCharKey?: string;
-    }): any;
+    deserialize(mapper: Mapper, responseBody: any, objectName: string, options?: XmlOptions): any;
     // (undocumented)
     readonly isXML?: boolean | undefined;
     // (undocumented)
     readonly modelMappers: {
         [key: string]: any;
     };
-    serialize(mapper: Mapper, object: any, objectName?: string, options?: {
-        xmlCharKey?: string;
-    }): any;
+    serialize(mapper: Mapper, object: any, objectName?: string, options?: XmlOptions): any;
     // (undocumented)
     validateConstraints(mapper: Mapper, value: any, objectName: string): void;
 }
@@ -797,10 +784,7 @@ export interface SimpleMapperType {
 }
 
 // @public
-export function stringifyXML(obj: any, opts?: {
-    rootName?: string;
-    xmlCharKey?: string;
-}): string;
+export function stringifyXML(obj: any, opts?: XmlOptions): string;
 
 // @public
 export function stripRequest(request: WebResourceLike): WebResourceLike;
@@ -972,6 +956,13 @@ export const XML_ATTRKEY = "$";
 
 // @public
 export const XML_CHARKEY = "_";
+
+// @public
+export interface XmlOptions {
+    includeRoot?: boolean;
+    rootName?: string;
+    xmlCharKey?: string;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -187,10 +187,10 @@ export interface DeserializationOptions {
 }
 
 // @public
-export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes, parsingOptions?: XmlOptions): RequestPolicyFactory;
+export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes, parsingOptions?: SerializerOptions): RequestPolicyFactory;
 
 // @public (undocumented)
-export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse, options?: XmlOptions): Promise<HttpOperationResponse>;
+export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse, options?: SerializerOptions): Promise<HttpOperationResponse>;
 
 // @public (undocumented)
 export interface DictionaryMapper extends BaseMapper {
@@ -514,7 +514,7 @@ export interface ParameterValue {
 }
 
 // @public
-export function parseXML(str: string, opts?: XmlOptions): Promise<any>;
+export function parseXML(str: string, opts?: SerializerOptions): Promise<any>;
 
 // @public
 export interface PipelineOptions {
@@ -597,10 +597,10 @@ export interface RequestOptionsBase {
     };
     onDownloadProgress?: (progress: TransferProgressEvent) => void;
     onUploadProgress?: (progress: TransferProgressEvent) => void;
+    serializerOptions?: SerializerOptions;
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
     spanOptions?: SpanOptions;
     timeout?: number;
-    xmlOptions?: XmlOptions;
 }
 
 // @public (undocumented)
@@ -727,16 +727,23 @@ export class Serializer {
     constructor(modelMappers?: {
         [key: string]: any;
     }, isXML?: boolean | undefined);
-    deserialize(mapper: Mapper, responseBody: any, objectName: string, options?: XmlOptions): any;
+    deserialize(mapper: Mapper, responseBody: any, objectName: string, options?: SerializerOptions): any;
     // (undocumented)
     readonly isXML?: boolean | undefined;
     // (undocumented)
     readonly modelMappers: {
         [key: string]: any;
     };
-    serialize(mapper: Mapper, object: any, objectName?: string, options?: XmlOptions): any;
+    serialize(mapper: Mapper, object: any, objectName?: string, options?: SerializerOptions): any;
     // (undocumented)
     validateConstraints(mapper: Mapper, value: any, objectName: string): void;
+}
+
+// @public
+export interface SerializerOptions {
+    includeRoot?: boolean;
+    rootName?: string;
+    xmlCharKey?: string;
 }
 
 // @public
@@ -784,7 +791,7 @@ export interface SimpleMapperType {
 }
 
 // @public
-export function stringifyXML(obj: any, opts?: XmlOptions): string;
+export function stringifyXML(obj: any, opts?: SerializerOptions): string;
 
 // @public
 export function stripRequest(request: WebResourceLike): WebResourceLike;
@@ -956,13 +963,6 @@ export const XML_ATTRKEY = "$";
 
 // @public
 export const XML_CHARKEY = "_";
-
-// @public
-export interface XmlOptions {
-    includeRoot?: boolean;
-    rootName?: string;
-    xmlCharKey?: string;
-}
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -187,10 +187,14 @@ export interface DeserializationOptions {
 }
 
 // @public
-export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes): RequestPolicyFactory;
+export function deserializationPolicy(deserializationContentTypes?: DeserializationContentTypes, parsingOptions?: {
+    xmlCharKey?: string;
+}): RequestPolicyFactory;
 
 // @public (undocumented)
-export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse): Promise<HttpOperationResponse>;
+export function deserializeResponseBody(jsonContentTypes: string[], xmlContentTypes: string[], response: HttpOperationResponse, options?: {
+    xmlCharKey?: string;
+}): Promise<HttpOperationResponse>;
 
 // @public (undocumented)
 export interface DictionaryMapper extends BaseMapper {
@@ -516,6 +520,7 @@ export interface ParameterValue {
 // @public
 export function parseXML(str: string, opts?: {
     includeRoot?: boolean;
+    xmlCharKey?: string;
 }): Promise<any>;
 
 // @public
@@ -599,6 +604,9 @@ export interface RequestOptionsBase {
     };
     onDownloadProgress?: (progress: TransferProgressEvent) => void;
     onUploadProgress?: (progress: TransferProgressEvent) => void;
+    parsingOptions?: {
+        xmlCharKey?: string;
+    };
     shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
     spanOptions?: SpanOptions;
     timeout?: number;
@@ -728,14 +736,18 @@ export class Serializer {
     constructor(modelMappers?: {
         [key: string]: any;
     }, isXML?: boolean | undefined);
-    deserialize(mapper: Mapper, responseBody: any, objectName: string): any;
+    deserialize(mapper: Mapper, responseBody: any, objectName: string, options?: {
+        xmlCharKey?: string;
+    }): any;
     // (undocumented)
     readonly isXML?: boolean | undefined;
     // (undocumented)
     readonly modelMappers: {
         [key: string]: any;
     };
-    serialize(mapper: Mapper, object: any, objectName?: string): any;
+    serialize(mapper: Mapper, object: any, objectName?: string, options?: {
+        xmlCharKey?: string;
+    }): any;
     // (undocumented)
     validateConstraints(mapper: Mapper, value: any, objectName: string): void;
 }
@@ -787,6 +799,7 @@ export interface SimpleMapperType {
 // @public
 export function stringifyXML(obj: any, opts?: {
     rootName?: string;
+    xmlCharKey?: string;
 }): string;
 
 // @public
@@ -953,6 +966,12 @@ export interface WebResourceLike {
     validateRequestProperties(): void;
     withCredentials: boolean;
 }
+
+// @public
+export const XML_ATTRKEY = "$";
+
+// @public
+export const XML_CHARKEY = "_";
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -125,4 +125,4 @@ export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
 
 export { parseXML, stringifyXML } from "./util/xml";
-export { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./util/xml.common";
+export { XML_ATTRKEY, XML_CHARKEY, SerializerOptions } from "./util/serializer.common";

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -125,4 +125,4 @@ export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
 
 export { parseXML, stringifyXML } from "./util/xml";
-export { XML_ATTRKEY, XML_CHARKEY } from "./util/xml.common";
+export { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./util/xml.common";

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -125,3 +125,4 @@ export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
 
 export { parseXML, stringifyXML } from "./util/xml";
+export { XML_ATTRKEY, XML_CHARKEY } from "./util/xml.common";

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -14,7 +14,7 @@ import {
   RequestPolicyFactory,
   RequestPolicyOptions
 } from "./requestPolicy";
-import { XML_CHARKEY, XmlOptions } from "../util/xml.common";
+import { XML_CHARKEY, SerializerOptions } from "../util/serializer.common";
 
 /**
  * Options to configure API response deserialization.
@@ -51,7 +51,7 @@ export interface DeserializationContentTypes {
  */
 export function deserializationPolicy(
   deserializationContentTypes?: DeserializationContentTypes,
-  parsingOptions?: XmlOptions
+  parsingOptions?: SerializerOptions
 ): RequestPolicyFactory {
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
@@ -88,7 +88,7 @@ export class DeserializationPolicy extends BaseRequestPolicy {
     nextPolicy: RequestPolicy,
     requestPolicyOptions: RequestPolicyOptions,
     deserializationContentTypes?: DeserializationContentTypes,
-    parsingOptions: XmlOptions = {}
+    parsingOptions: SerializerOptions = {}
   ) {
     super(nextPolicy, requestPolicyOptions);
 
@@ -148,7 +148,7 @@ export function deserializeResponseBody(
   jsonContentTypes: string[],
   xmlContentTypes: string[],
   response: HttpOperationResponse,
-  options?: XmlOptions
+  options?: SerializerOptions
 ): Promise<HttpOperationResponse> {
   return parse(jsonContentTypes, xmlContentTypes, response, options).then((parsedResponse) => {
     if (!shouldDeserializeResponse(parsedResponse)) {

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -4,7 +4,7 @@
 
 import * as base64 from "./util/base64";
 import * as utils from "./util/utils";
-import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./util/xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, SerializerOptions } from "./util/serializer.common";
 
 export class Serializer {
   constructor(
@@ -90,7 +90,13 @@ export class Serializer {
    *
    * @returns {object|string|Array|number|boolean|Date|stream} A valid serialized Javascript object
    */
-  serialize(mapper: Mapper, object: any, objectName?: string, options: XmlOptions = {}): any {
+  serialize(
+    mapper: Mapper,
+    object: any,
+    objectName?: string,
+    options: SerializerOptions = {}
+  ): any {
+    const updatedOptions = options.xmlCharKey ? options : { ...options, xmlCharKey: XML_CHARKEY };
     let payload: any = {};
     const mapperType = mapper.type.name as string;
     if (!objectName) {
@@ -153,7 +159,7 @@ export class Serializer {
           object,
           objectName,
           Boolean(this.isXML),
-          options
+          updatedOptions
         );
       } else if (mapperType.match(/^Dictionary$/i) !== null) {
         payload = serializeDictionaryType(
@@ -162,7 +168,7 @@ export class Serializer {
           object,
           objectName,
           Boolean(this.isXML),
-          options
+          updatedOptions
         );
       } else if (mapperType.match(/^Composite$/i) !== null) {
         payload = serializeCompositeType(
@@ -171,7 +177,7 @@ export class Serializer {
           object,
           objectName,
           Boolean(this.isXML),
-          options
+          updatedOptions
         );
       }
     }
@@ -195,7 +201,7 @@ export class Serializer {
     mapper: Mapper,
     responseBody: any,
     objectName: string,
-    options: XmlOptions = {}
+    options: SerializerOptions = {}
   ): any {
     if (responseBody == undefined) {
       if (this.isXML && mapper.type.name === "Sequence" && !mapper.xmlIsWrapped) {
@@ -510,7 +516,7 @@ function serializeSequenceType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: XmlOptions
+  options: SerializerOptions
 ): any[] {
   if (!Array.isArray(object)) {
     throw new Error(`${objectName} must be of type Array.`);
@@ -551,7 +557,7 @@ function serializeDictionaryType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: XmlOptions
+  options: SerializerOptions
 ): { [key: string]: any } {
   if (typeof object !== "object") {
     throw new Error(`${objectName} must be of type object.`);
@@ -662,7 +668,7 @@ function serializeCompositeType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: XmlOptions
+  options: SerializerOptions
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, object, "clientName");
@@ -775,7 +781,7 @@ function getXmlObjectValue(
   propertyMapper: Mapper,
   serializedValue: any,
   isXml: boolean,
-  options: XmlOptions
+  options: SerializerOptions
 ) {
   if (!isXml || !propertyMapper.xmlNamespace) {
     return serializedValue;
@@ -801,7 +807,7 @@ function getXmlObjectValue(
   return result;
 }
 
-function isSpecialXmlProperty(propertyName: string, options: XmlOptions): boolean {
+function isSpecialXmlProperty(propertyName: string, options: SerializerOptions): boolean {
   return [XML_ATTRKEY, options.xmlCharKey ?? XML_CHARKEY].includes(propertyName);
 }
 
@@ -810,7 +816,7 @@ function deserializeCompositeType(
   mapper: CompositeMapper,
   responseBody: any,
   objectName: string,
-  options: XmlOptions
+  options: SerializerOptions
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, responseBody, "serializedName");
@@ -981,7 +987,7 @@ function deserializeDictionaryType(
   mapper: DictionaryMapper,
   responseBody: any,
   objectName: string,
-  options: XmlOptions
+  options: SerializerOptions
 ): { [key: string]: any } {
   const value = mapper.type.value;
   if (!value || typeof value !== "object") {
@@ -1005,7 +1011,7 @@ function deserializeSequenceType(
   mapper: SequenceMapper,
   responseBody: any,
   objectName: string,
-  options: XmlOptions
+  options: SerializerOptions
 ): any[] {
   const element = mapper.type.element;
   if (!element || typeof element !== "object") {

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -4,6 +4,7 @@
 
 import * as base64 from "./util/base64";
 import * as utils from "./util/utils";
+import { XML_ATTRKEY, XML_CHARKEY } from "./util/xml.common";
 
 export class Serializer {
   constructor(
@@ -85,9 +86,16 @@ export class Serializer {
    *
    * @param {string} objectName Name of the serialized object
    *
+   * @param {options} options additional options to deserialization
+   *
    * @returns {object|string|Array|number|boolean|Date|stream} A valid serialized Javascript object
    */
-  serialize(mapper: Mapper, object: any, objectName?: string): any {
+  serialize(
+    mapper: Mapper,
+    object: any,
+    objectName?: string,
+    options?: { xmlCharKey?: string }
+  ): any {
     let payload: any = {};
     const mapperType = mapper.type.name as string;
     if (!objectName) {
@@ -149,7 +157,8 @@ export class Serializer {
           mapper as SequenceMapper,
           object,
           objectName,
-          Boolean(this.isXML)
+          Boolean(this.isXML),
+          options
         );
       } else if (mapperType.match(/^Dictionary$/i) !== null) {
         payload = serializeDictionaryType(
@@ -157,7 +166,8 @@ export class Serializer {
           mapper as DictionaryMapper,
           object,
           objectName,
-          Boolean(this.isXML)
+          Boolean(this.isXML),
+          options
         );
       } else if (mapperType.match(/^Composite$/i) !== null) {
         payload = serializeCompositeType(
@@ -165,7 +175,8 @@ export class Serializer {
           mapper as CompositeMapper,
           object,
           objectName,
-          Boolean(this.isXML)
+          Boolean(this.isXML),
+          options
         );
       }
     }
@@ -181,9 +192,16 @@ export class Serializer {
    *
    * @param {string} objectName Name of the deserialized object
    *
+   * @param options
+   *
    * @returns {object|string|Array|number|boolean|Date|stream} A valid deserialized Javascript object
    */
-  deserialize(mapper: Mapper, responseBody: any, objectName: string): any {
+  deserialize(
+    mapper: Mapper,
+    responseBody: any,
+    objectName: string,
+    options?: { xmlCharKey?: string }
+  ): any {
     if (responseBody == undefined) {
       if (this.isXML && mapper.type.name === "Sequence" && !mapper.xmlIsWrapped) {
         // Edge case for empty XML non-wrapped lists. xml2js can't distinguish
@@ -205,16 +223,25 @@ export class Serializer {
     }
 
     if (mapperType.match(/^Composite$/i) !== null) {
-      payload = deserializeCompositeType(this, mapper as CompositeMapper, responseBody, objectName);
+      payload = deserializeCompositeType(
+        this,
+        mapper as CompositeMapper,
+        responseBody,
+        objectName,
+        options
+      );
     } else {
       if (this.isXML) {
         /**
          * If the mapper specifies this as a non-composite type value but the responseBody contains
-         * both header ("$") and body ("_") properties, then just reduce the responseBody value to
-         * the body ("_") property.
+         * both header ("$" i.e., XML_ATTRKEY) and body ("#" i.e., XML_CHARKEY) properties,
+         * then just reduce the responseBody value to the body ("#" i.e., XML_CHARKEY) property.
          */
-        if (responseBody["$"] != undefined && responseBody["_"] != undefined) {
-          responseBody = responseBody["_"];
+        if (
+          responseBody[XML_ATTRKEY] != undefined &&
+          responseBody[options?.xmlCharKey ?? XML_CHARKEY] != undefined
+        ) {
+          responseBody = responseBody[options?.xmlCharKey ?? XML_CHARKEY];
         }
       }
 
@@ -242,13 +269,20 @@ export class Serializer {
       } else if (mapperType.match(/^Base64Url$/i) !== null) {
         payload = base64UrlToByteArray(responseBody);
       } else if (mapperType.match(/^Sequence$/i) !== null) {
-        payload = deserializeSequenceType(this, mapper as SequenceMapper, responseBody, objectName);
+        payload = deserializeSequenceType(
+          this,
+          mapper as SequenceMapper,
+          responseBody,
+          objectName,
+          options
+        );
       } else if (mapperType.match(/^Dictionary$/i) !== null) {
         payload = deserializeDictionaryType(
           this,
           mapper as DictionaryMapper,
           responseBody,
-          objectName
+          objectName,
+          options
         );
       }
     }
@@ -482,7 +516,8 @@ function serializeSequenceType(
   mapper: SequenceMapper,
   object: any,
   objectName: string,
-  isXml: boolean
+  isXml: boolean,
+  options?: { xmlCharKey?: string }
 ): any[] {
   if (!Array.isArray(object)) {
     throw new Error(`${objectName} must be of type Array.`);
@@ -496,16 +531,19 @@ function serializeSequenceType(
   }
   const tempArray = [];
   for (let i = 0; i < object.length; i++) {
-    const serializedValue = serializer.serialize(elementType, object[i], objectName);
+    const serializedValue = serializer.serialize(elementType, object[i], objectName, options);
 
     if (isXml && elementType.xmlNamespace) {
       const xmlnsKey = elementType.xmlNamespacePrefix
         ? `xmlns:${elementType.xmlNamespacePrefix}`
         : "xmlns";
       if (elementType.type.name === "Composite") {
-        tempArray[i] = { ...serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
+        tempArray[i] = { ...serializedValue };
+        tempArray[i][XML_ATTRKEY] = { [xmlnsKey]: elementType.xmlNamespace };
       } else {
-        tempArray[i] = { _: serializedValue, $: { [xmlnsKey]: elementType.xmlNamespace } };
+        tempArray[i] = {};
+        tempArray[i][options?.xmlCharKey ?? XML_CHARKEY] = serializedValue;
+        tempArray[i][XML_ATTRKEY] = { [xmlnsKey]: elementType.xmlNamespace };
       }
     } else {
       tempArray[i] = serializedValue;
@@ -519,7 +557,8 @@ function serializeDictionaryType(
   mapper: DictionaryMapper,
   object: any,
   objectName: string,
-  isXml: boolean
+  isXml: boolean,
+  options?: { xmlCharKey?: string }
 ): { [key: string]: any } {
   if (typeof object !== "object") {
     throw new Error(`${objectName} must be of type object.`);
@@ -533,7 +572,7 @@ function serializeDictionaryType(
   }
   const tempDictionary: { [key: string]: any } = {};
   for (const key of Object.keys(object)) {
-    const serializedValue = serializer.serialize(valueType, object[key], objectName);
+    const serializedValue = serializer.serialize(valueType, object[key], objectName, options);
     // If the element needs an XML namespace we need to add it within the $ property
     tempDictionary[key] = getXmlObjectValue(valueType, serializedValue, isXml);
   }
@@ -629,7 +668,8 @@ function serializeCompositeType(
   mapper: CompositeMapper,
   object: any,
   objectName: string,
-  isXml: boolean
+  isXml: boolean,
+  options?: { xmlCharKey?: string }
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, object, "clientName");
@@ -673,7 +713,10 @@ function serializeCompositeType(
           const xmlnsKey = mapper.xmlNamespacePrefix
             ? `xmlns:${mapper.xmlNamespacePrefix}`
             : "xmlns";
-          parentObject.$ = { ...parentObject.$, [xmlnsKey]: mapper.xmlNamespace };
+          parentObject[XML_ATTRKEY] = {
+            ...parentObject[XML_ATTRKEY],
+            [xmlnsKey]: mapper.xmlNamespace
+          };
         }
         const propertyObjectName =
           propertyMapper.serializedName !== ""
@@ -693,17 +736,18 @@ function serializeCompositeType(
         const serializedValue = serializer.serialize(
           propertyMapper,
           toSerialize,
-          propertyObjectName
+          propertyObjectName,
+          options
         );
 
         if (serializedValue !== undefined && propName != undefined) {
           const value = getXmlObjectValue(propertyMapper, serializedValue, isXml);
           if (isXml && propertyMapper.xmlIsAttribute) {
-            // $ is the key attributes are kept under in xml2js.
+            // XML_ATTRKEY, i.e., $ is the key attributes are kept under in xml2js.
             // This keeps things simple while preventing name collision
             // with names in user documents.
-            parentObject.$ = parentObject.$ || {};
-            parentObject.$[propName] = serializedValue;
+            parentObject[XML_ATTRKEY] = parentObject[XML_ATTRKEY] || {};
+            parentObject[XML_ATTRKEY][propName] = serializedValue;
           } else if (isXml && propertyMapper.xmlIsWrapped) {
             parentObject[propName] = { [propertyMapper.xmlElementName!]: value };
           } else {
@@ -722,7 +766,8 @@ function serializeCompositeType(
           payload[clientPropName] = serializer.serialize(
             additionalPropertiesMapper,
             object[clientPropName],
-            objectName + '["' + clientPropName + '"]'
+            objectName + '["' + clientPropName + '"]',
+            options
           );
         }
       }
@@ -733,7 +778,12 @@ function serializeCompositeType(
   return object;
 }
 
-function getXmlObjectValue(propertyMapper: Mapper, serializedValue: any, isXml: boolean) {
+function getXmlObjectValue(
+  propertyMapper: Mapper,
+  serializedValue: any,
+  isXml: boolean,
+  options?: { xmlCharKey?: string }
+) {
   if (!isXml || !propertyMapper.xmlNamespace) {
     return serializedValue;
   }
@@ -744,20 +794,30 @@ function getXmlObjectValue(propertyMapper: Mapper, serializedValue: any, isXml: 
   const xmlNamespace = { [xmlnsKey]: propertyMapper.xmlNamespace };
 
   if (["Composite"].includes(propertyMapper.type.name)) {
-    return { $: xmlNamespace, ...serializedValue };
+    if (serializedValue[XML_ATTRKEY]) {
+      return serializedValue;
+    } else {
+      const result: any = { ...serializedValue };
+      result[XML_ATTRKEY] = xmlNamespace;
+      return result;
+    }
   }
-  return { _: serializedValue, $: xmlNamespace };
+  const result: any = {};
+  result[options?.xmlCharKey ?? XML_CHARKEY] = serializedValue;
+  result[XML_ATTRKEY] = xmlNamespace;
+  return result;
 }
 
-function isSpecialXmlProperty(propertyName: string): boolean {
-  return ["$", "_"].includes(propertyName);
+function isSpecialXmlProperty(propertyName: string, options?: { xmlCharKey?: string }): boolean {
+  return [XML_ATTRKEY, options?.xmlCharKey ?? XML_CHARKEY].includes(propertyName);
 }
 
 function deserializeCompositeType(
   serializer: Serializer,
   mapper: CompositeMapper,
   responseBody: any,
-  objectName: string
+  objectName: string,
+  options?: { xmlCharKey?: string }
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, responseBody, "serializedName");
@@ -785,7 +845,8 @@ function deserializeCompositeType(
           dictionary[headerKey.substring(headerCollectionPrefix.length)] = serializer.deserialize(
             (propertyMapper as DictionaryMapper).type.value,
             responseBody[headerKey],
-            propertyObjectName
+            propertyObjectName,
+            options
           );
         }
 
@@ -793,11 +854,12 @@ function deserializeCompositeType(
       }
       instance[key] = dictionary;
     } else if (serializer.isXML) {
-      if (propertyMapper.xmlIsAttribute && responseBody.$) {
+      if (propertyMapper.xmlIsAttribute && responseBody[XML_ATTRKEY]) {
         instance[key] = serializer.deserialize(
           propertyMapper,
-          responseBody.$[xmlName!],
-          propertyObjectName
+          responseBody[XML_ATTRKEY][xmlName!],
+          propertyObjectName,
+          options
         );
       } else {
         const propertyName = xmlElementName || xmlName || serializedName;
@@ -818,10 +880,20 @@ function deserializeCompositeType(
           */
           const wrapped = responseBody[xmlName!];
           const elementList = wrapped?.[xmlElementName!] ?? [];
-          instance[key] = serializer.deserialize(propertyMapper, elementList, propertyObjectName);
+          instance[key] = serializer.deserialize(
+            propertyMapper,
+            elementList,
+            propertyObjectName,
+            options
+          );
         } else {
           const property = responseBody[propertyName!];
-          instance[key] = serializer.deserialize(propertyMapper, property, propertyObjectName);
+          instance[key] = serializer.deserialize(
+            propertyMapper,
+            property,
+            propertyObjectName,
+            options
+          );
         }
       }
     } else {
@@ -856,12 +928,18 @@ function deserializeCompositeType(
       // paging
       if (Array.isArray(responseBody[key]) && modelProps[key].serializedName === "") {
         propertyInstance = responseBody[key];
-        instance = serializer.deserialize(propertyMapper, propertyInstance, propertyObjectName);
+        instance = serializer.deserialize(
+          propertyMapper,
+          propertyInstance,
+          propertyObjectName,
+          options
+        );
       } else if (propertyInstance !== undefined || propertyMapper.defaultValue !== undefined) {
         serializedValue = serializer.deserialize(
           propertyMapper,
           propertyInstance,
-          propertyObjectName
+          propertyObjectName,
+          options
         );
         instance[key] = serializedValue;
       }
@@ -885,7 +963,8 @@ function deserializeCompositeType(
         instance[responsePropName] = serializer.deserialize(
           additionalPropertiesMapper,
           responseBody[responsePropName],
-          objectName + '["' + responsePropName + '"]'
+          objectName + '["' + responsePropName + '"]',
+          options
         );
       }
     }
@@ -894,7 +973,7 @@ function deserializeCompositeType(
       if (
         instance[key] === undefined &&
         !handledPropertyNames.includes(key) &&
-        !isSpecialXmlProperty(key)
+        !isSpecialXmlProperty(key, options)
       ) {
         instance[key] = responseBody[key];
       }
@@ -908,7 +987,8 @@ function deserializeDictionaryType(
   serializer: Serializer,
   mapper: DictionaryMapper,
   responseBody: any,
-  objectName: string
+  objectName: string,
+  options?: { xmlCharKey?: string }
 ): { [key: string]: any } {
   const value = mapper.type.value;
   if (!value || typeof value !== "object") {
@@ -920,7 +1000,7 @@ function deserializeDictionaryType(
   if (responseBody) {
     const tempDictionary: { [key: string]: any } = {};
     for (const key of Object.keys(responseBody)) {
-      tempDictionary[key] = serializer.deserialize(value, responseBody[key], objectName);
+      tempDictionary[key] = serializer.deserialize(value, responseBody[key], objectName, options);
     }
     return tempDictionary;
   }
@@ -931,7 +1011,8 @@ function deserializeSequenceType(
   serializer: Serializer,
   mapper: SequenceMapper,
   responseBody: any,
-  objectName: string
+  objectName: string,
+  options?: { xmlCharKey?: string }
 ): any[] {
   const element = mapper.type.element;
   if (!element || typeof element !== "object") {
@@ -948,7 +1029,12 @@ function deserializeSequenceType(
 
     const tempArray = [];
     for (let i = 0; i < responseBody.length; i++) {
-      tempArray[i] = serializer.deserialize(element, responseBody[i], `${objectName}[${i}]`);
+      tempArray[i] = serializer.deserialize(
+        element,
+        responseBody[i],
+        `${objectName}[${i}]`,
+        options
+      );
     }
     return tempArray;
   }

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -96,7 +96,11 @@ export class Serializer {
     objectName?: string,
     options: SerializerOptions = {}
   ): any {
-    const updatedOptions = options.xmlCharKey ? options : { ...options, xmlCharKey: XML_CHARKEY };
+    const updatedOptions: Required<SerializerOptions> = {
+      rootName: options.rootName ?? "",
+      includeRoot: options.includeRoot ?? false,
+      xmlCharKey: options.xmlCharKey ?? XML_CHARKEY
+    };
     let payload: any = {};
     const mapperType = mapper.type.name as string;
     if (!objectName) {
@@ -203,6 +207,11 @@ export class Serializer {
     objectName: string,
     options: SerializerOptions = {}
   ): any {
+    const updatedOptions: Required<SerializerOptions> = {
+      rootName: options.rootName ?? "",
+      includeRoot: options.includeRoot ?? false,
+      xmlCharKey: options.xmlCharKey ?? XML_CHARKEY
+    };
     if (responseBody == undefined) {
       if (this.isXML && mapper.type.name === "Sequence" && !mapper.xmlIsWrapped) {
         // Edge case for empty XML non-wrapped lists. xml2js can't distinguish
@@ -229,11 +238,11 @@ export class Serializer {
         mapper as CompositeMapper,
         responseBody,
         objectName,
-        options
+        updatedOptions
       );
     } else {
       if (this.isXML) {
-        const xmlCharKey = options?.xmlCharKey ?? XML_CHARKEY;
+        const xmlCharKey = updatedOptions.xmlCharKey;
         /**
          * If the mapper specifies this as a non-composite type value but the responseBody contains
          * both header ("$" i.e., XML_ATTRKEY) and body ("#" i.e., XML_CHARKEY) properties,
@@ -273,7 +282,7 @@ export class Serializer {
           mapper as SequenceMapper,
           responseBody,
           objectName,
-          options
+          updatedOptions
         );
       } else if (mapperType.match(/^Dictionary$/i) !== null) {
         payload = deserializeDictionaryType(
@@ -281,7 +290,7 @@ export class Serializer {
           mapper as DictionaryMapper,
           responseBody,
           objectName,
-          options
+          updatedOptions
         );
       }
     }
@@ -516,7 +525,7 @@ function serializeSequenceType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): any[] {
   if (!Array.isArray(object)) {
     throw new Error(`${objectName} must be of type Array.`);
@@ -541,7 +550,7 @@ function serializeSequenceType(
         tempArray[i][XML_ATTRKEY] = { [xmlnsKey]: elementType.xmlNamespace };
       } else {
         tempArray[i] = {};
-        tempArray[i][options?.xmlCharKey ?? XML_CHARKEY] = serializedValue;
+        tempArray[i][options.xmlCharKey] = serializedValue;
         tempArray[i][XML_ATTRKEY] = { [xmlnsKey]: elementType.xmlNamespace };
       }
     } else {
@@ -557,7 +566,7 @@ function serializeDictionaryType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): { [key: string]: any } {
   if (typeof object !== "object") {
     throw new Error(`${objectName} must be of type object.`);
@@ -668,7 +677,7 @@ function serializeCompositeType(
   object: any,
   objectName: string,
   isXml: boolean,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, object, "clientName");
@@ -781,7 +790,7 @@ function getXmlObjectValue(
   propertyMapper: Mapper,
   serializedValue: any,
   isXml: boolean,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ) {
   if (!isXml || !propertyMapper.xmlNamespace) {
     return serializedValue;
@@ -802,13 +811,13 @@ function getXmlObjectValue(
     }
   }
   const result: any = {};
-  result[options?.xmlCharKey ?? XML_CHARKEY] = serializedValue;
+  result[options.xmlCharKey] = serializedValue;
   result[XML_ATTRKEY] = xmlNamespace;
   return result;
 }
 
-function isSpecialXmlProperty(propertyName: string, options: SerializerOptions): boolean {
-  return [XML_ATTRKEY, options.xmlCharKey ?? XML_CHARKEY].includes(propertyName);
+function isSpecialXmlProperty(propertyName: string, options: Required<SerializerOptions>): boolean {
+  return [XML_ATTRKEY, options.xmlCharKey].includes(propertyName);
 }
 
 function deserializeCompositeType(
@@ -816,7 +825,7 @@ function deserializeCompositeType(
   mapper: CompositeMapper,
   responseBody: any,
   objectName: string,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): any {
   if (getPolymorphicDiscriminatorRecursively(serializer, mapper)) {
     mapper = getPolymorphicMapper(serializer, mapper, responseBody, "serializedName");
@@ -987,7 +996,7 @@ function deserializeDictionaryType(
   mapper: DictionaryMapper,
   responseBody: any,
   objectName: string,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): { [key: string]: any } {
   const value = mapper.type.value;
   if (!value || typeof value !== "object") {
@@ -1011,7 +1020,7 @@ function deserializeSequenceType(
   mapper: SequenceMapper,
   responseBody: any,
   objectName: string,
-  options: SerializerOptions
+  options: Required<SerializerOptions>
 ): any[] {
   const element = mapper.type.element;
   if (!element || typeof element !== "object") {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -60,7 +60,7 @@ import { DefaultKeepAliveOptions, keepAlivePolicy } from "./policies/keepAlivePo
 import { tracingPolicy } from "./policies/tracingPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 import { ndJsonPolicy } from "./policies/ndJsonPolicy";
-import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./util/xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, SerializerOptions } from "./util/serializer.common";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).
@@ -304,7 +304,7 @@ export class ServiceClient {
       operationArguments.options = undefined;
     }
 
-    const xmlOptions = operationArguments.options?.xmlOptions;
+    const serializerOptions = operationArguments.options?.serializerOptions;
     const httpRequest: WebResourceLike = new WebResource();
 
     let result: Promise<RestResponse>;
@@ -335,7 +335,7 @@ export class ServiceClient {
             urlParameter.mapper,
             urlParameterValue,
             getPathStringFromParameter(urlParameter),
-            xmlOptions
+            serializerOptions
           );
           if (!urlParameter.skipEncoding) {
             urlParameterValue = encodeURIComponent(urlParameterValue);
@@ -359,7 +359,7 @@ export class ServiceClient {
               queryParameter.mapper,
               queryParameterValue,
               getPathStringFromParameter(queryParameter),
-              xmlOptions
+              serializerOptions
             );
             if (
               queryParameter.collectionFormat !== undefined &&
@@ -432,7 +432,7 @@ export class ServiceClient {
               headerParameter.mapper,
               headerValue,
               getPathStringFromParameter(headerParameter),
-              xmlOptions
+              serializerOptions
             );
             const headerCollectionPrefix = (headerParameter.mapper as DictionaryMapper)
               .headerCollectionPrefix;
@@ -535,8 +535,8 @@ export function serializeRequestBody(
   operationArguments: OperationArguments,
   operationSpec: OperationSpec
 ): void {
-  const xmlOptions = operationArguments.options?.xmlOptions ?? {};
-  const xmlCharKey = xmlOptions?.xmlCharKey;
+  const serializerOptions = operationArguments.options?.serializerOptions ?? {};
+  const xmlCharKey = serializerOptions.xmlCharKey;
   if (operationSpec.requestBody && operationSpec.requestBody.mapper) {
     httpRequest.body = getOperationArgumentValueFromParameter(
       serviceClient,
@@ -565,7 +565,7 @@ export function serializeRequestBody(
           bodyMapper,
           httpRequest.body,
           requestBodyParameterPathString,
-          xmlOptions
+          serializerOptions
         );
 
         const isStream = typeName === MapperType.Stream;
@@ -577,7 +577,7 @@ export function serializeRequestBody(
             xmlnsKey,
             typeName,
             httpRequest.body,
-            xmlOptions
+            serializerOptions
           );
           if (typeName === MapperType.Sequence) {
             httpRequest.body = stringifyXML(
@@ -634,7 +634,7 @@ export function serializeRequestBody(
           formDataParameter.mapper,
           formDataParameterValue,
           getPathStringFromParameter(formDataParameter),
-          xmlOptions
+          serializerOptions
         );
       }
     }
@@ -649,7 +649,7 @@ function getXmlValueWithNamespace(
   xmlnsKey: string,
   typeName: string,
   serializedValue: any,
-  options: XmlOptions
+  options: SerializerOptions
 ): any {
   // Composite and Sequence schemas already got their root namespace set during serialization
   // We just need to add xmlns to the other schema types
@@ -858,7 +858,7 @@ export function getOperationArgumentValueFromParameterPath(
   if (typeof parameterPath === "string") {
     parameterPath = [parameterPath];
   }
-  const xmlOptions = operationArguments.options?.xmlOptions;
+  const serializerOptions = operationArguments.options?.serializerOptions;
   if (Array.isArray(parameterPath)) {
     if (parameterPath.length > 0) {
       if (parameterMapper.isConstant) {
@@ -886,7 +886,7 @@ export function getOperationArgumentValueFromParameterPath(
         parameterPath,
         parameterMapper
       );
-      serializer.serialize(parameterMapper, value, parameterPathString, xmlOptions);
+      serializer.serialize(parameterMapper, value, parameterPathString, serializerOptions);
     }
   } else {
     if (parameterMapper.required) {
@@ -910,7 +910,7 @@ export function getOperationArgumentValueFromParameterPath(
         propertyPath,
         propertyMapper
       );
-      serializer.serialize(propertyMapper, propertyValue, propertyPathString, xmlOptions);
+      serializer.serialize(propertyMapper, propertyValue, propertyPathString, serializerOptions);
       if (propertyValue !== undefined && propertyValue !== null) {
         if (!value) {
           value = {};

--- a/sdk/core/core-http/src/util/serializer.common.ts
+++ b/sdk/core/core-http/src/util/serializer.common.ts
@@ -9,10 +9,11 @@ export const XML_ATTRKEY = "$";
  * Default key used to access the XML value content.
  */
 export const XML_CHARKEY = "_";
+
 /**
  * Options to govern behavior of xml parser and builder.
  */
-export interface XmlOptions {
+export interface SerializerOptions {
   /**
    * indicates the name of the root element in the resulting XML when building XML.
    */

--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -203,7 +203,7 @@ export function prepareXMLRootList(
     return { [elementName]: obj };
   }
 
-  return { [elementName]: obj, $: {[xmlNamespaceKey]: xmlNamespace} };
+  return { [elementName]: obj, $: { [xmlNamespaceKey]: xmlNamespace } };
 }
 
 /**

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { XML_ATTRKEY, XML_CHARKEY } from "./xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
 
 // tslint:disable-next-line:no-null-keyword
 const doc = document.implementation.createDocument(null, null, null);
 
 const parser = new DOMParser();
-export function parseXML(
-  str: string,
-  opts?: { includeRoot?: boolean; xmlCharKey?: string }
-): Promise<any> {
+export function parseXML(str: string, opts: XmlOptions = {}): Promise<any> {
   try {
     const dom = parser.parseFromString(str, "application/xml");
     throwIfError(dom);
@@ -57,7 +54,7 @@ function asElementWithAttributes(node: Node): Element | undefined {
   return isElement(node) && node.hasAttributes() ? node : undefined;
 }
 
-function domToObject(node: Node, options?: { xmlCharKey?: string }): any {
+function domToObject(node: Node, options: XmlOptions): any {
   let result: any = {};
 
   const childNodeCount: number = node.childNodes.length;
@@ -110,10 +107,7 @@ function domToObject(node: Node, options?: { xmlCharKey?: string }): any {
 
 const serializer = new XMLSerializer();
 
-export function stringifyXML(
-  content: any,
-  opts?: { rootName?: string; xmlCharKey?: string }
-): string {
+export function stringifyXML(content: any, opts: XmlOptions = {}): string {
   const rootName = (opts && opts.rootName) || "root";
   const dom = buildNode(content, rootName, opts)[0];
   return (
@@ -131,7 +125,7 @@ function buildAttributes(attrs: { [key: string]: { toString(): string } }): Attr
   return result;
 }
 
-function buildNode(obj: any, elementName: string, options?: { xmlCharKey?: string }): Node[] {
+function buildNode(obj: any, elementName: string, options: XmlOptions): Node[] {
   if (
     obj === undefined ||
     obj === null ||
@@ -157,7 +151,7 @@ function buildNode(obj: any, elementName: string, options?: { xmlCharKey?: strin
         for (const attr of buildAttributes(obj[key])) {
           elem.attributes.setNamedItem(attr);
         }
-      } else if (key === (options?.xmlCharKey ?? XML_CHARKEY)) {
+      } else if (key === (options.xmlCharKey ?? XML_CHARKEY)) {
         elem.textContent = obj[key].toString();
       } else {
         for (const child of buildNode(obj[key], key, options)) {

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -1,20 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { XML_ATTRKEY, XML_CHARKEY } from "./xml.common";
+
 // tslint:disable-next-line:no-null-keyword
 const doc = document.implementation.createDocument(null, null, null);
 
 const parser = new DOMParser();
-export function parseXML(str: string, opts?: { includeRoot?: boolean }): Promise<any> {
+export function parseXML(
+  str: string,
+  opts?: { includeRoot?: boolean; xmlCharKey?: string }
+): Promise<any> {
   try {
     const dom = parser.parseFromString(str, "application/xml");
     throwIfError(dom);
 
     let obj;
     if (opts && opts.includeRoot) {
-      obj = domToObject(dom);
+      obj = domToObject(dom, opts);
     } else {
-      obj = domToObject(dom.childNodes[0]);
+      obj = domToObject(dom.childNodes[0], opts);
     }
 
     return Promise.resolve(obj);
@@ -52,7 +57,7 @@ function asElementWithAttributes(node: Node): Element | undefined {
   return isElement(node) && node.hasAttributes() ? node : undefined;
 }
 
-function domToObject(node: Node): any {
+function domToObject(node: Node, options?: { xmlCharKey?: string }): any {
   let result: any = {};
 
   const childNodeCount: number = node.childNodes.length;
@@ -67,15 +72,15 @@ function domToObject(node: Node): any {
 
   const elementWithAttributes: Element | undefined = asElementWithAttributes(node);
   if (elementWithAttributes) {
-    result["$"] = {};
+    result[XML_ATTRKEY] = {};
 
     for (let i = 0; i < elementWithAttributes.attributes.length; i++) {
       const attr = elementWithAttributes.attributes[i];
-      result["$"][attr.nodeName] = attr.nodeValue;
+      result[XML_ATTRKEY][attr.nodeName] = attr.nodeValue;
     }
 
     if (onlyChildTextValue) {
-      result["_"] = onlyChildTextValue;
+      result[options?.xmlCharKey ?? XML_CHARKEY] = onlyChildTextValue;
     }
   } else if (childNodeCount === 0) {
     result = "";
@@ -88,7 +93,7 @@ function domToObject(node: Node): any {
       const child = node.childNodes[i];
       // Ignore leading/trailing whitespace nodes
       if (child.nodeType !== Node.TEXT_NODE) {
-        const childObject: any = domToObject(child);
+        const childObject: any = domToObject(child, options);
         if (!result[child.nodeName]) {
           result[child.nodeName] = childObject;
         } else if (Array.isArray(result[child.nodeName])) {
@@ -105,9 +110,12 @@ function domToObject(node: Node): any {
 
 const serializer = new XMLSerializer();
 
-export function stringifyXML(content: any, opts?: { rootName?: string }): string {
+export function stringifyXML(
+  content: any,
+  opts?: { rootName?: string; xmlCharKey?: string }
+): string {
   const rootName = (opts && opts.rootName) || "root";
-  const dom = buildNode(content, rootName)[0];
+  const dom = buildNode(content, rootName, opts)[0];
   return (
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + serializer.serializeToString(dom)
   );
@@ -123,7 +131,7 @@ function buildAttributes(attrs: { [key: string]: { toString(): string } }): Attr
   return result;
 }
 
-function buildNode(obj: any, elementName: string): Node[] {
+function buildNode(obj: any, elementName: string, options?: { xmlCharKey?: string }): Node[] {
   if (
     obj === undefined ||
     obj === null ||
@@ -137,7 +145,7 @@ function buildNode(obj: any, elementName: string): Node[] {
   } else if (Array.isArray(obj)) {
     const result = [];
     for (const arrayElem of obj) {
-      for (const child of buildNode(arrayElem, elementName)) {
+      for (const child of buildNode(arrayElem, elementName, options)) {
         result.push(child);
       }
     }
@@ -145,14 +153,14 @@ function buildNode(obj: any, elementName: string): Node[] {
   } else if (typeof obj === "object") {
     const elem = doc.createElement(elementName);
     for (const key of Object.keys(obj)) {
-      if (key === "$") {
+      if (key === XML_ATTRKEY) {
         for (const attr of buildAttributes(obj[key])) {
           elem.attributes.setNamedItem(attr);
         }
-      } else if (key === "_") {
+      } else if (key === (options?.xmlCharKey ?? XML_CHARKEY)) {
         elem.textContent = obj[key].toString();
       } else {
-        for (const child of buildNode(obj[key], key)) {
+        for (const child of buildNode(obj[key], key, options)) {
           elem.appendChild(child);
         }
       }

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, SerializerOptions } from "./serializer.common";
 
 // tslint:disable-next-line:no-null-keyword
 const doc = document.implementation.createDocument(null, null, null);
 
 const parser = new DOMParser();
-export function parseXML(str: string, opts: XmlOptions = {}): Promise<any> {
+export function parseXML(str: string, opts: SerializerOptions = {}): Promise<any> {
   try {
     const dom = parser.parseFromString(str, "application/xml");
     throwIfError(dom);
@@ -54,7 +54,7 @@ function asElementWithAttributes(node: Node): Element | undefined {
   return isElement(node) && node.hasAttributes() ? node : undefined;
 }
 
-function domToObject(node: Node, options: XmlOptions): any {
+function domToObject(node: Node, options: SerializerOptions): any {
   let result: any = {};
 
   const childNodeCount: number = node.childNodes.length;
@@ -107,7 +107,7 @@ function domToObject(node: Node, options: XmlOptions): any {
 
 const serializer = new XMLSerializer();
 
-export function stringifyXML(content: any, opts: XmlOptions = {}): string {
+export function stringifyXML(content: any, opts: SerializerOptions = {}): string {
   const rootName = (opts && opts.rootName) || "root";
   const dom = buildNode(content, rootName, opts)[0];
   return (
@@ -125,7 +125,7 @@ function buildAttributes(attrs: { [key: string]: { toString(): string } }): Attr
   return result;
 }
 
-function buildNode(obj: any, elementName: string, options: XmlOptions): Node[] {
+function buildNode(obj: any, elementName: string, options: SerializerOptions): Node[] {
   if (
     obj === undefined ||
     obj === null ||

--- a/sdk/core/core-http/src/util/xml.common.ts
+++ b/sdk/core/core-http/src/util/xml.common.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Default key used to access the XML attributes.
+ */
+export const XML_ATTRKEY = "$";
+/**
+ * Default key used to access the XML value content.
+ */
+export const XML_CHARKEY = "_";

--- a/sdk/core/core-http/src/util/xml.common.ts
+++ b/sdk/core/core-http/src/util/xml.common.ts
@@ -9,3 +9,20 @@ export const XML_ATTRKEY = "$";
  * Default key used to access the XML value content.
  */
 export const XML_CHARKEY = "_";
+/**
+ * Options to govern behavior of xml parser and builder.
+ */
+export interface XmlOptions {
+  /**
+   * indicates the name of the root element in the resulting XML when building XML.
+   */
+  rootName?: string;
+  /**
+   * indicates whether the root element is to be included or not in the output when parsing XML.
+   */
+  includeRoot?: boolean;
+  /**
+   * key used to access the XML value content when parsing XML.
+   */
+  xmlCharKey?: string;
+}

--- a/sdk/core/core-http/src/util/xml.ts
+++ b/sdk/core/core-http/src/util/xml.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as xml2js from "xml2js";
+import { XML_ATTRKEY, XML_CHARKEY } from "./xml.common";
 
 // Note: The reason we re-define all of the xml2js default settings (version 2.0) here is because the default settings object exposed
 // by the xm2js library is mutable. See https://github.com/Leonidas-from-XIV/node-xml2js/issues/536
@@ -12,8 +13,7 @@ const xml2jsDefaultOptionsV2 = {
   trim: false,
   normalize: false,
   normalizeTags: false,
-  attrkey: "$",
-  charkey: "_",
+  attrkey: XML_ATTRKEY,
   explicitArray: true,
   ignoreAttrs: false,
   mergeAttrs: false,
@@ -66,8 +66,9 @@ xml2jsBuilderSettings.renderOpts = {
  * @param opts Options that govern the parsing of given JSON object
  * `rootName` indicates the name of the root element in the resulting XML
  */
-export function stringifyXML(obj: any, opts?: { rootName?: string }): string {
+export function stringifyXML(obj: any, opts?: { rootName?: string; xmlCharKey?: string }): string {
   xml2jsBuilderSettings.rootName = (opts || {}).rootName;
+  xml2jsBuilderSettings.charkey = opts?.xmlCharKey ?? XML_CHARKEY;
   const builder = new xml2js.Builder(xml2jsBuilderSettings);
   return builder.buildObject(obj);
 }
@@ -78,8 +79,12 @@ export function stringifyXML(obj: any, opts?: { rootName?: string }): string {
  * @param opts Options that govern the parsing of given xml string
  * `includeRoot` indicates whether the root element is to be included or not in the output
  */
-export function parseXML(str: string, opts?: { includeRoot?: boolean }): Promise<any> {
+export function parseXML(
+  str: string,
+  opts?: { includeRoot?: boolean; xmlCharKey?: string }
+): Promise<any> {
   xml2jsParserSettings.explicitRoot = !!(opts && opts.includeRoot);
+  xml2jsParserSettings.charkey = opts?.xmlCharKey ?? XML_CHARKEY;
   const xmlParser = new xml2js.Parser(xml2jsParserSettings);
   return new Promise((resolve, reject) => {
     if (!str) {

--- a/sdk/core/core-http/src/util/xml.ts
+++ b/sdk/core/core-http/src/util/xml.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as xml2js from "xml2js";
-import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, SerializerOptions } from "./serializer.common";
 
 // Note: The reason we re-define all of the xml2js default settings (version 2.0) here is because the default settings object exposed
 // by the xm2js library is mutable. See https://github.com/Leonidas-from-XIV/node-xml2js/issues/536
@@ -66,7 +66,7 @@ xml2jsBuilderSettings.renderOpts = {
  * @param opts Options that govern the parsing of given JSON object
  * `rootName` indicates the name of the root element in the resulting XML
  */
-export function stringifyXML(obj: any, opts: XmlOptions = {}): string {
+export function stringifyXML(obj: any, opts: SerializerOptions = {}): string {
   xml2jsBuilderSettings.rootName = opts.rootName;
   xml2jsBuilderSettings.charkey = opts.xmlCharKey ?? XML_CHARKEY;
   const builder = new xml2js.Builder(xml2jsBuilderSettings);
@@ -79,7 +79,7 @@ export function stringifyXML(obj: any, opts: XmlOptions = {}): string {
  * @param opts Options that govern the parsing of given xml string
  * `includeRoot` indicates whether the root element is to be included or not in the output
  */
-export function parseXML(str: string, opts: XmlOptions = {}): Promise<any> {
+export function parseXML(str: string, opts: SerializerOptions = {}): Promise<any> {
   xml2jsParserSettings.explicitRoot = !!opts.includeRoot;
   xml2jsParserSettings.charkey = opts.xmlCharKey ?? XML_CHARKEY;
   const xmlParser = new xml2js.Parser(xml2jsParserSettings);

--- a/sdk/core/core-http/src/util/xml.ts
+++ b/sdk/core/core-http/src/util/xml.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import * as xml2js from "xml2js";
-import { XML_ATTRKEY, XML_CHARKEY } from "./xml.common";
+import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
 
 // Note: The reason we re-define all of the xml2js default settings (version 2.0) here is because the default settings object exposed
 // by the xm2js library is mutable. See https://github.com/Leonidas-from-XIV/node-xml2js/issues/536
 // By creating a new copy of the settings each time we instantiate the parser,
 // we are safeguarding against the possibility of the default settings being mutated elsewhere unintentionally.
-const xml2jsDefaultOptionsV2 = {
+const xml2jsDefaultOptionsV2: xml2js.OptionsV2 = {
   explicitCharkey: false,
   trim: false,
   normalize: false,
@@ -18,7 +18,7 @@ const xml2jsDefaultOptionsV2 = {
   ignoreAttrs: false,
   mergeAttrs: false,
   explicitRoot: true,
-  validator: null,
+  validator: undefined,
   xmlns: false,
   explicitChildren: false,
   preserveChildrenOrder: false,
@@ -27,17 +27,17 @@ const xml2jsDefaultOptionsV2 = {
   includeWhiteChars: false,
   async: false,
   strict: true,
-  attrNameProcessors: null,
-  attrValueProcessors: null,
-  tagNameProcessors: null,
-  valueProcessors: null,
+  attrNameProcessors: undefined,
+  attrValueProcessors: undefined,
+  tagNameProcessors: undefined,
+  valueProcessors: undefined,
   rootName: "root",
   xmldec: {
     version: "1.0",
     encoding: "UTF-8",
     standalone: true
   },
-  doctype: null,
+  doctype: undefined,
   renderOpts: {
     pretty: true,
     indent: "  ",
@@ -66,9 +66,9 @@ xml2jsBuilderSettings.renderOpts = {
  * @param opts Options that govern the parsing of given JSON object
  * `rootName` indicates the name of the root element in the resulting XML
  */
-export function stringifyXML(obj: any, opts?: { rootName?: string; xmlCharKey?: string }): string {
-  xml2jsBuilderSettings.rootName = (opts || {}).rootName;
-  xml2jsBuilderSettings.charkey = opts?.xmlCharKey ?? XML_CHARKEY;
+export function stringifyXML(obj: any, opts: XmlOptions = {}): string {
+  xml2jsBuilderSettings.rootName = opts.rootName;
+  xml2jsBuilderSettings.charkey = opts.xmlCharKey ?? XML_CHARKEY;
   const builder = new xml2js.Builder(xml2jsBuilderSettings);
   return builder.buildObject(obj);
 }
@@ -79,12 +79,9 @@ export function stringifyXML(obj: any, opts?: { rootName?: string; xmlCharKey?: 
  * @param opts Options that govern the parsing of given xml string
  * `includeRoot` indicates whether the root element is to be included or not in the output
  */
-export function parseXML(
-  str: string,
-  opts?: { includeRoot?: boolean; xmlCharKey?: string }
-): Promise<any> {
-  xml2jsParserSettings.explicitRoot = !!(opts && opts.includeRoot);
-  xml2jsParserSettings.charkey = opts?.xmlCharKey ?? XML_CHARKEY;
+export function parseXML(str: string, opts: XmlOptions = {}): Promise<any> {
+  xml2jsParserSettings.explicitRoot = !!opts.includeRoot;
+  xml2jsParserSettings.charkey = opts.xmlCharKey ?? XML_CHARKEY;
   const xmlParser = new xml2js.Parser(xml2jsParserSettings);
   return new Promise((resolve, reject) => {
     if (!str) {

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -10,6 +10,7 @@ import { OperationResponse } from "./operationResponse";
 import { ProxySettings } from "./serviceClient";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { SpanOptions } from "@azure/core-tracing";
+import { XmlOptions } from "./util/xml.common";
 
 export type HttpMethods =
   | "GET"
@@ -669,12 +670,7 @@ export interface RequestOptionsBase {
   [key: string]: any;
 
   /**
-   * Options to override parsing behavior.
+   * Options to override XML parsing/building behavior.
    */
-  parsingOptions?: {
-    /**
-     * Options to override the default xml parser CHARKEY.
-     */
-    xmlCharKey?: string;
-  };
+  xmlOptions?: XmlOptions;
 }

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -667,4 +667,14 @@ export interface RequestOptionsBase {
   spanOptions?: SpanOptions;
 
   [key: string]: any;
+
+  /**
+   * Options to override parsing behavior.
+   */
+  parsingOptions?: {
+    /**
+     * Options to override the default xml parser CHARKEY.
+     */
+    xmlCharKey?: string;
+  };
 }

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -10,7 +10,7 @@ import { OperationResponse } from "./operationResponse";
 import { ProxySettings } from "./serviceClient";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { SpanOptions } from "@azure/core-tracing";
-import { XmlOptions } from "./util/xml.common";
+import { SerializerOptions } from "./util/serializer.common";
 
 export type HttpMethods =
   | "GET"
@@ -672,5 +672,5 @@ export interface RequestOptionsBase {
   /**
    * Options to override XML parsing/building behavior.
    */
-  xmlOptions?: XmlOptions;
+  serializerOptions?: SerializerOptions;
 }

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -27,12 +27,7 @@ describe("deserializationPolicy", function() {
   };
 
   it(`should not modify a request that has no request body mapper`, async function() {
-    const deserializationPolicy = new DeserializationPolicy(
-      mockPolicy,
-      {},
-      undefined,
-      new RequestPolicyOptions()
-    );
+    const deserializationPolicy = new DeserializationPolicy(mockPolicy, new RequestPolicyOptions());
 
     const request = createRequest();
     request.body = "hello there!";
@@ -54,9 +49,9 @@ describe("deserializationPolicy", function() {
     };
     const deserializationPolicy = new DeserializationPolicy(
       mockClient,
+      new RequestPolicyOptions(),
       {},
-      { xmlCharKey: "#" },
-      new RequestPolicyOptions()
+      { xmlCharKey: "#" }
     );
 
     const response = await deserializationPolicy.sendRequest(request);

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -1269,7 +1269,9 @@ describe("ServiceClient", function() {
             "#": "pound value"
           },
           options: {
-            xmlCharKey: "#"
+            xmlOptions: {
+              xmlCharKey: "#"
+            }
           }
         },
         {

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -1259,6 +1259,50 @@ describe("ServiceClient", function() {
       assert.strictEqual(httpRequest.body, "body value");
     });
 
+    it("should serialize an XML request body with custom xml char key", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          requestBody: {
+            "#": "pound value"
+          },
+          options: {
+            xmlCharKey: "#"
+          }
+        },
+        {
+          httpMethod: "POST",
+          requestBody: {
+            parameterPath: "requestBody",
+            mapper: {
+              serializedName: "Body",
+              xmlName: "entry",
+              type: {
+                name: "Composite",
+                className: "Body",
+                modelProperties: {
+                  "#": {
+                    serializedName: "#",
+                    xmlName: "#",
+                    type: { name: "String" }
+                  }
+                }
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer(undefined, true /** isXML */),
+          isXML: true
+        }
+      );
+      assert.strictEqual(
+        httpRequest.body,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><entry>pound value</entry>`
+      );
+    });
+
     it("should serialize a string send to a text/plain endpoint as just a string", () => {
       const httpRequest = new WebResource();
       serializeRequestBody(

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -1269,7 +1269,7 @@ describe("ServiceClient", function() {
             "#": "pound value"
           },
           options: {
-            xmlOptions: {
+            serializerOptions: {
               xmlCharKey: "#"
             }
           }

--- a/sdk/core/core-http/test/xmlTests.ts
+++ b/sdk/core/core-http/test/xmlTests.ts
@@ -115,6 +115,15 @@ describe("XML serializer", function() {
         }
       });
     });
+
+    it("with underscore element", async function() {
+      const str = "<Metadata><h>v</h><_>underscore</_></Metadata>";
+      const parsed = await parseXML(str, { xmlCharKey: "#" });
+      assert.deepStrictEqual(parsed, {
+        h: "v",
+        _: "underscore"
+      });
+    });
   });
 
   describe("parseXML(string) with root", function() {


### PR DESCRIPTION
Currently our xml parser uses hard-coded `_` as key to access parsed
xml element content. This causes issue like storage customer getting
errors listing blobs when they use `_` as Blob metadata key.

This PR adds support to allow customizing the xml parser char key via
options. Currently `xmlCharKey` option is supported, with room for
other options (e.g., attr key for accessing parsed xml attributes).