### PR TITLE
[service-bus] loosens parameter type in isServiceBusError type guard

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AmqpAnnotatedMessage } from '@azure/core-amqp';
-import { AmqpError } from 'rhea-promise';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import { HttpResponse } from '@azure/core-http';
@@ -136,7 +135,7 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {
 }
 
 // @public
-export function isServiceBusError(err: Error | AmqpError | ServiceBusError): err is ServiceBusError;
+export function isServiceBusError(err: unknown): err is ServiceBusError;
 
 // @public
 export interface MessageHandlers {

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -135,7 +135,7 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {
 }
 
 // @public
-export function isServiceBusError(err: unknown): err is ServiceBusError;
+export function isServiceBusError(err: any): err is ServiceBusError;
 
 // @public
 export interface MessageHandlers {

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -172,8 +172,6 @@ export function translateServiceBusError(err: AmqpError | Error): ServiceBusErro
  *
  * @param err An error to check to see if it's of type ServiceBusError
  */
-export function isServiceBusError(
-  err: Error | AmqpError | ServiceBusError
-): err is ServiceBusError {
-  return (err as Error | ServiceBusError).name === "ServiceBusError";
+export function isServiceBusError(err: unknown): err is ServiceBusError {
+  return (err as Error | ServiceBusError)?.name === "ServiceBusError";
 }

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -172,6 +172,6 @@ export function translateServiceBusError(err: AmqpError | Error): ServiceBusErro
  *
  * @param err An error to check to see if it's of type ServiceBusError
  */
-export function isServiceBusError(err: unknown): err is ServiceBusError {
-  return (err as Error | ServiceBusError)?.name === "ServiceBusError";
+export function isServiceBusError(err: any): err is ServiceBusError {
+  return err?.name === "ServiceBusError";
 }


### PR DESCRIPTION
Fixes #12264 

The goal with this change is to prevent exposing the `AmqpError` type to end-users. To accomplish this, the `err` parameter passed to `isServiceBusError` has been changed to be `unknown`. This doesn't change how the type guard can be used (while it is now more permissive, the end result should be the same.)

I did not add an entry to the changelog for this change since it doesn't change how `isServiceBusError` works, it just allows anything to be passed to it now without a compilation error. If this is a notable change I can add it to the changelog.

