### PR TITLE
[service-bus] Remove public usages of MessagingError and improve ServiceBusError GeneralError messages

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -303,6 +303,7 @@ export interface ServiceBusConnectionStringProperties {
 
 // @public
 export class ServiceBusError extends MessagingError {
+    constructor(message: string, code: ServiceBusErrorCode);
     constructor(messagingError: MessagingError);
     code: ServiceBusErrorCode;
     }

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { receiverLogger as logger } from "../log";
-import { MessagingError } from "@azure/core-amqp";
 import {
   AmqpError,
   EventContext,
@@ -21,7 +20,7 @@ import { checkAndRegisterWithAbortSignal } from "../util/utils";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
 import { createAndEndProcessingSpan } from "../diagnostics/instrumentServiceBusMessage";
 import { ReceiveMode } from "../models";
-import { translateServiceBusError } from "../serviceBusError";
+import { ServiceBusError, translateServiceBusError } from "../serviceBusError";
 
 /**
  * Describes the batching receiver where the user can receive a specified number of messages for
@@ -347,7 +346,10 @@ export class BatchingReceiverLite {
             `${loggingPrefix} '${eventType}' event occurred. Received an error`
           );
         } else {
-          error = new MessagingError("An error occurred while receiving messages.");
+          error = new ServiceBusError(
+            "An error occurred while receiving messages.",
+            "GeneralError"
+          );
         }
         reject(error);
       };

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  Constants,
-  TokenType,
-  defaultLock,
-  RequestResponseLink,
-  MessagingError
-} from "@azure/core-amqp";
+import { Constants, TokenType, defaultLock, RequestResponseLink } from "@azure/core-amqp";
 import { AccessToken } from "@azure/core-auth";
 import { ConnectionContext } from "../connectionContext";
 import {
@@ -22,6 +16,7 @@ import { getUniqueName, StandardAbortMessage } from "../util/utils";
 import { AbortError, AbortSignalLike } from "@azure/abort-controller";
 import { ServiceBusLogger } from "../log";
 import { SharedKeyCredential } from "../servicebusSharedKeyCredential";
+import { ServiceBusError } from "../serviceBusError";
 
 /**
  * @internal
@@ -471,7 +466,10 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
     this._logger.verbose(
       `${this._logPrefix} Connection is reopening, aborting link initialization.`
     );
-    const err = new MessagingError("Connection is reopening, aborting link initialization.");
+    const err = new ServiceBusError(
+      "Connection is reopening, aborting link initialization.",
+      "GeneralError"
+    );
     err.retryable = true;
     throw err;
   }

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -91,7 +91,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {Promise<any>} The state of that session
    * @throws Error if the underlying connection or receiver is closed.
-   * @throws MessagingError if the service returns an error while retrieving session state.
+   * @throws `ServiceBusError` if the service returns an error while retrieving session state.
    */
   getSessionState(options?: OperationOptionsBase): Promise<any>;
 
@@ -101,7 +101,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @param state The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
-   * @throws MessagingError if the service returns an error while setting the session state.
+   * @throws `ServiceBusError` if the service returns an error while setting the session state.
    *
    * @param {*} state
    * @returns {Promise<void>}
@@ -208,7 +208,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<Date> - New lock token expiry date and time in UTC format.
    * @throws Error if the underlying connection or receiver is closed.
-   * @throws MessagingError if the service returns an error while renewing session lock.
+   * @throws `ServiceBusError` if the service returns an error while renewing session lock.
    */
   async renewSessionLock(options?: OperationOptionsBase): Promise<Date> {
     this._throwIfReceiverOrConnectionClosed();
@@ -239,7 +239,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * @param state The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
-   * @throws MessagingError if the service returns an error while setting the session state.
+   * @throws `ServiceBusError` if the service returns an error while setting the session state.
    */
   async setSessionState(state: any, options: OperationOptionsBase = {}): Promise<void> {
     this._throwIfReceiverOrConnectionClosed();
@@ -271,7 +271,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<any> The state of that session
    * @throws Error if the underlying connection or receiver is closed.
-   * @throws MessagingError if the service returns an error while retrieving session state.
+   * @throws `ServiceBusError` if the service returns an error while retrieving session state.
    */
   async getSessionState(options: OperationOptionsBase = {}): Promise<any> {
     this._throwIfReceiverOrConnectionClosed();
@@ -466,7 +466,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * @returns void
    * @throws Error if the underlying connection or receiver is closed.
    * @throws Error if the receiver is already in state of receiving messages.
-   * @throws MessagingError if the service returns an error while receiving messages. These are bubbled up to be handled by user provided `onError` handler.
+   * @throws `ServiceBusError` if the service returns an error while receiving messages. These are bubbled up to be handled by user provided `onError` handler.
    */
   private _registerMessageHandler(
     onMessage: OnMessage,

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -134,6 +134,11 @@ export class ServiceBusError extends MessagingError {
       }
 
       this.code = ServiceBusError.normalizeMessagingCode(messageOrError.code);
+      // For GeneralErrors, prefix the error message with the MessagingError code to provide
+      // more context to the user.
+      if (this.code === "GeneralError" && messageOrError.code) {
+        this.message = `${messageOrError.code}: ${this.message}`;
+      }
     }
 
     this.name = "ServiceBusError";

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -79,8 +79,6 @@ export const wellKnownMessageCodesToServiceBusCodes: Map<string, ServiceBusError
   ["QuotaExceededError", "QuotaExceeded"],
   ["ServerBusyError", "ServiceBusy"],
 
-  // not sure about these two.
-  ["MessageWaitTimeout", "ServiceTimeout"],
   ["OperationTimeoutError", "ServiceTimeout"],
   ["ServiceCommunicationError", "ServiceCommunicationProblem"],
   ["SessionCannotBeLockedError", "SessionCannotBeLocked"],

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -114,17 +114,29 @@ export class ServiceBusError extends MessagingError {
   code: ServiceBusErrorCode;
 
   /**
+   * @param message The error message that provides more information about the error.
+   * @param code The reason for the failure.
+   */
+  constructor(message: string, code: ServiceBusErrorCode);
+  /**
    * @param messagingError An error whose properties will be copied to the ServiceBusError.
    */
-  constructor(messagingError: MessagingError) {
-    super(messagingError.message);
+  constructor(messagingError: MessagingError);
+  constructor(messageOrError: string | MessagingError, code?: ServiceBusErrorCode) {
+    const message = typeof messageOrError === "string" ? messageOrError : messageOrError.message;
+    super(message);
 
-    for (const prop in messagingError) {
-      (this as any)[prop] = (messagingError as any)[prop];
+    if (typeof messageOrError === "string") {
+      this.code = code ?? "GeneralError";
+    } else {
+      for (const prop in messageOrError) {
+        (this as any)[prop] = (messageOrError as any)[prop];
+      }
+
+      this.code = ServiceBusError.normalizeMessagingCode(messageOrError.code);
     }
 
     this.name = "ServiceBusError";
-    this.code = ServiceBusError.normalizeMessagingCode(messagingError.code);
   }
 
   private static normalizeMessagingCode(oldCode?: string): ServiceBusErrorCode {

--- a/sdk/servicebus/service-bus/test/internal/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/linkentity.unittest.spec.ts
@@ -160,7 +160,7 @@ describe("LinkEntity unit tests", () => {
 
       function assertInitAbortError(err: any) {
         assert.equal(err.message, "Connection is reopening, aborting link initialization.");
-        assert.equal(err.name, "MessagingError");
+        assert.equal(err.name, "ServiceBusError");
         assert.isTrue(
           err.retryable,
           "Exception thrown when the connection is closing should be retryable"

--- a/sdk/servicebus/service-bus/test/internal/shared.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/shared.spec.ts
@@ -60,6 +60,7 @@ describe("shared", () => {
       let messagingError = new MessagingError("hello");
       messagingError.code = unknownCode;
       let translatedError = translateServiceBusError(messagingError) as ServiceBusError;
+      const expectedMessage = unknownCode ? `${unknownCode}: hello` : "hello";
 
       assert.deepEqual(
         {
@@ -71,7 +72,7 @@ describe("shared", () => {
         {
           name: "ServiceBusError",
           code: "GeneralError",
-          message: messagingError.message,
+          message: expectedMessage,
           retryable: messagingError.retryable
         } as ServiceBusError,
         "The code should be intact and the reason code, since it matches our blessed list, should match."

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -15,7 +15,6 @@ import {
   getRandomTestClientTypeWithNoSessions
 } from "./utils/testutils2";
 import { ServiceBusSender, ServiceBusSenderImpl } from "../src/sender";
-import { ConditionErrorNameMapper } from "@azure/core-amqp";
 
 describe("Send Batch", () => {
   let sender: ServiceBusSender;
@@ -452,7 +451,8 @@ describe("Send Batch", () => {
         "Messages were too big to fit in a single batch. Remove some messages and try again or create your own batch using createBatch(), which gives more fine-grained control.",
         err.message
       );
-      should.equal(ConditionErrorNameMapper["amqp:link:message-size-exceeded"], err.code);
+      should.equal(err.code, "MessageSizeExceeded");
+      should.equal(err.name, "ServiceBusError");
     }
   });
 

--- a/sdk/servicebus/service-bus/test/serviceBusError.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusError.spec.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { MessagingError, ServiceBusError, ServiceBusErrorCode } from "../src";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+
+describe("ServiceBusError", () => {
+  describe("constructor", () => {
+    it("accepts message and code", () => {
+      const expectedCode: ServiceBusErrorCode = "MessageNotFound";
+      const expectedMessage = "Where is the message?";
+      const error = new ServiceBusError(expectedMessage, expectedCode);
+      should.equal(error.name, "ServiceBusError");
+      should.equal(error.code, expectedCode);
+      should.equal(error.message, expectedMessage);
+    });
+
+    it("accepts MessagingError", () => {
+      const expectedMessage = "This service is busy!";
+      const messagingError = new MessagingError(expectedMessage);
+      messagingError.code = "ServerBusyError";
+
+      const error = new ServiceBusError(messagingError);
+      should.equal(error.name, "ServiceBusError");
+      should.equal(error.code, "ServiceBusy");
+      should.equal(error.message, expectedMessage);
+    });
+
+    it("prefixes message with MessagingError code for if it exists and is GeneralError", () => {
+      const message = "Just some general error.";
+      const messagingErrorCode = "TotallyUnexpectedError";
+      const messagingError = new MessagingError(message);
+      messagingError.code = messagingErrorCode;
+
+      const error = new ServiceBusError(messagingError);
+      should.equal(error.name, "ServiceBusError");
+      should.equal(error.code, "GeneralError");
+      should.equal(error.message, `${messagingErrorCode}: ${message}`);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #12559 and #12573 

This change updates `ServiceBusError` in 2 ways.
1. Adds a constructor that accepts `message` and `code` directly. This lets us throw `ServiceBusError`s from the client without having to first create a `MessagingError`.
2. Update the constructor so that if a MessagingError's code is translated to `GeneralError`, the MessagingError's code is prefixed in the ServiceBusError message. This should provide additional context to the user on what went wrong.