### PR TITLE
Revert "[ESLint plugin] Deprecate support for preview and dev versions"

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md
@@ -3,7 +3,6 @@
 Requires `version` in `package.json` to be in [SemVer](https://semver.org/).
 
 Additionally, the following rules are checked:
-
 - Major versions of `0` are not permitted,
 - Alpha versions must be in the format `<version>-alpha.<date>.<alpha-version>` where `date` is an integer representing a particular day (e.g. 20200728 is July 28th, 2020), and `alpha-version` is an integer.
 - Beta versions must be in the format `<version>-beta.<beta-version>`, where `beta-version` is an integer.
@@ -17,6 +16,18 @@ Additionally, the following rules are checked:
 ```json
 {
   "version": "1.0.0"
+}
+```
+
+```json
+{
+  "version": "1.0.0-preview.1"
+}
+```
+
+```json
+{
+  "version": "1.0.0-dev.20200728.1"
 }
 ```
 
@@ -66,13 +77,31 @@ Additionally, the following rules are checked:
 
 ```json
 {
-  "version": "1.0.0-preview.1"
+  "version": "1.0.0-preview1"
 }
 ```
 
 ```json
 {
-  "version": "1.0.0-dev.20200728.1"
+  "version": "1.0.0-preview.1.0"
+}
+```
+
+```json
+{
+  "version": "1.0.0-Preview.1"
+}
+```
+
+```json
+{
+  "version": "1.0.0-dev.1.0"
+}
+```
+
+```json
+{
+  "version": "1.0.0-dev.1"
 }
 ```
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -42,9 +42,7 @@ export = {
             const version = nodeValue.value as string;
 
             // check for violations specific to semver
-            const versionMatch = version.match(
-              /^(0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(.+)|$)/
-            );
+            const versionMatch = version.match(/^(0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(.+)|$)/);
             if (versionMatch === null) {
               context.report({
                 node: nodeValue,
@@ -60,13 +58,13 @@ export = {
                 message: "major version should not be set to 0"
               });
             }
-
-            // check that if alpha or beta is in proper syntax if provided
+            
+            // check that if preview or dev is in proper syntax if provided
             const secondPart = versionMatch[2];
             if (secondPart === undefined) {
               return;
             }
-            const ver = secondPart.match(/^(alpha|beta)(.*)/);
+            const ver = secondPart.match(/^(dev|preview|alpha|beta)(.*)/);
             if (ver === null) {
               context.report({
                 node: nodeValue,
@@ -78,6 +76,7 @@ export = {
             const verKeyword = ver[1];
             const verNumber = ver[2];
             switch (verKeyword) {
+              case "preview":
               case "beta":
                 if (!/^\.(:?0|(?:[1-9]\d*))$/.test(verNumber)) {
                   context.report({
@@ -87,6 +86,7 @@ export = {
                   return;
                 }
                 break;
+              case "dev":
               case "alpha":
                 if (!/^\.[2-9]\d\d\d[0-1]\d[0-3]\d\.(:?0|(?:[1-9]\d*))$/.test(verNumber)) {
                   context.report({

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
@@ -43,7 +43,7 @@ const examplePackageGood = `{
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-beta.5",
+    "@azure/amqp-common": "^1.0.0-preview.5",
     "@types/is-buffer": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/long": "^4.0.0",
@@ -156,7 +156,7 @@ const examplePackageBad = `{
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-beta.5",
+    "@azure/amqp-common": "^1.0.0-preview.5",
     "@types/is-buffer": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/long": "^4.0.0",
@@ -283,6 +283,18 @@ ruleTester.run("ts-versioning-semver", rule, {
       filename: "package.json"
     },
     {
+      code: '{"version": "1.1.10-preview.0"}',
+      filename: "package.json"
+    },
+    {
+      code: '{"version": "1.1.10-preview.1"}',
+      filename: "package.json"
+    },
+    {
+      code: '{"version": "1.1.10-preview.10"}',
+      filename: "package.json"
+    },
+    {
       code: '{"version": "1.1.10-beta.0"}',
       filename: "package.json"
     },
@@ -292,6 +304,18 @@ ruleTester.run("ts-versioning-semver", rule, {
     },
     {
       code: '{"version": "1.1.10-beta.10"}',
+      filename: "package.json"
+    },
+    {
+      code: '{"version": "1.1.10-dev.20200728.0"}',
+      filename: "package.json"
+    },
+    {
+      code: '{"version": "1.1.10-dev.20210128.1"}',
+      filename: "package.json"
+    },
+    {
+      code: '{"version": "1.1.10-dev.20200728.10"}',
       filename: "package.json"
     },
     {
@@ -402,13 +426,40 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // beta violations
+    // preview and beta violations
     {
-      code: '{"version": "1.0.0-preview.1"}',
+      code: '{"version": "1.0.0-Preview-1"}',
       filename: "package.json",
       errors: [
         {
-          message: "unrecognized version syntax: preview.1"
+          message: "unrecognized version syntax: Preview-1"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-preview-1"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "preview format is not x.y.z-preview.i"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-preview1"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "preview format is not x.y.z-preview.i"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-preview.01"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "preview format is not x.y.z-preview.i"
         }
       ]
     },
@@ -448,13 +499,49 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // alpha violations
+    // dev and alpha violations
     {
-      code: '{"version": "1.0.0-dev.20200728.1"}',
+      code: '{"version": "1.0.0-Dev-1"}',
       filename: "package.json",
       errors: [
         {
-          message: "unrecognized version syntax: dev.20200728.1"
+          message: "unrecognized version syntax: Dev-1"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-dev-1"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "dev format is not x.y.z-dev.<date>.i"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-dev1"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "dev format is not x.y.z-dev.<date>.i"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-dev.01"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "dev format is not x.y.z-dev.<date>.i"
+        }
+      ]
+    },
+    {
+      code: '{"version": "1.0.0-dev.2.1"}',
+      filename: "package.json",
+      errors: [
+        {
+          message: "dev format is not x.y.z-dev.<date>.i"
         }
       ]
     },
@@ -513,16 +600,16 @@ ruleTester.run("ts-versioning-semver", rule, {
         }
       ]
     },
-    // major version 0 and beta violations
+    // major version 0 and preview violations
     {
-      code: '{"version": "0.1.0-beta1"}',
+      code: '{"version": "0.1.0-preview1"}',
       filename: "package.json",
       errors: [
         {
           message: "major version should not be set to 0"
         },
         {
-          message: "beta format is not x.y.z-beta.i"
+          message: "preview format is not x.y.z-preview.i"
         }
       ]
     },


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-js#12606
#12606 caused failures in master because there are still a few packages using the old versioning scheme.