### PR TITLE
[core-http] Throw on unexpected status code and no default mapper

### DIFF
--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -209,13 +209,6 @@ function handleErrorResponse(
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 
-  if (!errorResponseSpec) {
-    throw parsedResponse;
-  }
-
-  const defaultBodyMapper = errorResponseSpec.bodyMapper;
-  const defaultHeadersMapper = errorResponseSpec.headersMapper;
-
   const initialErrorMessage = isStreamOperation(operationSpec)
     ? `Unexpected status code: ${parsedResponse.status}`
     : (parsedResponse.bodyAsText as string);
@@ -225,6 +218,15 @@ function handleErrorResponse(
     request: parsedResponse.request,
     response: parsedResponse
   });
+
+  // If the item failed but there's no error spec or default spec to deserialize the error,
+  // we should fail so we just throw the parsed response
+  if (!errorResponseSpec) {
+    throw error;
+  }
+
+  const defaultBodyMapper = errorResponseSpec.bodyMapper;
+  const defaultHeadersMapper = errorResponseSpec.headersMapper;
 
   try {
     // If error response has a body, try to extract error code & message from it

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -210,7 +210,7 @@ function handleErrorResponse(
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 
   if (!errorResponseSpec) {
-    return { error: null, shouldReturnResponse: true };
+    throw parsedResponse;
   }
 
   const defaultBodyMapper = errorResponseSpec.bodyMapper;

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -513,8 +513,8 @@ describe("deserializationPolicy", function() {
         assert.fail();
       } catch (e) {
         assert(e);
-        assert.strictEqual(e.status, 400);
-        assert.strictEqual(e.parsedBody.message, "InternalServerError");
+        assert.strictEqual(e.statusCode, 400);
+        assert.include(e.message, "InternalServerError");
       }
     });
 

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -493,6 +493,31 @@ describe("deserializationPolicy", function() {
       }
     });
 
+    it(`should throw when the response code is not defined in the operationSpec`, async function() {
+      const serializer = createSerializer(undefined, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          200: {}
+        },
+        serializer
+      };
+      try {
+        await getDeserializedResponse({
+          operationSpec,
+          headers: {},
+          bodyAsText: '{"message": "InternalServerError"}',
+          status: 400
+        });
+        assert.fail();
+      } catch (e) {
+        assert(e);
+        assert.strictEqual(e.status, 400);
+        assert.strictEqual(e.parsedBody.message, "InternalServerError");
+      }
+    });
+
     it(`with non default complex error response`, async function() {
       const BodyMapper: CompositeMapper = {
         serializedName: "getproperties-body",

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -237,9 +237,10 @@ function handleErrorResponse(
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
 
-  // If the item failed but there's no error spec or default spec, just return it as-is.
+  // If the item failed but there's no error spec or default spec to deserialize the error,
+  // we should fail so we just throw the parsed response
   if (!errorResponseSpec) {
-    return { error: null, shouldReturnResponse: true };
+    throw parsedResponse;
   }
 
   const defaultBodyMapper = errorResponseSpec.bodyMapper;

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -236,16 +236,6 @@ function handleErrorResponse(
   }
 
   const errorResponseSpec = responseSpec ?? operationSpec.responses.default;
-
-  // If the item failed but there's no error spec or default spec to deserialize the error,
-  // we should fail so we just throw the parsed response
-  if (!errorResponseSpec) {
-    throw parsedResponse;
-  }
-
-  const defaultBodyMapper = errorResponseSpec.bodyMapper;
-  const defaultHeadersMapper = errorResponseSpec.headersMapper;
-
   const initialErrorMessage = isStreamOperation(operationSpec)
     ? `Unexpected status code: ${parsedResponse.status}`
     : (parsedResponse.bodyAsText as string);
@@ -257,6 +247,15 @@ function handleErrorResponse(
     parsedResponse.request,
     parsedResponse
   );
+
+  // If the item failed but there's no error spec or default spec to deserialize the error,
+  // we should fail so we just throw the parsed response
+  if (!errorResponseSpec) {
+    throw error;
+  }
+
+  const defaultBodyMapper = errorResponseSpec.bodyMapper;
+  const defaultHeadersMapper = errorResponseSpec.headersMapper;
 
   try {
     // If error response has a body, try to extract error code & message from it

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -808,6 +808,34 @@ describe("deserializationPolicy", function() {
       }
     });
 
+    it(`should throw when the response code is not defined in the operationSpec`, async function() {
+      const serializer = new Serializer(undefined, true);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          200: {}
+        },
+        serializer
+      };
+
+      const response: HttpOperationResponse = {
+        request: createRequest(operationSpec),
+        status: 400,
+        headers: new HttpHeaders(),
+        bodyAsText: '{"message": "InternalServerError"}'
+      };
+
+      try {
+        await deserializeResponse(response);
+        assert.fail();
+      } catch (e) {
+        assert(e);
+        assert.strictEqual(e.status, 400);
+        assert.strictEqual(e.parsedBody.message, "InternalServerError");
+      }
+    });
+
     it(`with non default complex error response`, async function() {
       const BodyMapper: CompositeMapper = {
         serializedName: "getproperties-body",

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -831,8 +831,8 @@ describe("deserializationPolicy", function() {
         assert.fail();
       } catch (e) {
         assert(e);
-        assert.strictEqual(e.status, 400);
-        assert.strictEqual(e.parsedBody.message, "InternalServerError");
+        assert.strictEqual(e.statusCode, 400);
+        assert.include(e.message, "InternalServerError");
       }
     });
 

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -821,17 +821,17 @@ describe("deserializationPolicy", function() {
 
       const response: HttpOperationResponse = {
         request: createRequest(operationSpec),
-        status: 400,
+        status: 500,
         headers: new HttpHeaders(),
         bodyAsText: '{"message": "InternalServerError"}'
       };
 
       try {
         await deserializeResponse(response);
-        assert.fail();
+        assert.fail("Expected deserializeResponse to throw an error");
       } catch (e) {
         assert(e);
-        assert.strictEqual(e.statusCode, 400);
+        assert.strictEqual(e.statusCode, 500);
         assert.include(e.message, "InternalServerError");
       }
     });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/unit/platform/nodejs/httpSender.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/unit/platform/nodejs/httpSender.test.ts
@@ -44,9 +44,13 @@ describe("HttpSender", () => {
     it("should send an invalid non-retriable envelope", async () => {
       const sender = new HttpSender();
       scope.reply(403, JSON.stringify(failedBreezeResponse(2, 403)));
-      const { result, statusCode } = await sender.send([envelope, envelope]);
-      assert.strictEqual(statusCode, 403);
-      assert.deepStrictEqual(JSON.parse(result), failedBreezeResponse(2, 403));
+
+      try {
+        await sender.send([envelope, envelope]);
+      } catch (error) {
+        assert.strictEqual(error.statusCode, 403);
+        assert.deepStrictEqual(error.details, failedBreezeResponse(2, 403));
+      }
     });
 
     it("should send a partially retriable envelope", async () => {


### PR DESCRIPTION
Currently, if we receive an un expected HTTP status code (not defined in the operation spec) we'll try to use the `default` mapper. However there are cases when a default mapper is not defined, in this case we are treating it as a success.

This PR makes sure that the unexpected status code is handled as an error by throwing the parsedResponse in the scenario where the deserializer is not provided with a mapper, this aligns with what other languages are doing for unexpected status codes and no default mapper

As an example, with the current behavior, the following operation will return a success response with a 400 status code:
https://github.com/Azure/autorest.testserver/blob/23eb8f04399596f2efea1a8828f080946edfc049/swagger/httpInfrastructure.quirks.json#L2746

With the changes in this PR the deserializer will throw an error with the parsed response