### PR TITLE
Build transitive dependent packages

### DIFF
--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -10,13 +10,13 @@ steps:
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js build --verbose -p max
+      node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max --TransitiveDep
     displayName: "Build libraries"
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js build:test --verbose -p max
+      node eng/tools/rush-runner.js build:test "${{parameters.ServiceDirectory}}" --verbose -p max --TransitiveDep
     displayName: "Build test assets"
 
   - template: ../steps/use-node-test-version.yml

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -68,9 +68,7 @@ const getPackageGraph = (baseDir) => {
     const pkgName = contents["name"];
     if (!contents.hasOwnProperty("dependencies")) continue;
 
-    const dependencies = Object.keys(contents["dependencies"]).filter((f) =>
-      f.startsWith("@azure")
-    );
+    const dependencies = Object.keys(contents["dependencies"]);
     // Process each package dependency and build dependency graph that links all packages that are dependent on current package
     for (let dependentPkg of dependencies) {
       if (!packageGraph.has(dependentPkg)) {

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -66,9 +66,15 @@ const getPackageGraph = (baseDir) => {
   for (const filePath of packageJsons) {
     const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
     const pkgName = contents["name"];
-    if (!contents.hasOwnProperty("dependencies")) continue;
+    const dependencies = [];
+    if (contents.hasOwnProperty("dependencies")) {
+      for (const pkg in contents["dependencies"]) dependencies.push(pkg);
+    }
 
-    const dependencies = Object.keys(contents["dependencies"]);
+    if (contents.hasOwnProperty("devDependencies")) {
+      for (const pkg in contents["devDependencies"]) dependencies.push(pkg);
+    }
+
     // Process each package dependency and build dependency graph that links all packages that are dependent on current package
     for (let dependentPkg of dependencies) {
       if (!packageGraph.has(dependentPkg)) {


### PR DESCRIPTION
Currently we build all projects in repo to include transitive dependency which is required to test packages. Currently rush doesn't build transitive dependency even when we pass --from <package-name> flag. This change will build all packages that are required for testing.