### PR TITLE
[MetricsAdvisor] Flatten DataFeedOptions in data feed

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/CHANGELOG.md
@@ -46,6 +46,7 @@
   - `IngestionStatus.timestamp`
   - `latestSuccessTimestamp` and `latestActiveTimestamp` in the return type of `getDataFeedIngestionProgress()`.
 - [Breaking] property `createdTime` on `DataFeed` and `MetricFeedbackCommon` to `createdOn`.
+- [Breaking] Remove the wrapping data feed `options` property from `DataFeed` and `DataFeedPatch` and flatten its child properties.
 - Parameters of `Date` type now also accept strings. No validation is done for the strings. The SDK calls `new Date()` to convert them to `Date`.
 - Handle potential new data feed source types gracefully
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -197,18 +197,16 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     },
-    options: {
-      rollupSettings: {
-        rollupType: "AutoRollup",
-        rollupMethod: "Sum",
-        rollupIdentificationValue: "__CUSTOM_SUM__"
-      },
-      missingDataPointFillSettings: {
-        fillType: "SmartFilling"
-      },
-      accessMode: "Private",
-      adminEmails: ["xyz@example.com"]
-    }
+    rollupSettings: {
+      rollupType: "AutoRollup",
+      rollupMethod: "Sum",
+      rollupIdentificationValue: "__CUSTOM_SUM__"
+    },
+    missingDataPointFillSettings: {
+      fillType: "SmartFilling"
+    },
+    accessMode: "Private",
+    adminEmails: ["xyz@example.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -194,19 +194,18 @@ export type ChangeThresholdConditionUnion = {
 export type CreateDataFeedOptions = DataFeedOptions & OperationOptions;
 
 // @public
-export interface DataFeed {
-    createdOn: Date;
-    creator: string;
-    granularity: DataFeedGranularity;
+export type DataFeed = {
     id: string;
-    ingestionSettings: DataFeedIngestionSettings;
-    isAdmin: boolean;
     name: string;
-    options?: DataFeedOptions;
-    schema: DataFeedSchema;
-    source: DataFeedSource;
+    createdOn: Date;
     status: DataFeedStatus;
-}
+    isAdmin: boolean;
+    creator: string;
+    source: DataFeedSource;
+    schema: DataFeedSchema;
+    granularity: DataFeedGranularity;
+    ingestionSettings: DataFeedIngestionSettings;
+} & DataFeedOptions;
 
 // @public
 export type DataFeedAccessMode = "Private" | "Public";
@@ -274,17 +273,16 @@ export interface DataFeedOptions {
 }
 
 // @public
-export interface DataFeedPatch {
-    ingestionSettings?: DataFeedIngestionSettings;
+export type DataFeedPatch = {
     name?: string;
-    options?: DataFeedOptions & {
-        status?: DataFeedDetailStatus;
-    };
+    source: DataFeedSourcePatch;
     schema?: {
         timestampColumn?: string;
     };
-    source: DataFeedSourcePatch;
-}
+    ingestionSettings?: DataFeedIngestionSettings;
+} & DataFeedOptions & {
+    status?: DataFeedDetailStatus;
+};
 
 // @public
 export type DataFeedRollupMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/dataFeed.js
@@ -109,18 +109,16 @@ async function createDataFeed(client) {
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     },
-    options: {
-      rollupSettings: {
-        rollupType: "AutoRollup",
-        rollupMethod: "Sum",
-        rollupIdentificationValue: "__SUM__"
-      },
-      missingDataPointFillSettings: {
-        fillType: "CustomValue",
-        customFillValue: 567
-      },
-      accessMode: "Private"
-    }
+    rollupSettings: {
+      rollupType: "AutoRollup",
+      rollupMethod: "Sum",
+      rollupIdentificationValue: "__SUM__"
+    },
+    missingDataPointFillSettings: {
+      fillType: "CustomValue",
+      customFillValue: 567
+    },
+    accessMode: "Private"
   };
 
   const result = await client.createDataFeed(feed);
@@ -149,13 +147,11 @@ async function updateDataFeed(client, dataFeedId) {
       stopRetryAfterInSeconds: 667777,
       ingestionStartOffsetInSeconds: 4444
     },
-    options: {
-      description: "New datafeed description",
-      missingDataPointFillSettings: {
-        fillType: "SmartFilling"
-      },
-      status: "Paused"
-    }
+    description: "New datafeed description",
+    missingDataPointFillSettings: {
+      fillType: "SmartFilling"
+    },
+    status: "Paused"
   };
 
   try {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -116,18 +116,16 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     },
-    options: {
-      rollupSettings: {
-        rollupType: "AutoRollup",
-        rollupMethod: "Sum",
-        rollupIdentificationValue: "__SUM__"
-      },
-      missingDataPointFillSettings: {
-        fillType: "SmartFilling"
-      },
-      accessMode: "Private",
-      adminEmails: ["xyz@microsoft.com"]
-    }
+    rollupSettings: {
+      rollupType: "AutoRollup",
+      rollupMethod: "Sum",
+      rollupIdentificationValue: "__SUM__"
+    },
+    missingDataPointFillSettings: {
+      fillType: "SmartFilling"
+    },
+    accessMode: "Private",
+    adminEmails: ["xyz@microsoft.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
   return result;

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
@@ -115,18 +115,16 @@ async function createDataFeed(
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     },
-    options: {
-      rollupSettings: {
-        rollupType: "AutoRollup",
-        rollupMethod: "Sum",
-        rollupIdentificationValue: "__CUSTOM_SUM__"
-      },
-      missingDataPointFillSettings: {
-        fillType: "CustomValue",
-        customFillValue: 567
-      },
-      accessMode: "Private"
-    }
+    rollupSettings: {
+      rollupType: "AutoRollup",
+      rollupMethod: "Sum",
+      rollupIdentificationValue: "__CUSTOM_SUM__"
+    },
+    missingDataPointFillSettings: {
+      fillType: "CustomValue",
+      customFillValue: 567
+    },
+    accessMode: "Private"
   };
   const result = await client.createDataFeed(feed);
 
@@ -155,13 +153,11 @@ async function updateDataFeed(client: MetricsAdvisorAdministrationClient, dataFe
       stopRetryAfterInSeconds: 667777,
       ingestionStartOffsetInSeconds: 4444
     },
-    options: {
-      description: "New datafeed description",
-      missingDataPointFillSettings: {
-        fillType: "SmartFilling"
-      },
-      status: "Paused"
-    }
+    description: "New datafeed description",
+    missingDataPointFillSettings: {
+      fillType: "SmartFilling"
+    },
+    status: "Paused"
   };
 
   try {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -128,18 +128,16 @@ async function createDataFeed(
       ingestionRetryDelayInSeconds: -1,
       stopRetryAfterInSeconds: -1
     },
-    options: {
-      rollupSettings: {
-        rollupType: "AutoRollup",
-        rollupMethod: "Sum",
-        rollupIdentificationValue: "__SUM__"
-      },
-      missingDataPointFillSettings: {
-        fillType: "SmartFilling"
-      },
-      accessMode: "Private",
-      adminEmails: ["xyz@microsoft.com"]
-    }
+    rollupSettings: {
+      rollupType: "AutoRollup",
+      rollupMethod: "Sum",
+      rollupIdentificationValue: "__SUM__"
+    },
+    missingDataPointFillSettings: {
+      fillType: "SmartFilling"
+    },
+    accessMode: "Private",
+    adminEmails: ["xyz@microsoft.com"]
   };
   const result = await adminClient.createDataFeed(dataFeed);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -187,35 +187,46 @@ export class MetricsAdvisorAdministrationClient {
       "MetricsAdvisorAdministrationClient-createDataFeed",
       operationOptions
     );
-    const { name, granularity, source, schema, ingestionSettings, options } = feed;
+    const {
+      name,
+      granularity,
+      source,
+      schema,
+      ingestionSettings,
+      rollupSettings,
+      missingDataPointFillSettings,
+      accessMode,
+      adminEmails,
+      viewerEmails,
+      description
+    } = feed;
+
     if (source.dataSourceType === "Unknown") {
       throw new Error("Cannot create a data feed with the Unknown source type.");
     }
+
     const needRollup: NeedRollupEnum | undefined =
-      options?.rollupSettings?.rollupType === "AutoRollup"
+      rollupSettings?.rollupType === "AutoRollup"
         ? "NeedRollup"
-        : options?.rollupSettings?.rollupType === "AlreadyRollup"
+        : rollupSettings?.rollupType === "AlreadyRollup"
         ? "AlreadyRollup"
-        : options?.rollupSettings?.rollupType === "NoRollup"
+        : rollupSettings?.rollupType === "NoRollup"
         ? "NoRollup"
         : undefined;
     const rollUpColumns: string[] | undefined =
-      options?.rollupSettings?.rollupType === "AutoRollup"
-        ? options?.rollupSettings.autoRollupGroupByColumnNames
+      rollupSettings?.rollupType === "AutoRollup"
+        ? rollupSettings.autoRollupGroupByColumnNames
         : undefined;
     const allUpIdentification: string | undefined =
-      options?.rollupSettings?.rollupType === "AutoRollup" ||
-      options?.rollupSettings?.rollupType === "AlreadyRollup"
-        ? options?.rollupSettings.rollupIdentificationValue
+      rollupSettings?.rollupType === "AutoRollup" || rollupSettings?.rollupType === "AlreadyRollup"
+        ? rollupSettings.rollupIdentificationValue
         : undefined;
     const rollUpMethod: DataFeedRollupMethod | undefined =
-      options?.rollupSettings?.rollupType === "AutoRollup"
-        ? options?.rollupSettings.rollupMethod
-        : undefined;
-    const fillMissingPointType = options?.missingDataPointFillSettings?.fillType;
+      rollupSettings?.rollupType === "AutoRollup" ? rollupSettings.rollupMethod : undefined;
+    const fillMissingPointType = missingDataPointFillSettings?.fillType;
     const fillMissingPointValue =
-      options?.missingDataPointFillSettings?.fillType === "CustomValue"
-        ? options?.missingDataPointFillSettings.customFillValue
+      missingDataPointFillSettings?.fillType === "CustomValue"
+        ? missingDataPointFillSettings.customFillValue
         : undefined;
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
@@ -237,10 +248,10 @@ export class MetricsAdvisorAdministrationClient {
         rollUpMethod,
         fillMissingPointType,
         fillMissingPointValue,
-        viewMode: options?.accessMode,
-        admins: options?.adminEmails,
-        viewers: options?.viewerEmails,
-        dataFeedDescription: options?.description,
+        viewMode: accessMode,
+        admins: adminEmails,
+        viewers: viewerEmails,
+        dataFeedDescription: description,
         ...finalOptions
       };
       const result = await this.client.createDataFeed(body, requestOptions);
@@ -467,7 +478,7 @@ export class MetricsAdvisorAdministrationClient {
         dataSourceParameter: patch.source.dataSourceParameter,
         // name and description
         dataFeedName: patch.name,
-        dataFeedDescription: patch.options?.description,
+        dataFeedDescription: patch.description,
         // schema
         timestampColumn: patch.schema?.timestampColumn,
         // ingestion settings
@@ -477,19 +488,19 @@ export class MetricsAdvisorAdministrationClient {
         minRetryIntervalInSeconds: patch.ingestionSettings?.ingestionRetryDelayInSeconds,
         stopRetryAfterInSeconds: patch.ingestionSettings?.stopRetryAfterInSeconds,
         // rollup settings
-        ...toServiceRollupSettings(patch.options?.rollupSettings),
+        ...toServiceRollupSettings(patch.rollupSettings),
         // missing point filling settings
-        fillMissingPointType: patch.options?.missingDataPointFillSettings?.fillType,
+        fillMissingPointType: patch.missingDataPointFillSettings?.fillType,
         fillMissingPointValue:
-          patch.options?.missingDataPointFillSettings?.fillType === "CustomValue"
-            ? patch.options.missingDataPointFillSettings.customFillValue
+          patch.missingDataPointFillSettings?.fillType === "CustomValue"
+            ? patch.missingDataPointFillSettings.customFillValue
             : undefined,
         // other options
-        viewMode: patch.options?.accessMode,
-        admins: patch.options?.adminEmails,
-        viewers: patch.options?.viewerEmails,
-        status: patch.options?.status,
-        actionLinkTemplate: patch.options?.actionLinkTemplate
+        viewMode: patch.accessMode,
+        admins: patch.adminEmails,
+        viewers: patch.viewerEmails,
+        status: patch.status,
+        actionLinkTemplate: patch.actionLinkTemplate
       };
       await this.client.updateDataFeed(dataFeedId, patchBody, requestOptions);
       return this.getDataFeed(dataFeedId);

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -258,7 +258,7 @@ export type DataFeedStatus = "Paused" | "Active";
 /**
  * Represents a Metrics Advisor data feed.
  */
-export interface DataFeed {
+export type DataFeed = {
   /**
    * Unique id of the data feed.
    */
@@ -299,11 +299,7 @@ export interface DataFeed {
    * Ingestion settings for the data feed.
    */
   ingestionSettings: DataFeedIngestionSettings;
-  /**
-   * Optional configurations for the data feed.
-   */
-  options?: DataFeedOptions;
-}
+} & DataFeedOptions;
 
 /**
  * Represents an Azure Application Insights data source.
@@ -439,7 +435,7 @@ export type DataFeedSource =
 /**
  * Represents the input type to the Update Data Feed operation.
  */
-export interface DataFeedPatch {
+export type DataFeedPatch = {
   /**
    * Name of the data feed
    */
@@ -461,16 +457,12 @@ export interface DataFeedPatch {
    * Ingestion settings for the data feed.
    */
   ingestionSettings?: DataFeedIngestionSettings;
-  /**
-   * Optional configurations for the data feed.
-   */
-  options?: DataFeedOptions & {
+} & DataFeedOptions & {
     /**
      * Status of the data feed.
      */
     status?: DataFeedDetailStatus;
   };
-}
 
 /**
  * A alias type of supported data sources to pass to Update Data Feed operation.

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -354,23 +354,21 @@ export function fromServiceDataFeedDetailUnion(original: ServiceDataFeedDetailUn
       ingestionRetryDelayInSeconds: original.minRetryIntervalInSeconds,
       stopRetryAfterInSeconds: original.stopRetryAfterInSeconds
     },
-    options: {
-      description: original.dataFeedDescription,
-      actionLinkTemplate: original.actionLinkTemplate,
-      rollupSettings: toRollupSettings(original),
-      missingDataPointFillSettings:
-        original.fillMissingPointType === "CustomValue"
-          ? {
-              fillType: original.fillMissingPointType!,
-              customFillValue: original.fillMissingPointValue!
-            }
-          : {
-              fillType: original.fillMissingPointType!
-            },
-      accessMode: original.viewMode,
-      adminEmails: original.admins,
-      viewerEmails: original.viewers
-    }
+    description: original.dataFeedDescription,
+    actionLinkTemplate: original.actionLinkTemplate,
+    rollupSettings: toRollupSettings(original),
+    missingDataPointFillSettings:
+      original.fillMissingPointType === "CustomValue"
+        ? {
+            fillType: original.fillMissingPointType!,
+            customFillValue: original.fillMissingPointValue!
+          }
+        : {
+            fillType: original.fillMissingPointType!
+          },
+    accessMode: original.viewMode,
+    adminEmails: original.admins,
+    viewerEmails: original.viewers
   };
   switch (original.dataSourceType) {
     case "AzureApplicationInsights": {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/datafeed.spec.ts
@@ -159,7 +159,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -191,48 +191,44 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         dataFeedIngestion,
         "Ingesting settings mismatch!"
       );
-      assert.ok(actual.options, "Expecting valid datafeed options");
-      assert.equal(
-        actual.options!.description,
-        options.description,
-        "options.description mismatch"
-      );
-      assert.equal(actual.options!.accessMode, options.accessMode, "options.accessMode mismatch");
+
+      assert.equal(actual.description, options.description, "options.description mismatch");
+      assert.equal(actual.accessMode, options.accessMode, "options.accessMode mismatch");
       assert.ok(
-        actual.options!.missingDataPointFillSettings,
+        actual.missingDataPointFillSettings,
         "Expecting valid options.missingDataPointFillSettings"
       );
       assert.equal(
-        actual.options!.missingDataPointFillSettings!.fillType,
+        actual.missingDataPointFillSettings!.fillType,
         options.missingDataPointFillSettings!.fillType,
         "options.missingDataPointFillSettings.fillType mismatch"
       );
       assert.ok(
-        actual.options!.missingDataPointFillSettings!.fillType,
+        actual.missingDataPointFillSettings!.fillType,
         "Expecting valid options.missingDataPointFillSettings.fillType"
       );
-      if (actual.options!.missingDataPointFillSettings!.fillType! === "CustomValue") {
+      if (actual.missingDataPointFillSettings!.fillType! === "CustomValue") {
         // not sure why TS didn't narrow down the union type for us...so casting to any
         assert.equal(
-          (actual.options!.missingDataPointFillSettings! as any).customFillValue,
+          (actual.missingDataPointFillSettings! as any).customFillValue,
           (options.missingDataPointFillSettings! as any).customFillValue,
           "options.missingDataPointFillSettings.customFillValue mismatch"
         );
       }
-      assert.ok(actual.options!.rollupSettings, "Expecting valid options.rollupSettings");
+      assert.ok(actual.rollupSettings, "Expecting valid options.rollupSettings");
       assert.equal(
-        actual.options!.rollupSettings!.rollupType,
+        actual.rollupSettings!.rollupType,
         options.rollupSettings!.rollupType,
         "options.missingDataPointFillSettings.rollupType mismatch"
       );
       assert.ok(
-        actual.options!.rollupSettings!.rollupType,
+        actual.rollupSettings!.rollupType,
         "Expecting valid options.missingDataPointFillSettings.fillType"
       );
-      if (actual.options!.rollupSettings!.rollupType! === "AutoRollup") {
+      if (actual.rollupSettings!.rollupType! === "AutoRollup") {
         // not sure why TS didn't narrow down the union type for us...so casting to any
         assert.equal(
-          (actual.options!.rollupSettings! as any).rollupIdentificationValue,
+          (actual.rollupSettings! as any).rollupIdentificationValue,
           (options.rollupSettings! as any).rollupIdentificationValue,
           "options.missingDataPointFillSettings.fillType mismatch"
         );
@@ -306,19 +302,17 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           timestampColumn: "UpdatedTimestampeColumn"
         },
         ingestionSettings: expectedIngestionSettings,
-        options: {
-          description: "Updated Azure Blob description",
-          rollupSettings: {
-            rollupType: "AlreadyRollup",
-            rollupIdentificationValue: "__Existing__"
-          },
-          missingDataPointFillSettings: {
-            fillType: "PreviousValue"
-          },
-          accessMode: "Public",
-          viewerEmails: ["viewer1@example.com"],
-          actionLinkTemplate: "Updated Azure Blob action link template"
-        }
+        description: "Updated Azure Blob description",
+        rollupSettings: {
+          rollupType: "AlreadyRollup",
+          rollupIdentificationValue: "__Existing__"
+        },
+        missingDataPointFillSettings: {
+          fillType: "PreviousValue"
+        },
+        accessMode: "Public",
+        viewerEmails: ["viewer1@example.com"],
+        actionLinkTemplate: "Updated Azure Blob action link template"
       };
       const updated = await client.updateDataFeed(createdAzureBlobDataFeedId, patch);
 
@@ -326,18 +320,15 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
       assert.equal(updated.source.dataSourceType, "AzureBlob");
       assert.deepStrictEqual(updated.source.dataSourceParameter, expectedSourceParameter);
       assert.deepStrictEqual(updated.ingestionSettings, expectedIngestionSettings);
-      assert.ok(updated.options, "Expecting valid updated.options");
-      assert.equal(updated.options!.description, "Updated Azure Blob description");
-      assert.ok(updated.options!.rollupSettings, "Expecting valid updated.options.rollupSettings");
-      assert.equal(updated.options!.rollupSettings!.rollupType, "AlreadyRollup");
-      assert.equal(
-        (updated.options!.rollupSettings! as any).rollupIdentificationValue,
-        "__Existing__"
-      );
-      assert.equal(updated.options!.missingDataPointFillSettings?.fillType, "PreviousValue");
-      assert.equal(updated.options!.accessMode, "Public");
-      assert.deepStrictEqual(updated.options!.viewerEmails, ["viewer1@example.com"]);
-      assert.equal(updated.options?.actionLinkTemplate, "Updated Azure Blob action link template");
+
+      assert.equal(updated.description, "Updated Azure Blob description");
+      assert.ok(updated.rollupSettings, "Expecting valid updated.options.rollupSettings");
+      assert.equal(updated.rollupSettings!.rollupType, "AlreadyRollup");
+      assert.equal((updated.rollupSettings! as any).rollupIdentificationValue, "__Existing__");
+      assert.equal(updated.missingDataPointFillSettings?.fillType, "PreviousValue");
+      assert.equal(updated.accessMode, "Public");
+      assert.deepStrictEqual(updated.viewerEmails, ["viewer1@example.com"]);
+      assert.equal(updated.actionLinkTemplate, "Updated Azure Blob action link template");
     });
 
     it("creates an Azure Application Insights feed", async () => {
@@ -357,7 +348,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -394,7 +385,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -466,7 +457,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -504,7 +495,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -541,7 +532,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -577,7 +568,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -612,7 +603,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -649,7 +640,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -686,7 +677,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -722,7 +713,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
         granularity,
         schema: dataFeedSchema,
         ingestionSettings: dataFeedIngestion,
-        options
+        ...options
       });
 
       assert.ok(actual.id, "Expecting valid data feed id");
@@ -778,7 +769,7 @@ describe("MetricsAdvisorAdministrationClient datafeed", () => {
           granularity,
           schema: dataFeedSchema,
           ingestionSettings: dataFeedIngestion,
-          options
+          ...options
         });
         assert.fail("Test should throw error");
       } catch (error) {


### PR DESCRIPTION
and remove the wrapping `options`. We were putting into it all the
rest of optional settings that don't fit into any of groupings but
it's not necessary.