### PR TITLE
[data-plane] JS: 'Release for QnA Maker 2020-11-02'

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-qnamaker",
   "author": "Microsoft Corporation",
   "description": "QnAMakerClient Library with typescript type definitions for node.js and browser.",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/index.ts
@@ -69,6 +69,10 @@ export interface UpdateKbContentsDTO {
    * List of existing URLs to be refreshed. The content will be extracted again and re-indexed.
    */
   urls?: string[];
+  /**
+   * Default answer sent to user if no good match is found in the KB.
+   */
+  defaultAnswer?: string;
 }
 
 /**
@@ -245,6 +249,10 @@ export interface QnADTO {
    * Context of a QnA
    */
   context?: QnADTOContext;
+  /**
+   * Timestamp when the QnA was last updated.
+   */
+  lastUpdatedTimestamp?: string;
 }
 
 /**
@@ -353,9 +361,18 @@ export interface CreateKbDTO {
    */
   defaultAnswerUsedForExtraction?: string;
   /**
-   * Language of the knowledgebase.
+   * Language of the knowledgebase. Please find the list of supported languages <a
+   * href="https://aka.ms/qnamaker-languages#languages-supported" target="_blank">here</a>.
    */
   language?: string;
+  /**
+   * Set to true to enable creating KBs in different languages for the same resource.
+   */
+  enableMultipleLanguages?: boolean;
+  /**
+   * Default answer sent to user if no good match is found in the KB.
+   */
+  defaultAnswer?: string;
 }
 
 /**
@@ -591,6 +608,225 @@ export interface EndpointKeysDTO {
 }
 
 /**
+ * Context object with previous QnA's information.
+ */
+export interface QueryContextDTO {
+  /**
+   * Previous QnA Id - qnaId of the top result.
+   */
+  previousQnaId?: number;
+  /**
+   * Previous user query.
+   */
+  previousUserQuery?: string;
+}
+
+/**
+ * Context object with previous QnA's information.
+ */
+export interface QueryDTOContext extends QueryContextDTO {
+}
+
+/**
+ * To configure Answer span prediction feature.
+ */
+export interface AnswerSpanRequestDTO {
+  /**
+   * Enable or Disable Answer Span prediction.
+   */
+  enable?: boolean;
+  /**
+   * Minimum threshold score required to include an answer span.
+   */
+  scoreThreshold?: number;
+  /**
+   * Number of Top answers to be considered for span prediction.
+   */
+  topAnswersWithSpan?: number;
+}
+
+/**
+ * To configure Answer span prediction feature.
+ */
+export interface QueryDTOAnswerSpanRequest extends AnswerSpanRequestDTO {
+}
+
+/**
+ * POST body schema to query the knowledgebase.
+ */
+export interface QueryDTO {
+  /**
+   * Exact qnaId to fetch from the knowledgebase, this field takes priority over question.
+   */
+  qnaId?: string;
+  /**
+   * User question to query against the knowledge base.
+   */
+  question?: string;
+  /**
+   * Max number of answers to be returned for the question.
+   */
+  top?: number;
+  /**
+   * Unique identifier for the user.
+   */
+  userId?: string;
+  /**
+   * Query against the test index.
+   */
+  isTest?: boolean;
+  /**
+   * Minimum threshold score for answers.
+   */
+  scoreThreshold?: number;
+  /**
+   * Context object with previous QnA's information.
+   */
+  context?: QueryDTOContext;
+  /**
+   * Optional field. Set to 'QuestionOnly' for using a question only Ranker.
+   */
+  rankerType?: string;
+  /**
+   * Find QnAs that are associated with the given list of metadata.
+   */
+  strictFilters?: MetadataDTO[];
+  /**
+   * Optional field. Set to 'OR' for using OR operation for strict filters. Possible values
+   * include: 'AND', 'OR'
+   */
+  strictFiltersCompoundOperationType?: StrictFiltersCompoundOperationType;
+  /**
+   * To configure Answer span prediction feature.
+   */
+  answerSpanRequest?: QueryDTOAnswerSpanRequest;
+}
+
+/**
+ * Context object of the QnA
+ */
+export interface QnASearchResultContext extends ContextDTO {
+}
+
+/**
+ * Answer span object of QnA.
+ */
+export interface AnswerSpanResponseDTO {
+  /**
+   * Predicted text of answer span.
+   */
+  text?: string;
+  /**
+   * Predicted score of answer span.
+   */
+  score?: number;
+  /**
+   * Start index of answer span in answer.
+   */
+  startIndex?: number;
+  /**
+   * End index of answer span in answer.
+   */
+  endIndex?: number;
+}
+
+/**
+ * Answer span object of QnA with respect to user's question.
+ */
+export interface QnASearchResultAnswerSpan extends AnswerSpanResponseDTO {
+}
+
+/**
+ * Represents Search Result.
+ */
+export interface QnASearchResult {
+  /**
+   * List of questions.
+   */
+  questions?: string[];
+  /**
+   * Answer.
+   */
+  answer?: string;
+  /**
+   * Search result score.
+   */
+  score?: number;
+  /**
+   * Id of the QnA result.
+   */
+  id?: number;
+  /**
+   * Source of QnA result.
+   */
+  source?: string;
+  /**
+   * List of metadata.
+   */
+  metadata?: MetadataDTO[];
+  /**
+   * Context object of the QnA
+   */
+  context?: QnASearchResultContext;
+  /**
+   * Answer span object of QnA with respect to user's question.
+   */
+  answerSpan?: QnASearchResultAnswerSpan;
+}
+
+/**
+ * Represents List of Question Answers.
+ */
+export interface QnASearchResultList {
+  /**
+   * Represents Search Result list.
+   */
+  answers?: QnASearchResult[];
+}
+
+/**
+ * Active learning feedback record.
+ */
+export interface FeedbackRecordDTO {
+  /**
+   * Unique identifier for the user.
+   */
+  userId?: string;
+  /**
+   * The suggested question being provided as feedback.
+   */
+  userQuestion?: string;
+  /**
+   * The qnaId for which the suggested question is provided as feedback.
+   */
+  qnaId?: number;
+}
+
+/**
+ * Active learning feedback records.
+ */
+export interface FeedbackRecordsDTO {
+  /**
+   * List of feedback records.
+   */
+  feedbackRecords?: FeedbackRecordDTO[];
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface KnowledgebaseDownloadOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The source property filter to apply.
+   */
+  source?: string;
+  /**
+   * The last changed status property filter to apply.
+   */
+  changedSince?: string;
+}
+
+/**
  * Defines headers for GetDetails operation.
  */
 export interface OperationsGetDetailsHeaders {
@@ -631,6 +867,14 @@ export type ErrorCodeType = 'BadArgument' | 'Forbidden' | 'NotFound' | 'KbNotFou
 export type OperationStateType = 'Failed' | 'NotStarted' | 'Running' | 'Succeeded';
 
 /**
+ * Defines values for StrictFiltersCompoundOperationType.
+ * Possible values include: 'AND', 'OR'
+ * @readonly
+ * @enum {string}
+ */
+export type StrictFiltersCompoundOperationType = 'AND' | 'OR';
+
+/**
  * Defines values for EnvironmentType.
  * Possible values include: 'Prod', 'Test'
  * @readonly
@@ -655,31 +899,6 @@ export type EndpointSettingsGetSettingsResponse = EndpointSettingsDTO & {
        * The response body as parsed JSON or XML
        */
       parsedBody: EndpointSettingsDTO;
-    };
-};
-
-/**
- * Contains response data for the updateSettings operation.
- */
-export type EndpointSettingsUpdateSettingsResponse = {
-  /**
-   * The parsed response body.
-   */
-  body: string;
-
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: string;
     };
 };
 
@@ -727,6 +946,26 @@ export type EndpointKeysRefreshKeysResponse = EndpointKeysDTO & {
  * Contains response data for the get operation.
  */
 export type AlterationsGetResponse = WordAlterationsDTO & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: WordAlterationsDTO;
+    };
+};
+
+/**
+ * Contains response data for the getAlterationsForKb operation.
+ */
+export type AlterationsGetAlterationsForKbResponse = WordAlterationsDTO & {
   /**
    * The underlying HTTP response.
    */
@@ -845,6 +1084,26 @@ export type KnowledgebaseDownloadResponse = QnADocumentsDTO & {
        * The response body as parsed JSON or XML
        */
       parsedBody: QnADocumentsDTO;
+    };
+};
+
+/**
+ * Contains response data for the generateAnswer operation.
+ */
+export type KnowledgebaseGenerateAnswerResponse = QnASearchResultList & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: QnASearchResultList;
     };
 };
 

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/knowledgebaseMappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/knowledgebaseMappers.ts
@@ -7,6 +7,8 @@
  */
 
 export {
+  AnswerSpanRequestDTO,
+  AnswerSpanResponseDTO,
   ContextDTO,
   CreateKbDTO,
   CreateKbInputDTO,
@@ -14,6 +16,8 @@ export {
   ErrorModel,
   ErrorResponse,
   ErrorResponseError,
+  FeedbackRecordDTO,
+  FeedbackRecordsDTO,
   FileDTO,
   InnerErrorModel,
   KnowledgebaseDTO,
@@ -26,6 +30,14 @@ export {
   QnADocumentsDTO,
   QnADTO,
   QnADTOContext,
+  QnASearchResult,
+  QnASearchResultAnswerSpan,
+  QnASearchResultContext,
+  QnASearchResultList,
+  QueryContextDTO,
+  QueryDTO,
+  QueryDTOAnswerSpanRequest,
+  QueryDTOContext,
   ReplaceKbDTO,
   UpdateContextDTO,
   UpdateKbContentsDTO,

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/mappers.ts
@@ -142,6 +142,16 @@ export const UpdateKbContentsDTO: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      defaultAnswer: {
+        serializedName: "defaultAnswer",
+        constraints: {
+          MaxLength: 300,
+          MinLength: 1
+        },
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -493,6 +503,15 @@ export const QnADTO: msRest.CompositeMapper = {
           name: "Composite",
           className: "QnADTOContext"
         }
+      },
+      lastUpdatedTimestamp: {
+        serializedName: "lastUpdatedTimestamp",
+        constraints: {
+          MaxLength: 300
+        },
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -711,6 +730,22 @@ export const CreateKbDTO: msRest.CompositeMapper = {
         serializedName: "language",
         constraints: {
           MaxLength: 100,
+          MinLength: 1
+        },
+        type: {
+          name: "String"
+        }
+      },
+      enableMultipleLanguages: {
+        serializedName: "enableMultipleLanguages",
+        type: {
+          name: "Boolean"
+        }
+      },
+      defaultAnswer: {
+        serializedName: "defaultAnswer",
+        constraints: {
+          MaxLength: 300,
           MinLength: 1
         },
         type: {
@@ -1115,6 +1150,368 @@ export const EndpointKeysDTO: msRest.CompositeMapper = {
         serializedName: "language",
         type: {
           name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const QueryContextDTO: msRest.CompositeMapper = {
+  serializedName: "QueryContextDTO",
+  type: {
+    name: "Composite",
+    className: "QueryContextDTO",
+    modelProperties: {
+      previousQnaId: {
+        serializedName: "previousQnaId",
+        type: {
+          name: "Number"
+        }
+      },
+      previousUserQuery: {
+        serializedName: "previousUserQuery",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const QueryDTOContext: msRest.CompositeMapper = {
+  serializedName: "QueryDTO_context",
+  type: {
+    name: "Composite",
+    className: "QueryDTOContext",
+    modelProperties: {
+      ...QueryContextDTO.type.modelProperties
+    }
+  }
+};
+
+export const AnswerSpanRequestDTO: msRest.CompositeMapper = {
+  serializedName: "AnswerSpanRequestDTO",
+  type: {
+    name: "Composite",
+    className: "AnswerSpanRequestDTO",
+    modelProperties: {
+      enable: {
+        serializedName: "enable",
+        type: {
+          name: "Boolean"
+        }
+      },
+      scoreThreshold: {
+        serializedName: "scoreThreshold",
+        type: {
+          name: "Number"
+        }
+      },
+      topAnswersWithSpan: {
+        serializedName: "topAnswersWithSpan",
+        constraints: {
+          InclusiveMaximum: 10,
+          InclusiveMinimum: 1
+        },
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const QueryDTOAnswerSpanRequest: msRest.CompositeMapper = {
+  serializedName: "QueryDTO_answerSpanRequest",
+  type: {
+    name: "Composite",
+    className: "QueryDTOAnswerSpanRequest",
+    modelProperties: {
+      ...AnswerSpanRequestDTO.type.modelProperties
+    }
+  }
+};
+
+export const QueryDTO: msRest.CompositeMapper = {
+  serializedName: "QueryDTO",
+  type: {
+    name: "Composite",
+    className: "QueryDTO",
+    modelProperties: {
+      qnaId: {
+        serializedName: "qnaId",
+        type: {
+          name: "String"
+        }
+      },
+      question: {
+        serializedName: "question",
+        type: {
+          name: "String"
+        }
+      },
+      top: {
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      },
+      userId: {
+        serializedName: "userId",
+        type: {
+          name: "String"
+        }
+      },
+      isTest: {
+        serializedName: "isTest",
+        type: {
+          name: "Boolean"
+        }
+      },
+      scoreThreshold: {
+        serializedName: "scoreThreshold",
+        type: {
+          name: "Number"
+        }
+      },
+      context: {
+        serializedName: "context",
+        type: {
+          name: "Composite",
+          className: "QueryDTOContext"
+        }
+      },
+      rankerType: {
+        serializedName: "rankerType",
+        type: {
+          name: "String"
+        }
+      },
+      strictFilters: {
+        serializedName: "strictFilters",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MetadataDTO"
+            }
+          }
+        }
+      },
+      strictFiltersCompoundOperationType: {
+        serializedName: "strictFiltersCompoundOperationType",
+        type: {
+          name: "String"
+        }
+      },
+      answerSpanRequest: {
+        serializedName: "answerSpanRequest",
+        type: {
+          name: "Composite",
+          className: "QueryDTOAnswerSpanRequest"
+        }
+      }
+    }
+  }
+};
+
+export const QnASearchResultContext: msRest.CompositeMapper = {
+  serializedName: "QnASearchResult_context",
+  type: {
+    name: "Composite",
+    className: "QnASearchResultContext",
+    modelProperties: {
+      ...ContextDTO.type.modelProperties
+    }
+  }
+};
+
+export const AnswerSpanResponseDTO: msRest.CompositeMapper = {
+  serializedName: "AnswerSpanResponseDTO",
+  type: {
+    name: "Composite",
+    className: "AnswerSpanResponseDTO",
+    modelProperties: {
+      text: {
+        serializedName: "text",
+        type: {
+          name: "String"
+        }
+      },
+      score: {
+        serializedName: "score",
+        type: {
+          name: "Number"
+        }
+      },
+      startIndex: {
+        serializedName: "startIndex",
+        type: {
+          name: "Number"
+        }
+      },
+      endIndex: {
+        serializedName: "endIndex",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const QnASearchResultAnswerSpan: msRest.CompositeMapper = {
+  serializedName: "QnASearchResult_answerSpan",
+  type: {
+    name: "Composite",
+    className: "QnASearchResultAnswerSpan",
+    modelProperties: {
+      ...AnswerSpanResponseDTO.type.modelProperties
+    }
+  }
+};
+
+export const QnASearchResult: msRest.CompositeMapper = {
+  serializedName: "QnASearchResult",
+  type: {
+    name: "Composite",
+    className: "QnASearchResult",
+    modelProperties: {
+      questions: {
+        serializedName: "questions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      },
+      answer: {
+        serializedName: "answer",
+        type: {
+          name: "String"
+        }
+      },
+      score: {
+        serializedName: "score",
+        type: {
+          name: "Number"
+        }
+      },
+      id: {
+        serializedName: "id",
+        type: {
+          name: "Number"
+        }
+      },
+      source: {
+        serializedName: "source",
+        type: {
+          name: "String"
+        }
+      },
+      metadata: {
+        serializedName: "metadata",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MetadataDTO"
+            }
+          }
+        }
+      },
+      context: {
+        serializedName: "context",
+        type: {
+          name: "Composite",
+          className: "QnASearchResultContext"
+        }
+      },
+      answerSpan: {
+        serializedName: "answerSpan",
+        type: {
+          name: "Composite",
+          className: "QnASearchResultAnswerSpan"
+        }
+      }
+    }
+  }
+};
+
+export const QnASearchResultList: msRest.CompositeMapper = {
+  serializedName: "QnASearchResultList",
+  type: {
+    name: "Composite",
+    className: "QnASearchResultList",
+    modelProperties: {
+      answers: {
+        serializedName: "answers",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "QnASearchResult"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const FeedbackRecordDTO: msRest.CompositeMapper = {
+  serializedName: "FeedbackRecordDTO",
+  type: {
+    name: "Composite",
+    className: "FeedbackRecordDTO",
+    modelProperties: {
+      userId: {
+        serializedName: "userId",
+        type: {
+          name: "String"
+        }
+      },
+      userQuestion: {
+        serializedName: "userQuestion",
+        constraints: {
+          MaxLength: 1000
+        },
+        type: {
+          name: "String"
+        }
+      },
+      qnaId: {
+        serializedName: "qnaId",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const FeedbackRecordsDTO: msRest.CompositeMapper = {
+  serializedName: "FeedbackRecordsDTO",
+  type: {
+    name: "Composite",
+    className: "FeedbackRecordsDTO",
+    modelProperties: {
+      feedbackRecords: {
+        serializedName: "feedbackRecords",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "FeedbackRecordDTO"
+            }
+          }
         }
       }
     }

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/models/parameters.ts
@@ -10,6 +10,18 @@
 
 import * as msRest from "@azure/ms-rest-js";
 
+export const changedSince: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "changedSince"
+  ],
+  mapper: {
+    serializedName: "changedSince",
+    type: {
+      name: "String"
+    }
+  }
+};
 export const endpoint: msRest.OperationURLParameter = {
   parameterPath: "endpoint",
   mapper: {
@@ -57,6 +69,18 @@ export const operationId: msRest.OperationURLParameter = {
   mapper: {
     required: true,
     serializedName: "operationId",
+    type: {
+      name: "String"
+    }
+  }
+};
+export const source: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "source"
+  ],
+  mapper: {
+    serializedName: "source",
     type: {
       name: "String"
     }

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/alterations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/alterations.ts
@@ -77,6 +77,66 @@ export class Alterations {
       replaceOperationSpec,
       callback);
   }
+
+  /**
+   * @summary Download alterations per Knowledgebase (QnAMaker Managed).
+   * @param kbId Knowledgebase id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.AlterationsGetAlterationsForKbResponse>
+   */
+  getAlterationsForKb(kbId: string, options?: msRest.RequestOptionsBase): Promise<Models.AlterationsGetAlterationsForKbResponse>;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param callback The callback
+   */
+  getAlterationsForKb(kbId: string, callback: msRest.ServiceCallback<Models.WordAlterationsDTO>): void;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getAlterationsForKb(kbId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.WordAlterationsDTO>): void;
+  getAlterationsForKb(kbId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.WordAlterationsDTO>, callback?: msRest.ServiceCallback<Models.WordAlterationsDTO>): Promise<Models.AlterationsGetAlterationsForKbResponse> {
+    return this.client.sendOperationRequest(
+      {
+        kbId,
+        options
+      },
+      getAlterationsForKbOperationSpec,
+      callback) as Promise<Models.AlterationsGetAlterationsForKbResponse>;
+  }
+
+  /**
+   * @summary Replace alterations data per Knowledgebase (QnAMaker Managed).
+   * @param kbId Knowledgebase id.
+   * @param wordAlterations New alterations data.
+   * @param [options] The optional parameters
+   * @returns Promise<msRest.RestResponse>
+   */
+  replaceAlterationsForKb(kbId: string, wordAlterations: Models.WordAlterationsDTO, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param wordAlterations New alterations data.
+   * @param callback The callback
+   */
+  replaceAlterationsForKb(kbId: string, wordAlterations: Models.WordAlterationsDTO, callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param wordAlterations New alterations data.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  replaceAlterationsForKb(kbId: string, wordAlterations: Models.WordAlterationsDTO, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  replaceAlterationsForKb(kbId: string, wordAlterations: Models.WordAlterationsDTO, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+    return this.client.sendOperationRequest(
+      {
+        kbId,
+        wordAlterations,
+        options
+      },
+      replaceAlterationsForKbOperationSpec,
+      callback);
+  }
 }
 
 // Operation Specifications
@@ -103,6 +163,47 @@ const replaceOperationSpec: msRest.OperationSpec = {
   path: "alterations",
   urlParameters: [
     Parameters.endpoint
+  ],
+  requestBody: {
+    parameterPath: "wordAlterations",
+    mapper: {
+      ...Mappers.WordAlterationsDTO,
+      required: true
+    }
+  },
+  responses: {
+    204: {},
+    default: {
+      bodyMapper: Mappers.ErrorResponse
+    }
+  },
+  serializer
+};
+
+const getAlterationsForKbOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "alterations/{kbId}",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.kbId
+  ],
+  responses: {
+    200: {
+      bodyMapper: Mappers.WordAlterationsDTO
+    },
+    default: {
+      bodyMapper: Mappers.ErrorResponse
+    }
+  },
+  serializer
+};
+
+const replaceAlterationsForKbOperationSpec: msRest.OperationSpec = {
+  httpMethod: "PUT",
+  path: "alterations/{kbId}",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.kbId
   ],
   requestBody: {
     parameterPath: "wordAlterations",

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/endpointSettings.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/endpointSettings.ts
@@ -54,28 +54,28 @@ export class EndpointSettings {
    * @summary Updates endpoint settings for an endpoint.
    * @param endpointSettingsPayload Post body of the request.
    * @param [options] The optional parameters
-   * @returns Promise<Models.EndpointSettingsUpdateSettingsResponse>
+   * @returns Promise<msRest.RestResponse>
    */
-  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options?: msRest.RequestOptionsBase): Promise<Models.EndpointSettingsUpdateSettingsResponse>;
+  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
   /**
    * @param endpointSettingsPayload Post body of the request.
    * @param callback The callback
    */
-  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, callback: msRest.ServiceCallback<string>): void;
+  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param endpointSettingsPayload Post body of the request.
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<string>): void;
-  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<string>, callback?: msRest.ServiceCallback<string>): Promise<Models.EndpointSettingsUpdateSettingsResponse> {
+  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  updateSettings(endpointSettingsPayload: Models.EndpointSettingsDTO, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.client.sendOperationRequest(
       {
         endpointSettingsPayload,
         options
       },
       updateSettingsOperationSpec,
-      callback) as Promise<Models.EndpointSettingsUpdateSettingsResponse>;
+      callback);
   }
 }
 
@@ -112,14 +112,7 @@ const updateSettingsOperationSpec: msRest.OperationSpec = {
     }
   },
   responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "String"
-        }
-      }
-    },
+    204: {},
     default: {
       bodyMapper: Mappers.ErrorResponse
     }

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/knowledgebase.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/knowledgebase.ts
@@ -234,7 +234,7 @@ export class Knowledgebase {
    * @param [options] The optional parameters
    * @returns Promise<Models.KnowledgebaseDownloadResponse>
    */
-  download(kbId: string, environment: Models.EnvironmentType, options?: msRest.RequestOptionsBase): Promise<Models.KnowledgebaseDownloadResponse>;
+  download(kbId: string, environment: Models.EnvironmentType, options?: Models.KnowledgebaseDownloadOptionalParams): Promise<Models.KnowledgebaseDownloadResponse>;
   /**
    * @param kbId Knowledgebase id.
    * @param environment Specifies whether environment is Test or Prod. Possible values include:
@@ -249,8 +249,8 @@ export class Knowledgebase {
    * @param options The optional parameters
    * @param callback The callback
    */
-  download(kbId: string, environment: Models.EnvironmentType, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.QnADocumentsDTO>): void;
-  download(kbId: string, environment: Models.EnvironmentType, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.QnADocumentsDTO>, callback?: msRest.ServiceCallback<Models.QnADocumentsDTO>): Promise<Models.KnowledgebaseDownloadResponse> {
+  download(kbId: string, environment: Models.EnvironmentType, options: Models.KnowledgebaseDownloadOptionalParams, callback: msRest.ServiceCallback<Models.QnADocumentsDTO>): void;
+  download(kbId: string, environment: Models.EnvironmentType, options?: Models.KnowledgebaseDownloadOptionalParams | msRest.ServiceCallback<Models.QnADocumentsDTO>, callback?: msRest.ServiceCallback<Models.QnADocumentsDTO>): Promise<Models.KnowledgebaseDownloadResponse> {
     return this.client.sendOperationRequest(
       {
         kbId,
@@ -259,6 +259,70 @@ export class Knowledgebase {
       },
       downloadOperationSpec,
       callback) as Promise<Models.KnowledgebaseDownloadResponse>;
+  }
+
+  /**
+   * @summary GenerateAnswer call to query knowledgebase (QnA Maker Managed).
+   * @param kbId Knowledgebase id.
+   * @param generateAnswerPayload Post body of the request.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.KnowledgebaseGenerateAnswerResponse>
+   */
+  generateAnswer(kbId: string, generateAnswerPayload: Models.QueryDTO, options?: msRest.RequestOptionsBase): Promise<Models.KnowledgebaseGenerateAnswerResponse>;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param generateAnswerPayload Post body of the request.
+   * @param callback The callback
+   */
+  generateAnswer(kbId: string, generateAnswerPayload: Models.QueryDTO, callback: msRest.ServiceCallback<Models.QnASearchResultList>): void;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param generateAnswerPayload Post body of the request.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  generateAnswer(kbId: string, generateAnswerPayload: Models.QueryDTO, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.QnASearchResultList>): void;
+  generateAnswer(kbId: string, generateAnswerPayload: Models.QueryDTO, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.QnASearchResultList>, callback?: msRest.ServiceCallback<Models.QnASearchResultList>): Promise<Models.KnowledgebaseGenerateAnswerResponse> {
+    return this.client.sendOperationRequest(
+      {
+        kbId,
+        generateAnswerPayload,
+        options
+      },
+      generateAnswerOperationSpec,
+      callback) as Promise<Models.KnowledgebaseGenerateAnswerResponse>;
+  }
+
+  /**
+   * @summary Train call to add suggestions to knowledgebase (QnAMaker Managed).
+   * @param kbId Knowledgebase id.
+   * @param trainPayload Post body of the request.
+   * @param [options] The optional parameters
+   * @returns Promise<msRest.RestResponse>
+   */
+  train(kbId: string, trainPayload: Models.FeedbackRecordsDTO, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param trainPayload Post body of the request.
+   * @param callback The callback
+   */
+  train(kbId: string, trainPayload: Models.FeedbackRecordsDTO, callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param kbId Knowledgebase id.
+   * @param trainPayload Post body of the request.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  train(kbId: string, trainPayload: Models.FeedbackRecordsDTO, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  train(kbId: string, trainPayload: Models.FeedbackRecordsDTO, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+    return this.client.sendOperationRequest(
+      {
+        kbId,
+        trainPayload,
+        options
+      },
+      trainOperationSpec,
+      callback);
   }
 }
 
@@ -374,8 +438,7 @@ const updateOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.KnowledgebaseUpdateHeaders
     },
     default: {
-      bodyMapper: Mappers.ErrorResponse,
-      headersMapper: Mappers.KnowledgebaseUpdateHeaders
+      bodyMapper: Mappers.ErrorResponse
     }
   },
   serializer
@@ -413,10 +476,62 @@ const downloadOperationSpec: msRest.OperationSpec = {
     Parameters.kbId,
     Parameters.environment
   ],
+  queryParameters: [
+    Parameters.source,
+    Parameters.changedSince
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.QnADocumentsDTO
     },
+    default: {
+      bodyMapper: Mappers.ErrorResponse
+    }
+  },
+  serializer
+};
+
+const generateAnswerOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "knowledgebases/{kbId}/generateAnswer",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.kbId
+  ],
+  requestBody: {
+    parameterPath: "generateAnswerPayload",
+    mapper: {
+      ...Mappers.QueryDTO,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.QnASearchResultList
+    },
+    default: {
+      bodyMapper: Mappers.ErrorResponse
+    }
+  },
+  serializer
+};
+
+const trainOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "knowledgebases/{kbId}/train",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.kbId
+  ],
+  requestBody: {
+    parameterPath: "trainPayload",
+    mapper: {
+      ...Mappers.FeedbackRecordsDTO,
+      required: true
+    }
+  },
+  responses: {
+    204: {},
     default: {
       bodyMapper: Mappers.ErrorResponse
     }

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/operations.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/operations/operations.ts
@@ -70,8 +70,7 @@ const getDetailsOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.OperationsGetDetailsHeaders
     },
     default: {
-      bodyMapper: Mappers.ErrorResponse,
-      headersMapper: Mappers.OperationsGetDetailsHeaders
+      bodyMapper: Mappers.ErrorResponse
     }
   },
   serializer

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/qnAMakerClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/qnAMakerClient.ts
@@ -24,8 +24,8 @@ class QnAMakerClient extends QnAMakerClientContext {
 
   /**
    * Initializes a new instance of the QnAMakerClient class.
-   * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
-   * https://westus.api.cognitive.microsoft.com).
+   * @param endpoint Supported Cognitive Services endpoint (e.g., https://< qnamaker-resource-name
+   * >.api.cognitiveservices.azure.com).
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/src/qnAMakerClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/src/qnAMakerClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-qnamaker";
-const packageVersion = "3.1.1";
+const packageVersion = "4.0.0";
 
 export class QnAMakerClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -19,8 +19,8 @@ export class QnAMakerClientContext extends msRest.ServiceClient {
 
   /**
    * Initializes a new instance of the QnAMakerClientContext class.
-   * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
-   * https://westus.api.cognitive.microsoft.com).
+   * @param endpoint Supported Cognitive Services endpoint (e.g., https://< qnamaker-resource-name
+   * >.api.cognitiveservices.azure.com).
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
@@ -43,7 +43,7 @@ export class QnAMakerClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/qnamaker/v4.0";
+    this.baseUri = "{Endpoint}/qnamaker/v5.0-preview.1";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
     this.credentials = credentials;

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/swagger/readme.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/swagger/readme.md
@@ -17,7 +17,7 @@ These settings apply only when `--typescript` is specified on the command line.
 
 ```yaml $(typescript)
 typescript:
-  package-version: 3.1.0
+  package-version: 4.0.0
   package-name: "@azure/cognitiveservices-qnamaker"
   output-folder: ..
   azure-arm: false

--- a/sdk/cognitiveservices/cognitiveservices-qnamaker/swagger/readme.md
+++ b/sdk/cognitiveservices/cognitiveservices-qnamaker/swagger/readme.md
@@ -8,7 +8,7 @@ Configuration for generating QnAMaker SDK.
 add-credentials: true
 openapi-type: data-plane
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMaker.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/QnAMaker/preview/v5.0-preview.1/QnAMaker.json
 ```
 
 ## TypeScript


### PR DESCRIPTION
This is to address the Issue: https://github.com/Azure/sdk-release-request/issues/923 

**Command Used**
```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --use=@microsoft.azure/autorest.typescript@4.2.2 --package-version=4.0.0 swagger\readme.md
AutoRest code generation utility [cli version: 3.0.6247; node: v12.18.4, max-memory: 2048 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
NOTE: AutoRest core version selected from configuration: ~2.0.4413.
   Loading AutoRest core      'C:\Users\sarajama\.autorest\@microsoft.azure_autorest-core@2.0.4417\node_modules\@microsoft.azure\autorest-core\dist' (2.0.4417)
   Loading AutoRest extension '@microsoft.azure/autorest.typescript' (4.2.2->4.2.2)
   Loading AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.51->2.3.51)
```

***As I see breaking changes, I have updated the major version of SDK***

@ramya-rao-a Please review and approve.
