### PR TITLE
Updates to Language Settings file

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -38,7 +38,7 @@ stages:
                           pwsh: true
                           workingDirectory: $(Build.SourcesDirectory)
                           filePath: eng/scripts/SetTestPipelineVersion.ps1
-                          arguments: '-BuildNumber $(Build.BuildNumber)'
+                          arguments: '-BuildID $(Build.BuildId)'
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -12,7 +12,7 @@ steps:
         pwsh: true
         workingDirectory: $(Build.SourcesDirectory)
         filePath: eng/scripts/SetTestPipelineVersion.ps1
-        arguments: '-BuildNumber $(Build.BuildNumber)'
+        arguments: '-BuildID $(Build.BuildId)'
 
   - pwsh: |
       $folder = "${{parameters.ServiceDirectory}}"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -149,7 +149,7 @@ function Get-javascript-GithubIoDocIndex()
 # Updates a js CI configuration json.
 # For "latest", we simply set a target package name
 # For "preview", we add @next to the target package name
-function UpdateParamsJsonJS($pkgs, $ciRepo, $locationInDocRepo)
+function Update-javascript-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $monikerId = $null)
 {
   $pkgJsonLoc = (Join-Path -Path $ciRepo -ChildPath $locationInDocRepo)
   

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -3,7 +3,7 @@
 
 param (
   [Parameter(mandatory = $true)]
-  $BuildNumber
+  $BuildID
 )
 
 . "${PSScriptRoot}\..\common\scripts\common.ps1"
@@ -24,7 +24,7 @@ LogDebug "Last Published Version $($semVarsSorted[0])"
 
 $newVersion = [AzureEngSemanticVersion]::ParseVersionString($semVarsSorted[0])
 $newVersion.PrereleaseLabel = "beta"
-$newVersion.PrereleaseNumber = $BuildNumber
+$newVersion.PrereleaseNumber = $BuildID
 
 $packageFileContent = Get-Content -Path $templatePackageFile | ConvertFrom-Json
 LogDebug "Version in Source $($packageFileContent.version)"


### PR DESCRIPTION
- Move `UpdateParamsJsonJS` from `https://github.com/Azure/azure-sdk-tools/blob/master/eng/common/scripts/update-docs-ci.ps1` to LanguageSettings.ps1.
- Rename function to `Update-javascript-CIConfig`
- Add default `$monikerId=$null` argument to help function reuse across the languages.
- Switch from `BuildNumber` to `BuildID` for test release version.