### PR TITLE
[Service Bus] This test is doesn't test anything

### DIFF
--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -66,14 +66,6 @@ describe("Atom management - Namespace", function(): void {
       ["_response", "createdAt", "modifiedAt", "name"]
     );
   });
-
-  it("Create queue response", async () => {
-    const response = await serviceBusAtomManagementClient.createQueue("random");
-    // @ts-expect-error
-    response.authorizationRules = "";
-    // @ts-expect-error
-    response.maxDeliveryCount = undefined;
-  });
 });
 
 describe("Listing methods - PagedAsyncIterableIterator", function(): void {


### PR DESCRIPTION
This test was unintentionally checked-in as part of a huge PR, I meant to remove it but left it since it was harmless.
Just cleaning it up now to reduce the false positives in [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=606570&view=logs&j=073ebbf1-9390-59a1-0ff8-08c656576bcd&t=428931fe-c351-55db-0604-c27a1c97620f).