### PR TITLE
[Service Bus] Pick older core-http for service-bus preview.8 🏁

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -41,6 +41,11 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
+    /**
+     * Temporary workaround to release service-bus v7 preview.8.
+     * Supposed to be reverted after the release.
+     */
+    "@azure/core-http": ["^1.1.6"],
     "@azure/ms-rest-js": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -45,7 +45,7 @@
      * Temporary workaround to release service-bus v7 preview.8.
      * Supposed to be reverted after the release.
      */
-    "@azure/core-http": ["^1.1.6"],
+    "@azure/core-http": ["^1.1.9"],
     "@azure/ms-rest-js": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -99,7 +99,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "2.0.0-beta.1",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.1.6",
+    "@azure/core-http": "^1.1.9",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-auth": "^1.1.3",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -99,7 +99,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "2.0.0-beta.1",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
+    "@azure/core-http": "^1.1.6",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-auth": "^1.1.3",


### PR DESCRIPTION
Pick older core-http(~~1.1.6~~ 1.1.9) for service-bus preview.8 since 1.2.0 is not released.

This will be reverted once the service-bus preview.8 is released.