### PR TITLE
[service-bus] Don't throw errors when you try to settle messages that aren't settleable

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -30,7 +30,8 @@ import {
   ServiceBusMessageImpl,
   getMessagePropertyTypeMismatchError,
   toAmqpMessage,
-  fromAmqpMessage
+  fromAmqpMessage,
+  createServiceBusMessage
 } from "../serviceBusMessage";
 import { LinkEntity, RequestResponseLinkOptions } from "./linkEntity";
 import { managementClientLogger, receiverLogger, senderLogger, ServiceBusLogger } from "../log";
@@ -795,7 +796,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       }[];
       for (const msg of messages) {
         const decodedMessage = RheaMessageUtil.decode(msg.message);
-        const message = new ServiceBusMessageImpl(
+        const message = createServiceBusMessage(
           this._context,
           this.entityPath,
           decodedMessage as any,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -739,6 +739,10 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   ): Promise<ServiceBusMessageImpl[]> {
     throwErrorIfConnectionClosed(this._context);
 
+    if (sequenceNumbers.length === 0) {
+      throw new TypeError("At least one sequence number must be specified.");
+    }
+
     const messageList: ServiceBusMessageImpl[] = [];
     const messageBody: any = {};
     messageBody[Constants.sequenceNumbers] = [];

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -16,7 +16,11 @@ import { OnError, OnMessage } from "../core/messageReceiver";
 import { assertValidMessageHandlers, getMessageIterator, wrapProcessErrorHandler } from "./shared";
 import { defaultMaxTimeAfterFirstMessageForBatchingMs, ServiceBusReceiver } from "./receiver";
 import Long from "long";
-import { ServiceBusMessageImpl, DeadLetterOptions } from "../serviceBusMessage";
+import {
+  ServiceBusMessageImpl,
+  DeadLetterOptions,
+  throwIfNotSettleableMessage
+} from "../serviceBusMessage";
 import {
   Constants,
   RetryConfig,
@@ -484,32 +488,28 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
   }
 
   async completeMessage(message: ServiceBusReceivedMessage): Promise<void> {
-    const msgImpl = message as ServiceBusMessageImpl;
-    return msgImpl.complete();
+    return throwIfNotSettleableMessage(message).complete();
   }
 
   async abandonMessage(
     message: ServiceBusReceivedMessage,
     propertiesToModify?: { [key: string]: any }
   ): Promise<void> {
-    const msgImpl = message as ServiceBusMessageImpl;
-    return msgImpl.abandon(propertiesToModify);
+    return throwIfNotSettleableMessage(message).abandon(propertiesToModify);
   }
 
   async deferMessage(
     message: ServiceBusReceivedMessage,
     propertiesToModify?: { [key: string]: any }
   ): Promise<void> {
-    const msgImpl = message as ServiceBusMessageImpl;
-    return msgImpl.defer(propertiesToModify);
+    return throwIfNotSettleableMessage(message).defer(propertiesToModify);
   }
 
   async deadLetterMessage(
     message: ServiceBusReceivedMessage,
     options?: DeadLetterOptions & { [key: string]: any }
   ): Promise<void> {
-    const msgImpl = message as ServiceBusMessageImpl;
-    return msgImpl.deadLetter(options);
+    return throwIfNotSettleableMessage(message).deadLetter(options);
   }
 
   async renewMessageLock(): Promise<Date> {

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -435,9 +435,13 @@ describe("BatchingReceiver unit tests", () => {
 
         batchingReceiver["_link"] = fakeRheaReceiver;
 
-        batchingReceiver["_batchingReceiverLite"]["_createServiceBusMessage"] = (eventContext) => {
+        batchingReceiver["_batchingReceiverLite"]["_createServiceBusMessage"] = (
+          _context,
+          _entityPath,
+          message
+        ) => {
           return {
-            body: eventContext.message?.body
+            body: message.body
           } as ServiceBusMessageImpl;
         };
 

--- a/sdk/servicebus/service-bus/test/internal/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/managementClient.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ManagementClient } from "../../src/core/managementClient";
+import { createConnectionContextForTests } from "./unittestUtils";
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+describe("managementLinkClient unit tests", () => {
+  it("getDeferredMessages, empty array", async () => {
+    const mgmtClient = new ManagementClient(createConnectionContextForTests(), "entity path");
+
+    try {
+      await mgmtClient.receiveDeferredMessages([], "peekLock");
+      assert.fail("Should have thrown a validation error");
+    } catch (err) {
+      assert.deepEqual(
+        {
+          name: err.name,
+          message: err.message
+        },
+        {
+          name: "TypeError",
+          message: "At least one sequence number must be specified."
+        }
+      );
+    }
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
@@ -327,9 +327,13 @@ describe("Message session unit tests", () => {
 
       batchingReceiver["_link"] = fakeRheaReceiver;
 
-      batchingReceiver["_batchingReceiverLite"]["_createServiceBusMessage"] = (eventContext) => {
+      batchingReceiver["_batchingReceiverLite"]["_createServiceBusMessage"] = (
+        _context,
+        _entityPath,
+        message
+      ) => {
         return {
-          body: eventContext.message?.body
+          body: message.body
         } as ServiceBusMessageImpl;
       };
 

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -12,7 +12,7 @@ import { ProcessErrorArgs } from "../src/models";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
-describe("Sample scenarios for track 2", () => {
+describe("Smoke tests - basic scenarios", () => {
   let serviceBusClient: ServiceBusClientForTests;
 
   before(async () => {


### PR DESCRIPTION
When we moved the settlement methods from the message to the receiver we opened up some new scenarios for the user that could cause confusion.

This PR closes those up so we throw a descriptive error if the user tries to settle a peeked message or a receive and delete message. Most of this PR is just refactoring a bit and some other cleanup that fell out from some of the changes.

Fixes #12012