### PR TITLE
Bump core http dependency version for all packages

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-auth": "^1.1.3",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -63,7 +63,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "1.0.0-beta.3",
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -68,7 +68,7 @@
     "@azure/communication-common": "1.0.0-beta.3",
     "@azure/communication-signaling": "1.0.0-beta.1",
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
     "events": "^3.0.0",
     "jwt-decode": "~2.2.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -67,7 +67,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "1.0.0-beta.3",
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -101,7 +101,7 @@
     ]
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -92,7 +92,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -78,7 +78,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -80,7 +80,7 @@
     "@azure/core-auth": "^1.1.3",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -79,7 +79,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity/README.md",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@azure/msal-node": "^1.0.0-alpha.8",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -78,7 +78,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -44,7 +44,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -84,7 +84,7 @@
     ]
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -79,7 +79,7 @@
     "@azure/core-auth": "^1.1.3",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -78,7 +78,7 @@
     "typescript": "~3.9.3"
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
     "@opentelemetry/core": "^0.10.2",
     "@opentelemetry/semantic-conventions": "^0.10.2",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -61,7 +61,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/schema-registry": "1.0.0-beta.2",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",
     "avsc": "^5.5.1",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -76,7 +76,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -75,7 +75,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -99,7 +99,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "^1.1.6",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.3.0-beta.1",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -118,7 +118,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -65,7 +65,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -62,7 +62,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -62,7 +62,7 @@
   "private": true,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0",
     "node-fetch": "^2.6.0",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "private": true,
   "dependencies": {
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
     "fs-extra": "^8.1.0",
     "nise": "^4.0.3",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -77,7 +77,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.1.3",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",


### PR DESCRIPTION
This bump is needed for text analytics and rush requires all packages dependencies to be consistent.

Command: `rush add -p "@azure/core-http" --caret --make-consistent`