### PR TITLE
[communication] Fix SDK_VERSION value

### DIFF
--- a/sdk/communication/communication-administration/src/communicationIdentity/constants.ts
+++ b/sdk/communication/communication-administration/src/communicationIdentity/constants.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { apiVersion } from "./generated/src/models/parameters";
-
-export const SDK_VERSION: string = apiVersion.mapper.defaultValue;
+export const SDK_VERSION: string = "1.0.0-beta.3";

--- a/sdk/communication/communication-administration/src/phoneNumber/constants.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/constants.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { apiVersion } from "./generated/src/models/parameters";
-
-export const SDK_VERSION: string = apiVersion.mapper.defaultValue;
+export const SDK_VERSION: string = "1.0.0-beta.3";

--- a/sdk/communication/communication-administration/test/phoneNumberAdministrationClient.mocked.spec.ts
+++ b/sdk/communication/communication-administration/test/phoneNumberAdministrationClient.mocked.spec.ts
@@ -10,14 +10,16 @@ import {
   PhoneNumberAdministrationClient,
   PhoneNumberCapabilitiesUpdates
 } from "../src";
-import { SDK_VERSION } from "../src/phoneNumber/constants";
 import { NumberConfigurationPhoneNumber } from "../src/phoneNumber/generated/src/models";
+import { apiVersion } from "../src/phoneNumber/generated/src/models/parameters";
 import {
   baseHttpClient,
   getAreaCodesHttpClient,
   phoneNumbersCapabilitiesHttpClient
 } from "./utils/mockHttpClients";
 import { TestPhoneNumberAdministrationClient } from "./utils/testPhoneNumberAdministrationClient";
+
+const API_VERSION = apiVersion.mapper.defaultValue;
 
 describe("PhoneNumberAdministrationClient [Mocked]", () => {
   const dateHeader = isNode ? "date" : "x-ms-date";
@@ -118,7 +120,7 @@ describe("PhoneNumberAdministrationClient [Mocked]", () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `https://contoso.spool.azure.local/administration/phonenumbers/capabilities/${capabilitiesUpdateId}?api-version=${SDK_VERSION}`
+      `https://contoso.spool.azure.local/administration/phonenumbers/capabilities/${capabilitiesUpdateId}?api-version=${API_VERSION}`
     );
   });
 
@@ -145,7 +147,7 @@ describe("PhoneNumberAdministrationClient [Mocked]", () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `https://contoso.spool.azure.local/administration/phonenumbers/countries/${searchRequest.countryCode}/areacodes?locationType=${searchRequest.locationType}&phonePlanId=${searchRequest.phonePlanId}&api-version=${SDK_VERSION}`
+      `https://contoso.spool.azure.local/administration/phonenumbers/countries/${searchRequest.countryCode}/areacodes?locationType=${searchRequest.locationType}&phonePlanId=${searchRequest.phonePlanId}&api-version=${API_VERSION}`
     );
   });
 });

--- a/sdk/communication/communication-chat/src/constants.ts
+++ b/sdk/communication/communication-chat/src/constants.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { apiVersion } from "./generated/src/models/parameters";
-
-export const SDK_VERSION: string = apiVersion.mapper.defaultValue;
+export const SDK_VERSION: string = "1.0.0-beta.3";

--- a/sdk/communication/communication-chat/test/chatClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/chatClient.mocked.spec.ts
@@ -5,7 +5,7 @@ import sinon from "sinon";
 import { assert } from "chai";
 import { ChatClient, CreateChatThreadRequest } from "../src";
 import * as RestModel from "../src/generated/src/models";
-import { SDK_VERSION } from "../src/constants";
+import { apiVersion } from "../src/generated/src/models/parameters";
 import { baseUri, generateToken } from "./utils/connectionUtils";
 import { AzureCommunicationUserCredential } from "@azure/communication-common";
 import {
@@ -14,6 +14,8 @@ import {
   createChatClient,
   mockThreadInfo
 } from "./utils/mockClient";
+
+const API_VERSION = apiVersion.mapper.defaultValue;
 
 describe("[Mocked] ChatClient", async () => {
   let chatClient: ChatClient;
@@ -54,7 +56,7 @@ describe("[Mocked] ChatClient", async () => {
 
     const request = spy.getCall(0).args[0];
 
-    assert.equal(request.url, `${baseUri}/chat/threads?api-version=${SDK_VERSION}`);
+    assert.equal(request.url, `${baseUri}/chat/threads?api-version=${API_VERSION}`);
     assert.equal(request.method, "POST");
     assert.deepEqual(JSON.parse(request.body), sendRequest);
   });
@@ -86,7 +88,7 @@ describe("[Mocked] ChatClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${mockThread.id}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${mockThread.id}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "GET");
   });
@@ -111,7 +113,7 @@ describe("[Mocked] ChatClient", async () => {
     assert.equal(count, mockResponse.value?.length);
     const request = spy.getCall(0).args[0];
 
-    assert.equal(request.url, `${baseUri}/chat/threads?api-version=${SDK_VERSION}`);
+    assert.equal(request.url, `${baseUri}/chat/threads?api-version=${API_VERSION}`);
     assert.equal(request.method, "GET");
   });
 
@@ -126,7 +128,7 @@ describe("[Mocked] ChatClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${mockThread.id}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${mockThread.id}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "DELETE");
   });

--- a/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
@@ -13,7 +13,7 @@ import {
   AddMembersRequest
 } from "../src";
 import * as RestModel from "../src/generated/src/models";
-import { SDK_VERSION } from "../src/constants";
+import { apiVersion } from "../src/generated/src/models/parameters";
 import { baseUri, generateToken } from "./utils/connectionUtils";
 import {
   generateHttpClient,
@@ -23,6 +23,8 @@ import {
   mockSdkModelMember,
   mockReadReceipt
 } from "./utils/mockClient";
+
+const API_VERSION = apiVersion.mapper.defaultValue;
 
 describe("[Mocked] ChatThreadClient", async () => {
   const threadId: string = "threadId";
@@ -50,7 +52,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     sinon.assert.calledOnce(spy);
     const request = spy.getCall(0).args[0];
-    assert.equal(request.url, `${baseUri}/chat/threads/${threadId}?api-version=${SDK_VERSION}`);
+    assert.equal(request.url, `${baseUri}/chat/threads/${threadId}?api-version=${API_VERSION}`);
     assert.equal(request.method, "PATCH");
     assert.deepEqual(JSON.parse(request.body), { topic: sendOptions.topic });
   });
@@ -79,7 +81,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/messages?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/messages?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "POST");
     assert.deepEqual(JSON.parse(request.body), {
@@ -108,7 +110,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "GET");
   });
@@ -140,7 +142,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/messages?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/messages?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "GET");
   });
@@ -160,7 +162,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "PATCH");
     assert.deepEqual(JSON.parse(request.body), { content: mockMessage.content });
@@ -177,7 +179,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/messages/${mockMessage.id}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "DELETE");
   });
@@ -198,7 +200,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/members?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/members?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "POST");
     const requestJson = JSON.parse(request.body);
@@ -234,7 +236,7 @@ describe("[Mocked] ChatThreadClient", async () => {
 
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/members?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/members?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "GET");
   });
@@ -250,7 +252,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/members/${mockSdkModelMember.user.communicationUserId}?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/members/${mockSdkModelMember.user.communicationUserId}?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "DELETE");
   });
@@ -267,7 +269,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/typing?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/typing?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "POST");
   });
@@ -283,7 +285,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/readreceipts?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/readreceipts?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "POST");
   });
@@ -309,7 +311,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const request = spy.getCall(0).args[0];
     assert.equal(
       request.url,
-      `${baseUri}/chat/threads/${threadId}/readreceipts?api-version=${SDK_VERSION}`
+      `${baseUri}/chat/threads/${threadId}/readreceipts?api-version=${API_VERSION}`
     );
     assert.equal(request.method, "GET");
   });

--- a/sdk/communication/communication-sms/src/constants.ts
+++ b/sdk/communication/communication-sms/src/constants.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { apiVersion } from "./generated/src/models/parameters";
-
-export const SDK_VERSION: string = apiVersion.mapper.defaultValue;
+export const SDK_VERSION: string = "1.0.0-beta.3";

--- a/sdk/communication/communication-sms/test/smsClient.mocked.spec.ts
+++ b/sdk/communication/communication-sms/test/smsClient.mocked.spec.ts
@@ -12,7 +12,9 @@ import { AzureKeyCredential } from "@azure/core-auth";
 import { assert } from "chai";
 import sinon from "sinon";
 import { SmsClient, SendRequest } from "../src/smsClient";
-import { SDK_VERSION } from "../src/constants";
+import { apiVersion } from "../src/generated/src/models/parameters";
+
+const API_VERSION = apiVersion.mapper.defaultValue;
 
 describe("[mocked] SmsClient", async () => {
   const baseUri = "https://contoso.api.fake:443";
@@ -57,7 +59,7 @@ describe("[mocked] SmsClient", async () => {
 
     const request = spy.getCall(0).args[0];
 
-    assert.equal(request.url, `${baseUri}/sms?api-version=${SDK_VERSION}`);
+    assert.equal(request.url, `${baseUri}/sms?api-version=${API_VERSION}`);
     assert.equal(request.method, "POST");
     assert.deepEqual(JSON.parse(request.body), { ...sendRequest, sendSmsOptions: {} });
   });
@@ -79,7 +81,7 @@ describe("[mocked] SmsClient", async () => {
 
     const request = spy.getCall(0).args[0];
 
-    assert.equal(request.url, `${baseUri}/sms?api-version=${SDK_VERSION}`);
+    assert.equal(request.url, `${baseUri}/sms?api-version=${API_VERSION}`);
     assert.equal(request.method, "POST");
     assert.deepEqual(JSON.parse(request.body), { ...sendRequest, sendSmsOptions: {} });
   });


### PR DESCRIPTION
We mistakingly used the service api version for constructing the SDK user agent string.
Following the pattern of other services and hard-coding the version string.