### PR TITLE
[event-hubs] fixes issue where processEvents ignores maxWaitTime after retryable disconnect event

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.3.1 (Unreleased)
 
+- Fixes issue [#12278](https://github.com/Azure/azure-sdk-for-js/issues/12278)
+  where the `processEvents` handler could ignore the `maxWaitTimeInSeconds`
+  parameter after a disconnection.
 
 ## 5.3.0 (2020-09-08)
 

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -177,6 +177,13 @@ export class EventHubReceiver extends LinkEntity {
   }
 
   /**
+   * Indicates if the receiver has been closed.
+   */
+  get isClosed(): boolean {
+    return this._isClosed;
+  }
+
+  /**
    * @property The last enqueued event information. This property will only
    * be enabled when `trackLastEnqueuedEventProperties` option is set to true
    * @readonly

--- a/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
@@ -49,7 +49,7 @@ describe("disconnected", function() {
       await client.close();
     });
 
-    it.only("should receive after a disconnect", async () => {
+    it("should receive after a disconnect", async () => {
       const client = new EventHubConsumerClient(
         EventHubConsumerClient.defaultConsumerGroupName,
         service.connectionString,

--- a/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
@@ -49,7 +49,7 @@ describe("disconnected", function() {
       await client.close();
     });
 
-    it("should receive after a disconnect", async () => {
+    it.only("should receive after a disconnect", async () => {
       const client = new EventHubConsumerClient(
         EventHubConsumerClient.defaultConsumerGroupName,
         service.connectionString,
@@ -103,6 +103,8 @@ describe("disconnected", function() {
                   true,
                   "Expected elapsed time between first and second processEvents invocations to be >= maxWaitTimeInSeconds."
                 );
+                const newConnectionId = clientConnectionContext.connectionId;
+                should.not.equal(originalConnectionId, newConnectionId);
                 // Send a new event that will be immediately receivable.
                 await producer.sendBatch([eventsToSend[1]], { partitionId });
               } else if (processEventsInvocationCount === 3) {


### PR DESCRIPTION
Fixes #12278 

## Description
This PR adds a check within the `PartitionPump`'s receive events loop to determine whether the receiver has been closed. If the receiver has been closed, it will create a new receiver using an event start position that matches the last event seen by the pump.

The receiver is explicitly closed when a disconnected event is received on the underlying AMQP connection, which causes calls to `receiveBatch` to immediately return any events it had collected up to this point. Note that once the receiver is closed, the receiver's onAmqpMessage handler is removed so it won't receive any additional events.

## Updates to testing
I manually tested the changes in this PR against the sample code in the linked issue.

I also updated the existing `disconnect` test to confirm that
- the `maxWaitTimeInSeconds` is honoured after a disconnected event is encountered.
- new events can be received on subsequent `processEvents` invocations.