### PR TITLE
Add common to core ci.yml

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -24,8 +24,10 @@ pr:
     include:
       - sdk/core/
       - eng/
-      - common/config/rush/
+      - common/
       - rush.json
+    exclude:
+      - common/smoke-test/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
The `core` pipeline should run on any changes under `common`, with the exception of `common/smoke-test` which has it's own pipeline and should not be able to break the `core` build.