### PR TITLE
[service-bus] Small README.md update for sessions

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -277,7 +277,7 @@ which is handled by Service Bus. Conceptually, this is similar to how message
 locking works when using `peekLock` mode - when a message (or session) is
 locked your receiver has exclusive access to it.
 
-In order to open and lock a session, use an instance of `ServiceBusClient` to create a [SessionReceiver][sessionreceiver] using [createSessionReceiver][sbclient_createsessionreceiver].
+In order to open and lock a session, use an instance of `ServiceBusClient` to create a [SessionReceiver][sessionreceiver].
 
 There are two ways of choosing which session to open:
 


### PR DESCRIPTION
It looks like the README.md still had a reference to the
`createSessionReciver` function which was removed in a previous preview.
I removed the reference to this method as the next two paragraphs
describe the two ways to actually create the session.