### PR TITLE
Handle packages in Microsoft scopeto support renaming of opentelemetry

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -393,8 +393,8 @@ function GetExistingTags($apiUrl) {
   }
 }
 
-# Retrieve package info for artiface package.
-function RetrieveReleasePackageInfo($pkgRepository, $artifactLocation, $continueOnError = $true) {
+# Retrieve release tag for artiface package. If multiple packages, then output the first one.
+function RetrieveReleaseTag($pkgRepository, $artifactLocation, $continueOnError = $true) {
   if (!$artifactLocation) {
     return ""
   }
@@ -402,39 +402,17 @@ function RetrieveReleasePackageInfo($pkgRepository, $artifactLocation, $continue
     $pkgs, $parsePkgInfoFn = RetrievePackages -pkgRepository $pkgRepository -artifactLocation $artifactLocation
     if (!$pkgs -or !$pkgs[0]) {
       Write-Host "No packages retrieved from artifact location."
-      return $null
+      return ""
     }
     if ($pkgs.Count -gt 1) {
       Write-Host "There are more than 1 packages retieved from artifact location."
       foreach ($pkg in $pkgs) {
         Write-Host "The package name is $($pkg.BaseName)"
       }
-      return $null
+      return ""
     }
     $parsedPackage = &$parsePkgInfoFn -pkg $pkgs[0] -workingDirectory $artifactLocation
-    return $parsedPackage
-  }
-  catch {
-    if ($continueOnError) {
-      return $null
-    }
-    Write-Error "No release tag retrieved from $artifactLocation"
-  }
-}
-
-# Retrieve release tag for artiface package. If multiple packages, then output the first one.
-function RetrieveReleaseTag($pkgRepository, $artifactLocation, $continueOnError = $true) {
-  if (!$artifactLocation) {
-    return ""
-  }
-  try {
-    $parsedPackage = RetrieveReleasePackageInfo -pkgRepository $pkgRepository -artifactLocation $artifactLocation
-    $tag = ""
-    if ($parsedPackage -ne $null)
-    {
-      $tag = $parsedPackage.ReleaseTag
-    }
-    return $tag
+    return $parsedPackage.ReleaseTag
   }
   catch {
     if ($continueOnError) {

--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -421,7 +421,6 @@ function RetrieveReleaseTag($pkgRepository, $artifactLocation, $continueOnError 
     Write-Error "No release tag retrieved from $artifactLocation"
   }
 }
-
 function RetrievePackages($pkgRepository, $artifactLocation) {
   $parsePkgInfoFn = ""
   $packagePattern = ""

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -11,8 +11,8 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory, $pkgNa
   if (Test-Path $projectPath)
   {
     $projectJson = Get-Content $projectPath | ConvertFrom-Json
-    $jsStylePkgName = $pkgName.replace("azure-", "@azure/")
-    if ($projectJson.name -eq "$jsStylePkgName")
+    $jsStylePkgName = $projectJson.name.Replace("@", "").Replace("/", "-")
+    if ($pkgName -eq "$jsStylePkgName")
     {
       return [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceDirectory)
     }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -94,7 +94,7 @@ function Publish-javascript-GithubIODocs ($DocLocation, $PublicArtifactLocation)
     if ($dirList.Length -eq 1)
     {
       $DocVersion = $dirList[0].Name
-      $pkgs, $parsePkgInfoFn = RetrievePackages "NPM" $PublicArtifactLocation
+      $pkgs = Get-ChildItem -Path $PublicArtifactLocation -Include "*.tgz" -Recurse -File
       # set default package name
       $PkgName = "azure-$($Item.BaseName)"
       if ($pkgs -and $pkgs.Count -gt 0)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -94,14 +94,13 @@ function Publish-javascript-GithubIODocs ($DocLocation, $PublicArtifactLocation)
     if ($dirList.Length -eq 1)
     {
       $DocVersion = $dirList[0].Name
-      $parsedPackage = RetrieveReleasePackageInfo "NPM" $PublicArtifactLocation
-      $tag = ""
+      $pkgs, $parsePkgInfoFn = RetrievePackages "NPM" $PublicArtifactLocation
       # set default package name
       $PkgName = "azure-$($Item.BaseName)"
-      if ($parsedPackage -ne $null)
+      if ($pkgs -and $pkgs.Count -gt 0)
       {        
+        $parsedPackage = Get-javascript-PackageInfoFromPackageFile $pkgs[0] $PublicArtifactLocation
         $PkgName = $parsedPackage.PackageId.Replace("@", "").Replace("/", "-")
-        $tag = $parsedPackage.ReleaseTag
       }
       Write-Host "Uploading Doc for $($PkgName) Version:- $($DocVersion)..."
       $releaseTag = RetrieveReleaseTag "NPM" $PublicArtifactLocation

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -97,10 +97,13 @@ function Publish-javascript-GithubIODocs ($DocLocation, $PublicArtifactLocation)
       $pkgs = Get-ChildItem -Path $PublicArtifactLocation -Include "*.tgz" -Recurse -File
       # set default package name
       $PkgName = "azure-$($Item.BaseName)"
-      if ($pkgs -and $pkgs.Count -gt 0)
+      if ($pkgs -and $pkgs.Count -eq 1)
       {        
         $parsedPackage = Get-javascript-PackageInfoFromPackageFile $pkgs[0] $PublicArtifactLocation
         $PkgName = $parsedPackage.PackageId.Replace("@", "").Replace("/", "-")
+      }
+      else{
+        Write-Host "Package info is not available from artifact. Assuming package is in default scope @azure."
       }
       Write-Host "Uploading Doc for $($PkgName) Version:- $($DocVersion)..."
       $releaseTag = RetrieveReleaseTag "NPM" $PublicArtifactLocation

--- a/eng/tools/analyze-deps/index.js
+++ b/eng/tools/analyze-deps/index.js
@@ -186,7 +186,7 @@ const dumpRushPackages = (rushPackages, internalPackages, external) => {
 };
 
 const resolveRushPackageDeps = (packages, internalPackages, pnpmLock, pkgId, external) => {
-  const yamlKey = `@rush-temp/${packages[pkgId].name.replace("@azure/", "")}`;
+  const yamlKey = `@rush-temp/${packages[pkgId].name.replace(/@[a-z]*\//i, "")}`;
   const packageKey = pnpmLock.dependencies[yamlKey];
   const resolvedDeps = pnpmLock.packages[packageKey].dependencies;
 

--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -332,13 +332,7 @@ async function main(argv) {
   const testFolder = argv["test-folder"];
   const dryRun = argv["dry-run"];
 
-  let packageName = "";
-  if (artifactName.startsWith("microsoft-")) {
-    packageName = artifactName.replace("microsoft-", "@microsoft/");
-  }
-  else {
-    packageName = artifactName.replace("azure-", "@azure/");
-  }
+  const packageName = artifactName.replace(/"?([a-z]*)"?-/i, "@$1/");
   const targetPackage = await getPackageFromRush(repoRoot, packageName);
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);
 

--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -332,7 +332,13 @@ async function main(argv) {
   const testFolder = argv["test-folder"];
   const dryRun = argv["dry-run"];
 
-  const packageName = artifactName.replace("azure-", "@azure/");
+  let packageName = "";
+  if (artifactName.startsWith("microsoft-")) {
+    packageName = artifactName.replace("microsoft-", "@microsoft/");
+  }
+  else {
+    packageName = artifactName.replace("azure-", "@azure/");
+  }
   const targetPackage = await getPackageFromRush(repoRoot, packageName);
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);
 

--- a/eng/tools/generate-static-index/templates/matthews/styles/main.js
+++ b/eng/tools/generate-static-index/templates/matthews/styles/main.js
@@ -106,7 +106,7 @@ function getPackageUrl(language, package, version) {
 $(function () {
   $('h4').each(function () {
     var pkgName = $(this).text()
-      .replace("@azure/", "azure-");
+      .replace("@", "").replace("/", "-");
     populateIndexList($(this), pkgName)
   });
 })

--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -37,10 +37,9 @@ async function main(argv) {
   const repoRoot = argv["repo-root"];
   const dryRun = argv["dry-run"];
 
-  const packageName = artifactName.replace("azure-", "@azure/");
   const rushSpec = await packageUtils.getRushSpec(repoRoot);
   const targetPackage = rushSpec.projects.find(
-    packageSpec => packageSpec.packageName == packageName
+    packageSpec => packageSpec.packageName.replace("@", "").replace("/", "-") == artifactName
   );
 
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);

--- a/eng/tools/versioning/set-version.js
+++ b/eng/tools/versioning/set-version.js
@@ -33,11 +33,10 @@ async function main(argv) {
   const repoRoot = argv["repo-root"];
   const dryRun = argv["dry-run"];
 
-  const packageName = artifactName.replace("azure-", "@azure/");
   const rushSpec = await packageUtils.getRushSpec(repoRoot);
 
   const targetPackage = rushSpec.projects.find(
-    packageSpec => packageSpec.packageName == packageName
+    packageSpec => packageSpec.packageName.replace("@", "").replace("/", "-") == packageName
   );
 
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Release History
+## 1.0.10-beta.1 (2020-11-16)
+- Test Release Pipeline
+
 ## 1.0.9-beta.13 (2020-10-13)
 - Test Release Pipeline
 

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.9-beta.13",
+  "version": "1.0.10-beta.1",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Support packages in both azure and microsoft scope and allow packages with "azure-" inside pacakge name. for e.g. openetelemetry-azure-monitor"