### PR TITLE
[Service Bus] Remove ReceiveMode from public API surface

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -217,9 +217,6 @@ export interface ReceiveMessagesOptions extends OperationOptionsBase {
     maxWaitTimeInMs?: number;
 }
 
-// @public
-export type ReceiveMode = "peekLock" | "receiveAndDelete";
-
 export { RetryOptions }
 
 // @public
@@ -439,7 +436,7 @@ export interface ServiceBusReceiver {
 // @public
 export interface ServiceBusReceiverOptions {
     maxAutoLockRenewalDurationInMs?: number;
-    receiveMode?: ReceiveMode;
+    receiveMode?: "peekLock" | "receiveAndDelete";
     subQueueType?: "deadLetter" | "transferDeadLetter";
 }
 
@@ -470,7 +467,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
 // @public
 export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
     maxAutoLockRenewalDurationInMs?: number;
-    receiveMode?: ReceiveMode;
+    receiveMode?: "peekLock" | "receiveAndDelete";
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -19,7 +19,6 @@ export {
   ProcessErrorArgs,
   PeekMessagesOptions,
   ReceiveMessagesOptions,
-  ReceiveMode,
   SubscribeOptions
 } from "./models";
 export { OperationOptionsBase, TryAddOptions } from "./modelsToBeSharedWithEventHubs";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -67,6 +67,8 @@ export interface InternalMessageHandlers extends MessageHandlers {
 
 /**
  * Represents the possible receive modes for the receiver.
+ * @internal
+ * @ignore
  */
 export type ReceiveMode = "peekLock" | "receiveAndDelete";
 
@@ -93,7 +95,7 @@ export interface ServiceBusReceiverOptions {
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    */
-  receiveMode?: ReceiveMode;
+  receiveMode?: "peekLock" | "receiveAndDelete";
   /**
    * Represents the sub queue that is applicable for any queue or subscription.
    * Valid values are "deadLetter" and "transferDeadLetter". To learn more about dead letter queues,
@@ -191,7 +193,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    */
-  receiveMode?: ReceiveMode;
+  receiveMode?: "peekLock" | "receiveAndDelete";
   /**
    * @property The maximum duration in milliseconds
    * until which, the lock on the session will be renewed automatically by the sdk.

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -132,7 +132,7 @@ export interface ServiceBusReceiver {
    */
   entityPath: string;
   /**
-   * ReceiveMode provided to the client.
+   * The receive mode used to create the receiver.
    */
   receiveMode: "peekLock" | "receiveAndDelete";
   /**

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -370,9 +370,9 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
   readonly deadLetterErrorDescription?: string;
   /**
    * @property The lock token is a reference to the lock that is being held by the broker in
-   * `ReceiveMode.PeekLock` mode. Locks are used internally settle messages as explained in the
+   * `peekLock` receive mode. Locks are used internally settle messages as explained in the
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
-   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * - Not applicable when the message is received in `receiveAndDelete` receive mode.
    * mode.
    * @readonly
    */
@@ -399,7 +399,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
    * @property The UTC instant until which the message is held locked in the queue/subscription.
    * When the lock expires, the `deliveryCount` is incremented and the message is again available
    * for retrieval.
-   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * - Not applicable when the message is received in `receiveAndDelete` receive mode.
    * mode.
    */
   lockedUntilUtc?: Date;
@@ -682,9 +682,9 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
   scheduledEnqueueTimeUtc?: Date;
   /**
    * @property The lock token is a reference to the lock that is being held by the broker in
-   * `ReceiveMode.PeekLock` mode. Locks are used internally settle messages as explained in the
+   * `peekLock` receive mode. Locks are used internally settle messages as explained in the
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
-   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * - Not applicable when the message is received in `receiveAndDelete` receive mode.
    * mode.
    * @readonly
    */
@@ -711,7 +711,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    * @property The UTC instant until which the message is held locked in the queue/subscription.
    * When the lock expires, the `deliveryCount` is incremented and the message is again available
    * for retrieval.
-   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * - Not applicable when the message is received in `receiveAndDelete` receive mode.
    * mode.
    */
   lockedUntilUtc?: Date;

--- a/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
@@ -24,7 +24,8 @@ import { isLinkLocked } from "../utils/misc";
 import { ServiceBusSessionReceiverImpl } from "../../src/receivers/sessionReceiver";
 import { ServiceBusReceiverImpl } from "../../src/receivers/receiver";
 import { MessageSession } from "../../src/session/messageSession";
-import { ProcessErrorArgs, ReceiveMode } from "../../src";
+import { ProcessErrorArgs } from "../../src";
+import { ReceiveMode } from "../../src/models";
 
 describe("AbortSignal", () => {
   const defaultOptions = {

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -31,7 +31,7 @@ import { OnAmqpEventAsPromise } from "../../src/core/messageReceiver";
 import { ConnectionContext } from "../../src/connectionContext";
 import { ServiceBusReceiverImpl } from "../../src/receivers/receiver";
 import { OperationOptionsBase } from "../../src/modelsToBeSharedWithEventHubs";
-import { ReceiveMode } from "../../src";
+import { ReceiveMode } from "../../src/models";
 
 describe("BatchingReceiver unit tests", () => {
   let closeables: { close(): Promise<void> }[];

--- a/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
@@ -20,7 +20,8 @@ import {
 } from "rhea-promise";
 import { OnAmqpEventAsPromise } from "../../src/core/messageReceiver";
 import { ServiceBusMessageImpl } from "../../src/serviceBusMessage";
-import { ProcessErrorArgs, ReceiveMode } from "../../src";
+import { ProcessErrorArgs } from "../../src";
+import { ReceiveMode } from "../../src/models";
 import { Constants } from "@azure/core-amqp";
 
 chai.use(chaiAsPromised);

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
@@ -4,7 +4,8 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createConnectionContextForTests } from "./unittestUtils";
-import { ProcessErrorArgs, ReceiveMode } from "../../src";
+import { ProcessErrorArgs } from "../../src";
+import { ReceiveMode } from "../../src/models";
 import { StreamingReceiver, StreamingReceiverError } from "../../src/core/streamingReceiver";
 import sinon from "sinon";
 import { EventContext } from "rhea-promise";


### PR DESCRIPTION
When working on #12223, we had a discussion on whether we need the type for ReceiveMode at all since it is also essentially a union of string literals. Having a dedicated type to it does not add any value. Previously, this was useful when ReceiveMode was an enum.

cc @bterlson 