### PR TITLE
[Service Bus] ATOM API: Correlation Filter - `int` and `double` as values under properties

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.0 (Unreleased)
 
-- "number"s set as values in the key-value pairs of properties under correlation rule filter would get serialized as "double"(used to be "int") while sending the requests, "double" and "int" values get deserialized as "number"("double" wasn't supported before) in the responses.
+- "number"s set as values in the key-value pairs of properties under correlation rule filter(and sqlParameters under SQLRuleFilter) would get serialized as "double"(used to be "int") while sending the requests, "double" and "int" values get deserialized as "number"("double" wasn't supported before) in the responses.
   [PR 12349](https://github.com/Azure/azure-sdk-for-js/pull/12349)
 
 ## 7.0.0-preview.8 (2020-11-04)

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.0.0 (Unreleased)
 
+- "number"s set as values in the key-value pairs of properties under correlation rule filter would get serialized as "double"(used to be "int") while sending the requests, "double" and "int" values get deserialized as "number"("double" wasn't supported before) in the responses.
+  [PR 12349](https://github.com/Azure/azure-sdk-for-js/pull/12349)
+
 ## 7.0.0-preview.8 (2020-11-04)
 
 ### New features:

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.0 (Unreleased)
 
-- "number"s set as values in the key-value pairs of properties under correlation rule filter(and sqlParameters under SQLRuleFilter) would get serialized as "double"(used to be "int") while sending the requests, "double" and "int" values get deserialized as "number"("double" wasn't supported before) in the responses.
+- Numbers passed in `applicationProperties` of the correlation rule filter and `sqlParameters` under SQLRuleFilter will now be serialized as "double"(used to be "int") while sending the requests. The  "double" and "int" values in the response will now be deserialized as "number"("double" wasn't supported before).
   [PR 12349](https://github.com/Azure/azure-sdk-for-js/pull/12349)
 
 ## 7.0.0-preview.8 (2020-11-04)

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -325,15 +325,17 @@ function getKeyValuePairsOrUndefined(
   }
   if (Array.isArray(rawProperties)) {
     for (const rawProperty of rawProperties) {
+      const key = rawProperty.Key;
+      const value = rawProperty.Value["_"];
       const encodedValueType = rawProperty.Value["$"]["i:type"].toString().substring(5);
       if (encodedValueType === TypeMapForResponseDeserialization.number) {
-        properties[rawProperty.Key] = Number(rawProperty.Value["_"]);
+        properties[key] = Number(value);
       } else if (encodedValueType === TypeMapForResponseDeserialization.string) {
-        properties[rawProperty.Key] = rawProperty.Value["_"];
+        properties[key] = value;
       } else if (encodedValueType === TypeMapForResponseDeserialization.boolean) {
-        properties[rawProperty.Key] = rawProperty.Value["_"] === "true" ? true : false;
+        properties[key] = value === "true" ? true : false;
       } else if (encodedValueType === TypeMapForResponseDeserialization.date) {
-        properties[rawProperty.Key] = new Date(rawProperty.Value["_"]);
+        properties[key] = new Date(value);
       } else {
         throw new TypeError(
           `Unable to parse the key-value pairs in the response - ${JSON.stringify(rawProperty)}`

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -252,24 +252,25 @@ export function isSqlRuleAction(action: any): action is SqlRuleAction {
  * @internal
  * @ignore
  */
-const TypeMapForRequestSerialization: Record<string, string> = {
-  int: "l28:int",
-  string: "l28:string",
-  long: "l28:long",
-  date: "l28:dateTime",
-  boolean: "l28:boolean"
-};
+enum TypeMapForRequestSerialization {
+  double = "l28:double",
+  string = "l28:string",
+  long = "l28:long",
+  date = "l28:dateTime",
+  boolean = "l28:boolean"
+}
 
 /**
  * @internal
  * @ignore
  */
-const TypeMapForResponseDeserialization: Record<string, string> = {
-  number: "int",
-  string: "string",
-  boolean: "boolean",
-  date: "dateTime"
-};
+enum TypeMapForResponseDeserialization {
+  int = "int",
+  double = "double",
+  string = "string",
+  boolean = "boolean",
+  date = "dateTime"
+}
 
 /**
  * @internal
@@ -328,7 +329,10 @@ function getKeyValuePairsOrUndefined(
       const key = rawProperty.Key;
       const value = rawProperty.Value["_"];
       const encodedValueType = rawProperty.Value["$"]["i:type"].toString().substring(5);
-      if (encodedValueType === TypeMapForResponseDeserialization.number) {
+      if (
+        encodedValueType === TypeMapForResponseDeserialization.int ||
+        encodedValueType === TypeMapForResponseDeserialization.double
+      ) {
         properties[key] = Number(value);
       } else if (encodedValueType === TypeMapForResponseDeserialization.string) {
         properties[key] = value;
@@ -382,7 +386,7 @@ export function buildInternalRawKeyValuePairs(
   for (let [key, value] of Object.entries(parameters)) {
     let type: string | number | boolean;
     if (typeof value === "number") {
-      type = TypeMapForRequestSerialization.int;
+      type = TypeMapForRequestSerialization.double;
     } else if (typeof value === "string") {
       type = TypeMapForRequestSerialization.string;
     } else if (typeof value === "boolean") {

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1768,7 +1768,9 @@ const createRuleTests: {
         applicationProperties: {
           randomState: "WA",
           randomCountry: "US",
-          randomCount: 25,
+          randomInt: 25,
+          randomIntDisguisedAsDouble: 3.0,
+          randomDouble: 12.4,
           randomBool: true,
           randomDate: randomDate
         }
@@ -1788,7 +1790,9 @@ const createRuleTests: {
         applicationProperties: {
           randomState: "WA",
           randomCountry: "US",
-          randomCount: 25,
+          randomInt: 25,
+          randomIntDisguisedAsDouble: 3.0,
+          randomDouble: 12.4,
           randomBool: true,
           randomDate: randomDate
         }


### PR DESCRIPTION
### Issue https://github.com/Azure/azure-sdk-for-js/issues/9850 (part 9)

### Description
This PR is regarding the serialization/deserialization of int-double-number types in the applicationProps under correlation rule filter and the optimal way to support them in the SDK.
<img src="https://user-images.githubusercontent.com/10452642/98731900-3eee6280-2353-11eb-8da1-81c0e8cb731d.png" height=150>

#### Before this PR
All numbers are treated as "int"

#### With this PR
For serialization, numbers are treated as "double".
During deserialization, "int" and "double" are treated as numbers.(To allow interop)

Reference https://github.com/Azure/azure-sdk-for-js/issues/9850#issuecomment-713183518