### PR TITLE
[event-hubs] prepare 5.3.1 release

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.3.1 (Unreleased)
+## 5.3.1 (2020-11-09)
 
 - Fixes issue [#12278](https://github.com/Azure/azure-sdk-for-js/issues/12278)
   where the `processEvents` handler could ignore the `maxWaitTimeInSeconds`

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -134,6 +134,7 @@
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",
     "esm": "^3.2.18",
+    "https-proxy-agent": "^5.0.0",
     "karma": "^5.1.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",

--- a/sdk/eventhub/event-hubs/samples/javascript/iothubConnectionString.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/iothubConnectionString.js
@@ -131,7 +131,7 @@ async function main() {
         }
       },
       processError: async (err, context) => {
-        console.log(`Error : ${err}`);
+        console.log(`Error on partition "${context.partitionId}" : ${err}`);
       }
     },
     { startPosition: earliestEventPosition }

--- a/sdk/eventhub/event-hubs/samples/javascript/receiveEvents.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/receiveEvents.js
@@ -48,7 +48,7 @@ async function main() {
         }
       },
       processError: async (err, context) => {
-        console.log(`Error : ${err}`);
+        console.log(`Error on partition "${context.partitionId}": ${err}`);
       }
     },
     { startPosition: earliestEventPosition }

--- a/sdk/eventhub/event-hubs/samples/typescript/src/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/iothubConnectionString.ts
@@ -131,7 +131,7 @@ async function convertIotHubToEventHubsConnectionString(connectionString: string
   });
 }
 
-async function main() {
+export async function main() {
   console.log(`Running iothubConnectionString sample`);
 
   const eventHubsConnectionString = await convertIotHubToEventHubsConnectionString(
@@ -151,7 +151,7 @@ async function main() {
         }
       },
       processError: async (err, context) => {
-        console.log(`Error : ${err}`);
+        console.log(`Error on partition "${context.partitionId}" : ${err}`);
       }
     },
     { startPosition: earliestEventPosition }

--- a/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts
@@ -49,7 +49,7 @@ export async function main() {
         }
       },
       processError: async (err, context) => {
-        console.log(`Error : ${err}`);
+        console.log(`Error on partition "${context.partitionId}": ${err}`);
       }
     },
     { startPosition: earliestEventPosition }


### PR DESCRIPTION
Noticed that the samples weren't compiling when running `npm run build:samples` so I fixed the issues.

Note that `https-proxy-agent` was made a devDependency in the root event-hubs package since the dev tool doesn't actually install sample dependencies.

/cc @HarshaNalluru 