### PR TITLE
Convenience method for adding single chat participant

### DIFF
--- a/sdk/communication/communication-chat/review/communication-chat.api.md
+++ b/sdk/communication/communication-chat/review/communication-chat.api.md
@@ -18,9 +18,17 @@ import { ReadReceiptReceivedEvent } from '@azure/communication-signaling';
 import { TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 
 // @public
+export interface AddChatParticipantRequest extends Omit<RestAddChatParticipantsRequest, "participants"> {
+    participant: ChatParticipant;
+}
+
+// @public
 export interface AddChatParticipantsRequest extends Omit<RestAddChatParticipantsRequest, "participants"> {
     participants: ChatParticipant[];
 }
+
+// @public
+export type AddParticipantOptions = OperationOptions;
 
 // @public
 export type AddParticipantsOptions = OperationOptions;
@@ -78,6 +86,7 @@ export interface ChatThread extends Omit<RestChatThread, "createdBy" | "particip
 // @public
 export class ChatThreadClient {
     constructor(threadId: string, url: string, credential: CommunicationUserCredential, options?: ChatThreadClientOptions);
+    addParticipant(request: AddChatParticipantRequest, options?: AddParticipantOptions): Promise<OperationResponse>;
     addParticipants(request: AddChatParticipantsRequest, options?: AddParticipantsOptions): Promise<OperationResponse>;
     deleteMessage(messageId: string, options?: DeleteMessageOptions): Promise<OperationResponse>;
     dispose(): void;

--- a/sdk/communication/communication-chat/src/chatThreadClient.ts
+++ b/sdk/communication/communication-chat/src/chatThreadClient.ts
@@ -14,7 +14,11 @@ import {
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { CanonicalCode } from "@opentelemetry/api";
 import { createSpan } from "./tracing";
-import { SendMessageRequest, AddChatParticipantsRequest } from "./models/requests";
+import {
+  SendMessageRequest,
+  AddChatParticipantsRequest,
+  AddChatParticipantRequest
+} from "./models/requests";
 import { SendReadReceiptRequest } from "./generated/src/models";
 import { OperationResponse } from "./models/models";
 import {
@@ -30,7 +34,8 @@ import {
   RemoveParticipantOptions,
   SendTypingNotificationOptions,
   SendReadReceiptOptions,
-  ListReadReceiptsOptions
+  ListReadReceiptsOptions,
+  AddParticipantOptions
 } from "./models/options";
 import {
   ChatMessage,
@@ -329,6 +334,38 @@ export class ChatThreadClient {
       return await this.api.addChatParticipants(
         this.threadId,
         mapToAddChatParticipantsRequestRestModel(request),
+        operationOptionsToRequestOptionsBase(updatedOptions)
+      );
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
+  }
+
+  /**
+   * Adds the details of a single chat participant belonging to the thread identified by threadId.
+   * @param request Thread participant's details to add.
+   * @param options Operation options.
+   */
+  public async addParticipant(
+    request: AddChatParticipantRequest,
+    options: AddParticipantOptions = {}
+  ): Promise<OperationResponse> {
+    const { span, updatedOptions } = createSpan("ChatThreadClient-AddParticipant", options);
+
+    const addParticipantsRequest = {
+      participants: [request.participant]
+    };
+
+    try {
+      return await this.api.addChatParticipants(
+        this.threadId,
+        mapToAddChatParticipantsRequestRestModel(addParticipantsRequest),
         operationOptionsToRequestOptionsBase(updatedOptions)
       );
     } catch (e) {

--- a/sdk/communication/communication-chat/src/models/options.ts
+++ b/sdk/communication/communication-chat/src/models/options.ts
@@ -80,9 +80,14 @@ export type GetMessageOptions = OperationOptions;
 export type DeleteMessageOptions = OperationOptions;
 
 /**
- * Options to add a chat participant.
+ * Options to add chat participants.
  */
 export type AddParticipantsOptions = OperationOptions;
+
+/**
+ * Options to add a chat participant.
+ */
+export type AddParticipantOptions = OperationOptions;
 
 /**
  * Options to list chat participants.

--- a/sdk/communication/communication-chat/src/models/requests.ts
+++ b/sdk/communication/communication-chat/src/models/requests.ts
@@ -35,3 +35,14 @@ export interface AddChatParticipantsRequest
    */
   participants: ChatParticipant[];
 }
+
+/**
+ * Thread participant to be added to the thread.
+ */
+export interface AddChatParticipantRequest
+  extends Omit<RestAddChatParticipantsRequest, "participants"> {
+  /**
+   * Participant to add to a chat thread.
+   */
+  participant: ChatParticipant;
+}

--- a/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
@@ -10,7 +10,8 @@ import {
   SendMessageRequest,
   SendMessageOptions,
   UpdateMessageOptions,
-  AddChatParticipantsRequest
+  AddChatParticipantsRequest,
+  AddChatParticipantRequest
 } from "../src";
 import * as RestModel from "../src/generated/src/models";
 import { apiVersion } from "../src/generated/src/models/parameters";
@@ -211,6 +212,37 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(sendRequest.participants[0].displayName, requestJson.participants[0].displayName);
     assert.equal(
       sendRequest.participants[0].shareHistoryTime?.toDateString(),
+      new Date(requestJson.participants[0].shareHistoryTime).toDateString()
+    );
+  });
+
+  it("makes successful add chat participant request", async () => {
+    const mockHttpClient = generateHttpClient(201);
+    chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
+    const sendRequest: AddChatParticipantRequest = {
+      participant: mockSdkModelParticipant
+    };
+
+    await chatThreadClient.addParticipant(sendRequest);
+
+    sinon.assert.calledOnce(spy);
+    const request = spy.getCall(0).args[0];
+
+    assert.equal(
+      request.url,
+      `${baseUri}/chat/threads/${threadId}/participants?api-version=${API_VERSION}`
+    );
+    assert.equal(request.method, "POST");
+    const requestJson = JSON.parse(request.body);
+    assert.equal(
+      sendRequest.participant.user.communicationUserId,
+      requestJson.participants[0].id
+    );
+    assert.equal(sendRequest.participant.displayName, requestJson.participants[0].displayName);
+    assert.equal(
+      sendRequest.participant.shareHistoryTime?.toDateString(),
       new Date(requestJson.participants[0].shareHistoryTime).toDateString()
     );
   });


### PR DESCRIPTION
Changes:
- Added addChatParticipant() for adding just one chat member
- Added corresponding request interface and options
- Added unit test