### PR TITLE
Disable sovereign cloud smoke tests

### DIFF
--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -17,26 +17,26 @@ jobs:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "10.x"
-        Linux Node10 (AzureUSGovernment):
-          OSVmImage: "ubuntu-18.04"
-          SubscriptionConfiguration: $(sub-config-gov-test-resources)
-          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-          NodeTestVersion: "10.x"
-        Windows Node14 (AzureUSGovernment):
-          OSVmImage: "windows-2019"
-          SubscriptionConfiguration: $(sub-config-gov-test-resources)
-          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-          NodeTestVersion: "14.x"
-        Linux Node12 (AzureChinaCloud):
-          OSVmImage: "ubuntu-18.04"
-          SubscriptionConfiguration: $(sub-config-cn-test-resources)
-          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-          NodeTestVersion: "12.x"
-        Windows Node10 (AzureChinaCloud):
-          OSVmImage: "windows-2019"
-          SubscriptionConfiguration: $(sub-config-cn-test-resources)
-          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-          NodeTestVersion: "10.x"
+#        Linux Node10 (AzureUSGovernment):
+#          OSVmImage: "ubuntu-18.04"
+#          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+#          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
+#          NodeTestVersion: "10.x"
+#        Windows Node14 (AzureUSGovernment):
+#          OSVmImage: "windows-2019"
+#          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+#          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
+#          NodeTestVersion: "14.x"
+#        Linux Node12 (AzureChinaCloud):
+#          OSVmImage: "ubuntu-18.04"
+#          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+#          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
+#          NodeTestVersion: "12.x"
+#        Windows Node10 (AzureChinaCloud):
+#          OSVmImage: "windows-2019"
+#          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+#          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
+#          NodeTestVersion: "10.x"
 
     pool:
       vmImage: $(OSVmImage)


### PR DESCRIPTION
There is still some SDK work to get these working. In the meantime, we'd like to keep the smoke test pipeline passing so it can be used for PRs and to locate when regressions happen.