### PR TITLE
[Core AMQP] Remove userId until its type is fixed in rhea

### DIFF
--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -79,7 +79,6 @@ export interface AmqpMessageProperties {
     replyToGroupId?: string;
     subject?: string;
     to?: string;
-    userId?: string;
 }
 
 // @public

--- a/sdk/core/core-amqp/src/messageProperties.ts
+++ b/sdk/core/core-amqp/src/messageProperties.ts
@@ -60,10 +60,10 @@ export interface AmqpMessageProperties {
    * content and purpose.
    */
   subject?: string;
-  /**
-   * @property {string} [userId] The identity of the user responsible for producing the message.
-   */
-  userId?: string;
+  // /**
+  //  * @property {string} [userId] The identity of the user responsible for producing the message.
+  //  */
+  // userId?: string;
 }
 
 /**
@@ -114,9 +114,9 @@ export const AmqpMessageProperties = {
     if (props.to != undefined) {
       amqpProperties.to = props.to;
     }
-    if (props.userId != undefined) {
-      amqpProperties.user_id = props.userId;
-    }
+    // if (props.userId != undefined) {
+    //   amqpProperties.user_id = props.userId;
+    // }
 
     logger.verbose("To RheaMessageProperties: %O", amqpProperties);
     return amqpProperties;
@@ -165,9 +165,9 @@ export const AmqpMessageProperties = {
     if (props.to != undefined) {
       msgProperties.to = props.to;
     }
-    if (props.user_id != undefined) {
-      msgProperties.userId = props.user_id;
-    }
+    // if (props.user_id != undefined) {
+    //   msgProperties.userId = props.user_id;
+    // }
 
     logger.verbose("From RheaMessageProperties: %O", msgProperties);
     return msgProperties;

--- a/sdk/core/core-amqp/test/message.spec.ts
+++ b/sdk/core/core-amqp/test/message.spec.ts
@@ -89,8 +89,8 @@ describe("message", function() {
         replyTo: "",
         replyToGroupId: "",
         subject: "",
-        to: "",
-        userId: ""
+        to: ""
+        // userId: ""
       };
       const amqpMsgPropertiesExpected: RheaMessageProperties = {
         absolute_expiry_time: 0,
@@ -136,8 +136,8 @@ describe("message", function() {
         replyTo: "",
         replyToGroupId: "",
         subject: "",
-        to: "",
-        userId: ""
+        to: ""
+        // userId: ""
       };
       const amqpMsgProperties: RheaMessageProperties = {
         absolute_expiry_time: 0,

--- a/sdk/core/core-amqp/test/message.spec.ts
+++ b/sdk/core/core-amqp/test/message.spec.ts
@@ -104,8 +104,8 @@ describe("message", function() {
         reply_to: "",
         reply_to_group_id: "",
         subject: "",
-        to: "",
-        user_id: ""
+        to: ""
+        // user_id: ""
       };
       const amqpMsgProperties: RheaMessageProperties = AmqpMessageProperties.toRheaMessageProperties(
         msgProperties

--- a/sdk/servicebus/service-bus/test/internal/serviceBusMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusMessage.spec.ts
@@ -196,7 +196,7 @@ describe("ServiceBusMessageImpl AmqpAnnotations unit tests", () => {
       amqpMessage.group_sequence
     );
     assert.equal(sbMessage._amqpAnnotatedMessage.properties?.subject, amqpMessage.subject);
-    assert.equal(sbMessage._amqpAnnotatedMessage.properties?.userId, amqpMessage.user_id);
+    // assert.equal(sbMessage._amqpAnnotatedMessage.properties?.userId, amqpMessage.user_id);
 
     assert.equal(sbMessage._amqpAnnotatedMessage.properties?.messageId, sbMessage.messageId);
     assert.equal(sbMessage._amqpAnnotatedMessage.properties?.replyTo, sbMessage.replyTo);


### PR DESCRIPTION
As seen in https://github.com/amqp/rhea/issues/323, `user-id` is wrongly typed in rhea.

This PR removes userId from the AMQP message properties in `@azure/core-amqp` package for now.
We will add it back once the type for `user-id` is settled on and rhea releases an update