### PR TITLE
[Service Bus] Improve docs

### DIFF
--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -105,8 +105,8 @@ export interface ServiceBusReceiverOptions {
 
   /**
    * The maximum duration in milliseconds until which the lock on the message will be renewed
-   * by the sdk automatically. This auto renewal stops once the message is settled or once the user
-   * provided onMessage handler completes ite execution.
+   * by the sdk automatically. This auto renewal stops once the message is settled(or once the user
+   * provided processMessage handler completes its execution if used `ServiceBusReceiver.subscribe()` method).
    *
    * - **Default**: `300 * 1000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -105,8 +105,7 @@ export interface ServiceBusReceiverOptions {
 
   /**
    * The maximum duration in milliseconds until which the lock on the message will be renewed
-   * by the sdk automatically. This auto renewal stops once the message is settled(or once the user
-   * provided processMessage handler completes its execution if used `ServiceBusReceiver.subscribe()` method).
+   * by the sdk automatically. This auto renewal stops once the message is settled.
    *
    * - **Default**: `300 * 1000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -139,7 +139,9 @@ export interface CreateQueueOptions extends OperationOptions {
   /**
    * Determines the amount of time in seconds in which a message should be locked for
    * processing by a receiver. After this period, the message is unlocked and available
-   * for consumption by the next receiver. Settable only at queue creation time.
+   * for consumption by the next receiver.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
@@ -282,7 +284,9 @@ export interface QueueProperties {
   /**
    * Determines the amount of time in seconds in which a message should be locked for
    * processing by a receiver. After this period, the message is unlocked and available
-   * for consumption by the next receiver. Settable only at queue creation time.
+   * for consumption by the next receiver.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
@@ -419,7 +423,8 @@ export interface InternalQueueOptions {
    * Determines the amount of time in seconds in which a message should be locked for
    * processing by a receiver. After this period, the message is unlocked and
    * can be consumed by the next receiver.
-   * Settable only at queue creation time.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -143,7 +143,9 @@ export function buildSubscriptionRuntimeProperties(
 export interface CreateSubscriptionOptions extends OperationOptions {
   /**
    * The default lock duration is applied to subscriptions that do not define a lock
-   * duration. Settable only at subscription creation time.
+   * duration.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
@@ -286,7 +288,9 @@ export interface SubscriptionProperties {
 
   /**
    * The default lock duration is applied to subscriptions that do not define a lock
-   * duration. Settable only at subscription creation time.
+   * duration.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
@@ -394,7 +398,9 @@ export interface SubscriptionProperties {
 export interface InternalSubscriptionOptions {
   /**
    * The default lock duration is applied to subscriptions that do not define a lock
-   * duration. Settable only at subscription creation time.
+   * duration.
+   * (If sessions are enabled, this lock duration is applicable for sessions and not for messages.)
+   *
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *


### PR DESCRIPTION
- `Create{Entity}Options.lockduration` clarification
- `onMessage` is only applicable for subscribe