### PR TITLE
[Identity] Remove version check for now, until other services support it

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -116,46 +116,26 @@ export class ManagedIdentityCredential implements TokenCredential {
   private createAppServiceMsiAuthRequest(
     resource: string,
     clientId?: string,
-    version?: "2019-08-01" | "2017-09-01"
+    _version?: "2019-08-01" | "2017-09-01"
   ): RequestPrepareOptions {
     const queryParameters: any = {
       resource,
       "api-version": AppServiceMsiApiVersion
     };
 
-    if (version === "2019-08-01") {
-      if (clientId) {
-        queryParameters.client_id = clientId;
-      }
-
-      return {
-        url: process.env.IDENTITY_ENDPOINT,
-        method: "GET",
-        queryParameters,
-        headers: {
-          Accept: "application/json",
-          "X-IDENTITY-HEADER": process.env.IDENTITY_HEADER
-        }
-      };
-    } else if (version === "2017-09-01") {
-      if (clientId) {
-        queryParameters.clientid = clientId;
-      }
-
-      return {
-        url: process.env.MSI_ENDPOINT,
-        method: "GET",
-        queryParameters,
-        headers: {
-          Accept: "application/json",
-          secret: process.env.MSI_SECRET
-        }
-      };
-    } else {
-      throw new Error(
-        `Unsupported version ${version}. The supported versions are "2019-08-01" and "2017-09-01"`
-      );
+    if (clientId) {
+      queryParameters.clientid = clientId;
     }
+
+    return {
+      url: process.env.MSI_ENDPOINT,
+      method: "GET",
+      queryParameters,
+      headers: {
+        Accept: "application/json",
+        secret: process.env.MSI_SECRET
+      }
+    };
   }
 
   private createCloudShellMsiAuthRequest(

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -134,43 +134,44 @@ describe("ManagedIdentityCredential", function() {
   //   assert.strictEqual(mockHttpClient.requests.length, 1);
   // });
 
-  it("sends an authorization request correctly in an App Service environment version 2019-08-01", async () => {
-    // Trigger App Service behavior by setting environment variables
-    process.env.IDENTITY_ENDPOINT = "https://endpoint";
-    process.env.IDENTITY_HEADER = "secret";
+  // Currently not enabled. Re-enable when we add back in API version support for this API version
+  // it("sends an authorization request correctly in an App Service environment version 2019-08-01", async () => {
+  //   // Trigger App Service behavior by setting environment variables
+  //   process.env.IDENTITY_ENDPOINT = "https://endpoint";
+  //   process.env.IDENTITY_HEADER = "secret";
 
-    const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client", {
-      authResponse: {
-        status: 200,
-        parsedBody: {
-          token: "token",
-          expires_on: "1560999478"
-        }
-      }
-    });
+  //   const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client", {
+  //     authResponse: {
+  //       status: 200,
+  //       parsedBody: {
+  //         token: "token",
+  //         expires_on: "1560999478"
+  //       }
+  //     }
+  //   });
 
-    const authRequest = authDetails.requests[0];
-    assert.ok(authRequest.query, "No query string parameters on request");
-    if (authRequest.query) {
-      assert.equal(authRequest.method, "GET");
-      assert.equal(authRequest.query["client_id"], "client");
-      assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
-      assert.ok(
-        authRequest.url.startsWith(process.env.IDENTITY_ENDPOINT),
-        "URL does not start with expected host and path"
-      );
-      assert.equal(authRequest.headers.get("X-IDENTITY-HEADER"), process.env.IDENTITY_HEADER);
-      assert.ok(
-        authRequest.url.indexOf(`api-version=${AppServiceMsiApiVersion}`) > -1,
-        "URL does not have expected version"
-      );
-      if (authDetails.token) {
-        assert.equal(authDetails.token.expiresOnTimestamp, 1560999478);
-      } else {
-        assert.fail("No token was returned!");
-      }
-    }
-  });
+  //   const authRequest = authDetails.requests[0];
+  //   assert.ok(authRequest.query, "No query string parameters on request");
+  //   if (authRequest.query) {
+  //     assert.equal(authRequest.method, "GET");
+  //     assert.equal(authRequest.query["client_id"], "client");
+  //     assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
+  //     assert.ok(
+  //       authRequest.url.startsWith(process.env.IDENTITY_ENDPOINT),
+  //       "URL does not start with expected host and path"
+  //     );
+  //     assert.equal(authRequest.headers.get("X-IDENTITY-HEADER"), process.env.IDENTITY_HEADER);
+  //     assert.ok(
+  //       authRequest.url.indexOf(`api-version=${AppServiceMsiApiVersion}`) > -1,
+  //       "URL does not have expected version"
+  //     );
+  //     if (authDetails.token) {
+  //       assert.equal(authDetails.token.expiresOnTimestamp, 1560999478);
+  //     } else {
+  //       assert.fail("No token was returned!");
+  //     }
+  //   }
+  // });
 
   it("sends an authorization request correctly in an App Service environment", async () => {
     // Trigger App Service behavior by setting environment variables


### PR DESCRIPTION
We'd like to support more versions for MSI, but this currently isn't supported broadly enough to roll out. We'll use the older API version for now until we get broader support.

Fixes #12058 
