### PR TITLE
[Service Bus] Remove userId on the top level message

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,12 +11,12 @@
 - The `processError` passed to `Receiver.subscribe` now receives a `ProcessErrorArgs` instead of just an error. This parameter provides additional context that can make it simpler to distinguish
   errors that were thrown from your callback (via the `errorSource` member of `ProcessErrorArgs`) as well as giving you some information about the entity that generated the error.
   [PR 11927](https://github.com/Azure/azure-sdk-for-js/pull/11927)
-- A helper method `parseServiceBusConnectionString` has been added which validates and parses a given connection string for Azure Service Bus. [PR 11949](https://github.com/Azure/azure-sdk-for-js/pull/11949)
-- Added new "userId" property to `ServiceBusMessage` interface. [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
-
-- `NamespaceProperties` interface property "messageSku" type changed from "string" to string literal type "Basic" | "Premium" | "Standard". [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
-- `NamespaceProperties` interface property "namespaceType" has been removed. [PR 11995](https://github.com/Azure/azure-sdk-for-js/pull/11995)
-
+- A helper method `parseServiceBusConnectionString` has been added which validates and parses a given connection string for Azure Service Bus.
+  [PR 11949](https://github.com/Azure/azure-sdk-for-js/pull/11949)
+- `NamespaceProperties` interface property "messageSku" type changed from "string" to string literal type "Basic" | "Premium" | "Standard".
+  [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
+- `NamespaceProperties` interface property "namespaceType" has been removed.
+  [PR 11995](https://github.com/Azure/azure-sdk-for-js/pull/11995)
 - Internal improvement - For the operations depending on `$management` link such as peek or lock renewals, the listeners for the "sender_error" and "receiver_error" events were added to the link for each new request made before the link is initialized which would have resulted in too many listeners and a warning such as `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 sender_error listeners added to [Sender]. Use emittr.setMaxListeners() to increase limit`(same for `receiver_error`). This has been improved such that the listeners are reused.
   [PR 11738](https://github.com/Azure/azure-sdk-for-js/pull/11738)
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -363,7 +363,6 @@ export interface ServiceBusMessage {
     subject?: string;
     timeToLive?: number;
     to?: string;
-    userId?: string;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -213,11 +213,6 @@ export interface ServiceBusMessage {
    * used for custom message metadata.
    */
   applicationProperties?: { [key: string]: number | boolean | string | Date };
-
-  /**
-   * @property The identity of the user producing the message.
-   */
-  userId?: string;
 }
 
 /**
@@ -484,10 +479,6 @@ export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
     amqpMsg.message_annotations![Constants.scheduledEnqueueTime] = msg.scheduledEnqueueTimeUtc;
   }
 
-  if (msg.userId != null) {
-    amqpMsg.user_id = msg.userId;
-  }
-
   logger.verbose("SBMessage to AmqpMessage: %O", amqpMsg);
   return amqpMsg;
 }
@@ -669,10 +660,6 @@ export function fromAmqpMessage(
     props.expiresAtUtc = new Date(Constants.maxDurationValue);
   } else {
     props.expiresAtUtc = new Date(props.enqueuedTimeUtc.getTime() + msg.ttl!);
-  }
-
-  if (msg.user_id != null) {
-    sbmsg.userId = msg.user_id;
   }
 
   const rcvdsbmsg: ServiceBusReceivedMessage = {

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -33,8 +33,7 @@ export class TestMessage {
         propTwo: "two",
         propThree: true,
         propFour: Date()
-      },
-      userId: `${randomTag} userId`
+      }
     };
   }
 
@@ -57,8 +56,7 @@ export class TestMessage {
         propThree: true
       },
       sessionId: TestMessage.sessionId,
-      replyToSessionId: "some-other-session-id",
-      userId: `${randomNumber} userId`
+      replyToSessionId: "some-other-session-id"
     };
   }
 
@@ -130,8 +128,6 @@ export class TestMessage {
         `Unexpected partitionKey in received msg`
       );
     }
-
-    chai.assert.equal(received.userId, sent.userId, "Unexpected userId in received msg");
   }
 }
 


### PR DESCRIPTION
Removing `userId` from the top level ServiceBusMessage
- It will still be present in the `ServiceBusReceivedMessage._amqpAnnotatedMessage.properties`
- Since this property is something not present on the top level interface/object from the beginning, this is being removed