### PR TITLE
Convert artifact name to package name only if required

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -332,7 +332,10 @@ async function main(argv) {
   const testFolder = argv["test-folder"];
   const dryRun = argv["dry-run"];
 
-  const packageName = artifactName.replace(/"?([a-z]*)"?-/i, "@$1/");
+  let packageName = artifactName;
+  if (!artifactName.startsWith("@")) {
+    packageName = artifactName.replace(/"?([a-z]*)"?-/i, "@$1/");
+  }
   const targetPackage = await getPackageFromRush(repoRoot, packageName);
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);
 


### PR DESCRIPTION
Package name is passed as artifact name when running min max testing as part of integration test and this causes an issue when it is converted to package name. This issue was hidden earlier due to hardcoded replace of "azure-" in parameter value which it will never find if package name itself is passed. We have removed this hardcoding to support different scope like @microsoft using regex and this new logic has surfaced incorrect replace issue. Change in this PR is to convert input value only if it's not package name.