### PR TITLE
[core-http] de-serialize before checking internalError

### DIFF
--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -242,13 +242,11 @@ function handleErrorResponse(
             valueToDeserialize = parsedBody[elementName];
           }
         }
-        if (error.response) {
-          deserializedError = operationSpec.serializer.deserialize(
-            defaultBodyMapper,
-            valueToDeserialize,
-            "error.response.parsedBody"
-          );
-        }
+        deserializedError = operationSpec.serializer.deserialize(
+          defaultBodyMapper,
+          valueToDeserialize,
+          "error.response.parsedBody"
+        );
       }
 
       const internalError: any = parsedBody.error || deserializedError || parsedBody;
@@ -258,17 +256,13 @@ function handleErrorResponse(
       }
 
       if (defaultBodyMapper) {
-        if (error.response) {
-          const errorResponse: FullOperationResponse = error.response;
-          errorResponse.parsedBody = deserializedError;
-        }
+        (error.response! as FullOperationResponse).parsedBody = deserializedError;
       }
     }
 
     // If error response has headers, try to deserialize it using default header mapper
-    if (parsedResponse.headers && defaultHeadersMapper && error.response) {
-      const errorResponse: FullOperationResponse = error.response;
-      errorResponse.parsedHeaders = operationSpec.serializer.deserialize(
+    if (parsedResponse.headers && defaultHeadersMapper) {
+      (error.response! as FullOperationResponse).parsedHeaders = operationSpec.serializer.deserialize(
         defaultHeadersMapper,
         parsedResponse.headers.toJSON(),
         "operationRes.parsedHeaders"

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -566,6 +566,64 @@ describe("deserializationPolicy", function() {
         assert.strictEqual(e.response.parsedBody.message3, "InvalidResourceNameBody3");
       }
     });
+
+    it(`with default error response body`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "StorageError",
+        type: {
+          name: "Composite",
+          className: "StorageError",
+          modelProperties: {
+            code: {
+              xmlName: "Code",
+              serializedName: "Code",
+              type: {
+                name: "String"
+              }
+            },
+            message: {
+              xmlName: "Message",
+              serializedName: "Message",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = createSerializer(undefined, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          default: {
+            bodyMapper: BodyMapper
+          }
+        },
+        serializer
+      };
+
+      try {
+        await getDeserializedResponse({
+          operationSpec,
+          headers: {},
+          bodyAsText:
+            '{"Code": "ContainerAlreadyExists", "Message": "The specified container already exists."}',
+          status: 500
+        });
+        assert.fail();
+      } catch (e) {
+        assert.exists(e);
+        assert.strictEqual(e.code, "ContainerAlreadyExists");
+        assert.strictEqual(e.message, "The specified container already exists.");
+        assert.strictEqual(e.response.parsedBody.code, "ContainerAlreadyExists");
+        assert.strictEqual(
+          e.response.parsedBody.message,
+          "The specified container already exists."
+        );
+      }
+    });
   });
 });
 

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -258,27 +258,32 @@ function handleErrorResponse(
   );
 
   try {
-    // If error response has a body, try to extract error code & message from it
-    // Then try to deserialize it using default body mapper
+    // If error response has a body, try to deserialize it using default body mapper.
+    // Then try to extract error code & message from it
     if (parsedResponse.parsedBody) {
       const parsedBody = parsedResponse.parsedBody;
-      const internalError: any = parsedBody.error || parsedBody;
-      error.code = internalError.code;
-      if (internalError.message) {
-        error.message = internalError.message;
-      }
-
+      let parsedError;
       if (defaultBodyMapper) {
         let valueToDeserialize: any = parsedBody;
         if (operationSpec.isXML && defaultBodyMapper.type.name === MapperType.Sequence) {
           valueToDeserialize =
             typeof parsedBody === "object" ? parsedBody[defaultBodyMapper.xmlElementName!] : [];
         }
-        error.response!.parsedBody = operationSpec.serializer.deserialize(
+        parsedError = operationSpec.serializer.deserialize(
           defaultBodyMapper,
           valueToDeserialize,
           "error.response.parsedBody"
         );
+      }
+
+      const internalError: any = parsedBody.error || parsedError || parsedBody;
+      error.code = internalError.code;
+      if (internalError.message) {
+        error.message = internalError.message;
+      }
+
+      if (defaultBodyMapper) {
+        error.response!.parsedBody = parsedError;
       }
     }
 

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -885,6 +885,62 @@ describe("deserializationPolicy", function() {
         assert.strictEqual(e.response.parsedBody.message3, "InvalidResourceNameBody3");
       }
     });
+
+    it(`with default error response body`, async function() {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "StorageError",
+        type: {
+          name: "Composite",
+          className: "StorageError",
+          modelProperties: {
+            code: {
+              xmlName: "Code",
+              serializedName: "Code",
+              type: {
+                name: "String"
+              }
+            },
+            message: {
+              xmlName: "Message",
+              serializedName: "Message",
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      };
+
+      const serializer = new Serializer(undefined, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          default: {
+            bodyMapper: BodyMapper
+          }
+        },
+        serializer
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 500,
+        headers: new HttpHeaders({
+          "content-type": "application/xml"
+        }),
+        bodyAsText: `<?xml version="1.0" encoding="utf-8"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.</Message></Error>`
+      };
+
+      try {
+        await deserializeResponse(response);
+        assert.fail();
+      } catch (e) {
+        assert(e);
+        assert.equal(e.code, "ContainerAlreadyExists");
+        assert.equal(e.message, "The specified container already exists.");
+      }
+    });
   });
 });
 

--- a/sdk/storage/storage-blob/test/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/appendblobclient.spec.ts
@@ -148,7 +148,12 @@ describe("AppendBlobClient", () => {
         transactionalContentCrc64: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
       });
     } catch (err) {
-      if (err instanceof Error && err.message.indexOf("Crc64Mismatch") != -1) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith(
+          "The CRC64 value specified in the request did not match with the CRC64 value calculated by the server."
+        )
+      ) {
         exceptionCaught = true;
       }
 

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -394,7 +394,12 @@ describe("BlockBlobClient", () => {
         transactionalContentCrc64: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
       });
     } catch (err) {
-      if (err instanceof Error && err.message.indexOf("Crc64Mismatch") != -1) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith(
+          "The CRC64 value specified in the request did not match with the CRC64 value calculated by the server."
+        )
+      ) {
         exceptionCaught = true;
       }
     }

--- a/sdk/storage/storage-blob/test/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/pageblobclient.spec.ts
@@ -91,10 +91,7 @@ describe("PageBlobClient", () => {
       const properties = await blobClient.getProperties();
       assert.equal(properties.accessTier, options.tier);
     } catch (err) {
-      if (err.message.indexOf("AccessTierNotSupportedForBlobType") == -1) {
-        // not found
-        assert.fail("Error thrown while it's not AccessTierNotSupportedForBlobType.");
-      }
+      assert.ok(err.message.startsWith("The access tier is not supported for this blob type."));
     }
   });
 
@@ -264,7 +261,12 @@ describe("PageBlobClient", () => {
         transactionalContentCrc64: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
       });
     } catch (err) {
-      if (err instanceof Error && err.message.indexOf("Crc64Mismatch") != -1) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith(
+          "The CRC64 value specified in the request did not match with the CRC64 value calculated by the server."
+        )
+      ) {
         exceptionCaught = true;
       }
     }

--- a/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
@@ -369,7 +369,10 @@ describe("QueueServiceClient", () => {
       err = error;
     }
     assert.equal(err.details.errorCode, "QueueNotFound", "Error does not contain details property");
-    assert.ok(err.message.includes("QueueNotFound"), "Error doesn't say `QueueNotFound`");
+    assert.ok(
+      err.message.startsWith("The specified queue does not exist."),
+      "Error doesn't say `QueueNotFound`"
+    );
   });
 
   it("verify custom endpoint without valid accountName", async () => {


### PR DESCRIPTION
Currently we check `parsedBody.error` or `parsedBody` for `code` and
`message` to use in the `RestError` to be thrown. However, we do this
on the raw object from parsing XML.

In the example added to the test, without this fix, the `parsedBody`
from xml parsing is
```js
{ Code: "ContainerAlreadyExists", Message: "The specified container already exists." }
```
but we are accessing the properties with lowercase `code` and `message`.

We should check on the object after de-serializing when we have error
object properly mapped already.