### PR TITLE
[cosmosdb] Expand integration test matrix

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -34,6 +34,18 @@ stages:
               OSVmImage: "windows-2019"
               NodeTestVersion: "8.x"
               TestType: "node"
+            Windows_Node10:
+              OSVmImage: "windows-2019"
+              NodeTestVersion: "10.x"
+              TestType: "node"
+            Windows_Node12:
+              OSVmImage: "windows-2019"
+              NodeTestVersion: "12.x"
+              TestType: "node"
+            Windows_Node14:
+              OSVmImage: "windows-2019"
+              NodeTestVersion: "14.x"
+              TestType: "node"
           PreIntegrationSteps: cosmos-integration-public
           PostIntegrationSteps: cosmos-additional-steps
           EnvVars:

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -12,6 +12,8 @@ trigger:
       - eng/
       - common/config/rush/
       - rush.json
+    exclude:
+      - eng/pipelines/templates/stages/cosmos-sdk-client.yml
 
 pr:
   branches:
@@ -28,6 +30,7 @@ pr:
       - rush.json
     exclude:
       - common/smoke-test/
+      - eng/pipelines/templates/stages/cosmos-sdk-client.yml
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/cosmosdb/ci.yml
+++ b/sdk/cosmosdb/ci.yml
@@ -8,6 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
+      - eng/pipelines/templates/stages/cosmos-sdk-client.yml
       - sdk/cosmosdb/
 
 pr:
@@ -19,6 +20,7 @@ pr:
       - hotfix/*
   paths:
     include:
+      - eng/pipelines/templates/stages/cosmos-sdk-client.yml
       - sdk/cosmosdb/
 
 extends:


### PR DESCRIPTION
This change expands the integration CI run to work across multiple Node versions instead of only Node 8.