### PR TITLE
[Service Bus] subQueue -> subQueueType

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -23,22 +23,21 @@
 ### Breaking changes
 
 - The methods to complete, abandon, defer and deadletter a message along with the method to renew message lock have been moved from the message to the receiver.
-- The `createBatch` method on the sender is renamed to `createMessageBatch`.
-- The interface `CreateBatchOptions` followed by the options that are passed to the `createBatch` method is renamed to `CreateMessageBatchOptions`.
-- The `tryAdd` method on the message batch object is renamed to `tryAddMessage`.
-- `ServiceBusMessage` interface updates:
-  - "properties" renamed to "applicationProperties".
-  - "label" renamed to "subject".
-- `CorrelationRuleFilter` interface updates:
+- The word "Message" is added to all methods and interfaces related to creating and sending a batch of messages for clarity based on user studies:
+  - The `createBatch` method on the sender is renamed to `createMessageBatch`.
+  - The interface `CreateBatchOptions` followed by the options that are passed to the `createBatch` method is renamed to `CreateMessageBatchOptions`.
+  - The `tryAdd` method on the message batch object is renamed to `tryAddMessage`.
+- Renames to `ServiceBusMessage` and `CorrelationRuleFilter` fields to better align with the AMQP spec:
   - "properties" renamed to "applicationProperties".
   - "label" renamed to "subject".
 - `SqlRuleFilter` interface "sqlExpression" changed from optional to required.
 - The interface `CreateReceiverOptions` followed by options that are passed to `ServiceBusClient.createReceiver` method is renamed to `ServiceBusReceiverOptions`.
 - The interface `AcceptSessionOptions` followed by options that are passed to `ServiceBusClient` `acceptSession` and `acceptNextSession` methods is renamed to `ServiceBusSessionReceiverOptions`.
-- The property `maxAutoRenewLockDurationInMs` of interface `ServiceBusSessionReceiverOptions` is renamed to `maxAutoLockRenewalDurationInMs`.
-- `ServiceBusSender.scheduleMessages` method signature updated: `scheduledEnqueueTimeUtc` and `messages` parameters are swapped.
-- `NamespaceProperties` interface property "messageSku" type changed from "string" to string literal type "Basic" | "Premium" | "Standard". [PR 11810](https://github.com/Azure/azure-sdk-for-js/pull/11810)
-- `NamespaceProperties` interface property "namespaceType" has been removed. [PR 11995](https://github.com/Azure/azure-sdk-for-js/pull/11995)
+- The property `maxAutoRenewLockDurationInMs` of interface `ServiceBusSessionReceiverOptions` is renamed to `maxAutoLockRenewalDurationInMs` to be consistent with a similar option for renewing messages.
+- `ServiceBusSender.scheduleMessages` method signature updated: `scheduledEnqueueTimeUtc` and `messages` parameters are swapped as the messages are the primary object that is being worked with.
+- `NamespaceProperties` interface property "messageSku" type changed from "string" to string literal type "Basic" | "Premium" | "Standard" to reflect the limited types it supports.
+- `NamespaceProperties` interface property "namespaceType" has been removed as it does not provide any value.
+- The property `subQueue` in the options passed to the `createReceiver()` method is renamed to `subQueueType` to reflect that the value is restricted and not meant to contain any queue names.
 - Interfaces corresponding to the returned responses from the methods under the `ServiceBusAdministrationClient` such as `NamespacePropertiesResponse`, `QueueResponse`, `TopicRuntimePropertiesResponse` have been removed in favor of using generic type `WithResponse<T>` for a cleaner API surface.
   [PR 10491](https://github.com/Azure/azure-sdk-for-js/pull/10491)
 - Updated the `update{Entity}` methods under `ServiceBusAdministrationClient` with relevant param names and types, more docs.

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -378,7 +378,7 @@ export interface ServiceBusReceiver {
 export interface ServiceBusReceiverOptions {
     maxAutoLockRenewalDurationInMs?: number;
     receiveMode?: ReceiveMode;
-    subQueue?: SubQueue;
+    subQueueType?: "deadLetter" | "transferDeadLetter";
 }
 
 // @public
@@ -426,9 +426,6 @@ export interface SqlRuleFilter {
         [key: string]: string | number | boolean;
     };
 }
-
-// @public
-export type SubQueue = "deadLetter" | "transferDeadLetter";
 
 // @public
 export interface SubscribeOptions extends OperationOptionsBase {

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -28,7 +28,6 @@ export {
   PeekMessagesOptions,
   ReceiveMessagesOptions,
   ReceiveMode,
-  SubQueue,
   SubscribeOptions
 } from "./models";
 export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEventHubs";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -71,13 +71,6 @@ export interface InternalMessageHandlers extends MessageHandlers {
 export type ReceiveMode = "peekLock" | "receiveAndDelete";
 
 /**
- * Represents the sub queue that is applicable for any queue or subscription.
- * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
- * see https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
- */
-export type SubQueue = "deadLetter" | "transferDeadLetter";
-
-/**
  * Options to use when creating a receiver.
  */
 export interface ServiceBusReceiverOptions {
@@ -106,7 +99,7 @@ export interface ServiceBusReceiverOptions {
    * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
    * see https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    */
-  subQueueType?: SubQueue;
+  subQueueType?: "deadLetter" | "transferDeadLetter";
 
   /**
    * The maximum duration in milliseconds until which the lock on the message will be renewed

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -106,7 +106,7 @@ export interface ServiceBusReceiverOptions {
    * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
    * see https://docs.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
    */
-  subQueue?: SubQueue;
+  subQueueType?: SubQueue;
 
   /**
    * The maximum duration in milliseconds until which the lock on the message will be renewed

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -172,8 +172,8 @@ export class ServiceBusClient {
     );
 
     let entityPathWithSubQueue = entityPath;
-    if (options?.subQueue) {
-      switch (options?.subQueue) {
+    if (options?.subQueueType) {
+      switch (options?.subQueueType) {
         case "deadLetter":
           entityPathWithSubQueue += "/$DeadLetterQueue";
           break;
@@ -182,7 +182,7 @@ export class ServiceBusClient {
           break;
         default:
           throw new Error(
-            `Invalid subQueue '${options?.subQueue}' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`
+            `Invalid subQueueType '${options?.subQueueType}' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`
           );
       }
     }

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -232,13 +232,13 @@ describe("invalid parameters", () => {
       let errorCaught: string = "";
       try {
         // @ts-expect-error
-        sbClient.createReceiver("dummyQueue", { subQueue: 123 });
+        sbClient.createReceiver("dummyQueue", { subQueueType: 123 });
       } catch (error) {
         errorCaught = error.message;
       }
       should.equal(
         errorCaught,
-        `Invalid subQueue '123' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`,
+        `Invalid subQueueType '123' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`,
         "Did not throw error if created a client with invalid subQueue."
       );
     });

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -43,7 +43,7 @@ describe("dead lettering", () => {
       // receiveAndDelete since I don't care about further settlement after it's been dead lettered!
       serviceBusClient.createReceiver(entityNames.queue, {
         receiveMode: "receiveAndDelete",
-        subQueue: "deadLetter"
+        subQueueType: "deadLetter"
       })
     );
 

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -792,7 +792,7 @@ describe("ServiceBusClient live tests", () => {
 
     it("Entity Path on Queue deadletter Receiver", () => {
       const dummyQueueName = "dummy";
-      const receiver = sbClient.createReceiver(dummyQueueName, { subQueue: "deadLetter" });
+      const receiver = sbClient.createReceiver(dummyQueueName, { subQueueType: "deadLetter" });
       should.equal(
         receiver.entityPath,
         `${dummyQueueName}/$DeadLetterQueue`,
@@ -815,7 +815,7 @@ describe("ServiceBusClient live tests", () => {
       const dummyTopicName = "dummyTopicName";
       const dummySubscriptionName = "dummySubscriptionName";
       const receiver = sbClient.createReceiver(dummyTopicName, dummySubscriptionName, {
-        subQueue: "deadLetter"
+        subQueueType: "deadLetter"
       });
       should.equal(
         receiver.entityPath,

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -438,10 +438,10 @@ export class ServiceBusTestHelpers {
     return this.addToCleanup(
       entityNames.queue
         ? this._serviceBusClient.createReceiver(entityNames.queue, {
-            subQueue: "deadLetter"
+            subQueueType: "deadLetter"
           })
         : this._serviceBusClient.createReceiver(entityNames.topic!, entityNames.subscription!, {
-            subQueue: "deadLetter"
+            subQueueType: "deadLetter"
           })
     );
   }
@@ -470,7 +470,7 @@ async function purgeForTestClientType(
     receiver = serviceBusClient.createReceiver(entityPaths.queue, "receiveAndDelete");
     deadLetterReceiver = serviceBusClient.createReceiver(entityPaths.queue, {
       receiveMode: "receiveAndDelete",
-      subQueue: "deadLetter"
+      subQueueType: "deadLetter"
     });
   } else if (entityPaths.topic && entityPaths.subscription) {
     receiver = serviceBusClient.createReceiver(entityPaths.topic, entityPaths.subscription, {
@@ -479,7 +479,7 @@ async function purgeForTestClientType(
     deadLetterReceiver = serviceBusClient.createReceiver(
       entityPaths.topic,
       entityPaths.subscription,
-      { receiveMode: "receiveAndDelete", subQueue: "deadLetter" }
+      { receiveMode: "receiveAndDelete", subQueueType: "deadLetter" }
     );
   } else {
     throw new Error(`Unsupported TestClientType for purge: ${testClientType}`);


### PR DESCRIPTION
Unlike other languages, we don not use enums and use string literals instead. For the `subQueue` property, this opens up a potential confusion for people if they think they can pass in queue names. To help with this, in this PR we
- rename the option `subQueue` to `subQueueType`
- inline the string literals instead of exporting an explicit type