### PR TITLE
Move LRO files into a package

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Release History
 
-## 1.0.3 (Unreleased)
+## 1.1.0 (Unreleased)
 
+- Added LRO specific policy and code. Refer [#613](https://github.com/Azure/autorest.typescript/issues/613) for further details.
 
 ## 1.0.2 (2020-04-28)
+
 - Moved `@opentelemetry/types` to the `devDependencies`.
 
 ## 1.0.1 (2020-02-28)

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "LRO Polling strtegy for the Azure SDK in TypeScript",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -31,12 +31,13 @@ export function createBodyPollingStrategy<TResult extends BaseResult>(initialOpe
 export function createLocationStrategy<TResult extends BaseResult>(initialOperation: LROOperationStep<TResult>, sendOperationFn: SendOperationFn<TResult>): LROStrategy<TResult>;
 
 // @public (undocumented)
+export type FinalStateVia = "azure-async-operation" | "location" | "original-uri";
+
+// @public (undocumented)
 export type LROOperation<TResult extends BaseResult> = PollOperation<LROOperationState<TResult>, TResult>;
 
 // @public (undocumented)
 export interface LROOperationState<TResult extends BaseResult> extends PollOperationState<TResult> {
-    // Warning: (ae-forgotten-export) The symbol "FinalStateVia" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     finalStateVia?: FinalStateVia;
     // (undocumented)

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -5,9 +5,111 @@
 ```ts
 
 import { AbortSignalLike } from '@azure/abort-controller';
+import { BaseRequestPolicy } from '@azure/core-http';
+import { HttpMethods } from '@azure/core-http';
+import { HttpOperationResponse } from '@azure/core-http';
+import { OperationArguments } from '@azure/core-http';
+import { OperationSpec } from '@azure/core-http';
+import { RequestPolicy } from '@azure/core-http';
+import { RequestPolicyOptions } from '@azure/core-http';
+import { RestResponse } from '@azure/core-http';
+import { WebResource } from '@azure/core-http';
+
+// @public (undocumented)
+export interface BaseResult extends RestResponse {
+    // (undocumented)
+    _lroData?: LROResponseInfo;
+}
 
 // @public
 export type CancelOnProgress = () => void;
+
+// @public
+export function createBodyPollingStrategy<TResult extends BaseResult>(initialOperation: LROOperationStep<TResult>, sendOperation: SendOperationFn<TResult>): LROStrategy<TResult>;
+
+// @public (undocumented)
+export function createLocationStrategy<TResult extends BaseResult>(initialOperation: LROOperationStep<TResult>, sendOperationFn: SendOperationFn<TResult>): LROStrategy<TResult>;
+
+// @public (undocumented)
+export type LROOperation<TResult extends BaseResult> = PollOperation<LROOperationState<TResult>, TResult>;
+
+// @public (undocumented)
+export interface LROOperationState<TResult extends BaseResult> extends PollOperationState<TResult> {
+    // Warning: (ae-forgotten-export) The symbol "FinalStateVia" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    finalStateVia?: FinalStateVia;
+    // (undocumented)
+    initialOperation: LROOperationStep<TResult>;
+    // (undocumented)
+    lastOperation: LROOperationStep<TResult>;
+    // (undocumented)
+    pollingStrategy: LROStrategy<TResult>;
+}
+
+// @public (undocumented)
+export interface LROOperationStep<TResult extends BaseResult> {
+    // (undocumented)
+    args: OperationArguments;
+    // (undocumented)
+    result: TResult;
+    // (undocumented)
+    spec: OperationSpec;
+}
+
+// @public (undocumented)
+export function lroPolicy(): {
+    create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => LROPolicy;
+};
+
+// @public (undocumented)
+export class LROPoller<TResult extends BaseResult> extends Poller<LROOperationState<TResult>, TResult> {
+    constructor({ initialOperationArguments, initialOperationResult, initialOperationSpec, sendOperation, finalStateVia, intervalInMs }: LROPollerOptions<TResult>);
+    delay(): Promise<void>;
+    }
+
+// @public (undocumented)
+export interface LROPollerOptions<TResult extends BaseResult> {
+    finalStateVia?: FinalStateVia;
+    initialOperationArguments: OperationArguments;
+    initialOperationResult: TResult;
+    initialOperationSpec: OperationSpec;
+    intervalInMs?: number;
+    sendOperation: SendOperationFn<TResult>;
+}
+
+// @public (undocumented)
+export interface LROResponseInfo {
+    // (undocumented)
+    azureAsyncOperation?: string;
+    // (undocumented)
+    isInitialRequest?: boolean;
+    // (undocumented)
+    location?: string;
+    // (undocumented)
+    operationLocation?: string;
+    // (undocumented)
+    provisioningState?: string;
+    // (undocumented)
+    requestMethod: HttpMethods;
+    // (undocumented)
+    status?: string;
+    // (undocumented)
+    statusCode: number;
+}
+
+// @public (undocumented)
+export interface LROStrategy<TResult extends BaseResult> {
+    // (undocumented)
+    isTerminal: () => boolean;
+    // (undocumented)
+    poll: () => Promise<LROOperationStep<TResult>>;
+    // (undocumented)
+    sendFinalRequest: () => Promise<LROOperationStep<TResult>>;
+}
+
+// @public
+export function makeOperation<TResult extends BaseResult>(state: LROOperationState<TResult>): LROOperation<TResult>;
 
 // @public
 export abstract class Poller<TState extends PollOperationState<TResult>, TResult> implements PollerLike<TState, TResult> {
@@ -83,6 +185,19 @@ export interface PollOperationState<TResult> {
 // @public
 export type PollProgressCallback<TState> = (state: TState) => void;
 
+// @public (undocumented)
+export type SendOperationFn<TResult extends BaseResult> = (args: OperationArguments, spec: OperationSpec) => Promise<TResult>;
+
+// @public
+export function shouldDeserializeLRO(finalStateVia?: string): (response: HttpOperationResponse) => boolean;
+
+// @public (undocumented)
+export const terminalStates: string[];
+
+
+// Warnings were encountered during analysis:
+//
+// src/lroPolicy.ts:13:26 - (ae-forgotten-export) The symbol "LROPolicy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
+++ b/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  LROStrategy,
+  BaseResult,
+  LROOperationStep,
+  LROResponseInfo,
+  FinalStateVia
+} from "./models";
+import { OperationSpec, OperationArguments } from "@azure/core-http";
+import { terminalStates } from "./constants";
+import { SendOperationFn } from ".";
+
+export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>,
+  sendOperationFn: SendOperationFn<TResult>,
+  finalStateVia?: FinalStateVia
+): LROStrategy<TResult> {
+  const lroData = initialOperation.result._lroData;
+  if (!lroData) {
+    throw new Error(
+      "Expected lroData to be defined for Azure-AsyncOperation strategy"
+    );
+  }
+
+  let currentOperation = initialOperation;
+  let lastKnownPollingUrl =
+    lroData.azureAsyncOperation || lroData.operationLocation;
+
+  return {
+    isTerminal: () => {
+      const currentResult = currentOperation.result._lroData;
+
+      if (!currentResult) {
+        throw new Error("Expected lroData to determine terminal status");
+      }
+
+      if (currentOperation === initialOperation) {
+        // Azure-AsyncOperations don't need to check for terminal state
+        // on originalOperation result, always need to poll
+        return false;
+      }
+
+      const { status = "succeeded" } = currentResult;
+      return terminalStates.includes(status.toLowerCase());
+    },
+    sendFinalRequest: async () => {
+      if (!initialOperation.result._lroData) {
+        throw new Error("Expected lroData to determine terminal status");
+      }
+
+      if (!currentOperation.result._lroData) {
+        throw new Error("Expected lroData to determine terminal status");
+      }
+
+      const initialOperationResult = initialOperation.result._lroData;
+      const currentOperationResult = currentOperation.result._lroData;
+
+      if (
+        !shouldPerformFinalGet(initialOperationResult, currentOperationResult)
+      ) {
+        return currentOperation;
+      }
+
+      if (initialOperationResult.requestMethod === "PUT") {
+        currentOperation = await sendFinalGet(
+          initialOperation,
+          sendOperationFn
+        );
+
+        return currentOperation;
+      }
+
+      if (initialOperationResult.location) {
+        switch (finalStateVia) {
+          case "original-uri":
+            currentOperation = await sendFinalGet(
+              initialOperation,
+              sendOperationFn
+            );
+            return currentOperation;
+
+          case "azure-async-operation":
+            return currentOperation;
+          case "location":
+          default:
+            const location =
+              initialOperationResult.location ||
+              currentOperationResult.location;
+
+            if (!location) {
+              throw new Error("Couldn't determine final GET URL from location");
+            }
+
+            return await sendFinalGet(
+              initialOperation,
+              sendOperationFn,
+              location
+            );
+        }
+      }
+
+      // All other cases return the last operation
+      return currentOperation;
+    },
+    poll: async () => {
+      if (!lastKnownPollingUrl) {
+        throw new Error("Unable to determine polling url");
+      }
+
+      const pollingArgs = currentOperation.args;
+      // Make sure we don't send any body to the get request
+      const { requestBody, ...restSpec } = currentOperation.spec;
+      const pollingSpec: OperationSpec = {
+        ...restSpec,
+        httpMethod: "GET",
+        path: lastKnownPollingUrl
+      };
+
+      const result = await sendOperationFn(pollingArgs, pollingSpec);
+
+      // Update latest polling url
+      lastKnownPollingUrl =
+        result._lroData?.azureAsyncOperation ||
+        result._lroData?.operationLocation ||
+        lastKnownPollingUrl;
+
+      // Update lastOperation result
+      currentOperation = {
+        args: pollingArgs,
+        spec: pollingSpec,
+        result
+      };
+
+      return currentOperation;
+    }
+  };
+}
+
+function shouldPerformFinalGet(
+  initialResult: LROResponseInfo,
+  currentResult: LROResponseInfo
+) {
+  const { status } = currentResult;
+  const { requestMethod: initialRequestMethod, location } = initialResult;
+  if (status && status.toLowerCase() !== "succeeded") {
+    return false;
+  }
+
+  if (initialRequestMethod === "DELETE") {
+    return false;
+  }
+
+  if (initialRequestMethod !== "PUT" && !location) {
+    return false;
+  }
+
+  return true;
+}
+
+async function sendFinalGet<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>,
+  sendOperationFn: SendOperationFn<TResult>,
+  path?: string
+): Promise<LROOperationStep<TResult>> {
+  // Make sure we don't send any body to the get request
+  const { requestBody, ...restSpec } = initialOperation.spec;
+  const finalGetSpec: OperationSpec = {
+    ...restSpec,
+    httpMethod: "GET"
+  };
+
+  // Send final GET request to the Original URL
+  const spec = {
+    ...finalGetSpec,
+    ...(path && { path })
+  };
+
+  let operationArgs: OperationArguments = initialOperation.args;
+  if (operationArgs.options) {
+    operationArgs.options.shouldDeserialize = true;
+  }
+
+  const finalResult = await sendOperationFn(initialOperation.args, spec);
+
+  return {
+    args: initialOperation.args,
+    spec,
+    result: finalResult
+  };
+}

--- a/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
+++ b/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
@@ -80,7 +80,12 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
               throw new Error("Couldn't determine final GET URL from location");
             }
 
-            return await sendFinalGet(initialOperation, sendOperationFn, location);
+            const result: LROOperationStep<TResult> = await sendFinalGet(
+              initialOperation,
+              sendOperationFn,
+              location
+            );
+            return result;
         }
       }
 
@@ -121,7 +126,10 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   };
 }
 
-function shouldPerformFinalGet(initialResult: LROResponseInfo, currentResult: LROResponseInfo) {
+function shouldPerformFinalGet(
+  initialResult: LROResponseInfo,
+  currentResult: LROResponseInfo
+): boolean {
   const { status } = currentResult;
   const { requestMethod: initialRequestMethod, location } = initialResult;
   if (status && status.toLowerCase() !== "succeeded") {
@@ -157,7 +165,7 @@ async function sendFinalGet<TResult extends BaseResult>(
     ...(path && { path })
   };
 
-  let operationArgs: OperationArguments = initialOperation.args;
+  const operationArgs: OperationArguments = initialOperation.args;
   if (operationArgs.options) {
     operationArgs.options.shouldDeserialize = true;
   }

--- a/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
+++ b/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
@@ -19,14 +19,11 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
 ): LROStrategy<TResult> {
   const lroData = initialOperation.result._lroData;
   if (!lroData) {
-    throw new Error(
-      "Expected lroData to be defined for Azure-AsyncOperation strategy"
-    );
+    throw new Error("Expected lroData to be defined for Azure-AsyncOperation strategy");
   }
 
   let currentOperation = initialOperation;
-  let lastKnownPollingUrl =
-    lroData.azureAsyncOperation || lroData.operationLocation;
+  let lastKnownPollingUrl = lroData.azureAsyncOperation || lroData.operationLocation;
 
   return {
     isTerminal: () => {
@@ -57,17 +54,12 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
       const initialOperationResult = initialOperation.result._lroData;
       const currentOperationResult = currentOperation.result._lroData;
 
-      if (
-        !shouldPerformFinalGet(initialOperationResult, currentOperationResult)
-      ) {
+      if (!shouldPerformFinalGet(initialOperationResult, currentOperationResult)) {
         return currentOperation;
       }
 
       if (initialOperationResult.requestMethod === "PUT") {
-        currentOperation = await sendFinalGet(
-          initialOperation,
-          sendOperationFn
-        );
+        currentOperation = await sendFinalGet(initialOperation, sendOperationFn);
 
         return currentOperation;
       }
@@ -75,29 +67,20 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
       if (initialOperationResult.location) {
         switch (finalStateVia) {
           case "original-uri":
-            currentOperation = await sendFinalGet(
-              initialOperation,
-              sendOperationFn
-            );
+            currentOperation = await sendFinalGet(initialOperation, sendOperationFn);
             return currentOperation;
 
           case "azure-async-operation":
             return currentOperation;
           case "location":
           default:
-            const location =
-              initialOperationResult.location ||
-              currentOperationResult.location;
+            const location = initialOperationResult.location || currentOperationResult.location;
 
             if (!location) {
               throw new Error("Couldn't determine final GET URL from location");
             }
 
-            return await sendFinalGet(
-              initialOperation,
-              sendOperationFn,
-              location
-            );
+            return await sendFinalGet(initialOperation, sendOperationFn, location);
         }
       }
 
@@ -138,10 +121,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   };
 }
 
-function shouldPerformFinalGet(
-  initialResult: LROResponseInfo,
-  currentResult: LROResponseInfo
-) {
+function shouldPerformFinalGet(initialResult: LROResponseInfo, currentResult: LROResponseInfo) {
   const { status } = currentResult;
   const { requestMethod: initialRequestMethod, location } = initialResult;
   if (status && status.toLowerCase() !== "succeeded") {

--- a/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
+++ b/sdk/core/core-lro/src/azureAsyncOperationStrategy.ts
@@ -74,12 +74,14 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
             return currentOperation;
           case "location":
           default:
+            // eslint-disable-next-line no-case-declarations
             const location = initialOperationResult.location || currentOperationResult.location;
 
             if (!location) {
               throw new Error("Couldn't determine final GET URL from location");
             }
 
+            // eslint-disable-next-line no-case-declarations
             const result: LROOperationStep<TResult> = await sendFinalGet(
               initialOperation,
               sendOperationFn,

--- a/sdk/core/core-lro/src/bodyPollingStrategy.ts
+++ b/sdk/core/core-lro/src/bodyPollingStrategy.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { LROStrategy, BaseResult, LROOperationStep } from "./models";
+import { OperationSpec } from "@azure/core-http";
+import { terminalStates } from "./constants";
+import { SendOperationFn } from "./lroPoller";
+
+/**
+ * Creates a polling strategy based on BodyPolling which uses the provisioning state
+ * from the result to determine the current operation state
+ */
+export function createBodyPollingStrategy<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>,
+  sendOperation: SendOperationFn<TResult>
+): LROStrategy<TResult> {
+  if (!initialOperation.result._lroData) {
+    throw new Error("Expected lroData to be defined for BodyPolling strategy");
+  }
+
+  let currentOperation = initialOperation;
+
+  return {
+    isTerminal: () => {
+      const currentResult = currentOperation.result._lroData;
+      if (!currentResult) {
+        throw new Error("Expected lroData to determine terminal status");
+      }
+
+      const { provisioningState = "succeeded" } = currentResult;
+      // If provisioning state is missing, default to Success
+
+      return terminalStates.includes(provisioningState.toLowerCase());
+    },
+    sendFinalRequest: () => {
+      // BodyPolling doesn't require a final get so return the lastOperation
+      return Promise.resolve(currentOperation);
+    },
+    poll: async () => {
+      // When doing BodyPolling, we need to poll to the original url with a
+      // GET http method
+      const { requestBody, ...restSpec } = initialOperation.spec;
+      const pollingSpec: OperationSpec = {
+        // Make sure we don't send any body to the get request
+        ...restSpec,
+        httpMethod: "GET"
+      };
+
+      // Execute the polling operation
+      initialOperation.result = await sendOperation(
+        initialOperation.args,
+        pollingSpec
+      );
+      return initialOperation;
+    }
+  };
+}

--- a/sdk/core/core-lro/src/bodyPollingStrategy.ts
+++ b/sdk/core/core-lro/src/bodyPollingStrategy.ts
@@ -47,10 +47,7 @@ export function createBodyPollingStrategy<TResult extends BaseResult>(
       };
 
       // Execute the polling operation
-      initialOperation.result = await sendOperation(
-        initialOperation.args,
-        pollingSpec
-      );
+      initialOperation.result = await sendOperation(initialOperation.args, pollingSpec);
       return initialOperation;
     }
   };

--- a/sdk/core/core-lro/src/bodyPollingStrategy.ts
+++ b/sdk/core/core-lro/src/bodyPollingStrategy.ts
@@ -18,7 +18,7 @@ export function createBodyPollingStrategy<TResult extends BaseResult>(
     throw new Error("Expected lroData to be defined for BodyPolling strategy");
   }
 
-  let currentOperation = initialOperation;
+  const currentOperation = initialOperation;
 
   return {
     isTerminal: () => {

--- a/sdk/core/core-lro/src/constants.ts
+++ b/sdk/core/core-lro/src/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -14,7 +14,8 @@ export {
   LROOperationStep,
   LROOperationState,
   LROStrategy,
-  LROOperation
+  LROOperation,
+  FinalStateVia
 } from "./models";
 export { makeOperation } from "./operation";
 export * from "./locationStrategy";

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -3,3 +3,18 @@
 
 export * from "./pollOperation";
 export * from "./poller";
+export { shouldDeserializeLRO } from "./requestUtils";
+export { createBodyPollingStrategy } from "./bodyPollingStrategy";
+export { terminalStates } from "./constants";
+export { lroPolicy } from "./lroPolicy";
+export { LROPoller, LROPollerOptions, SendOperationFn } from "./lroPoller";
+export {
+  LROResponseInfo,
+  BaseResult,
+  LROOperationStep,
+  LROOperationState,
+  LROStrategy,
+  LROOperation
+} from "./models";
+export { makeOperation } from "./operation";
+export * from "./locationStrategy";

--- a/sdk/core/core-lro/src/locationStrategy.ts
+++ b/sdk/core/core-lro/src/locationStrategy.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BaseResult, LROOperationStep, LROStrategy } from "./models";
+import { SendOperationFn } from "./lroPoller";
+import { OperationSpec } from "@azure/core-http";
+
+export function createLocationStrategy<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>,
+  sendOperationFn: SendOperationFn<TResult>
+): LROStrategy<TResult> {
+  const lroData = initialOperation.result._lroData;
+  if (!lroData) {
+    throw new Error(
+      "Expected lroData to be defined for Azure-AsyncOperation strategy"
+    );
+  }
+
+  let currentOperation = initialOperation;
+  let lastKnownPollingUrl = lroData.location;
+
+  return {
+    isTerminal: () => {
+      const currentResult = currentOperation.result._lroData;
+      if (!currentResult) {
+        throw new Error("Expected lroData to determine terminal status");
+      }
+
+      if (currentOperation === initialOperation) {
+        return false;
+      }
+
+      if (currentResult.statusCode === 202) {
+        return false;
+      }
+
+      return true;
+    },
+    sendFinalRequest: () => Promise.resolve(currentOperation),
+    poll: async () => {
+      if (!lastKnownPollingUrl) {
+        throw new Error("Unable to determine polling url");
+      }
+
+      const pollingArgs = currentOperation.args;
+      // Make sure we don't send any body to the get request
+      const { requestBody, ...restSpec } = currentOperation.spec;
+      const pollingSpec: OperationSpec = {
+        ...restSpec,
+        httpMethod: "GET",
+        path: lastKnownPollingUrl
+      };
+
+      const result = await sendOperationFn(pollingArgs, pollingSpec);
+
+      // Update latest polling url
+      lastKnownPollingUrl = result._lroData?.location || lastKnownPollingUrl;
+
+      // Update lastOperation result
+      currentOperation = {
+        args: pollingArgs,
+        spec: pollingSpec,
+        result
+      };
+
+      return currentOperation;
+    }
+  };
+}

--- a/sdk/core/core-lro/src/locationStrategy.ts
+++ b/sdk/core/core-lro/src/locationStrategy.ts
@@ -11,9 +11,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
 ): LROStrategy<TResult> {
   const lroData = initialOperation.result._lroData;
   if (!lroData) {
-    throw new Error(
-      "Expected lroData to be defined for Azure-AsyncOperation strategy"
-    );
+    throw new Error("Expected lroData to be defined for Azure-AsyncOperation strategy");
   }
 
   let currentOperation = initialOperation;

--- a/sdk/core/core-lro/src/lroPolicy.ts
+++ b/sdk/core/core-lro/src/lroPolicy.ts
@@ -23,9 +23,7 @@ class LROPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public async sendRequest(
-    webResource: WebResource
-  ): Promise<HttpOperationResponse> {
+  public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
     let result = await this._nextPolicy.sendRequest(webResource);
 
     if (webResource.shouldDeserialize !== undefined) {

--- a/sdk/core/core-lro/src/lroPolicy.ts
+++ b/sdk/core/core-lro/src/lroPolicy.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  RequestPolicy,
+  RequestPolicyOptions,
+  BaseRequestPolicy,
+  HttpOperationResponse,
+  WebResource
+} from "@azure/core-http";
+import { getLROData } from "./requestUtils";
+
+export function lroPolicy() {
+  return {
+    create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
+      return new LROPolicy(nextPolicy, options);
+    }
+  };
+}
+
+class LROPolicy extends BaseRequestPolicy {
+  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
+    super(nextPolicy, options);
+  }
+
+  public async sendRequest(
+    webResource: WebResource
+  ): Promise<HttpOperationResponse> {
+    let result = await this._nextPolicy.sendRequest(webResource);
+
+    if (webResource.shouldDeserialize !== undefined) {
+      const _lroData = getLROData(result);
+      result.parsedBody = { ...result.parsedBody, _lroData };
+    }
+
+    return result;
+  }
+}

--- a/sdk/core/core-lro/src/lroPolicy.ts
+++ b/sdk/core/core-lro/src/lroPolicy.ts
@@ -19,12 +19,13 @@ export function lroPolicy() {
 }
 
 class LROPolicy extends BaseRequestPolicy {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
   }
 
   public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
-    let result = await this._nextPolicy.sendRequest(webResource);
+    const result = await this._nextPolicy.sendRequest(webResource);
 
     if (webResource.shouldDeserialize !== undefined) {
       const _lroData = getLROData(result);

--- a/sdk/core/core-lro/src/lroPoller.ts
+++ b/sdk/core/core-lro/src/lroPoller.ts
@@ -2,18 +2,8 @@
 // Licensed under the MIT license.
 
 import { Poller } from "./poller";
-import {
-  OperationSpec,
-  OperationArguments,
-  delay,
-  RestError
-} from "@azure/core-http";
-import {
-  BaseResult,
-  LROOperationState,
-  LROOperationStep,
-  FinalStateVia
-} from "./models";
+import { OperationSpec, OperationArguments, delay, RestError } from "@azure/core-http";
+import { BaseResult, LROOperationState, LROOperationStep, FinalStateVia } from "./models";
 import { makeOperation } from "./operation";
 import { createBodyPollingStrategy } from "./bodyPollingStrategy";
 import { createAzureAsyncOperationStrategy } from "./azureAsyncOperationStrategy";
@@ -72,11 +62,7 @@ export class LROPoller<TResult extends BaseResult> extends Poller<
       result: initialOperationResult
     };
 
-    const pollingStrategy = getPollingStrategy(
-      initialOperation,
-      sendOperation,
-      finalStateVia
-    );
+    const pollingStrategy = getPollingStrategy(initialOperation, sendOperation, finalStateVia);
 
     const state: LROOperationState<TResult> = {
       // Initial operation will become the last operation
@@ -129,11 +115,7 @@ function getPollingStrategy<TResult extends BaseResult>(
   }
 
   if (lroData.azureAsyncOperation || lroData.operationLocation) {
-    return createAzureAsyncOperationStrategy(
-      initialOperation,
-      sendOperationFn,
-      finalStateVia
-    );
+    return createAzureAsyncOperationStrategy(initialOperation, sendOperationFn, finalStateVia);
   }
 
   if (lroData.location) {

--- a/sdk/core/core-lro/src/lroPoller.ts
+++ b/sdk/core/core-lro/src/lroPoller.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Poller } from "./poller";
+import {
+  OperationSpec,
+  OperationArguments,
+  delay,
+  RestError
+} from "@azure/core-http";
+import {
+  BaseResult,
+  LROOperationState,
+  LROOperationStep,
+  FinalStateVia
+} from "./models";
+import { makeOperation } from "./operation";
+import { createBodyPollingStrategy } from "./bodyPollingStrategy";
+import { createAzureAsyncOperationStrategy } from "./azureAsyncOperationStrategy";
+import { createLocationStrategy } from "./locationStrategy";
+import { createPassthroughStrategy } from "./passthroughStrategy";
+
+export type SendOperationFn<TResult extends BaseResult> = (
+  args: OperationArguments,
+  spec: OperationSpec
+) => Promise<TResult>;
+
+export interface LROPollerOptions<TResult extends BaseResult> {
+  /**
+   * Defines how much time the poller is going to wait before making a new request to the service.
+   */
+  intervalInMs?: number;
+  /**
+   * Arguments used to send the initial operation
+   */
+  initialOperationArguments: OperationArguments;
+  /**
+   * Operation spec provided for the initial operation
+   */
+  initialOperationSpec: OperationSpec;
+  /**
+   * Result from the initial operation
+   */
+  initialOperationResult: TResult;
+  /**
+   * Function to execute an operation based on an operation spec and arguments
+   */
+  sendOperation: SendOperationFn<TResult>;
+  /**
+   * Optional information on where to poll. When not defined it defaults to "Location"
+   */
+  finalStateVia?: FinalStateVia;
+}
+
+export class LROPoller<TResult extends BaseResult> extends Poller<
+  LROOperationState<TResult>,
+  TResult
+> {
+  private intervalInMs: number;
+
+  constructor({
+    initialOperationArguments,
+    initialOperationResult,
+    initialOperationSpec,
+    sendOperation,
+    finalStateVia,
+    intervalInMs = 2000
+  }: LROPollerOptions<TResult>) {
+    const initialOperation = {
+      args: initialOperationArguments,
+      spec: initialOperationSpec,
+      result: initialOperationResult
+    };
+
+    const pollingStrategy = getPollingStrategy(
+      initialOperation,
+      sendOperation,
+      finalStateVia
+    );
+
+    const state: LROOperationState<TResult> = {
+      // Initial operation will become the last operation
+      initialOperation,
+      lastOperation: initialOperation,
+      pollingStrategy,
+      finalStateVia
+    };
+
+    const operation = makeOperation(state);
+    super(operation);
+
+    this.intervalInMs = intervalInMs;
+  }
+
+  /**
+   * The method used by the poller to wait before attempting to update its operation.
+   */
+  delay(): Promise<void> {
+    return delay(this.intervalInMs);
+  }
+}
+
+/**
+ * This function determines which strategy to use based on the response from
+ * the last operation executed, this last operation can be an initial operation
+ * or a polling operation. The 3 possible strategies are described below:
+ *
+ * A) Azure-AsyncOperation or Operation-Location
+ * B) Location
+ * C) BodyPolling (provisioningState)
+ *  - This strategy is used when:
+ *    - Response doesn't contain any of the following headers Location, Azure-AsyncOperation or Operation-Location
+ *    - Last operation method is PUT
+ */
+function getPollingStrategy<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>,
+  sendOperationFn: SendOperationFn<TResult>,
+  finalStateVia?: FinalStateVia
+) {
+  const lroData = initialOperation.result._lroData;
+
+  if (!lroData) {
+    const error = new RestError(
+      "Service response doesn't include the required LRO data to continue polling"
+    );
+    error.statusCode = initialOperation.result._response.status;
+    error.response = initialOperation.result._response;
+    throw error;
+  }
+
+  if (lroData.azureAsyncOperation || lroData.operationLocation) {
+    return createAzureAsyncOperationStrategy(
+      initialOperation,
+      sendOperationFn,
+      finalStateVia
+    );
+  }
+
+  if (lroData.location) {
+    return createLocationStrategy(initialOperation, sendOperationFn);
+  }
+
+  if (["PUT", "PATCH"].includes(lroData.requestMethod || "")) {
+    return createBodyPollingStrategy(initialOperation, sendOperationFn);
+  }
+
+  // Default strategy is just a passthrough returning the initial operation
+  return createPassthroughStrategy(initialOperation);
+}

--- a/sdk/core/core-lro/src/models.ts
+++ b/sdk/core/core-lro/src/models.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  OperationArguments,
+  OperationSpec,
+  RestResponse,
+  HttpMethods
+} from "@azure/core-http";
+import { PollOperationState, PollOperation } from "./pollOperation";
+
+export type FinalStateVia =
+  | "azure-async-operation"
+  | "location"
+  | "original-uri";
+
+export interface LROResponseInfo {
+  requestMethod: HttpMethods;
+  statusCode: number;
+  isInitialRequest?: boolean;
+  azureAsyncOperation?: string;
+  operationLocation?: string;
+  location?: string;
+  provisioningState?: string;
+  status?: string;
+}
+
+export interface BaseResult extends RestResponse {
+  _lroData?: LROResponseInfo;
+}
+
+export interface LROOperationStep<TResult extends BaseResult> {
+  args: OperationArguments;
+  spec: OperationSpec;
+  result: TResult;
+}
+
+export interface LROOperationState<TResult extends BaseResult>
+  extends PollOperationState<TResult> {
+  lastOperation: LROOperationStep<TResult>;
+  initialOperation: LROOperationStep<TResult>;
+  pollingStrategy: LROStrategy<TResult>;
+  finalStateVia?: FinalStateVia;
+}
+
+export interface LROStrategy<TResult extends BaseResult> {
+  isTerminal: () => boolean;
+  sendFinalRequest: () => Promise<LROOperationStep<TResult>>;
+  poll: () => Promise<LROOperationStep<TResult>>;
+}
+
+export type LROOperation<TResult extends BaseResult> = PollOperation<
+  LROOperationState<TResult>,
+  TResult
+>;

--- a/sdk/core/core-lro/src/models.ts
+++ b/sdk/core/core-lro/src/models.ts
@@ -1,18 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  OperationArguments,
-  OperationSpec,
-  RestResponse,
-  HttpMethods
-} from "@azure/core-http";
+import { OperationArguments, OperationSpec, RestResponse, HttpMethods } from "@azure/core-http";
 import { PollOperationState, PollOperation } from "./pollOperation";
 
-export type FinalStateVia =
-  | "azure-async-operation"
-  | "location"
-  | "original-uri";
+export type FinalStateVia = "azure-async-operation" | "location" | "original-uri";
 
 export interface LROResponseInfo {
   requestMethod: HttpMethods;
@@ -35,8 +27,7 @@ export interface LROOperationStep<TResult extends BaseResult> {
   result: TResult;
 }
 
-export interface LROOperationState<TResult extends BaseResult>
-  extends PollOperationState<TResult> {
+export interface LROOperationState<TResult extends BaseResult> extends PollOperationState<TResult> {
   lastOperation: LROOperationStep<TResult>;
   initialOperation: LROOperationStep<TResult>;
   pollingStrategy: LROStrategy<TResult>;

--- a/sdk/core/core-lro/src/operation.ts
+++ b/sdk/core/core-lro/src/operation.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BaseResult, LROOperationState, LROOperation } from "./models";
+
+/**
+ * Creates a copy of the operation from a given State
+ */
+export function makeOperation<TResult extends BaseResult>(
+  state: LROOperationState<TResult>
+): LROOperation<TResult> {
+  return {
+    state: { ...state },
+    update,
+    cancel,
+    toString: function(this: LROOperation<TResult>) {
+      return JSON.stringify(this.state);
+    }
+  };
+}
+
+/**
+ * General update function for LROPoller, the general process is as follows
+ * 1. Check initial operation result to determine the strategy to use
+ *  - Strategies: Location, Azure-AsyncOperation, Original Uri
+ * 2. Check if the operation result has a terminal state
+ *  - Terminal state will be determined by each strategy
+ *  2.1 If it is terminal state Check if a final GET request is required, if so
+ *      send final GET request and return result from operation. If no final GET
+ *      is required, just return the result from operation.
+ *      - Determining what to call for final request is responsibility of each strategy
+ *  2.2 If it is not terminal state, call the polling operation call it and go to step 1
+ *      - Determining what to call for polling is responsibility of each strategy
+ *      - Strategies will always use the latest URI for polling if provided otherwise
+ *        the last known one
+ */
+async function update<TResult extends BaseResult>(
+  this: LROOperation<TResult>
+): Promise<LROOperation<TResult>> {
+  const state = { ...this.state };
+
+  const { sendFinalRequest, poll, isTerminal } = state.pollingStrategy;
+  const currentResponse = state.lastOperation;
+  const currentLroData = currentResponse.result._lroData;
+
+  if (!currentLroData) {
+    throw new Error(
+      "Expected lroData to be defined for updating LRO operation"
+    );
+  }
+
+  if (state.result) {
+    state.isCompleted = true;
+    return makeOperation(state);
+  }
+
+  // Check if last result is terminal
+  if (isTerminal()) {
+    state.lastOperation = await sendFinalRequest();
+    state.result = state.lastOperation.result;
+  } else {
+    state.lastOperation = await poll();
+  }
+
+  // Return operation
+  return makeOperation(state);
+}
+
+/**
+ * Swagger doesn't support defining a cancel operation, we'll just mark
+ * the operation state as cancelled
+ */
+async function cancel<TResult extends BaseResult>(
+  this: LROOperation<TResult>
+): Promise<LROOperation<TResult>> {
+  return makeOperation({ ...this.state, isCancelled: true });
+}

--- a/sdk/core/core-lro/src/operation.ts
+++ b/sdk/core/core-lro/src/operation.ts
@@ -37,6 +37,7 @@ export function makeOperation<TResult extends BaseResult>(
 async function update<TResult extends BaseResult>(
   this: LROOperation<TResult>
 ): Promise<LROOperation<TResult>> {
+  // eslint-disable-next-line no-invalid-this
   const state = { ...this.state };
 
   const { sendFinalRequest, poll, isTerminal } = state.pollingStrategy;
@@ -71,5 +72,6 @@ async function update<TResult extends BaseResult>(
 async function cancel<TResult extends BaseResult>(
   this: LROOperation<TResult>
 ): Promise<LROOperation<TResult>> {
+  // eslint-disable-next-line no-invalid-this
   return makeOperation({ ...this.state, isCancelled: true });
 }

--- a/sdk/core/core-lro/src/operation.ts
+++ b/sdk/core/core-lro/src/operation.ts
@@ -44,9 +44,7 @@ async function update<TResult extends BaseResult>(
   const currentLroData = currentResponse.result._lroData;
 
   if (!currentLroData) {
-    throw new Error(
-      "Expected lroData to be defined for updating LRO operation"
-    );
+    throw new Error("Expected lroData to be defined for updating LRO operation");
   }
 
   if (state.result) {

--- a/sdk/core/core-lro/src/passthroughStrategy.ts
+++ b/sdk/core/core-lro/src/passthroughStrategy.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { LROStrategy, BaseResult, LROOperationStep } from "./models";
+
+/**
+ * Creates a polling strategy based on BodyPolling which uses the provisioning state
+ * from the result to determine the current operation state
+ */
+export function createPassthroughStrategy<TResult extends BaseResult>(
+  initialOperation: LROOperationStep<TResult>
+): LROStrategy<TResult> {
+  return {
+    isTerminal: () => {
+      return true;
+    },
+    sendFinalRequest: () => {
+      // BodyPolling doesn't require a final get so return the lastOperation
+      return Promise.resolve(initialOperation);
+    },
+    poll: async () => {
+      throw new Error("Passthrough strategy should never poll");
+    }
+  };
+}

--- a/sdk/core/core-lro/src/requestUtils.ts
+++ b/sdk/core/core-lro/src/requestUtils.ts
@@ -24,17 +24,10 @@ export function shouldDeserializeLRO(finalStateVia?: string) {
       isInitialRequest = false;
     }
 
-    if (
-      initialOperationInfo.azureAsyncOperation ||
-      initialOperationInfo.operationLocation
-    ) {
+    if (initialOperationInfo.azureAsyncOperation || initialOperationInfo.operationLocation) {
       return (
         !isInitialRequest &&
-        isAsyncOperationFinalResponse(
-          response,
-          initialOperationInfo,
-          finalStateVia
-        )
+        isAsyncOperationFinalResponse(response, initialOperationInfo, finalStateVia)
       );
     }
 
@@ -72,10 +65,7 @@ function isAsyncOperationFinalResponse(
     return true;
   }
 
-  if (
-    initialOperationInfo.requestMethod !== "PUT" &&
-    !initialOperationInfo.location
-  ) {
+  if (initialOperationInfo.requestMethod !== "PUT" && !initialOperationInfo.location) {
     return true;
   }
 

--- a/sdk/core/core-lro/src/requestUtils.ts
+++ b/sdk/core/core-lro/src/requestUtils.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpOperationResponse } from "@azure/core-http";
+import { terminalStates } from "./constants";
+import { LROResponseInfo } from "./models";
+
+/**
+ * We need to selectively deserialize our responses, only deserializing if we
+ * are in a final LRO response, not deserializing any polling non-terminal responses
+ */
+export function shouldDeserializeLRO(finalStateVia?: string) {
+  let initialOperationInfo: LROResponseInfo | undefined;
+  let isInitialRequest = true;
+
+  return (response: HttpOperationResponse) => {
+    if (response.status < 200 || response.status >= 300) {
+      return true;
+    }
+
+    if (!initialOperationInfo) {
+      initialOperationInfo = getLROData(response);
+    } else {
+      isInitialRequest = false;
+    }
+
+    if (
+      initialOperationInfo.azureAsyncOperation ||
+      initialOperationInfo.operationLocation
+    ) {
+      return (
+        !isInitialRequest &&
+        isAsyncOperationFinalResponse(
+          response,
+          initialOperationInfo,
+          finalStateVia
+        )
+      );
+    }
+
+    if (initialOperationInfo.location) {
+      return isLocationFinalResponse(response);
+    }
+
+    if (initialOperationInfo.requestMethod === "PUT") {
+      return isBodyPollingFinalResponse(response);
+    }
+
+    return true;
+  };
+}
+
+function isAsyncOperationFinalResponse(
+  response: HttpOperationResponse,
+  initialOperationInfo: LROResponseInfo,
+  finalStateVia?: string
+): boolean {
+  const status: string = response.parsedBody?.status || "Succeeded";
+  if (!terminalStates.includes(status.toLowerCase())) {
+    return false;
+  }
+
+  if (initialOperationInfo.requestMethod === "DELETE") {
+    return true;
+  }
+
+  if (
+    initialOperationInfo.requestMethod === "PUT" &&
+    finalStateVia &&
+    finalStateVia.toLowerCase() === "azure-asyncoperation"
+  ) {
+    return true;
+  }
+
+  if (
+    initialOperationInfo.requestMethod !== "PUT" &&
+    !initialOperationInfo.location
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isLocationFinalResponse(response: HttpOperationResponse): boolean {
+  return response.status !== 202;
+}
+
+function isBodyPollingFinalResponse(response: HttpOperationResponse): boolean {
+  const provisioningState: string =
+    response.parsedBody?.properties?.provisioningState || "Succeeded";
+
+  if (terminalStates.includes(provisioningState.toLowerCase())) {
+    return true;
+  }
+
+  return false;
+}
+
+export function getLROData(result: HttpOperationResponse): LROResponseInfo {
+  const statusCode = result.status;
+  const { status, properties } = result.parsedBody || {};
+  return {
+    statusCode,
+    azureAsyncOperation: result.headers.get("azure-asyncoperation"),
+    operationLocation: result.headers.get("operation-location"),
+    location: result.headers.get("location"),
+    requestMethod: result.request.method,
+    status,
+    provisioningState: properties?.provisioningState
+  };
+}


### PR DESCRIPTION
This is related to issue https://github.com/Azure/autorest.typescript/issues/613. 

Per the notes of the issue, the files can be moved to core-lro or core-http (or its counterpart core-client)

I have decided to move the files to core-lro for 2 reasons:

1. All these files are very specific to LRO. So, it is best to keep that logic in one package instead of distributing them among multiple packages. 

2. There is a dependency of core-lro in these files. If you add it to core-http, it will create a circular dependency between core-http and core-lro. We do not want such a behavior. 

@joheredi Please review and approve. 