### PR TITLE
revert removal of support for dev/preview versioning

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -66,7 +66,8 @@ export = {
             if (secondPart === undefined) {
               return;
             }
-            const ver = secondPart.match(/^(alpha|beta)(.*)/);
+            // FIXME: remove dev and preview
+            const ver = secondPart.match(/^(dev|preview|alpha|beta)(.*)/);
             if (ver === null) {
               context.report({
                 node: nodeValue,

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
@@ -403,15 +403,15 @@ ruleTester.run("ts-versioning-semver", rule, {
       ]
     },
     // beta violations
-    {
-      code: '{"version": "1.0.0-preview.1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "unrecognized version syntax: preview.1"
-        }
-      ]
-    },
+    // {
+    //   code: '{"version": "1.0.0-preview.1"}',
+    //   filename: "package.json",
+    //   errors: [
+    //     {
+    //       message: "unrecognized version syntax: preview.1"
+    //     }
+    //   ]
+    // },
     {
       code: '{"version": "1.0.0-Beta-1"}',
       filename: "package.json",
@@ -449,15 +449,15 @@ ruleTester.run("ts-versioning-semver", rule, {
       ]
     },
     // alpha violations
-    {
-      code: '{"version": "1.0.0-dev.20200728.1"}',
-      filename: "package.json",
-      errors: [
-        {
-          message: "unrecognized version syntax: dev.20200728.1"
-        }
-      ]
-    },
+    // {
+    //   code: '{"version": "1.0.0-dev.20200728.1"}',
+    //   filename: "package.json",
+    //   errors: [
+    //     {
+    //       message: "unrecognized version syntax: dev.20200728.1"
+    //     }
+    //   ]
+    // },
     {
       code: '{"version": "1.0.0-Alpha-1"}',
       filename: "package.json",


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/12606 caused failures in master because there are still a few packages using the old versioning scheme. This PR adds support back for `dev` and `preview` versions in the linter. The PR is a quick patch and I will follow up with a better handling for this soon.