### PR TITLE
[synapse] Add Jonathan as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,9 @@
 # PRLabel: %Storage
 /sdk/storage/ @XiaoningLiu @jeremymeng @HarshaNalluru @vinjiang @jiacfan @ljian3377
 
+# PRLabel: %Synapse
+/sdk/synapse/ @jonathandturner
+
 # PRLabel: %Tables
 /sdk/tables/ @mahdiva @joheredi
 


### PR DESCRIPTION
Since @jonathandturner is going to be shepherding Synapse packages for us, making him the code owner of this folder.