### PR TITLE
[Service Bus] Fix the flaky failure by increasing the max_wait_time

### DIFF
--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -912,9 +912,7 @@ describe("Batching Receiver", () => {
 
       let settledMessageCount = 0;
 
-      const messages1 = await receiver.receiveMessages(1, {
-        maxWaitTimeInMs: 5000
-      });
+      const messages1 = await receiver.receiveMessages(1);
       for (const message of messages1) {
         await receiver.completeMessage(message);
         settledMessageCount++;
@@ -937,9 +935,7 @@ describe("Batching Receiver", () => {
       await sender.sendMessages(TestMessage.getSample());
 
       // wait for the 2nd message to be received.
-      const messages2 = await (receiver as ServiceBusReceiver).receiveMessages(1, {
-        maxWaitTimeInMs: 5000
-      });
+      const messages2 = await (receiver as ServiceBusReceiver).receiveMessages(1);
       for (const message of messages2) {
         await receiver.completeMessage(message);
         settledMessageCount++;


### PR DESCRIPTION
### More info https://github.com/Azure/azure-sdk-for-js/issues/12000#issuecomment-716971749

By observation, this fix seems to have made all the entries in the matrix to be green and never failed in 1000 iterations. Hence, going with that and aborting the investigation.

Fixes #12000