### PR TITLE
[core-http] Add createSpan helper

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -12,6 +12,7 @@ import { Pipeline } from '@azure/core-https';
 import { PipelinePolicy } from '@azure/core-https';
 import { PipelineRequest } from '@azure/core-https';
 import { PipelineResponse } from '@azure/core-https';
+import { Span } from '@opentelemetry/api';
 import { TokenCredential } from '@azure/core-auth';
 import { TransferProgressEvent } from '@azure/core-https';
 
@@ -61,6 +62,14 @@ export interface CompositeMapperType {
 export function createSerializer(modelMappers?: {
     [key: string]: any;
 }, isXML?: boolean): Serializer;
+
+// Warning: (ae-forgotten-export) The symbol "SpanConfig" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function createSpan<T extends OperationOptions>({ operationName, packagePrefix, namespace }: SpanConfig, operationOptions: T): {
+    span: Span;
+    updatedOptions: T;
+};
 
 // @public
 export interface DeserializationContentTypes {

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -64,7 +64,7 @@ export function createSerializer(modelMappers?: {
 }, isXML?: boolean): Serializer;
 
 // @public
-export function createSpan<T extends OperationOptions>({ operationName, packagePrefix, namespace }: SpanConfig, operationOptions: T): {
+export function createSpanFunction({ packagePrefix, namespace }: SpanConfig): <T extends OperationOptions>(operationName: string, operationOptions: T) => {
     span: Span;
     updatedOptions: T;
 };
@@ -340,7 +340,6 @@ export interface SimpleMapperType {
 // @public
 export interface SpanConfig {
     namespace: string;
-    operationName: string;
     packagePrefix: string;
 }
 

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -63,8 +63,6 @@ export function createSerializer(modelMappers?: {
     [key: string]: any;
 }, isXML?: boolean): Serializer;
 
-// Warning: (ae-forgotten-export) The symbol "SpanConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function createSpan<T extends OperationOptions>({ operationName, packagePrefix, namespace }: SpanConfig, operationOptions: T): {
     span: Span;
@@ -337,6 +335,13 @@ export interface ServiceClientOptions {
 export interface SimpleMapperType {
     // (undocumented)
     name: "Base64Url" | "Boolean" | "ByteArray" | "Date" | "DateTime" | "DateTimeRfc1123" | "Object" | "Stream" | "String" | "TimeSpan" | "UnixTime" | "Uuid" | "Number" | "any";
+}
+
+// @public
+export interface SpanConfig {
+    namespace: string;
+    operationName: string;
+    packagePrefix: string;
 }
 
 

--- a/sdk/core/core-client/src/createSpan.ts
+++ b/sdk/core/core-client/src/createSpan.ts
@@ -8,7 +8,7 @@ import { OperationOptions, SpanConfig } from "./interfaces";
 type OperationTracingOptions = OperationOptions["tracingOptions"];
 
 /**
- * Creates a span using the global tracer.
+ * Creates a function called createSpan to create spans using the global tracer.
  * @ignore
  * @param spanConfig The name of the operation being performed.
  * @param tracingOptions The options for the underlying http request.

--- a/sdk/core/core-client/src/createSpan.ts
+++ b/sdk/core/core-client/src/createSpan.ts
@@ -3,27 +3,9 @@
 
 import { Span, SpanOptions, SpanKind } from "@opentelemetry/api";
 import { getTracer } from "@azure/core-tracing";
-import { OperationOptions } from "./coreHttp";
+import { OperationOptions, SpanConfig } from "./interfaces";
 
 type OperationTracingOptions = OperationOptions["tracingOptions"];
-
-/**
- * Configuration for creating a new Tracing Span
- */
-export interface SpanConfig {
-  /**
-   * Name of the operation to trace
-   */
-  operationName: string;
-  /**
-   * Package name prefix
-   */
-  packagePrefix: string;
-  /**
-   * Service namespace
-   */
-  namespace: string;
-}
 
 /**
  * Creates a span using the global tracer.

--- a/sdk/core/core-client/src/createSpan.ts
+++ b/sdk/core/core-client/src/createSpan.ts
@@ -13,45 +13,47 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
  * @param spanConfig The name of the operation being performed.
  * @param tracingOptions The options for the underlying http request.
  */
-export function createSpan<T extends OperationOptions>(
-  { operationName, packagePrefix, namespace }: SpanConfig,
-  operationOptions: T
-): { span: Span; updatedOptions: T } {
-  const tracer = getTracer();
-  const tracingOptions = operationOptions.tracingOptions || {};
-  const spanOptions: SpanOptions = {
-    ...tracingOptions.spanOptions,
-    kind: SpanKind.INTERNAL
-  };
-
-  const span = tracer.startSpan(`${packagePrefix}.${operationName}`, spanOptions);
-
-  span.setAttribute("az.namespace", namespace);
-
-  let newSpanOptions = tracingOptions.spanOptions || {};
-  if (span.isRecording()) {
-    newSpanOptions = {
+export function createSpanFunction({ packagePrefix, namespace }: SpanConfig) {
+  return function<T extends OperationOptions>(
+    operationName: string,
+    operationOptions: T
+  ): { span: Span; updatedOptions: T } {
+    const tracer = getTracer();
+    const tracingOptions = operationOptions.tracingOptions || {};
+    const spanOptions: SpanOptions = {
       ...tracingOptions.spanOptions,
-      parent: span.context(),
-      attributes: {
-        ...spanOptions.attributes,
-        "az.namespace": namespace
-      }
+      kind: SpanKind.INTERNAL
     };
-  }
 
-  const newTracingOptions: OperationTracingOptions = {
-    ...tracingOptions,
-    spanOptions: newSpanOptions
-  };
+    const span = tracer.startSpan(`${packagePrefix}.${operationName}`, spanOptions);
 
-  const newOperationOptions: T = {
-    ...operationOptions,
-    tracingOptions: newTracingOptions
-  };
+    span.setAttribute("az.namespace", namespace);
 
-  return {
-    span,
-    updatedOptions: newOperationOptions
+    let newSpanOptions = tracingOptions.spanOptions || {};
+    if (span.isRecording()) {
+      newSpanOptions = {
+        ...tracingOptions.spanOptions,
+        parent: span.context(),
+        attributes: {
+          ...spanOptions.attributes,
+          "az.namespace": namespace
+        }
+      };
+    }
+
+    const newTracingOptions: OperationTracingOptions = {
+      ...tracingOptions,
+      spanOptions: newSpanOptions
+    };
+
+    const newOperationOptions: T = {
+      ...operationOptions,
+      tracingOptions: newTracingOptions
+    };
+
+    return {
+      span,
+      updatedOptions: newOperationOptions
+    };
   };
 }

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export { createSerializer, MapperTypeNames } from "./serializer";
+export { createSpan } from "./createSpan";
 export { ServiceClient, ServiceClientOptions } from "./serviceClient";
 export {
   OperationSpec,

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -33,7 +33,8 @@ export {
   ParameterPath,
   OperationResponse,
   FullOperationResponse,
-  PolymorphicDiscriminator
+  PolymorphicDiscriminator,
+  SpanConfig
 } from "./interfaces";
 export {
   deserializationPolicy,

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export { createSerializer, MapperTypeNames } from "./serializer";
-export { createSpan } from "./createSpan";
+export { createSpanFunction } from "./createSpan";
 export { ServiceClient, ServiceClientOptions } from "./serviceClient";
 export {
   OperationSpec,

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -467,3 +467,21 @@ export interface UrlParameterValue {
   value: string;
   skipUrlEncoding: boolean;
 }
+
+/**
+ * Configuration for creating a new Tracing Span
+ */
+export interface SpanConfig {
+  /**
+   * Name of the operation to trace
+   */
+  operationName: string;
+  /**
+   * Package name prefix
+   */
+  packagePrefix: string;
+  /**
+   * Service namespace
+   */
+  namespace: string;
+}

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -473,10 +473,6 @@ export interface UrlParameterValue {
  */
 export interface SpanConfig {
   /**
-   * Name of the operation to trace
-   */
-  operationName: string;
-  /**
    * Package name prefix
    */
   packagePrefix: string;

--- a/sdk/core/core-client/test/createSpan.spec.ts
+++ b/sdk/core/core-client/test/createSpan.spec.ts
@@ -3,9 +3,12 @@
 
 import { assert } from "chai";
 import { SpanKind, TraceFlags } from "@opentelemetry/api";
-import { createSpan, OperationOptions } from "../src";
 import { setTracer, TestSpan, TestTracer } from "@azure/core-tracing";
 import sinon from "sinon";
+import { createSpanFunction } from "../src/createSpan";
+import { OperationOptions } from "../src/interfaces";
+
+const createSpan = createSpanFunction({ namespace: "Microsoft.Test", packagePrefix: "Azure.Test" });
 
 describe("createSpan", () => {
   it("returns a created span with the right metadata", () => {
@@ -20,10 +23,7 @@ describe("createSpan", () => {
     const startSpanStub = sinon.stub(tracer, "startSpan");
     startSpanStub.returns(testSpan);
     setTracer(tracer);
-    const { span } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      {}
-    );
+    const { span } = createSpan("testMethod", {});
     assert.strictEqual(span, testSpan, "Should return mocked span");
     assert.isTrue(startSpanStub.calledOnce);
     const [name, options] = startSpanStub.firstCall.args;
@@ -34,10 +34,7 @@ describe("createSpan", () => {
 
   it("returns updated SpanOptions", () => {
     const options: OperationOptions = {};
-    const { span, updatedOptions } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      options
-    );
+    const { span, updatedOptions } = createSpan("testMethod", options);
     assert.isEmpty(options, "original options should not be modified");
     assert.notStrictEqual(updatedOptions, options, "should return new object");
     const expected: OperationOptions = {
@@ -63,10 +60,7 @@ describe("createSpan", () => {
         }
       }
     };
-    const { span, updatedOptions } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      options
-    );
+    const { span, updatedOptions } = createSpan("testMethod", options);
     assert.notStrictEqual(updatedOptions, options, "should return new object");
     const expected: OperationOptions = {
       tracingOptions: {

--- a/sdk/core/core-client/test/createSpan.spec.ts
+++ b/sdk/core/core-client/test/createSpan.spec.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { SpanKind, TraceFlags } from "@opentelemetry/api";
+import { createSpan, OperationOptions } from "../src";
+import { setTracer, TestSpan, TestTracer } from "@azure/core-tracing";
+import sinon from "sinon";
+
+describe("createSpan", () => {
+  it("returns a created span with the right metadata", () => {
+    const tracer = new TestTracer();
+    const testSpan = new TestSpan(
+      tracer,
+      "testing",
+      { traceId: "", spanId: "", traceFlags: TraceFlags.NONE },
+      SpanKind.INTERNAL
+    );
+    const setAttributeSpy = sinon.spy(testSpan, "setAttribute");
+    const startSpanStub = sinon.stub(tracer, "startSpan");
+    startSpanStub.returns(testSpan);
+    setTracer(tracer);
+    const { span } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      {}
+    );
+    assert.strictEqual(span, testSpan, "Should return mocked span");
+    assert.isTrue(startSpanStub.calledOnce);
+    const [name, options] = startSpanStub.firstCall.args;
+    assert.strictEqual(name, "Azure.Test.testMethod");
+    assert.deepEqual(options, { kind: SpanKind.INTERNAL });
+    assert.isTrue(setAttributeSpy.calledOnceWithExactly("az.namespace", "Microsoft.Test"));
+  });
+
+  it("returns updated SpanOptions", () => {
+    const options: OperationOptions = {};
+    const { span, updatedOptions } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      options
+    );
+    assert.isEmpty(options, "original options should not be modified");
+    assert.notStrictEqual(updatedOptions, options, "should return new object");
+    const expected: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          parent: span.context(),
+          attributes: {
+            "az.namespace": "Microsoft.Test"
+          }
+        }
+      }
+    };
+    assert.deepEqual(updatedOptions, expected);
+  });
+
+  it("preserves existing attributes", () => {
+    const options: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          attributes: {
+            foo: "bar"
+          }
+        }
+      }
+    };
+    const { span, updatedOptions } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      options
+    );
+    assert.notStrictEqual(updatedOptions, options, "should return new object");
+    const expected: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          parent: span.context(),
+          attributes: {
+            "az.namespace": "Microsoft.Test",
+            foo: "bar"
+          }
+        }
+      }
+    };
+    assert.deepEqual(updatedOptions, expected);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+});

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -158,7 +158,7 @@ export const Constants: {
 export function createPipelineFromOptions(pipelineOptions: InternalPipelineOptions, authPolicyFactory?: RequestPolicyFactory): ServiceClientOptions;
 
 // @public
-export function createSpan<T extends OperationOptions>({ operationName, packagePrefix, namespace }: SpanConfig, operationOptions: T): {
+export function createSpanFunction({ packagePrefix, namespace }: SpanConfig): <T extends OperationOptions>(operationName: string, operationOptions: T) => {
     span: Span;
     updatedOptions: T;
 };
@@ -800,7 +800,6 @@ export interface SimpleMapperType {
 // @public
 export interface SpanConfig {
     namespace: string;
-    operationName: string;
     packagePrefix: string;
 }
 

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -10,6 +10,7 @@ import { Debugger } from '@azure/logger';
 import { GetTokenOptions } from '@azure/core-auth';
 import { isTokenCredential } from '@azure/core-auth';
 import { OperationTracingOptions } from '@azure/core-tracing';
+import { Span } from '@opentelemetry/api';
 import { SpanOptions } from '@azure/core-tracing';
 import { TokenCredential } from '@azure/core-auth';
 
@@ -155,6 +156,12 @@ export const Constants: {
 
 // @public (undocumented)
 export function createPipelineFromOptions(pipelineOptions: InternalPipelineOptions, authPolicyFactory?: RequestPolicyFactory): ServiceClientOptions;
+
+// @public
+export function createSpan<T extends OperationOptions>({ operationName, packagePrefix, namespace }: SpanConfig, operationOptions: T): {
+    span: Span;
+    updatedOptions: T;
+};
 
 // Warning: (ae-forgotten-export) The symbol "FetchHttpClient" needs to be exported by the entry point coreHttp.d.ts
 //
@@ -788,6 +795,13 @@ export function signingPolicy(authenticationProvider: ServiceClientCredentials):
 export interface SimpleMapperType {
     // (undocumented)
     name: "Base64Url" | "Boolean" | "ByteArray" | "Date" | "DateTime" | "DateTimeRfc1123" | "Object" | "Stream" | "String" | "TimeSpan" | "UnixTime" | "Uuid" | "Number" | "any";
+}
+
+// @public
+export interface SpanConfig {
+    namespace: string;
+    operationName: string;
+    packagePrefix: string;
 }
 
 // @public

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -43,7 +43,7 @@ export {
   ProxySettings,
   ProxyOptions
 } from "./serviceClient";
-export { createSpan, SpanConfig } from "./createSpan";
+export { createSpanFunction, SpanConfig } from "./createSpan";
 export { PipelineOptions, InternalPipelineOptions } from "./pipelineOptions";
 export { QueryCollectionFormat } from "./queryCollectionFormat";
 export { Constants } from "./util/constants";

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -43,6 +43,7 @@ export {
   ProxySettings,
   ProxyOptions
 } from "./serviceClient";
+export { createSpan, SpanConfig } from "./createSpan";
 export { PipelineOptions, InternalPipelineOptions } from "./pipelineOptions";
 export { QueryCollectionFormat } from "./queryCollectionFormat";
 export { Constants } from "./util/constants";

--- a/sdk/core/core-http/src/createSpan.ts
+++ b/sdk/core/core-http/src/createSpan.ts
@@ -22,7 +22,7 @@ export interface SpanConfig {
 }
 
 /**
- * Creates a span using the global tracer.
+ * Creates a function called createSpan to create spans using the global tracer.
  * @ignore
  * @param spanConfig The name of the operation being performed.
  * @param tracingOptions The options for the underlying http request.

--- a/sdk/core/core-http/src/createSpan.ts
+++ b/sdk/core/core-http/src/createSpan.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Span, SpanOptions, SpanKind } from "@opentelemetry/api";
+import { getTracer } from "@azure/core-tracing";
+import { OperationOptions } from "./coreHttp";
+
+type OperationTracingOptions = OperationOptions["tracingOptions"];
+type SpanConfig = { operationName: string; packagePrefix: string; namespace: string };
+
+/**
+ * Creates a span using the global tracer.
+ * @ignore
+ * @param spanConfig The name of the operation being performed.
+ * @param tracingOptions The options for the underlying http request.
+ */
+export function createSpan<T extends OperationOptions>(
+  { operationName, packagePrefix, namespace }: SpanConfig,
+  operationOptions: T
+): { span: Span; updatedOptions: T } {
+  const tracer = getTracer();
+  const tracingOptions = operationOptions.tracingOptions || {};
+  const spanOptions: SpanOptions = {
+    ...tracingOptions.spanOptions,
+    kind: SpanKind.INTERNAL
+  };
+
+  const span = tracer.startSpan(`${packagePrefix}.${operationName}`, spanOptions);
+
+  span.setAttribute("az.namespace", namespace);
+
+  let newSpanOptions = tracingOptions.spanOptions || {};
+  if (span.isRecording()) {
+    newSpanOptions = {
+      ...tracingOptions.spanOptions,
+      parent: span.context(),
+      attributes: {
+        ...spanOptions.attributes,
+        "az.namespace": namespace
+      }
+    };
+  }
+
+  const newTracingOptions: OperationTracingOptions = {
+    ...tracingOptions,
+    spanOptions: newSpanOptions
+  };
+
+  const newOperationOptions: T = {
+    ...operationOptions,
+    tracingOptions: newTracingOptions
+  };
+
+  return {
+    span,
+    updatedOptions: newOperationOptions
+  };
+}

--- a/sdk/core/core-http/test/createSpan.spec.ts
+++ b/sdk/core/core-http/test/createSpan.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { SpanKind, TraceFlags } from "@opentelemetry/api";
+import { setTracer, TestSpan, TestTracer } from "@azure/core-tracing";
+import sinon from "sinon";
+import { createSpan } from "../src/createSpan";
+import { OperationOptions } from "../src/coreHttp";
+
+describe("createSpan", () => {
+  it("returns a created span with the right metadata", () => {
+    const tracer = new TestTracer();
+    const testSpan = new TestSpan(
+      tracer,
+      "testing",
+      { traceId: "", spanId: "", traceFlags: TraceFlags.NONE },
+      SpanKind.INTERNAL
+    );
+    const setAttributeSpy = sinon.spy(testSpan, "setAttribute");
+    const startSpanStub = sinon.stub(tracer, "startSpan");
+    startSpanStub.returns(testSpan);
+    setTracer(tracer);
+    const { span } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      {}
+    );
+    assert.strictEqual(span, testSpan, "Should return mocked span");
+    assert.isTrue(startSpanStub.calledOnce);
+    const [name, options] = startSpanStub.firstCall.args;
+    assert.strictEqual(name, "Azure.Test.testMethod");
+    assert.deepEqual(options, { kind: SpanKind.INTERNAL });
+    assert.isTrue(setAttributeSpy.calledOnceWithExactly("az.namespace", "Microsoft.Test"));
+  });
+
+  it("returns updated SpanOptions", () => {
+    const options: OperationOptions = {};
+    const { span, updatedOptions } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      options
+    );
+    assert.isEmpty(options, "original options should not be modified");
+    assert.notStrictEqual(updatedOptions, options, "should return new object");
+    const expected: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          parent: span.context(),
+          attributes: {
+            "az.namespace": "Microsoft.Test"
+          }
+        }
+      }
+    };
+    assert.deepEqual(updatedOptions, expected);
+  });
+
+  it("preserves existing attributes", () => {
+    const options: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          attributes: {
+            foo: "bar"
+          }
+        }
+      }
+    };
+    const { span, updatedOptions } = createSpan(
+      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
+      options
+    );
+    assert.notStrictEqual(updatedOptions, options, "should return new object");
+    const expected: OperationOptions = {
+      tracingOptions: {
+        spanOptions: {
+          parent: span.context(),
+          attributes: {
+            "az.namespace": "Microsoft.Test",
+            foo: "bar"
+          }
+        }
+      }
+    };
+    assert.deepEqual(updatedOptions, expected);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+});

--- a/sdk/core/core-http/test/createSpan.spec.ts
+++ b/sdk/core/core-http/test/createSpan.spec.ts
@@ -5,8 +5,11 @@ import { assert } from "chai";
 import { SpanKind, TraceFlags } from "@opentelemetry/api";
 import { setTracer, TestSpan, TestTracer } from "@azure/core-tracing";
 import sinon from "sinon";
-import { createSpan } from "../src/createSpan";
+
 import { OperationOptions } from "../src/coreHttp";
+
+import { createSpanFunction } from "../src/createSpan";
+const createSpan = createSpanFunction({ namespace: "Microsoft.Test", packagePrefix: "Azure.Test" });
 
 describe("createSpan", () => {
   it("returns a created span with the right metadata", () => {
@@ -21,10 +24,7 @@ describe("createSpan", () => {
     const startSpanStub = sinon.stub(tracer, "startSpan");
     startSpanStub.returns(testSpan);
     setTracer(tracer);
-    const { span } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      {}
-    );
+    const { span } = createSpan("testMethod", {});
     assert.strictEqual(span, testSpan, "Should return mocked span");
     assert.isTrue(startSpanStub.calledOnce);
     const [name, options] = startSpanStub.firstCall.args;
@@ -35,10 +35,7 @@ describe("createSpan", () => {
 
   it("returns updated SpanOptions", () => {
     const options: OperationOptions = {};
-    const { span, updatedOptions } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      options
-    );
+    const { span, updatedOptions } = createSpan("testMethod", options);
     assert.isEmpty(options, "original options should not be modified");
     assert.notStrictEqual(updatedOptions, options, "should return new object");
     const expected: OperationOptions = {
@@ -64,10 +61,7 @@ describe("createSpan", () => {
         }
       }
     };
-    const { span, updatedOptions } = createSpan(
-      { operationName: "testMethod", namespace: "Microsoft.Test", packagePrefix: "Azure.Test" },
-      options
-    );
+    const { span, updatedOptions } = createSpan("testMethod", options);
     assert.notStrictEqual(updatedOptions, options, "should return new object");
     const expected: OperationOptions = {
       tracingOptions: {


### PR DESCRIPTION
Add helper to create a span using the global tracer. Many of our Track2 SDKs implement their own createSpan, this helper should remove the need to re-implement it for every SDK