### PR TITLE
[Service Bus] Empty array validation

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -641,9 +641,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       senderLogger.verbose("%s Schedule messages request body: %O.", this.logPrefix, request.body);
-      console.log("Making request");
       const result = await this._makeManagementRequest(request, senderLogger, options);
-      console.log("Got response:", result);
       const sequenceNumbers = result.body[Constants.sequenceNumbers];
       const sequenceNumbersAsLong = [];
       for (let i = 0; i < sequenceNumbers.length; i++) {
@@ -655,7 +653,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       }
       return sequenceNumbersAsLong;
     } catch (err) {
-      console.log("Got error:", err);
       const error = translate(err);
       senderLogger.logError(
         error,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -580,6 +580,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     options?: OperationOptionsBase & SendManagementRequestOptions
   ): Promise<Long[]> {
     throwErrorIfConnectionClosed(this._context);
+    if (!messages.length) {
+      return [];
+    }
     const messageBody: any[] = [];
     for (let i = 0; i < messages.length; i++) {
       const item = messages[i];
@@ -638,7 +641,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       senderLogger.verbose("%s Schedule messages request body: %O.", this.logPrefix, request.body);
+      console.log("Making request");
       const result = await this._makeManagementRequest(request, senderLogger, options);
+      console.log("Got response:", result);
       const sequenceNumbers = result.body[Constants.sequenceNumbers];
       const sequenceNumbersAsLong = [];
       for (let i = 0; i < sequenceNumbers.length; i++) {
@@ -650,6 +655,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       }
       return sequenceNumbersAsLong;
     } catch (err) {
+      console.log("Got error:", err);
       const error = translate(err);
       senderLogger.logError(
         error,
@@ -669,6 +675,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     options?: OperationOptionsBase & SendManagementRequestOptions
   ): Promise<void> {
     throwErrorIfConnectionClosed(this._context);
+    if (!sequenceNumbers.length) {
+      return;
+    }
     const messageBody: any = {};
     messageBody[Constants.sequenceNumbers] = [];
     for (let i = 0; i < sequenceNumbers.length; i++) {
@@ -738,6 +747,10 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     options?: OperationOptionsBase & SendManagementRequestOptions
   ): Promise<ServiceBusMessageImpl[]> {
     throwErrorIfConnectionClosed(this._context);
+
+    if (!sequenceNumbers.length) {
+      return [];
+    }
 
     const messageList: ServiceBusMessageImpl[] = [];
     const messageBody: any = {};

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -54,12 +54,14 @@ describe("Deferred Messages", () => {
 
   it(noSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
     await beforeEachTest(noSessionTestClientType);
-    await receiver.receiveDeferredMessages([]);
+    const msgs = await receiver.receiveDeferredMessages([]);
+    should.equal(msgs.length, 0);
   });
 
   it(withSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
     await beforeEachTest(withSessionTestClientType);
-    await receiver.receiveDeferredMessages([]);
+    const msgs = await receiver.receiveDeferredMessages([]);
+    should.equal(msgs.length, 0);
   });
 
   /**

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -52,17 +52,22 @@ describe("Deferred Messages", () => {
     await serviceBusClient.test.afterEach();
   });
 
-  it(noSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
+  it(noSessionTestClientType + ": Empty array as input throws no error", async function(): Promise<
+    void
+  > {
     await beforeEachTest(noSessionTestClientType);
     const msgs = await receiver.receiveDeferredMessages([]);
     should.equal(msgs.length, 0);
   });
 
-  it(withSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
-    await beforeEachTest(withSessionTestClientType);
-    const msgs = await receiver.receiveDeferredMessages([]);
-    should.equal(msgs.length, 0);
-  });
+  it(
+    withSessionTestClientType + ": Empty array as input throws no error",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      const msgs = await receiver.receiveDeferredMessages([]);
+      should.equal(msgs.length, 0);
+    }
+  );
 
   /**
    * Sends, defers, receives and then returns a test message

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -52,6 +52,16 @@ describe("Deferred Messages", () => {
     await serviceBusClient.test.afterEach();
   });
 
+  it(noSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
+    await beforeEachTest(noSessionTestClientType);
+    await receiver.receiveDeferredMessages([]);
+  });
+
+  it(withSessionTestClientType + ": Empty array as input", async function(): Promise<void> {
+    await beforeEachTest(withSessionTestClientType);
+    await receiver.receiveDeferredMessages([]);
+  });
+
   /**
    * Sends, defers, receives and then returns a test message
    * @param testMessage Test message to send, defer, receive and then return

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -220,7 +220,8 @@ describe("Sender Tests", () => {
     anyRandomTestClientType + ": Schedule with empty input does not throw error",
     async function(): Promise<void> {
       await beforeEachTest(anyRandomTestClientType);
-      await sender.scheduleMessages([], new Date());
+      const sequenceNumbers = await sender.scheduleMessages([], new Date());
+      should.equal(sequenceNumbers.length, 0);
     }
   );
 

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -216,6 +216,14 @@ describe("Sender Tests", () => {
     await testPeekMsgsLength(receiver, 0);
   }
 
+  it(
+    anyRandomTestClientType + ": Schedule with empty input does not throw error",
+    async function(): Promise<void> {
+      await beforeEachTest(anyRandomTestClientType);
+      await sender.scheduleMessages([], new Date());
+    }
+  );
+
   it(anyRandomTestClientType + ": Schedule single message", async function(): Promise<void> {
     await beforeEachTest(anyRandomTestClientType);
     await testScheduleSingleMessage();
@@ -261,6 +269,14 @@ describe("Sender Tests", () => {
     await delay(30000);
     await testReceivedMsgsLength(receiver, 0);
   }
+
+  it(
+    anyRandomTestClientType + ": Cancel Scheduled message with empty input does not throw error",
+    async function(): Promise<void> {
+      await beforeEachTest(anyRandomTestClientType);
+      await sender.cancelScheduledMessages([]);
+    }
+  );
 
   it(anyRandomTestClientType + ": Cancel single Scheduled message", async function(): Promise<
     void


### PR DESCRIPTION
This PR ensures we do an early exit when input is empty array to methods that take an array as input
This closes #12095 which was logged for the `receiveDeferredMessages()` method and also fixes the same for `scheduleMessages()` and `cancelScheduledMessages()` calls