### PR TITLE
[core-http] Do not serialize empty multi collection param 

### DIFF
--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -138,7 +138,7 @@ function calculateQueryParameters(
           });
         }
         if (queryParameter.collectionFormat === "Multi" && queryParameterValue.length === 0) {
-          queryParameterValue = "";
+          continue;
         } else if (
           Array.isArray(queryParameterValue) &&
           (queryParameter.collectionFormat === "SSV" || queryParameter.collectionFormat === "TSV")
@@ -205,7 +205,6 @@ function appendQueryParams(url: string, queryParams: Map<string, string | string
   }
 
   // QUIRK: we have to set search manually as searchParams will encode comma when it shouldn't.
-  parsedUrl.search = `?${searchPieces.join("&")}`;
-
+  parsedUrl.search = searchPieces.length ? `?${searchPieces.join("&")}` : "";
   return parsedUrl.toString();
 }

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -157,6 +157,7 @@ describe("ServiceClient", function() {
     await testSendOperationRequest(["1", "2", "3"], "Multi", false, "?q=1&q=2&q=3");
     await testSendOperationRequest(["1,2", "3,4", "5"], "Multi", false, "?q=1%2C2&q=3%2C4&q=5");
     await testSendOperationRequest(["1,2", "3,4", "5"], "Multi", true, "?q=1,2&q=3,4&q=5");
+    await testSendOperationRequest([], "Multi", true, "https://example.com/");
   });
 
   it("should deserialize response bodies", async function() {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -363,7 +363,8 @@ export class ServiceClient {
             ) {
               if (queryParameter.collectionFormat === QueryCollectionFormat.Multi) {
                 if (queryParameterValue.length === 0) {
-                  queryParameterValue = "";
+                  // The collection is empty, no need to try serializing the current queryParam
+                  continue;
                 } else {
                   for (const index in queryParameterValue) {
                     const item = queryParameterValue[index];

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -224,6 +224,10 @@ describe("ServiceClient", function() {
     );
   });
 
+  it("should serialize collection with empty multi query parameter", async function() {
+    await testSendOperationRequest([], QueryCollectionFormat.Multi, true, "httpbin.org");
+  });
+
   it("should apply withCredentials to requests", async function() {
     let request: WebResource;
     const httpClient: HttpClient = {


### PR DESCRIPTION
When serializing `multi` format query parameters, if the collection is empty we should omit the query parameter.

For context, a collection with multi format would be serialized as

Collection: [1,2,3]
Serialized Url: http://example.com?q=1&q=2&q2

So when the collection is empty: []
We should skip the parameter otherwise the service would interpret it as a collection with a null element i.e. [nul]

For an empty collection: []

**Current behavior**
http://example.com?q=

**Expected**
http://example.com