### PR TITLE
[core-tracing] Fix ESLint error

### DIFF
--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.0-preview.10 (Unreleased)
+## 1.0.0-beta.10 (Unreleased)
 
+- Change version from `1.0.0-preview.10` to `1.0.0-beta.10` as we now deprecate support of preview and dev version numbers
 
 ## 1.0.0-preview.9 (2020-08-04)
 

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-beta.10",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
After PR #12606 we no longer support preview version numbers and now linter reports error on those.
This change updates the version number to use `beta` suffix.