### PR TITLE
[ESLint plugin] Deprecate support for preview and dev versions

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md
@@ -3,6 +3,7 @@
 Requires `version` in `package.json` to be in [SemVer](https://semver.org/).
 
 Additionally, the following rules are checked:
+
 - Major versions of `0` are not permitted,
 - Alpha versions must be in the format `<version>-alpha.<date>.<alpha-version>` where `date` is an integer representing a particular day (e.g. 20200728 is July 28th, 2020), and `alpha-version` is an integer.
 - Beta versions must be in the format `<version>-beta.<beta-version>`, where `beta-version` is an integer.
@@ -16,18 +17,6 @@ Additionally, the following rules are checked:
 ```json
 {
   "version": "1.0.0"
-}
-```
-
-```json
-{
-  "version": "1.0.0-preview.1"
-}
-```
-
-```json
-{
-  "version": "1.0.0-dev.20200728.1"
 }
 ```
 
@@ -77,31 +66,13 @@ Additionally, the following rules are checked:
 
 ```json
 {
-  "version": "1.0.0-preview1"
+  "version": "1.0.0-preview.1"
 }
 ```
 
 ```json
 {
-  "version": "1.0.0-preview.1.0"
-}
-```
-
-```json
-{
-  "version": "1.0.0-Preview.1"
-}
-```
-
-```json
-{
-  "version": "1.0.0-dev.1.0"
-}
-```
-
-```json
-{
-  "version": "1.0.0-dev.1"
+  "version": "1.0.0-dev.20200728.1"
 }
 ```
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -42,7 +42,9 @@ export = {
             const version = nodeValue.value as string;
 
             // check for violations specific to semver
-            const versionMatch = version.match(/^(0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(.+)|$)/);
+            const versionMatch = version.match(
+              /^(0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(.+)|$)/
+            );
             if (versionMatch === null) {
               context.report({
                 node: nodeValue,
@@ -58,13 +60,13 @@ export = {
                 message: "major version should not be set to 0"
               });
             }
-            
-            // check that if preview or dev is in proper syntax if provided
+
+            // check that if alpha or beta is in proper syntax if provided
             const secondPart = versionMatch[2];
             if (secondPart === undefined) {
               return;
             }
-            const ver = secondPart.match(/^(dev|preview|alpha|beta)(.*)/);
+            const ver = secondPart.match(/^(alpha|beta)(.*)/);
             if (ver === null) {
               context.report({
                 node: nodeValue,
@@ -76,7 +78,6 @@ export = {
             const verKeyword = ver[1];
             const verNumber = ver[2];
             switch (verKeyword) {
-              case "preview":
               case "beta":
                 if (!/^\.(:?0|(?:[1-9]\d*))$/.test(verNumber)) {
                   context.report({
@@ -86,7 +87,6 @@ export = {
                   return;
                 }
                 break;
-              case "dev":
               case "alpha":
                 if (!/^\.[2-9]\d\d\d[0-1]\d[0-3]\d\.(:?0|(?:[1-9]\d*))$/.test(verNumber)) {
                   context.report({

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
@@ -43,7 +43,7 @@ const examplePackageGood = `{
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-preview.5",
+    "@azure/amqp-common": "^1.0.0-beta.5",
     "@types/is-buffer": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/long": "^4.0.0",
@@ -156,7 +156,7 @@ const examplePackageBad = `{
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-preview.5",
+    "@azure/amqp-common": "^1.0.0-beta.5",
     "@types/is-buffer": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/long": "^4.0.0",
@@ -283,18 +283,6 @@ ruleTester.run("ts-versioning-semver", rule, {
       filename: "package.json"
     },
     {
-      code: '{"version": "1.1.10-preview.0"}',
-      filename: "package.json"
-    },
-    {
-      code: '{"version": "1.1.10-preview.1"}',
-      filename: "package.json"
-    },
-    {
-      code: '{"version": "1.1.10-preview.10"}',
-      filename: "package.json"
-    },
-    {
       code: '{"version": "1.1.10-beta.0"}',
       filename: "package.json"
     },
@@ -304,18 +292,6 @@ ruleTester.run("ts-versioning-semver", rule, {
     },
     {
       code: '{"version": "1.1.10-beta.10"}',
-      filename: "package.json"
-    },
-    {
-      code: '{"version": "1.1.10-dev.20200728.0"}',
-      filename: "package.json"
-    },
-    {
-      code: '{"version": "1.1.10-dev.20210128.1"}',
-      filename: "package.json"
-    },
-    {
-      code: '{"version": "1.1.10-dev.20200728.10"}',
       filename: "package.json"
     },
     {
@@ -426,40 +402,13 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // preview and beta violations
+    // beta violations
     {
-      code: '{"version": "1.0.0-Preview-1"}',
+      code: '{"version": "1.0.0-preview.1"}',
       filename: "package.json",
       errors: [
         {
-          message: "unrecognized version syntax: Preview-1"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-preview-1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "preview format is not x.y.z-preview.i"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-preview1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "preview format is not x.y.z-preview.i"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-preview.01"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "preview format is not x.y.z-preview.i"
+          message: "unrecognized version syntax: preview.1"
         }
       ]
     },
@@ -499,49 +448,13 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // dev and alpha violations
+    // alpha violations
     {
-      code: '{"version": "1.0.0-Dev-1"}',
+      code: '{"version": "1.0.0-dev.20200728.1"}',
       filename: "package.json",
       errors: [
         {
-          message: "unrecognized version syntax: Dev-1"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-dev-1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "dev format is not x.y.z-dev.<date>.i"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-dev1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "dev format is not x.y.z-dev.<date>.i"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-dev.01"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "dev format is not x.y.z-dev.<date>.i"
-        }
-      ]
-    },
-    {
-      code: '{"version": "1.0.0-dev.2.1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "dev format is not x.y.z-dev.<date>.i"
+          message: "unrecognized version syntax: dev.20200728.1"
         }
       ]
     },
@@ -600,16 +513,16 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // major version 0 and preview violations
+    // major version 0 and beta violations
     {
-      code: '{"version": "0.1.0-preview1"}',
+      code: '{"version": "0.1.0-beta1"}',
       filename: "package.json",
       errors: [
         {
           message: "major version should not be set to 0"
         },
         {
-          message: "preview format is not x.y.z-preview.i"
+          message: "beta format is not x.y.z-beta.i"
         }
       ]
     },


### PR DESCRIPTION
Service Bus is out of preview so AFAICT, no other package uses the old versioning scheme. Fixes https://github.com/Azure/azure-sdk-for-js/issues/10987.

PR passes tests and linting locally. @praveenkuttappan please consider setting up a CI pipeline for the plugin.