### PR TITLE
[MetricsAdvisor] Rename methods

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
@@ -20,6 +20,24 @@
 - [Breaking] `IncidentRootCause` property `dimensionKey` is renamed to `seriesKey`. `AnomalyIncident.dimensionKey` is renamed to `rootDimensionKey`
 - [Breaking] The `-List` suffix is removed from Array properties in `MetricSeriesData` and `MetricsEnrichedSeriesData`. Plural form is used instead.
 - [Breaking] `*PageResponse` types now extends from `Array<ItemType>` instead of wrapping an array of `ItemType`. Their types names are also shortened.
+- [Breaking] Rename method for listing alerts
+  - `listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, timemode, options)` to `listAlerts(alertConfigId, startTime, endTime, timemode, options)`
+- [Breaking] Rename feedback methods :
+  - `listMetricFeedbacks()` to `listFeedback()`
+  - `getMetricFeedback()` to `getFeedback()`
+  - `createMetricFeedback()` to `createFeedback()`
+- [Breaking] Rename detection configuration methods:
+  - `createMetricAnomalyDetectionConfiguration(anomalyConfig)` to `createDetectionConfig(anomalyConfig)`
+  - `getMetricAnomalyDetectionConfiguration(detectionConfigId)` to `getDetectionConfig(detectionConfigId)`
+  - `createMetricAnomalyDetectionConfiguration(config)` to `createDetectionConfig(config)`
+  - `updateMetricAnomalyDetectionConfiguration(configId, patch)` to `updateDetectionConfig(configId, patch)`
+  - `deleteMetricAnomalyDetectionConfiguration(detectionConfigId)` to `deleteDetectionConfig(detectionConfigId)`
+  - `listMetricAnomalyDetectionConfigurations(metricId)` to `listDetectionConfigs(metricId)`
+- [Breaking] Rename anomaly alert configuration methods:
+  - `createAnomalyAlertConfiguration(anomalyAlertConfig)` to `createAlertConfig(anomalyAlertConfig)`
+  - `updateAnomalyAlertConfiguration(alertConfigId, patch)` to `updateAlertConfig(alertConfigId, patch)`
+  - `deleteAnomalyAlertConfiguration(alertConfigId)` to `deleteAlertConfig(alertConfigId)`
+  - `listAnomalyAlertConfigurations(detectdionConfigId)` to `listAlertConfigs(detectdionConfigId)`
 - [Breaking] Data feed ingestion granularity now has `"PerMinute"` and `"PerSecond"` instead of `"Minutely"` and `"Secondly"`.
 - [Breaking] Change the type of following timestamp properties from `Date` to `number`
   - `AnomalyAlert.timestamp`

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -429,7 +429,7 @@ async function main() {
 
 async function queryAlerts(client, alertConfigId, startTime, endTime) {
   let alerts = [];
-  for await (const alert of client.listAlertsForAlertConfiguration(
+  for await (const alert of client.listAlerts(
     alertConfigId,
     startTime,
     endTime,

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -298,7 +298,7 @@ async function configureAnomalyDetectionConfiguration(adminClient, metricId) {
     },
     description: "Detection configuration description"
   };
-  return await adminClient.createMetricAnomalyDetectionConfiguration(anomalyConfig);
+  return await adminClient.createDetectionConfig(anomalyConfig);
 }
 ```
 
@@ -391,7 +391,7 @@ async function configureAlertConfiguration(adminClient, detectionConfigId, hookI
     hookIds,
     description: "Alerting config description"
   };
-  return await adminClient.createAnomalyAlertConfiguration(anomalyAlertConfig);
+  return await adminClient.createAlertConfig(anomalyAlertConfig);
 }
 ```
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -835,11 +835,11 @@ export interface MetricsAdvisorAdministrationClientOptions extends PipelineOptio
 // @public
 export class MetricsAdvisorClient {
     constructor(endpointUrl: string, credential: MetricsAdvisorKeyCredential, options?: MetricsAdvisorClientOptions);
-    createMetricFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
+    createFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
     readonly endpointUrl: string;
+    getFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
     getMetricEnrichedSeriesData(detectionConfigId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
-    getMetricFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getMetricSeriesData(metricId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
     listAlerts(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
     listAnomalies(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -802,30 +802,30 @@ export type MetricPeriodFeedback = {
 // @public
 export class MetricsAdvisorAdministrationClient {
     constructor(endpointUrl: string, credential: MetricsAdvisorKeyCredential, options?: MetricsAdvisorAdministrationClientOptions);
-    createAnomalyAlertConfiguration(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     createDataFeed(feed: Omit<DataFeed, "id" | "metricIds" | "isAdmin" | "status" | "creator" | "createdTime">, operationOptions?: OperationOptions): Promise<GetDataFeedResponse>;
+    createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
     createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<GetHookResponse>;
-    createMetricAnomalyDetectionConfiguration(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
-    deleteAnomalyAlertConfiguration(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteAlertConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDataFeed(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteDetectionConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteHook(id: string, options?: OperationOptions): Promise<RestResponse>;
-    deleteMetricAnomalyDetectionConfiguration(id: string, options?: OperationOptions): Promise<RestResponse>;
     readonly endpointUrl: string;
-    getAnomalyAlertConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    getAlertConfig(id: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     getDataFeed(id: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
     getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GetIngestionProgressResponse>;
+    getDetectionConfig(id: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
     getHook(id: string, options?: OperationOptions): Promise<GetHookResponse>;
-    getMetricAnomalyDetectionConfiguration(id: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
-    listAnomalyAlertConfigurations(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;
+    listAlertConfigs(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;
     listDataFeedIngestionStatus(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: ListDataFeedIngestionStatusOptions): PagedAsyncIterableIterator<IngestionStatus, IngestionStatusPageResponse>;
     listDataFeeds(options?: ListDataFeedsOptions): PagedAsyncIterableIterator<DataFeed, DataFeedsPageResponse>;
+    listDetectionConfigs(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, DetectionConfigurationsPageResponse, undefined>;
     listHooks(options?: ListHooksOptions): PagedAsyncIterableIterator<NotificationHookUnion, HooksPageResponse>;
-    listMetricAnomalyDetectionConfigurations(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, DetectionConfigurationsPageResponse, undefined>;
     refreshDataFeedIngestion(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: OperationOptions): Promise<RestResponse>;
-    updateAnomalyAlertConfiguration(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    updateAlertConfig(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     updateDataFeed(dataFeedId: string, patch: DataFeedPatch, options?: OperationOptions): Promise<GetDataFeedResponse>;
+    updateDetectionConfig(id: string, patch: Partial<Omit<AnomalyDetectionConfiguration, "id" | "metricId">>, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
     updateHook(id: string, patch: EmailNotificationHookPatch | WebNotificationHookPatch, options?: OperationOptions): Promise<GetHookResponse>;
-    updateMetricAnomalyDetectionConfiguration(id: string, patch: Partial<Omit<AnomalyDetectionConfiguration, "id" | "metricId">>, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
 }
 
 // @public

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -624,7 +624,7 @@ export type ListDataFeedsOptions = {
 } & OperationOptions;
 
 // @public
-export type ListDimensionValuesForDetectionConfigurationOptions = {
+export type ListDimensionValuesForDetectionConfigOptions = {
     skip?: number;
     dimensionFilter?: DimensionKey;
 } & OperationOptions;
@@ -844,7 +844,7 @@ export class MetricsAdvisorClient {
     listAlerts(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
     listAnomalies(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listAnomalies(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
-    listDimensionValuesForDetectionConfiguration(detectionConfigId: string, startTime: Date | string, endTime: Date | string, dimensionName: string, options?: ListDimensionValuesForDetectionConfigurationOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
+    listDimensionValuesForDetectionConfig(detectionConfigId: string, startTime: Date | string, endTime: Date | string, dimensionName: string, options?: ListDimensionValuesForDetectionConfigOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listFeedback(metricId: string, options?: ListFeedbackOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse>;
     listIncidents(alert: AnomalyAlert, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
     listIncidents(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -630,7 +630,7 @@ export type ListDimensionValuesForDetectionConfigurationOptions = {
 } & OperationOptions;
 
 // @public
-export type ListFeedbacksOptions = {
+export type ListFeedbackOptions = {
     skip?: number;
     filter?: {
         dimensionFilter?: DimensionKey;
@@ -841,15 +841,15 @@ export class MetricsAdvisorClient {
     getMetricEnrichedSeriesData(detectionConfigId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
     getMetricFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getMetricSeriesData(metricId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
-    listAlertsForAlertConfiguration(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
+    listAlerts(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
     listAnomalies(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listAnomalies(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listDimensionValuesForDetectionConfiguration(detectionConfigId: string, startTime: Date | string, endTime: Date | string, dimensionName: string, options?: ListDimensionValuesForDetectionConfigurationOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
+    listFeedback(metricId: string, options?: ListFeedbackOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse>;
     listIncidents(alert: AnomalyAlert, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
     listIncidents(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
     listMetricDimensionValues(metricId: string, dimensionName: string, options?: ListMetricDimensionValuesOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listMetricEnrichmentStatus(metricId: string, startTime: Date | string, endTime: Date | string, options?: ListMetricEnrichmentStatusOptions): PagedAsyncIterableIterator<EnrichmentStatus, MetricEnrichmentStatusPageResponse>;
-    listMetricFeedbacks(metricId: string, options?: ListFeedbacksOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse>;
     listMetricSeriesDefinitions(metricId: string, activeSince: Date | string, options?: ListMetricSeriesDefinitionsOptions): PagedAsyncIterableIterator<MetricSeriesDefinition, MetricSeriesPageResponse>;
     }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/alertingConfig.js
@@ -67,7 +67,7 @@ async function createAlertConfig(adminClient, detectionConfigId) {
     hookIds: [],
     description: "alerting config description"
   };
-  const result = await adminClient.createAnomalyAlertConfiguration(alertConfig);
+  const result = await adminClient.createAlertConfig(alertConfig);
   console.log(result);
   return result;
 }
@@ -96,19 +96,19 @@ async function updateAlertConfig(adminClient, alertConfigId, detectionConfigId, 
     ]
   };
   console.log(`Updating alerting configuration ${detectionConfigId}`);
-  const updated = await adminClient.updateAnomalyAlertConfiguration(alertConfigId, patch);
+  const updated = await adminClient.updateAlertConfig(alertConfigId, patch);
   return updated;
 }
 
 async function deleteAlertConfig(adminClient, alertConfigId) {
   console.log(`Deleting alerting configuration ${alertConfigId}`);
-  await adminClient.deleteAnomalyAlertConfiguration(alertConfigId);
+  await adminClient.deleteAlertConfig(alertConfigId);
 }
 
 async function listAlertingConfig(adminClient, detectdionConfigId) {
   console.log(`Listing alerting configurations for detection configuration ${detectdionConfigId}`);
   let i = 1;
-  for await (const config of adminClient.listAnomalyAlertConfigurations(detectdionConfigId)) {
+  for await (const config of adminClient.listAlertConfigs(detectdionConfigId)) {
     console.log(`Alert configuration ${i++}`);
     console.log(config);
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
@@ -46,7 +46,7 @@ async function main() {
 
 async function getDetectionConfig(adminClient, detectionConfigId) {
   console.log("Retrieving an existing detection configuration...");
-  const result = await adminClient.getMetricAnomalyDetectionConfiguration(detectionConfigId);
+  const result = await adminClient.getDetectionConfig(detectionConfigId);
   console.log(result);
   return result;
 }
@@ -110,7 +110,7 @@ async function createDetectionConfig(adminClient, metricId) {
     seriesDetectionConditions
   };
   console.log("Creating a new anomaly detection configuration...");
-  return await adminClient.createMetricAnomalyDetectionConfiguration(config);
+  return await adminClient.createDetectionConfig(config);
 }
 
 // updating an detection configuration
@@ -160,14 +160,14 @@ async function updateDetectionConfig(adminClient, configId) {
   };
 
   console.log(`Updating existing detection configuration '${configId}'`);
-  const result = await adminClient.updateMetricAnomalyDetectionConfiguration(configId, patch);
+  const result = await adminClient.updateDetectionConfig(configId, patch);
   console.log(result);
   return result;
 }
 
 async function deleteDetectionConfig(adminClient, detectionConfigId) {
   console.log(`Deleting detection configuration '${detectionConfigId}'`);
-  await adminClient.deleteMetricAnomalyDetectionConfiguration(detectionConfigId);
+  await adminClient.deleteDetectionConfig(detectionConfigId);
 }
 
 async function listDetectionConfig(adminClient, metricId) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/detectionConfig.js
@@ -173,7 +173,7 @@ async function deleteDetectionConfig(adminClient, detectionConfigId) {
 async function listDetectionConfig(adminClient, metricId) {
   console.log(`Listing detection configurations for metric '${metricId}'...`);
   let i = 1;
-  for await (const config of adminClient.listMetricAnomalyDetectionConfigurations(metricId)) {
+  for await (const config of adminClient.listDetectionConfigs(metricId)) {
     console.log(`  detection configuration ${i++}`);
     console.log(config);
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
@@ -38,7 +38,7 @@ async function provideAnomalyFeedback(client, metricId) {
     value: "NotAnomaly",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(anomalyFeedback);
+  return await client.createFeedback(anomalyFeedback);
 }
 
 async function providePeriodFeedback(client, metricId) {
@@ -50,7 +50,7 @@ async function providePeriodFeedback(client, metricId) {
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(periodFeedback);
+  return await client.createFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client, metricId) {
@@ -62,7 +62,7 @@ async function provideChangePointFeedback(client, metricId) {
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(changePointFeedback);
+  return await client.createFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client, metricId) {
@@ -73,12 +73,12 @@ async function provideCommentFeedback(client, metricId) {
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  return await client.createMetricFeedback(commendFeedback);
+  return await client.createFeedback(commendFeedback);
 }
 
 async function getFeedback(client, feedbackId) {
   console.log(`Retrieving feedback with id '${feedbackId}'...`);
-  const feedback = await client.getMetricFeedback(feedbackId);
+  const feedback = await client.getFeedback(feedbackId);
   console.log(feedback);
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
@@ -85,7 +85,7 @@ async function getFeedback(client, feedbackId) {
 async function listFeedback(client, metricId, startTime, endTime) {
   console.log("Listing feedbacks...");
   console.log("  using for-await-of syntax");
-  for await (const feedback of client.listMetricFeedbacks(metricId, {
+  for await (const feedback of client.listFeedback(metricId, {
     filter: {
       startTime: new Date("08/01/2020"),
       endTime: new Date("08/03/2020"),
@@ -111,7 +111,7 @@ async function listFeedback(client, metricId, startTime, endTime) {
 
   console.log("  first two pages using iterator");
   const iterator = client
-    .listMetricFeedbacks(metricId, {
+    .listFeedback(metricId, {
       filter: {
         timeMode: "FeedbackCreatedTime"
       }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -218,7 +218,7 @@ async function queryAlerts(client, alertConfigId, startTime, endTime) {
   // This shows how to use `for-await-of` syntax to list alerts
   console.log("  using for-await-of syntax");
   let alerts = [];
-  for await (const alert of client.listAlertsForAlertConfiguration(
+  for await (const alert of client.listAlerts(
     alertConfigId,
     startTime,
     endTime,
@@ -233,7 +233,7 @@ async function queryAlerts(client, alertConfigId, startTime, endTime) {
   // alternatively we could list results by pages
   console.log(`  by pages`);
   const iterator = client
-    .listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, "AnomalyTime")
+    .listAlerts(alertConfigId, startTime, endTime, "AnomalyTime")
     .byPage({ maxPageSize: 2 });
 
   let result = await iterator.next();

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -162,7 +162,7 @@ async function configureAnomalyDetectionConfiguration(adminClient, metricId) {
     },
     description: "Detection configuration description"
   };
-  return await adminClient.createMetricAnomalyDetectionConfiguration(dataFeed);
+  return await adminClient.createDetectionConfig(dataFeed);
 }
 
 async function createWebhookHook(adminClient) {
@@ -210,7 +210,7 @@ async function configureAlertConfiguration(adminClient, detectionConfigId, hookI
     hookIds,
     description: "Alerting config description"
   };
-  return await adminClient.createAnomalyAlertConfiguration(anomalyAlert);
+  return await adminClient.createAlertConfig(anomalyAlert);
 }
 
 async function queryAlerts(client, alertConfigId, startTime, endTime) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/alertingConfig.ts
@@ -72,7 +72,7 @@ async function createAlertConfig(
     hookIds: [],
     description: "alerting config description"
   };
-  const result = await adminClient.createAnomalyAlertConfiguration(alertConfig);
+  const result = await adminClient.createAlertConfig(alertConfig);
   console.log(result);
   return result;
 }
@@ -106,7 +106,7 @@ async function updateAlertConfig(
     ]
   };
   console.log(`Updating alerting configuration ${detectionConfigId}`);
-  const updated = await adminClient.updateAnomalyAlertConfiguration(alertConfigId, patch);
+  const updated = await adminClient.updateAlertConfig(alertConfigId, patch);
   return updated;
 }
 
@@ -115,7 +115,7 @@ async function deleteAlertConfig(
   alertConfigId: string
 ) {
   console.log(`Deleting alerting configuration ${alertConfigId}`);
-  await adminClient.deleteAnomalyAlertConfiguration(alertConfigId);
+  await adminClient.deleteAlertConfig(alertConfigId);
 }
 
 async function listAlertConfig(
@@ -124,7 +124,7 @@ async function listAlertConfig(
 ) {
   console.log(`Listing alert configurations for detection configuration ${detectdionConfigId}`);
   let i = 1;
-  for await (const config of adminClient.listAnomalyAlertConfigurations(detectdionConfigId)) {
+  for await (const config of adminClient.listAlertConfigs(detectdionConfigId)) {
     console.log(`Alert configuration ${i++}`);
     console.log(config);
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
@@ -55,7 +55,7 @@ async function getDetectionConfig(
   detectionConfigId: string
 ) {
   console.log("Retrieving an existing detection configuration...");
-  const result = await adminClient.getMetricAnomalyDetectionConfiguration(detectionConfigId);
+  const result = await adminClient.getDetectionConfig(detectionConfigId);
   console.log(result);
   return result;
 }
@@ -122,7 +122,7 @@ async function createDetectionConfig(
     seriesDetectionConditions
   };
   console.log("Creating a new anomaly detection configuration...");
-  return await adminClient.createMetricAnomalyDetectionConfiguration(config);
+  return await adminClient.createDetectionConfig(config);
 }
 
 // updating an detection configuration
@@ -174,7 +174,7 @@ async function updateDetectionConfig(
     ]
   };
   console.log(`Updating existing detection configuration '${configId}'`);
-  const result = await adminClient.updateMetricAnomalyDetectionConfiguration(configId, patch);
+  const result = await adminClient.updateDetectionConfig(configId, patch);
   console.log(result);
   return result;
 }
@@ -184,7 +184,7 @@ async function deleteDetectionConfig(
   detectionConfigId: string
 ) {
   console.log(`Deleting detection configuration '${detectionConfigId}'`);
-  await adminClient.deleteMetricAnomalyDetectionConfiguration(detectionConfigId);
+  await adminClient.deleteDetectionConfig(detectionConfigId);
 }
 
 async function listDetectionConfig(

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/detectionConfig.ts
@@ -193,7 +193,7 @@ async function listDetectionConfig(
 ) {
   console.log(`Listing detection configurations for metric '${metricId}'...`);
   let i = 1;
-  for await (const config of adminClient.listMetricAnomalyDetectionConfigurations(metricId)) {
+  for await (const config of adminClient.listDetectionConfigs(metricId)) {
     console.log(`  detection configuration ${i++}`);
     console.log(config);
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
@@ -93,7 +93,7 @@ async function getFeedback(client: MetricsAdvisorClient, feedbackId: string) {
 async function listFeedback(client: MetricsAdvisorClient, metricId: string) {
   console.log("Listing feedbacks...");
   console.log("  using for-await-of syntax");
-  for await (const feedback of client.listMetricFeedbacks(metricId, {
+  for await (const feedback of client.listFeedback(metricId, {
     filter: {
       startTime: new Date("08/01/2020"),
       endTime: new Date("08/03/2020"),
@@ -119,7 +119,7 @@ async function listFeedback(client: MetricsAdvisorClient, metricId: string) {
 
   console.log("  first two pages using iterator");
   const iterator = client
-    .listMetricFeedbacks(metricId, {
+    .listFeedback(metricId, {
       filter: {
         timeMode: "FeedbackCreatedTime"
       }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
@@ -46,7 +46,7 @@ async function provideAnomalyFeedback(client: MetricsAdvisorClient, metricId: st
     value: "NotAnomaly",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(anomalyFeedback);
+  return await client.createFeedback(anomalyFeedback);
 }
 
 async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -58,7 +58,7 @@ async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: str
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(periodFeedback);
+  return await client.createFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -70,7 +70,7 @@ async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createMetricFeedback(changePointFeedback);
+  return await client.createFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -81,12 +81,12 @@ async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: st
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  return await client.createMetricFeedback(commendFeedback);
+  return await client.createFeedback(commendFeedback);
 }
 
 async function getFeedback(client: MetricsAdvisorClient, feedbackId: string) {
   console.log(`Retrieving feedback with id '${feedbackId}'...`);
-  const feedback = await client.getMetricFeedback(feedbackId);
+  const feedback = await client.getFeedback(feedbackId);
   console.log(feedback);
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -245,7 +245,7 @@ async function queryAlerts(
   // This shows how to use `for-await-of` syntax to list alerts
   console.log("  using for-await-of syntax");
   let alerts: AnomalyAlert[] = [];
-  for await (const alert of client.listAlertsForAlertConfiguration(
+  for await (const alert of client.listAlerts(
     alertConfigId,
     startTime,
     endTime,
@@ -260,7 +260,7 @@ async function queryAlerts(
   // alternatively we could list results by pages
   console.log(`  by pages`);
   const iterator = client
-    .listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, "AnomalyTime")
+    .listAlerts(alertConfigId, startTime, endTime, "AnomalyTime")
     .byPage({ maxPageSize: 2 });
 
   let result = await iterator.next();

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -42,7 +42,8 @@ import {
   DetectionConfigurationsPageResponse,
   HooksPageResponse,
   DataFeedStatus,
-  GetIngestionProgressResponse
+  GetIngestionProgressResponse,
+  AnomalyAlertConfiguration
 } from "./models";
 import { DataSourceType, NeedRollupEnum } from "./generated/models";
 import {
@@ -654,7 +655,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param config the alert configuration object to create
    */
   public async createAlertConfig(
-    config: Omit<AlertConfiguration, "id">,
+    config: Omit<AnomalyAlertConfiguration, "id">,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -693,7 +694,7 @@ export class MetricsAdvisorAdministrationClient {
    */
   public async updateAlertConfig(
     id: string,
-    patch: Partial<Omit<AlertConfiguration, "id">>,
+    patch: Partial<Omit<AnomalyAlertConfiguration, "id">>,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -804,7 +805,7 @@ export class MetricsAdvisorAdministrationClient {
   private async *listItemsOfAlertingConfigurations(
     detectionConfigId: string,
     options: OperationOptions = {}
-  ): AsyncIterableIterator<AlertConfiguration> {
+  ): AsyncIterableIterator<AnomalyAlertConfiguration> {
     for await (const segment of this.listSegmentsOfAlertingConfigurations(
       detectionConfigId,
       options
@@ -870,7 +871,7 @@ export class MetricsAdvisorAdministrationClient {
     detectionConfigId: string,
     options: OperationOptions = {}
   ): PagedAsyncIterableIterator<
-    AlertConfiguration,
+    AnomalyAlertConfiguration,
     AlertConfigurationsPageResponse,
     undefined // service does not support server-side paging
   > {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -30,7 +30,6 @@ import {
   WebNotificationHookPatch,
   EmailNotificationHookPatch,
   AnomalyDetectionConfiguration,
-  AlertConfiguration,
   GetDataFeedResponse,
   GetAnomalyDetectionConfigurationResponse,
   GetAnomalyAlertConfigurationResponse,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -837,7 +837,7 @@ export class MetricsAdvisorAdministrationClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listAnomalyAlertConfigurations(detectionConfigurationId);
+   * let iter = client.listAlertConfigs(detectionConfigurationId);
    * let result = await iter.next();
    * while (!result.done) {
    *   console.log(` alert - ${result.value.id}, ${result.value.name}`);
@@ -848,7 +848,7 @@ export class MetricsAdvisorAdministrationClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listAnomalyAlertConfigurations(detectionConfigurationId)
+   * const pages = client.listAlertConfigs(detectionConfigurationId)
    *   .byPage();
    * let page = await pages.next();
    * let i = 1;
@@ -867,7 +867,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public listAlertConfigurations(
+  public listAlertConfigs(
     detectionConfigId: string,
     options: OperationOptions = {}
   ): PagedAsyncIterableIterator<
@@ -1207,7 +1207,7 @@ export class MetricsAdvisorAdministrationClient {
    * ```js
    * const client = new MetricsAdvisorAdministrationClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const anomalyDetectionList = client.listMetricAnomalyDetectionConfigurations(metricId);
+   * const anomalyDetectionList = client.listDetectionConfigs(metricId);
    * let i = 1;
    * for await (const anomaly of anomalyDetectionList){
    *  console.log(`anomaly ${i++}:`);
@@ -1218,7 +1218,7 @@ export class MetricsAdvisorAdministrationClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listMetricAnomalyDetectionConfigurations(metricId);
+   * let iter = client.listDetectionConfigs(metricId);
    * let result = await iter.next();
    * while (!result.done) {
    *   console.log(` anomaly - ${result.value.id}, ${result.value.name}`);
@@ -1229,7 +1229,7 @@ export class MetricsAdvisorAdministrationClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listMetricAnomalyDetectionConfigurations(metricId)
+   * const pages = client.listDetectionConfigs(metricId)
    *   .byPage();
    * let page = await pages.next();
    * let i = 1;
@@ -1249,7 +1249,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public listMetricAnomalyDetectionConfigurations(
+  public listDetectionConfigs(
     metricId: string,
     options: OperationOptions = {}
   ): PagedAsyncIterableIterator<

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -30,7 +30,7 @@ import {
   WebNotificationHookPatch,
   EmailNotificationHookPatch,
   AnomalyDetectionConfiguration,
-  AnomalyAlertConfiguration,
+  AlertConfiguration,
   GetDataFeedResponse,
   GetAnomalyDetectionConfigurationResponse,
   GetAnomalyAlertConfigurationResponse,
@@ -607,23 +607,9 @@ export class MetricsAdvisorAdministrationClient {
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-<<<<<<< HEAD
       const transformed = toServiceAnomalyDetectionConfigurationPatch(patch);
       await this.client.updateAnomalyDetectionConfiguration(id, transformed, requestOptions);
-      return this.getMetricAnomalyDetectionConfiguration(id);
-=======
-      await this.client.updateAnomalyDetectionConfiguration(
-        id,
-        {
-          wholeMetricConfiguration: patch.wholeSeriesDetectionCondition,
-          dimensionGroupOverrideConfigurations: patch.seriesGroupDetectionConditions,
-          seriesOverrideConfigurations: patch.seriesDetectionConditions,
-          ...patch
-        },
-        requestOptions
-      );
       return this.getDetectionConfig(id);
->>>>>>> a335cd8a4... rename methods
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -669,7 +655,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param config the alert configuration object to create
    */
   public async createAlertConfig(
-    config: Omit<AnomalyAlertConfiguration, "id">,
+    config: Omit<AlertConfiguration, "id">,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -708,7 +694,7 @@ export class MetricsAdvisorAdministrationClient {
    */
   public async updateAlertConfig(
     id: string,
-    patch: Partial<Omit<AnomalyAlertConfiguration, "id">>,
+    patch: Partial<Omit<AlertConfiguration, "id">>,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -718,35 +704,9 @@ export class MetricsAdvisorAdministrationClient {
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-<<<<<<< HEAD
       const transformed = toServiceAlertConfigurationPatch(patch);
       await this.client.updateAnomalyAlertingConfiguration(id, transformed, requestOptions);
-      return this.getAnomalyAlertConfiguration(id);
-=======
-      const serviceMetricAlertingConfigs = patch.metricAlertConfigurations?.map((c) => {
-        return {
-          anomalyDetectionConfigurationId: c.detectionConfigurationId,
-          anomalyScopeType: c.alertScope.scopeType,
-          ...c.alertScope,
-          negationOperation: c.negationOperation,
-          severityFilter: c.alertConditions?.severityCondition,
-          snoozeFilter: c.snoozeCondition,
-          valueFilter: c.alertConditions?.metricBoundaryCondition
-        };
-      });
-      await this.client.updateAnomalyAlertingConfiguration(
-        id,
-        {
-          name: patch.name,
-          description: patch.description,
-          crossMetricsOperator: patch.crossMetricsOperator,
-          hookIds: patch.hookIds,
-          metricAlertingConfigurations: serviceMetricAlertingConfigs
-        },
-        requestOptions
-      );
       return this.getAlertConfig(id);
->>>>>>> a335cd8a4... rename methods
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -845,7 +805,7 @@ export class MetricsAdvisorAdministrationClient {
   private async *listItemsOfAlertingConfigurations(
     detectionConfigId: string,
     options: OperationOptions = {}
-  ): AsyncIterableIterator<AnomalyAlertConfiguration> {
+  ): AsyncIterableIterator<AlertConfiguration> {
     for await (const segment of this.listSegmentsOfAlertingConfigurations(
       detectionConfigId,
       options
@@ -907,11 +867,11 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public listAnomalyAlertConfigurations(
+  public listAlertConfigurations(
     detectionConfigId: string,
     options: OperationOptions = {}
   ): PagedAsyncIterableIterator<
-    AnomalyAlertConfiguration,
+    AlertConfiguration,
     AlertConfigurationsPageResponse,
     undefined // service does not support server-side paging
   > {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -523,12 +523,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param config The detection configuration object to create
    * @param options The options parameter
    */
-  public async createMetricAnomalyDetectionConfiguration(
+  public async createDetectionConfig(
     config: Omit<AnomalyDetectionConfiguration, "id">,
     options: OperationOptions = {}
   ): Promise<GetAnomalyDetectionConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-createMetricAnomalyDetectionConfiguration",
+      "MetricsAdvisorAdministrationClient-createDetectionConfig",
       options
     );
     try {
@@ -543,7 +543,7 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      return this.getMetricAnomalyDetectionConfiguration(configId);
+      return this.getDetectionConfig(configId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -561,12 +561,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public async getMetricAnomalyDetectionConfiguration(
+  public async getDetectionConfig(
     id: string,
     options: OperationOptions = {}
   ): Promise<GetAnomalyDetectionConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-getMetricAnomalyDetectionConfiguration",
+      "MetricsAdvisorAdministrationClient-getDetectionConfig",
       options
     );
 
@@ -595,21 +595,35 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public async updateMetricAnomalyDetectionConfiguration(
+  public async updateDetectionConfig(
     id: string,
     patch: Partial<Omit<AnomalyDetectionConfiguration, "id" | "metricId">>,
     options: OperationOptions = {}
   ): Promise<GetAnomalyDetectionConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-updateMetricAnomalyDetectionConfiguration",
+      "MetricsAdvisorAdministrationClient-updateDetectionConfig",
       options
     );
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
+<<<<<<< HEAD
       const transformed = toServiceAnomalyDetectionConfigurationPatch(patch);
       await this.client.updateAnomalyDetectionConfiguration(id, transformed, requestOptions);
       return this.getMetricAnomalyDetectionConfiguration(id);
+=======
+      await this.client.updateAnomalyDetectionConfiguration(
+        id,
+        {
+          wholeMetricConfiguration: patch.wholeSeriesDetectionCondition,
+          dimensionGroupOverrideConfigurations: patch.seriesGroupDetectionConditions,
+          seriesOverrideConfigurations: patch.seriesDetectionConditions,
+          ...patch
+        },
+        requestOptions
+      );
+      return this.getDetectionConfig(id);
+>>>>>>> a335cd8a4... rename methods
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -627,12 +641,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public async deleteMetricAnomalyDetectionConfiguration(
+  public async deleteDetectionConfig(
     id: string,
     options: OperationOptions = {}
   ): Promise<RestResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-deleteMetricAnomalyDetectionConfiguration",
+      "MetricsAdvisorAdministrationClient-deleteDetectionConfig",
       options
     );
 
@@ -654,12 +668,12 @@ export class MetricsAdvisorAdministrationClient {
    * Creates anomaly alerting configuration for a given metric
    * @param config the alert configuration object to create
    */
-  public async createAnomalyAlertConfiguration(
+  public async createAlertConfig(
     config: Omit<AnomalyAlertConfiguration, "id">,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-createAnomalyAlertConfiguration",
+      "MetricsAdvisorAdministrationClient-createAlertConfig",
       options
     );
     try {
@@ -674,7 +688,7 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      return this.getAnomalyAlertConfiguration(configId);
+      return this.getAlertConfig(configId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -692,21 +706,47 @@ export class MetricsAdvisorAdministrationClient {
    * @param patch Input to the update anomaly alert configuration operation {@link AnomalyAlertConfigurationPatch}
    * @param options The options parameter
    */
-  public async updateAnomalyAlertConfiguration(
+  public async updateAlertConfig(
     id: string,
     patch: Partial<Omit<AnomalyAlertConfiguration, "id">>,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-updateAnomalyAlertConfiguration",
+      "MetricsAdvisorAdministrationClient-updateAlertConfig",
       options
     );
 
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
+<<<<<<< HEAD
       const transformed = toServiceAlertConfigurationPatch(patch);
       await this.client.updateAnomalyAlertingConfiguration(id, transformed, requestOptions);
       return this.getAnomalyAlertConfiguration(id);
+=======
+      const serviceMetricAlertingConfigs = patch.metricAlertConfigurations?.map((c) => {
+        return {
+          anomalyDetectionConfigurationId: c.detectionConfigurationId,
+          anomalyScopeType: c.alertScope.scopeType,
+          ...c.alertScope,
+          negationOperation: c.negationOperation,
+          severityFilter: c.alertConditions?.severityCondition,
+          snoozeFilter: c.snoozeCondition,
+          valueFilter: c.alertConditions?.metricBoundaryCondition
+        };
+      });
+      await this.client.updateAnomalyAlertingConfiguration(
+        id,
+        {
+          name: patch.name,
+          description: patch.description,
+          crossMetricsOperator: patch.crossMetricsOperator,
+          hookIds: patch.hookIds,
+          metricAlertingConfigurations: serviceMetricAlertingConfigs
+        },
+        requestOptions
+      );
+      return this.getAlertConfig(id);
+>>>>>>> a335cd8a4... rename methods
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -724,12 +764,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public async getAnomalyAlertConfiguration(
+  public async getAlertConfig(
     id: string,
     options: OperationOptions = {}
   ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-getAnomalyAlertConfiguration",
+      "MetricsAdvisorAdministrationClient-getAlertConfig",
       options
     );
 
@@ -754,12 +794,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param options The options parameter.
    */
 
-  public async deleteAnomalyAlertConfiguration(
+  public async deleteAlertConfig(
     id: string,
     options: OperationOptions = {}
   ): Promise<RestResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-deleteAnomalyAlertConfiguration",
+      "MetricsAdvisorAdministrationClient-deleteAlertConfig",
       options
     );
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -826,7 +826,7 @@ export class MetricsAdvisorAdministrationClient {
    * ```js
    * const client = new MetricsAdvisorAdministrationClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const alertConfigurations = client.listAnomalyAlertConfigurations(detectionConfigurationId);
+   * const alertConfigurations = client.listAlertConfigs(detectionConfigurationId);
    * let i = 1;
    * for await (const alertConfiguration of alertConfigurations){
    *  console.log(`alertConfiguration ${i++}:`);

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -91,7 +91,7 @@ export type ListIncidentsForAlertOptions = {
  * Options for listing dimension values for detection configurations
  */
 
-export type ListDimensionValuesForDetectionConfigurationOptions = {
+export type ListDimensionValuesForDetectionConfigOptions = {
   skip?: number;
   dimensionFilter?: DimensionKey;
 } & OperationOptions;
@@ -1192,7 +1192,7 @@ export class MetricsAdvisorClient {
     dimensionName: string,
     continuationToken?: string,
     maxPageSize?: number,
-    options: ListDimensionValuesForDetectionConfigurationOptions = {}
+    options: ListDimensionValuesForDetectionConfigOptions = {}
   ): AsyncIterableIterator<DimensionValuesPageResponse> {
     let segmentResponse;
     const optionsBody = {
@@ -1250,7 +1250,7 @@ export class MetricsAdvisorClient {
     startTime: Date,
     endTime: Date,
     dimensionName: string,
-    options: ListDimensionValuesForDetectionConfigurationOptions
+    options: ListDimensionValuesForDetectionConfigOptions
   ): AsyncIterableIterator<string> {
     for await (const segment of this.listSegmentsOfDimensionValuesForDetectionConfig(
       detectionConfigId,
@@ -1324,12 +1324,12 @@ export class MetricsAdvisorClient {
    * @param endTime The end of time range to query anomalies
    * @param options The options parameter.
    */
-  public listDimensionValuesForDetectionConfiguration(
+  public listDimensionValuesForDetectionConfig(
     detectionConfigId: string,
     startTime: Date | string,
     endTime: Date | string,
     dimensionName: string,
-    options: ListDimensionValuesForDetectionConfigurationOptions = {}
+    options: ListDimensionValuesForDetectionConfigOptions = {}
   ): PagedAsyncIterableIterator<string, DimensionValuesPageResponse> {
     const iter = this.listItemsOfDimensionValues(
       detectionConfigId,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -225,7 +225,7 @@ export class MetricsAdvisorClient {
    * @private
    * List alert segments for alerting configuration
    */
-  private async *listSegmentOfAlertsForAlertingConfig(
+  private async *listSegmentOfAlerts(
     alertConfigId: string,
     startTime: Date,
     endTime: Date,
@@ -302,14 +302,14 @@ export class MetricsAdvisorClient {
    * @private
    * List alert items for alerting configuration
    */
-  private async *listItemsOfAlertsForAlertingConfig(
+  private async *listItemsOfAlerts(
     alertConfigId: string,
     startTime: Date,
     endTime: Date,
     timeMode: AlertQueryTimeMode,
     options: ListAlertsOptions
   ): AsyncIterableIterator<AnomalyAlert> {
-    for await (const segment of this.listSegmentOfAlertsForAlertingConfig(
+    for await (const segment of this.listSegmentOfAlerts(
       alertConfigId,
       startTime,
       endTime,
@@ -335,7 +335,7 @@ export class MetricsAdvisorClient {
    * const client = new MetricsAdvisorClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey)
    * );
-   * const alerts = client.listAlertsForAlertConfiguration(alertConfigId,
+   * const alerts = client.listAlerts(alertConfigId,
    *   startTime, endTime, timeMode
    * );
    * let i = 1;
@@ -348,7 +348,7 @@ export class MetricsAdvisorClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, timeMode);
+   * let iter = client.listAlerts(alertConfigId, startTime, endTime, timeMode);
    * let result = await iter.next();
    * while (!result.done) {
    *   console.log(` alert - ${result.value.id}`);
@@ -359,7 +359,7 @@ export class MetricsAdvisorClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, timeMode)
+   * const pages = client.listAlerts(alertConfigId, startTime, endTime, timeMode)
    *   .byPage({ maxPageSize: 10 });
    * let page = await pages.next();
    * let i = 1;
@@ -388,7 +388,7 @@ export class MetricsAdvisorClient {
     timeMode: AlertQueryTimeMode,
     options: ListAlertsOptions = {}
   ): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse> {
-    const iter = this.listItemsOfAlertsForAlertingConfig(
+    const iter = this.listItemsOfAlerts(
       alertConfigId,
       typeof startTime === "string" ? new Date(startTime) : startTime,
       typeof endTime === "string" ? new Date(endTime) : endTime,
@@ -412,7 +412,7 @@ export class MetricsAdvisorClient {
        * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.listSegmentOfAlertsForAlertingConfig(
+        return this.listSegmentOfAlerts(
           alertConfigId,
           typeof startTime === "string" ? new Date(startTime) : startTime,
           typeof endTime === "string" ? new Date(endTime) : endTime,
@@ -1570,12 +1570,12 @@ export class MetricsAdvisorClient {
    * @param feedback content of the feedback
    * @param options The options parameter
    */
-  public async createMetricFeedback(
+  public async createFeedback(
     feedback: MetricFeedbackUnion,
     options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-createMetricFeedback",
+      "MetricsAdvisorAdministrationClient-createFeedback",
       options
     );
 
@@ -1588,7 +1588,7 @@ export class MetricsAdvisorClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedbackId = result.location.substring(lastSlashIndex + 1);
-      return this.getMetricFeedback(feedbackId);
+      return this.getFeedback(feedbackId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -1605,12 +1605,12 @@ export class MetricsAdvisorClient {
    * @param id Id of the feedback to retrieve
    * @param options The options parameter
    */
-  public async getMetricFeedback(
+  public async getFeedback(
     id: string,
     options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-getMetricFeedback",
+      "MetricsAdvisorAdministrationClient-getFeedback",
       options
     );
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -100,7 +100,7 @@ export type ListDimensionValuesForDetectionConfigurationOptions = {
  * Options for listing feedbacks
  */
 
-export type ListFeedbacksOptions = {
+export type ListFeedbackOptions = {
   skip?: number;
   /**
    * filter when listing feedbacks
@@ -1632,11 +1632,11 @@ export class MetricsAdvisorClient {
     }
   }
 
-  private async *listSegmentsOfMetricFeedbacks(
+  private async *listSegmentsOfFeedback(
     metricId: string,
     continuationToken?: string,
     maxPageSize?: number,
-    options: ListFeedbacksOptions = {}
+    options: ListFeedbackOptions = {}
   ): AsyncIterableIterator<MetricFeedbackPageResponse> {
     let segmentResponse;
     const startTime =
@@ -1699,11 +1699,11 @@ export class MetricsAdvisorClient {
     }
   }
 
-  private async *listItemsOfMetricFeedback(
+  private async *listItemsOfFeedback(
     metricId: string,
-    options: ListFeedbacksOptions = {}
+    options: ListFeedbackOptions = {}
   ): AsyncIterableIterator<MetricFeedbackUnion> {
-    for await (const segment of this.listSegmentsOfMetricFeedbacks(
+    for await (const segment of this.listSegmentsOfFeedback(
       metricId,
       undefined,
       undefined,
@@ -1725,7 +1725,7 @@ export class MetricsAdvisorClient {
    * ```js
    * const client = new MetricsAdvisorClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const feedbacks = client.listMetricFeedbacks(metricId);
+   * const feedbacks = client.listFeedback(metricId);
    * let i = 1;
    * for await (const f of feedbacks){
    *  console.log(`feedback ${i++}:`);
@@ -1736,7 +1736,7 @@ export class MetricsAdvisorClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listMetricFeedbacks(metricId);
+   * let iter = client.listFeedback(metricId);
    * let result = await iter.next();
    * while (!result.done) {
    *   console.log(` feedback - ${result.value.id}`);
@@ -1748,7 +1748,7 @@ export class MetricsAdvisorClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listMetricFeedbacks(metricId)
+   * const pages = client.listFeedback(metricId)
    *   .byPage({ maxPageSize: 10 });
    * let page = await pages.next();
    * let i = 1;
@@ -1765,11 +1765,11 @@ export class MetricsAdvisorClient {
    * @param metricId Metric id
    * @param options The options parameter
    */
-  public listMetricFeedbacks(
+  public listFeedback(
     metricId: string,
-    options: ListFeedbacksOptions = {}
+    options: ListFeedbackOptions = {}
   ): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse> {
-    const iter = this.listItemsOfMetricFeedback(metricId, options);
+    const iter = this.listItemsOfFeedback(metricId, options);
     return {
       /**
        * @member {Promise} [next] The next method, part of the iteration protocol
@@ -1787,7 +1787,7 @@ export class MetricsAdvisorClient {
        * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.listSegmentsOfMetricFeedbacks(
+        return this.listSegmentsOfFeedback(
           metricId,
           settings.continuationToken,
           settings.maxPageSize,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -381,7 +381,7 @@ export class MetricsAdvisorClient {
    * @param options The options parameter.
    */
 
-  public listAlertsForAlertConfiguration(
+  public listAlerts(
     alertConfigId: string,
     startTime: Date | string,
     endTime: Date | string,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1653,7 +1653,7 @@ export interface MetricFeedbackPageResponse extends Array<MetricFeedbackUnion> {
 }
 
 /**
- * Contains response data for the listAnomalyAlertConfigurations operation.
+ * Contains response data for the listAlertConfigs operation.
  */
 export interface AlertConfigurationsPageResponse extends Array<AnomalyAlertConfiguration> {
   /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -475,7 +475,7 @@ export type DataFeedSourcePatch = Omit<DataFeedSource, "dataSourceParameter"> &
 /**
  * The logical operator to apply across multiple {@link MetricAlertConfiguration}
  */
-export type AlertConfigurationsOperator = "AND" | "OR" | "XOR";
+export type MetricAnomalyAlertConfigurationsOperator = "AND" | "OR" | "XOR";
 
 /**
  * The logical operator to apply across anomaly detection conditions.
@@ -1086,7 +1086,7 @@ export interface MetricAlertConfiguration {
 /**
  * Represents an anomaly alert configuration.
  */
-export interface AlertConfiguration {
+export interface AnomalyAlertConfiguration {
   /**
    * anomaly alerting configuration unique id
    */
@@ -1103,7 +1103,7 @@ export interface AlertConfiguration {
    * logical operator to apply across metric alert configurations in {@link metricAlertConfigurations}
    *
    */
-  crossMetricsOperator?: AlertConfigurationsOperator;
+  crossMetricsOperator?: MetricAnomalyAlertConfigurationsOperator;
   /**
    * unique hook ids
    */
@@ -1285,7 +1285,7 @@ export type GetAnomalyDetectionConfigurationResponse = AnomalyDetectionConfigura
 /**
  * Contains response data for the getAnomalyAlertConfiguration operation.
  */
-export type GetAnomalyAlertConfigurationResponse = AlertConfiguration & {
+export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
   /**
    * The underlying HTTP response.
    */
@@ -1655,7 +1655,7 @@ export interface MetricFeedbackPageResponse extends Array<MetricFeedbackUnion> {
 /**
  * Contains response data for the listAnomalyAlertConfigurations operation.
  */
-export interface AlertConfigurationsPageResponse extends Array<AlertConfiguration> {
+export interface AlertConfigurationsPageResponse extends Array<AnomalyAlertConfiguration> {
   /**
    * The underlying HTTP response.
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -475,7 +475,7 @@ export type DataFeedSourcePatch = Omit<DataFeedSource, "dataSourceParameter"> &
 /**
  * The logical operator to apply across multiple {@link MetricAlertConfiguration}
  */
-export type MetricAnomalyAlertConfigurationsOperator = "AND" | "OR" | "XOR";
+export type AlertConfigurationsOperator = "AND" | "OR" | "XOR";
 
 /**
  * The logical operator to apply across anomaly detection conditions.
@@ -1086,7 +1086,7 @@ export interface MetricAlertConfiguration {
 /**
  * Represents an anomaly alert configuration.
  */
-export interface AnomalyAlertConfiguration {
+export interface AlertConfiguration {
   /**
    * anomaly alerting configuration unique id
    */
@@ -1103,7 +1103,7 @@ export interface AnomalyAlertConfiguration {
    * logical operator to apply across metric alert configurations in {@link metricAlertConfigurations}
    *
    */
-  crossMetricsOperator?: MetricAnomalyAlertConfigurationsOperator;
+  crossMetricsOperator?: AlertConfigurationsOperator;
   /**
    * unique hook ids
    */
@@ -1285,7 +1285,7 @@ export type GetAnomalyDetectionConfigurationResponse = AnomalyDetectionConfigura
 /**
  * Contains response data for the getAnomalyAlertConfiguration operation.
  */
-export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
+export type GetAnomalyAlertConfigurationResponse = AlertConfiguration & {
   /**
    * The underlying HTTP response.
    */
@@ -1655,7 +1655,7 @@ export interface MetricFeedbackPageResponse extends Array<MetricFeedbackUnion> {
 /**
  * Contains response data for the listAnomalyAlertConfigurations operation.
  */
-export interface AlertConfigurationsPageResponse extends Array<AnomalyAlertConfiguration> {
+export interface AlertConfigurationsPageResponse extends Array<AlertConfiguration> {
   /**
    * The underlying HTTP response.
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -143,7 +143,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         seriesDetectionConditions: []
       };
 
-      const actual = await client.createMetricAnomalyDetectionConfiguration(expected);
+      const actual = await client.createDetectionConfiguration(expected);
 
       assert.ok(actual.id, "Expecting valid detecion config");
       createdDetectionConfigId = actual.id!;
@@ -205,7 +205,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         ]
       };
 
-      const actual = await client.updateMetricAnomalyDetectionConfiguration(
+      const actual = await client.updateDetectionConfiguration(
         createdDetectionConfigId,
         expected
       );
@@ -244,7 +244,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
     });
 
     it("retrieves a detection configuration", async function() {
-      const result = await client.getMetricAnomalyDetectionConfiguration(createdDetectionConfigId);
+      const result = await client.getDetectionConfiguration(createdDetectionConfigId);
 
       assert.equal(result.name, "new Name");
       assert.equal(result.description, "new description");
@@ -286,7 +286,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         hookIds: []
       };
 
-      const actual = await client.createAnomalyAlertConfiguration(expectedAlertConfig);
+      const actual = await client.createAlertConfig(expectedAlertConfig);
 
       assert.ok(actual.id, "Expecting valid alert config");
       createdAlertConfigId = actual.id;
@@ -301,7 +301,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
     });
 
     it("retrieves an alert configuration", async function() {
-      const actual = await client.getAnomalyAlertConfiguration(createdAlertConfigId);
+      const actual = await client.getAlertConfig(createdAlertConfigId);
 
       assert.ok(actual.id, "Expecting valid alert config");
       createdAlertConfigId = actual.id;
@@ -327,7 +327,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         metricAlertConfigurations: [metricAlertConfig, metricAlertConfig]
       };
 
-      const actual = await client.updateAnomalyAlertConfiguration(createdAlertConfigId, patch);
+      const actual = await client.updateAlertConfig(createdAlertConfigId, patch);
 
       assert.ok(actual.id, "Expecting valid alerting config");
       assert.equal(actual.name, "new alert config name");
@@ -352,14 +352,14 @@ describe("MetricsAdvisorAdministrationClient", () => {
           scopeType: "All"
         }
       };
-      const secondAlertConfig = await client.createAnomalyAlertConfiguration({
+      const secondAlertConfig = await client.createAlertConfig({
         name: secondAlertConfigName,
         crossMetricsOperator: "OR",
         metricAlertConfigurations: [metricAlertConfig],
         hookIds: []
       });
       try {
-        const iterator = client.listAnomalyAlertConfigurations(createdDetectionConfigId);
+        const iterator = client.listAlertConfigurations(createdDetectionConfigId);
         let result = await iterator.next();
 
         assert.ok(result.value.id, "Expecting first alert config");
@@ -367,12 +367,12 @@ describe("MetricsAdvisorAdministrationClient", () => {
         assert.ok(result.value.id, "Expecting second alert config");
 
         const pageIterator = client
-          .listAnomalyAlertConfigurations(createdDetectionConfigId)
+          .listAlertConfigurations(createdDetectionConfigId)
           .byPage();
         const pageResult = await pageIterator.next();
         assert.isTrue(pageResult.value.length > 1, "Expecting more than one entries in page");
       } finally {
-        await client.deleteAnomalyAlertConfiguration(secondAlertConfig.id);
+        await client.deleteAlertConfig(secondAlertConfig.id);
       }
     });
 
@@ -382,9 +382,9 @@ describe("MetricsAdvisorAdministrationClient", () => {
         this.skip();
       }
 
-      await client.deleteAnomalyAlertConfiguration(createdAlertConfigId);
+      await client.deleteAlertConfig(createdAlertConfigId);
       try {
-        await client.getAnomalyAlertConfiguration(createdAlertConfigId);
+        await client.getAlertConfig(createdAlertConfigId);
         assert.fail("Expecting error getting alert config");
       } catch (error) {
         assert.equal((error as any).code, "Not Found");
@@ -397,7 +397,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         this.skip();
       }
 
-      await client.deleteMetricAnomalyDetectionConfiguration(createdDetectionConfigId);
+      await client.deleteDetectionConfig(createdDetectionConfigId);
       try {
         await client.getMetricAnomalyDetectionConfiguration(createdDetectionConfigId);
         assert.fail("Expecting error getting detection config");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -205,10 +205,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         ]
       };
 
-      const actual = await client.updateDetectionConfig(
-        createdDetectionConfigId,
-        expected
-      );
+      const actual = await client.updateDetectionConfig(createdDetectionConfigId, expected);
 
       assert.ok(actual.id, "Expecting valid detecion config");
       createdDetectionConfigId = actual.id!;
@@ -366,9 +363,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         result = await iterator.next();
         assert.ok(result.value.id, "Expecting second alert config");
 
-        const pageIterator = client
-          .listAlertConfigurations(createdDetectionConfigId)
-          .byPage();
+        const pageIterator = client.listAlertConfigurations(createdDetectionConfigId).byPage();
         const pageResult = await pageIterator.next();
         assert.isTrue(pageResult.value.length > 1, "Expecting more than one entries in page");
       } finally {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -248,7 +248,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
     });
 
     it("lists detection configurations", async function() {
-      const iterator = client.listMetricAnomalyDetectionConfigurations(
+      const iterator = client.listDetectionConfigs(
         testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1
       );
       let result = await iterator.next();
@@ -260,7 +260,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
 
     it("lists detection configurations by page", async function() {
       const iterator = client
-        .listMetricAnomalyDetectionConfigurations(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1)
+        .listDetectionConfigs(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1)
         .byPage();
       const result = await iterator.next();
       assert.ok(result.value.length > 1, "Expecting more than one entries in page");
@@ -356,14 +356,14 @@ describe("MetricsAdvisorAdministrationClient", () => {
         hookIds: []
       });
       try {
-        const iterator = client.listAlertConfigurations(createdDetectionConfigId);
+        const iterator = client.listAlertConfigs(createdDetectionConfigId);
         let result = await iterator.next();
 
         assert.ok(result.value.id, "Expecting first alert config");
         result = await iterator.next();
         assert.ok(result.value.id, "Expecting second alert config");
 
-        const pageIterator = client.listAlertConfigurations(createdDetectionConfigId).byPage();
+        const pageIterator = client.listAlertConfigs(createdDetectionConfigId).byPage();
         const pageResult = await pageIterator.next();
         assert.isTrue(pageResult.value.length > 1, "Expecting more than one entries in page");
       } finally {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/adminclient.spec.ts
@@ -143,7 +143,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         seriesDetectionConditions: []
       };
 
-      const actual = await client.createDetectionConfiguration(expected);
+      const actual = await client.createDetectionConfig(expected);
 
       assert.ok(actual.id, "Expecting valid detecion config");
       createdDetectionConfigId = actual.id!;
@@ -205,7 +205,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
         ]
       };
 
-      const actual = await client.updateDetectionConfiguration(
+      const actual = await client.updateDetectionConfig(
         createdDetectionConfigId,
         expected
       );
@@ -244,7 +244,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
     });
 
     it("retrieves a detection configuration", async function() {
-      const result = await client.getDetectionConfiguration(createdDetectionConfigId);
+      const result = await client.getDetectionConfig(createdDetectionConfigId);
 
       assert.equal(result.name, "new Name");
       assert.equal(result.description, "new description");
@@ -399,7 +399,7 @@ describe("MetricsAdvisorAdministrationClient", () => {
 
       await client.deleteDetectionConfig(createdDetectionConfigId);
       try {
-        await client.getMetricAnomalyDetectionConfiguration(createdDetectionConfigId);
+        await client.getDetectionConfig(createdDetectionConfigId);
         assert.fail("Expecting error getting detection config");
       } catch (error) {
         assert.equal((error as any).code, "Not Found");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -182,7 +182,7 @@ describe("MetricsAdvisorClient", () => {
   });
 
   it("lists alerts for alert configuration", async function() {
-    const iterator = client.listAlertsForAlertConfiguration(
+    const iterator = client.listAlerts(
       testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
       new Date(Date.UTC(2020, 0, 1)),
       new Date(Date.UTC(2020, 8, 12)),
@@ -195,7 +195,7 @@ describe("MetricsAdvisorClient", () => {
   });
 
   it("lists alerts for alert configuration with datetime strings", async function() {
-    const iterator = client.listAlertsForAlertConfiguration(
+    const iterator = client.listAlerts(
       testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
       "2020-01-01T00:00:00.000Z",
       "2020-09-12T00:00:00.000Z",
@@ -209,7 +209,7 @@ describe("MetricsAdvisorClient", () => {
 
   it("lists alerts for alert configuration by page", async function() {
     const iterator = client
-      .listAlertsForAlertConfiguration(
+      .listAlerts(
         testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
         new Date(Date.UTC(2020, 0, 1)),
         new Date(Date.UTC(2020, 8, 12)),

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -599,7 +599,7 @@ describe("MetricsAdvisorClient", () => {
 
     // service issue, skipping for now
     it("lists Anomaly feedbacks", async function() {
-      const iterator = client.listMetricFeedbacks(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1, {
+      const iterator = client.listFeedback(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1, {
         filter: {
           startTime: new Date(Date.UTC(2020, 9, 19)),
           endTime: new Date(Date.UTC(2020, 9, 20)),
@@ -613,7 +613,7 @@ describe("MetricsAdvisorClient", () => {
     });
 
     it("lists Anomaly feedbacks with datetime strings", async function() {
-      const iterator = client.listMetricFeedbacks(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1, {
+      const iterator = client.listFeedback(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1, {
         filter: {
           startTime: "2020-10-19T00:00:00.000Z",
           endTime: "2020-10-20T00:00:00.000Z",
@@ -628,7 +628,7 @@ describe("MetricsAdvisorClient", () => {
 
     it("lists Anomaly feedbacks by page", async function() {
       const iterator = client
-        .listMetricFeedbacks(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1)
+        .listFeedback(testEnv.METRICS_ADVISOR_AZURE_BLOB_METRIC_ID_1)
         .byPage({ maxPageSize: 2 });
       let result = await iterator.next();
       assert.equal(result.value.length, 2, "Expecting two entries in first page");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -141,7 +141,7 @@ describe("MetricsAdvisorClient", () => {
   });
 
   it("listDimensionValuesForDetectionConfiguration()", async function() {
-    const iterator = client.listDimensionValuesForDetectionConfiguration(
+    const iterator = client.listDimensionValuesForDetectionConfig(
       testEnv.METRICS_ADVISOR_AZURE_BLOB_DETECTION_CONFIG_ID,
       new Date(Date.UTC(2020, 7, 5)),
       new Date(Date.UTC(2020, 8, 5)),
@@ -154,7 +154,7 @@ describe("MetricsAdvisorClient", () => {
   });
 
   it("listDimensionValuesForDetectionConfiguration() with datetime strings", async function() {
-    const iterator = client.listDimensionValuesForDetectionConfiguration(
+    const iterator = client.listDimensionValuesForDetectionConfig(
       testEnv.METRICS_ADVISOR_AZURE_BLOB_DETECTION_CONFIG_ID,
       "2020-08-05T00:00:00.000Z",
       "2020-09-05T00:00:00.000Z",
@@ -168,7 +168,7 @@ describe("MetricsAdvisorClient", () => {
 
   it("listDimensionValuesForDetectionConfiguration() by page", async function() {
     const iterator = client
-      .listDimensionValuesForDetectionConfiguration(
+      .listDimensionValuesForDetectionConfig(
         testEnv.METRICS_ADVISOR_AZURE_BLOB_DETECTION_CONFIG_ID,
         new Date(Date.UTC(2020, 7, 5)),
         new Date(Date.UTC(2020, 8, 5)),

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/advisorclient.spec.ts
@@ -521,7 +521,7 @@ describe("MetricsAdvisorClient", () => {
         value: "NotAnomaly",
         dimensionKey: { Dim1: "Common Lime", Dim2: "Ant" }
       };
-      const actual = await client.createMetricFeedback(anomalyFeedback);
+      const actual = await client.createFeedback(anomalyFeedback);
 
       assert.ok(actual.id, "Expecting valid feedback");
       createdFeedbackId = actual.id!;
@@ -539,7 +539,7 @@ describe("MetricsAdvisorClient", () => {
         value: "ChangePoint",
         dimensionKey: { Dim1: "Common Lime", Dim2: "Ant" }
       };
-      const actual = await client.createMetricFeedback(changePointFeedback);
+      const actual = await client.createFeedback(changePointFeedback);
 
       assert.ok(actual.id, "Expecting valid feedback");
       createdFeedbackId = actual.id!;
@@ -557,7 +557,7 @@ describe("MetricsAdvisorClient", () => {
         periodValue: 4,
         dimensionKey: { Dim1: "Common Lime", Dim2: "Ant" }
       };
-      const actual = await client.createMetricFeedback(periodFeedback);
+      const actual = await client.createFeedback(periodFeedback);
 
       assert.ok(actual.id, "Expecting valid feedback");
       createdFeedbackId = actual.id!;
@@ -576,7 +576,7 @@ describe("MetricsAdvisorClient", () => {
         comment: "This is a comment"
       };
 
-      const actual = await client.createMetricFeedback(expectedCommentFeedback);
+      const actual = await client.createFeedback(expectedCommentFeedback);
 
       assert.ok(actual.id, "Expecting valid feedback");
       createdFeedbackId = actual.id!;
@@ -587,7 +587,7 @@ describe("MetricsAdvisorClient", () => {
     });
 
     it("retrieves Anomaly feedback", async function() {
-      const actual = await client.getMetricFeedback(createdFeedbackId);
+      const actual = await client.getFeedback(createdFeedbackId);
 
       assert.ok(actual.id, "Expecting valid feedback");
       createdFeedbackId = actual.id!;


### PR DESCRIPTION
- [Breaking] Rename method for listing alerts
  - `listAlertsForAlertConfiguration(alertConfigId, startTime, endTime, timemode, options)` to `listAlerts(alertConfigId, startTime, endTime, timemode, options)`
- [Breaking] Rename feedback methods :
  - `listMetricFeedbacks()` to `listFeedback()`
  - `getMetricFeedback()` to `getFeedback()`
  - `createMetricFeedback()` to `createFeedback()`
- [Breaking] Rename detection configuration methods:
  - `createMetricAnomalyDetectionConfiguration(anomalyConfig)` to `createDetectionConfig(anomalyConfig)`
  - `getMetricAnomalyDetectionConfiguration(detectionConfigId)` to `getDetectionConfig(detectionConfigId)`
  - `createMetricAnomalyDetectionConfiguration(config)` to `createDetectionConfig(config)`
  - `updateMetricAnomalyDetectionConfiguration(configId, patch)` to `updateDetectionConfig(configId, patch)`
  - `deleteMetricAnomalyDetectionConfiguration(detectionConfigId)` to `deleteDetectionConfig(detectionConfigId)`
  - `listMetricAnomalyDetectionConfigurations(metricId)` to `listDetectionConfigs(metricId)`
- [Breaking] Rename anomaly alert configuration methods:
  - `createAnomalyAlertConfiguration(anomalyAlertConfig)` to `createAlertConfig(anomalyAlertConfig)`
  - `updateAnomalyAlertConfiguration(alertConfigId, patch)` to `updateAlertConfig(alertConfigId, patch)`
  - `deleteAnomalyAlertConfiguration(alertConfigId)` to `deleteAlertConfig(alertConfigId)`
  - `listAnomalyAlertConfigurations(detectdionConfigId)` to `listAlertConfigs(detectdionConfigId)`