### PR TITLE
[MetricsAdvisor] change timestamps type from Date to number

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
@@ -21,6 +21,12 @@
 - [Breaking] The `-List` suffix is removed from Array properties in `MetricSeriesData` and `MetricsEnrichedSeriesData`. Plural form is used instead.
 - [Breaking] `*PageResponse` types now extends from `Array<ItemType>` instead of wrapping an array of `ItemType`. Their types names are also shortened.
 - [Breaking] Data feed ingestion granularity now has `"PerMinute"` and `"PerSecond"` instead of `"Minutely"` and `"Secondly"`.
+- [Breaking] Change the type of following timestamp properties from `Date` to `number`
+  - `AnomalyAlert.timestamp`
+  - `DataPointAnomaly.timestamp`
+  - `EnrichmentStatus.timestamp`
+  - `IngestionStatus.timestamp`
+  - `latestSuccessTimestamp` and `latestActiveTimestamp` in the return type of `getDataFeedIngestionProgress()`.
 - Parameters of `Date` type now also accept strings. No validation is done for the strings. The SDK calls `new Date()` to convert them to `Date`.
 
 ## 1.0.0-beta.1 (2020-10-07)

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -417,14 +417,6 @@ export type FeedbackQueryTimeMode = "MetricTimestamp" | "FeedbackCreatedTime";
 export type FeedbackType = "Anomaly" | "ChangePoint" | "Period" | "Comment";
 
 // @public
-export type GeneratedClientGetIngestionProgressResponse = DataFeedIngestionProgress & {
-    _response: coreHttp.HttpResponse & {
-        bodyAsText: string;
-        parsedBody: DataFeedIngestionProgress;
-    };
-};
-
-// @public
 export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -52,7 +52,7 @@ export interface AnomalyAlert {
     createdOn?: Date;
     id: string;
     modifiedOn?: Date;
-    timestamp?: Date;
+    timestamp?: number;
 }
 
 // @public
@@ -335,7 +335,7 @@ export interface DataPointAnomaly {
     seriesKey: DimensionKey;
     severity: AnomalySeverity;
     status?: AnomalyStatus;
-    timestamp: Date;
+    timestamp: number;
 }
 
 // @public
@@ -407,7 +407,7 @@ export type EmailNotificationHookPatch = {
 export interface EnrichmentStatus {
     readonly message?: string;
     readonly status?: string;
-    readonly timestamp?: Date;
+    readonly timestamp?: number;
 }
 
 // @public
@@ -467,6 +467,17 @@ export type GetHookResponse = NotificationHookUnion & {
 // @public
 export type GetIncidentRootCauseResponse = {
     rootCauses: IncidentRootCause[];
+    _response: coreHttp.HttpResponse & {
+        bodyAsText: string;
+        parsedBody: any;
+    };
+};
+
+// @public
+export type GetIngestionProgressResponse = {
+    readonly latestSuccessTimestamp?: number;
+    readonly latestActiveTimestamp?: number;
+} & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
         parsedBody: any;
@@ -571,7 +582,7 @@ export interface InfluxDBParameter {
 export interface IngestionStatus {
     readonly message?: string;
     readonly status?: IngestionStatusType;
-    readonly timestamp?: Date;
+    readonly timestamp?: number;
 }
 
 // @public
@@ -810,7 +821,7 @@ export class MetricsAdvisorAdministrationClient {
     readonly endpointUrl: string;
     getAnomalyAlertConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     getDataFeed(id: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
-    getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GeneratedClientGetIngestionProgressResponse>;
+    getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GetIngestionProgressResponse>;
     getHook(id: string, options?: OperationOptions): Promise<GetHookResponse>;
     getMetricAnomalyDetectionConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
     listAnomalyAlertConfigurations(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -42,7 +42,8 @@ import {
   AlertConfigurationsPageResponse,
   DetectionConfigurationsPageResponse,
   HooksPageResponse,
-  DataFeedStatus
+  DataFeedStatus,
+  GetIngestionProgressResponse
 } from "./models";
 import { DataSourceType, NeedRollupEnum } from "./generated/models";
 import {
@@ -1339,16 +1340,20 @@ export class MetricsAdvisorAdministrationClient {
           top: options?.maxPageSize
         }
       );
-      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
-        return {
-          timestamp: s.timestamp?.getTime(),
-          status: s.status,
-          message: s.message
-        };
-      }) || [], "continuationToken", {
-        enumerable: true,
-        value: segmentResponse.nextLink
-      });
+      const resultArray = Object.defineProperty(
+        segmentResponse.value?.map((s) => {
+          return {
+            timestamp: s.timestamp?.getTime(),
+            status: s.status,
+            message: s.message
+          };
+        }) || [],
+        "continuationToken",
+        {
+          enumerable: true,
+          value: segmentResponse.nextLink
+        }
+      );
       yield Object.defineProperty(resultArray, "_response", {
         enumerable: false,
         value: segmentResponse._response
@@ -1369,16 +1374,20 @@ export class MetricsAdvisorAdministrationClient {
         options
       );
 
-      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
-        return {
-          timestamp: s.timestamp?.getTime(),
-          status: s.status,
-          message: s.message
-        };
-      }) || [], "continuationToken", {
-        enumerable: true,
-        value: segmentResponse.nextLink
-      });
+      const resultArray = Object.defineProperty(
+        segmentResponse.value?.map((s) => {
+          return {
+            timestamp: s.timestamp?.getTime(),
+            status: s.status,
+            message: s.message
+          };
+        }) || [],
+        "continuationToken",
+        {
+          enumerable: true,
+          value: segmentResponse.nextLink
+        }
+      );
       yield Object.defineProperty(resultArray, "_response", {
         enumerable: false,
         value: segmentResponse._response

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -44,11 +44,7 @@ import {
   HooksPageResponse,
   DataFeedStatus
 } from "./models";
-import {
-  DataSourceType,
-  GeneratedClientGetIngestionProgressResponse,
-  NeedRollupEnum
-} from "./generated/models";
+import { DataSourceType, NeedRollupEnum } from "./generated/models";
 import {
   fromServiceAnomalyDetectionConfiguration,
   fromServiceDataFeedDetailUnion,
@@ -1295,7 +1291,7 @@ export class MetricsAdvisorAdministrationClient {
   public async getDataFeedIngestionProgress(
     dataFeedId: string,
     options = {}
-  ): Promise<GeneratedClientGetIngestionProgressResponse> {
+  ): Promise<GetIngestionProgressResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-getDataFeedIngestionProgress",
       options
@@ -1303,7 +1299,12 @@ export class MetricsAdvisorAdministrationClient {
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-      return await this.client.getIngestionProgress(dataFeedId, requestOptions);
+      const response = await this.client.getIngestionProgress(dataFeedId, requestOptions);
+      return {
+        latestActiveTimestamp: response.latestActiveTimestamp?.getTime(),
+        latestSuccessTimestamp: response.latestSuccessTimestamp?.getTime(),
+        _response: response._response
+      };
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -1338,7 +1339,13 @@ export class MetricsAdvisorAdministrationClient {
           top: options?.maxPageSize
         }
       );
-      const resultArray = Object.defineProperty(segmentResponse.value || [], "continuationToken", {
+      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
+        return {
+          timestamp: s.timestamp?.getTime(),
+          status: s.status,
+          message: s.message
+        };
+      }) || [], "continuationToken", {
         enumerable: true,
         value: segmentResponse.nextLink
       });
@@ -1362,7 +1369,13 @@ export class MetricsAdvisorAdministrationClient {
         options
       );
 
-      const resultArray = Object.defineProperty(segmentResponse.value || [], "continuationToken", {
+      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
+        return {
+          timestamp: s.timestamp?.getTime(),
+          status: s.status,
+          message: s.message
+        };
+      }) || [], "continuationToken", {
         enumerable: true,
         value: segmentResponse.nextLink
       });

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -32,16 +32,12 @@ import {
   MetricEnrichmentStatusPageResponse,
   MetricSeriesDefinition,
   DimensionKey,
+  EnrichmentStatus,
   GetMetricSeriesDataResponse,
   MetricFeedbackPageResponse,
   AlertQueryTimeMode
 } from "./models";
-import {
-  SeverityFilterCondition,
-  EnrichmentStatus,
-  FeedbackType,
-  FeedbackQueryTimeMode
-} from "./generated/models";
+import { SeverityFilterCondition, FeedbackType, FeedbackQueryTimeMode } from "./generated/models";
 import { toServiceMetricFeedbackUnion, fromServiceMetricFeedbackUnion } from "./transforms";
 import { createClientPipeline } from "./createClientPipeline";
 
@@ -259,7 +255,7 @@ export class MetricsAdvisorClient {
           alertConfigId: alertConfigId,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          timestamp: a.timestamp
+          timestamp: a.timestamp?.getTime()
         };
       });
       const resultArray = Object.defineProperty(alerts || [], "continuationToken", {
@@ -287,7 +283,7 @@ export class MetricsAdvisorClient {
           alertConfigId: alertConfigId,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
-          timestamp: a.timestamp
+          timestamp: a.timestamp?.getTime()
         };
       });
       const resultArray = Object.defineProperty(alerts || [], "continuationToken", {
@@ -454,13 +450,12 @@ export class MetricsAdvisorClient {
         return {
           detectionConfigurationId: a.anomalyDetectionConfigurationId!,
           metricId: a.metricId,
-          timestampe: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
           seriesKey: a.dimension,
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus,
-          timestamp: a.timestamp
+          timestamp: a.timestamp.getTime()
         };
       });
       const resultArray = Object.defineProperty(anomalies || [], "continuationToken", {
@@ -490,13 +485,12 @@ export class MetricsAdvisorClient {
         return {
           detectionConfigurationId: a.anomalyDetectionConfigurationId!,
           metricId: a.metricId,
-          timestampe: a.timestamp,
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
           seriesKey: a.dimension,
           severity: a.property.anomalySeverity,
           status: a.property.anomalyStatus,
-          timestamp: a.timestamp
+          timestamp: a.timestamp.getTime()
         };
       });
       const resultArray = Object.defineProperty(anomalies || [], "continuationToken", {
@@ -931,7 +925,7 @@ export class MetricsAdvisorClient {
         return {
           detectionConfigurationId: detectionConfigId,
           metricId: a.metricId,
-          timestamp: a.timestamp,
+          timestamp: a.timestamp.getTime(),
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
           seriesKey: a.dimension,
@@ -963,7 +957,7 @@ export class MetricsAdvisorClient {
         return {
           detectionConfigurationId: detectionConfigId,
           metricId: a.metricId,
-          timestamp: a.timestamp,
+          timestamp: a.timestamp.getTime(),
           createdOn: a.createdTime,
           modifiedOn: a.modifiedTime,
           seriesKey: a.dimension,
@@ -2180,7 +2174,13 @@ export class MetricsAdvisorClient {
         ...options,
         top: maxPageSize
       });
-      const resultArray = Object.defineProperty(segmentResponse.value || [], "continuationToken", {
+      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
+        return {
+          timestamp: s.timestamp?.getTime(),
+          status: s.status,
+          message: s.message
+        };
+      }) || [], "continuationToken", {
         enumerable: true,
         value: segmentResponse.nextLink
       });
@@ -2199,7 +2199,13 @@ export class MetricsAdvisorClient {
         optionsBody,
         options
       );
-      const resultArray = Object.defineProperty(segmentResponse.value || [], "continuationToken", {
+      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
+        return {
+          timestamp: s.timestamp?.getTime(),
+          status: s.status,
+          message: s.message
+        };
+      }) || [], "continuationToken", {
         enumerable: true,
         value: segmentResponse.nextLink
       });

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -2174,16 +2174,20 @@ export class MetricsAdvisorClient {
         ...options,
         top: maxPageSize
       });
-      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
-        return {
-          timestamp: s.timestamp?.getTime(),
-          status: s.status,
-          message: s.message
-        };
-      }) || [], "continuationToken", {
-        enumerable: true,
-        value: segmentResponse.nextLink
-      });
+      const resultArray = Object.defineProperty(
+        segmentResponse.value?.map((s) => {
+          return {
+            timestamp: s.timestamp?.getTime(),
+            status: s.status,
+            message: s.message
+          };
+        }) || [],
+        "continuationToken",
+        {
+          enumerable: true,
+          value: segmentResponse.nextLink
+        }
+      );
       yield Object.defineProperty(resultArray, "_response", {
         enumerable: false,
         value: segmentResponse._response
@@ -2199,16 +2203,20 @@ export class MetricsAdvisorClient {
         optionsBody,
         options
       );
-      const resultArray = Object.defineProperty(segmentResponse.value?.map((s) => {
-        return {
-          timestamp: s.timestamp?.getTime(),
-          status: s.status,
-          message: s.message
-        };
-      }) || [], "continuationToken", {
-        enumerable: true,
-        value: segmentResponse.nextLink
-      });
+      const resultArray = Object.defineProperty(
+        segmentResponse.value?.map((s) => {
+          return {
+            timestamp: s.timestamp?.getTime(),
+            status: s.status,
+            message: s.message
+          };
+        }) || [],
+        "continuationToken",
+        {
+          enumerable: true,
+          value: segmentResponse.nextLink
+        }
+      );
       yield Object.defineProperty(resultArray, "_response", {
         enumerable: false,
         value: segmentResponse._response

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -50,7 +50,6 @@ export {
 export {
   AnomalyValue,
   DataFeedIngestionProgress,
-  GeneratedClientGetIngestionProgressResponse,
   IngestionStatusType,
   DataSourceType,
   SeverityFilterCondition,
@@ -1714,7 +1713,7 @@ export interface HooksPageResponse extends Array<NotificationHookUnion> {
      */
     parsedBody: any;
   };
-};
+}
 
 /**
  * Contains response data for the getDataFeedIngestionProgress operation.

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -4,7 +4,6 @@
 import * as coreHttp from "@azure/core-http";
 
 import {
-  IngestionStatus,
   SqlSourceParameter,
   SuppressCondition,
   SmartDetectionCondition,
@@ -22,8 +21,8 @@ import {
   TopNGroupScope,
   SeverityCondition,
   AlertSnoozeCondition,
-  EnrichmentStatus,
-  DataFeedDetailStatus
+  DataFeedDetailStatus,
+  IngestionStatusType
 } from "./generated/models";
 
 export {
@@ -31,8 +30,6 @@ export {
   AlertSnoozeCondition,
   SmartDetectionCondition,
   TopNGroupScope,
-  EnrichmentStatus,
-  IngestionStatus,
   AzureApplicationInsightsParameter,
   AzureBlobParameter,
   AzureCosmosDBParameter,
@@ -897,7 +894,7 @@ export interface DataPointAnomaly {
   /**
    * anomaly time
    */
-  timestamp: Date;
+  timestamp: number;
   /**
    * created time
    *
@@ -941,7 +938,7 @@ export interface AnomalyAlert {
   /**
    * anomaly time
    */
-  timestamp?: Date; // TODO: why optional?
+  timestamp?: number; // TODO: why optional?
   /**
    * created time
    */
@@ -1507,6 +1504,21 @@ export interface MetricSeriesPageResponse extends Array<MetricSeriesDefinition> 
   };
 }
 
+export interface EnrichmentStatus {
+  /**
+   * data slice timestamp.
+   */
+  readonly timestamp?: number;
+  /**
+   * latest enrichment status for this data slice.
+   */
+  readonly status?: string;
+  /**
+   * the trimmed message describes details of the enrichment status.
+   */
+  readonly message?: string;
+}
+
 /**
  * Contains response data for the listMetricEnrichmentStatus operation.
  */
@@ -1579,6 +1591,20 @@ export interface GetMetricSeriesDataResponse extends Array<MetricSeriesData> {
   };
 }
 
+export interface IngestionStatus {
+  /**
+   * data slice timestamp.
+   */
+  readonly timestamp?: number;
+  /**
+   * latest ingestion task status for this data slice.
+   */
+  readonly status?: IngestionStatusType;
+  /**
+   * the trimmed message of last ingestion job.
+   */
+  readonly message?: string;
+}
 /**
  * Contains response data for the ListDataFeedIngestionStatus operation.
  */
@@ -1688,4 +1714,35 @@ export interface HooksPageResponse extends Array<NotificationHookUnion> {
      */
     parsedBody: any;
   };
-}
+};
+
+/**
+ * Contains response data for the getDataFeedIngestionProgress operation.
+ */
+export type GetIngestionProgressResponse = {
+  /**
+   * the timestamp of lastest success ingestion job.
+   * null indicates not available
+   */
+  readonly latestSuccessTimestamp?: number;
+  /**
+   * the timestamp of lastest ingestion job with status update.
+   * null indicates not available
+   */
+  readonly latestActiveTimestamp?: number;
+} & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: any;
+  };
+};


### PR DESCRIPTION
This addresses one of the Arch Board review feedback. I still keep the
timestamps in MetricSeriesData and MetricEnrichedSeriesData as Date
type because their most common usage is plotting because keeping them as Date
make it easier to use year/month/date in x-axis labels.

This fixes #11832 