### PR TITLE
[Tables] Don't deserialize DateTime to avoid losing precision

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.0-beta.4 (Unreleased)
 
+### Breaking Changes
+
+- Don't deserialize DateTime into a JavaScript Date to avoid losing precision [#12650](https://github.com/Azure/azure-sdk-for-js/pull/12650)
 
 ## 1.0.0-beta.3 (2020-11-12)
 

--- a/sdk/tables/data-tables/recordings/browsers/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_date.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_date.json
@@ -4,21 +4,21 @@
    "method": "POST",
    "url": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser",
    "query": {},
-   "requestBody": "{\"PartitionKey\":\"P2_browser\",\"RowKey\":\"R2\",\"testField\":\"2020-09-17T00:00:00.000Z\",\"testField@odata.type\":\"Edm.DateTime\"}",
+   "requestBody": "{\"PartitionKey\":\"P2_browser\",\"RowKey\":\"R2\",\"testField\":\"2020-09-17T00:00:00.111Z\",\"testField@odata.type\":\"Edm.DateTime\"}",
    "status": 204,
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-length": "0",
     "dataserviceid": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser(PartitionKey='P2_browser',RowKey='R2')",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
-    "etag": "W/\"datetime'2020-10-01T00%3A39%3A09.5563707Z'\"",
+    "date": "Fri, 20 Nov 2020 20:54:02 GMT",
+    "etag": "W/\"datetime'2020-11-20T20%3A54%3A03.3452418Z'\"",
     "location": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser(PartitionKey='P2_browser',RowKey='R2')",
     "preference-applied": "return-no-content",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "4e684877-cd60-476a-9962-f879568ce764",
-    "x-ms-request-id": "a61af70b-3002-0027-578b-9733b0000000",
+    "x-ms-client-request-id": "bfefb501-9672-46cc-af10-983ac4d88a93",
+    "x-ms-request-id": "d0bc85d7-a002-0000-167f-bfa9f9000000",
     "x-ms-version": "2019-02-02"
    }
   },
@@ -28,17 +28,17 @@
    "query": {},
    "requestBody": null,
    "status": 200,
-   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2020-10-01T00%3A39%3A09.5563707Z'\\\"\",\"PartitionKey\":\"P2_browser\",\"RowKey\":\"R2\",\"Timestamp\":\"2020-10-01T00:39:09.5563707Z\",\"testField@odata.type\":\"Edm.DateTime\",\"testField\":\"2020-09-17T00:00:00Z\"}",
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2020-11-20T20%3A54%3A03.3452418Z'\\\"\",\"PartitionKey\":\"P2_browser\",\"RowKey\":\"R2\",\"Timestamp\":\"2020-11-20T20:54:03.3452418Z\",\"testField@odata.type\":\"Edm.DateTime\",\"testField\":\"2020-09-17T00:00:00.111Z\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
-    "etag": "W/\"datetime'2020-10-01T00%3A39%3A09.5563707Z'\"",
+    "date": "Fri, 20 Nov 2020 20:54:02 GMT",
+    "etag": "W/\"datetime'2020-11-20T20%3A54%3A03.3452418Z'\"",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "1c7c252d-2a41-45b2-ae55-8c03e9005c36",
-    "x-ms-request-id": "a61af712-3002-0027-5e8b-9733b0000000",
+    "x-ms-client-request-id": "9dff4831-afdc-475e-8dde-ba7c0349cc59",
+    "x-ms-request-id": "d0bc8624-a002-0000-627f-bfa9f9000000",
     "x-ms-version": "2019-02-02"
    }
   },
@@ -52,11 +52,11 @@
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-length": "0",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
+    "date": "Fri, 20 Nov 2020 20:54:02 GMT",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "bf8bbc9a-7238-4202-92a1-913e206f9fea",
-    "x-ms-request-id": "a61af71b-3002-0027-668b-9733b0000000",
+    "x-ms-client-request-id": "528e41f8-187b-48e7-a2f1-3c00c5b6e50f",
+    "x-ms-request-id": "d0bc866c-a002-0000-277f-bfa9f9000000",
     "x-ms-version": "2019-02-02"
    }
   }
@@ -65,5 +65,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "83deb3ab3b64ee032bc44586e6303e9b"
+ "hash": "1a5bad754fb23cb082d060dbb12eabc6"
 }

--- a/sdk/tables/data-tables/recordings/browsers/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_datetime.json
+++ b/sdk/tables/data-tables/recordings/browsers/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_datetime.json
@@ -4,21 +4,21 @@
    "method": "POST",
    "url": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser",
    "query": {},
-   "requestBody": "{\"PartitionKey\":\"P7_browser\",\"RowKey\":\"R7\",\"testField\":\"2020-09-17T00:00:00.000Z\",\"testField@odata.type\":\"Edm.DateTime\"}",
+   "requestBody": "{\"PartitionKey\":\"P7_browser\",\"RowKey\":\"R7\",\"testField\":\"2020-09-17T00:00:00.99999Z\",\"testField@odata.type\":\"Edm.DateTime\"}",
    "status": 204,
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-length": "0",
     "dataserviceid": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser(PartitionKey='P7_browser',RowKey='R7')",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
-    "etag": "W/\"datetime'2020-10-01T00%3A39%3A10.3128936Z'\"",
+    "date": "Fri, 20 Nov 2020 20:40:14 GMT",
+    "etag": "W/\"datetime'2020-11-20T20%3A40%3A15.2444478Z'\"",
     "location": "https://fakestorageaccount.table.core.windows.net/tableClientTestbrowser(PartitionKey='P7_browser',RowKey='R7')",
     "preference-applied": "return-no-content",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "561a1f5d-a0dc-49a2-95e4-aa41dada3871",
-    "x-ms-request-id": "a61af775-3002-0027-3c8b-9733b0000000",
+    "x-ms-client-request-id": "01c070b5-ec4d-45ef-9d44-95686ceafc07",
+    "x-ms-request-id": "1af1364c-4002-0001-427d-bfa804000000",
     "x-ms-version": "2019-02-02"
    }
   },
@@ -28,17 +28,17 @@
    "query": {},
    "requestBody": null,
    "status": 200,
-   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2020-10-01T00%3A39%3A10.3128936Z'\\\"\",\"PartitionKey\":\"P7_browser\",\"RowKey\":\"R7\",\"Timestamp\":\"2020-10-01T00:39:10.3128936Z\",\"testField@odata.type\":\"Edm.DateTime\",\"testField\":\"2020-09-17T00:00:00Z\"}",
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestbrowser/@Element\",\"odata.etag\":\"W/\\\"datetime'2020-11-20T20%3A40%3A15.2444478Z'\\\"\",\"PartitionKey\":\"P7_browser\",\"RowKey\":\"R7\",\"Timestamp\":\"2020-11-20T20:40:15.2444478Z\",\"testField@odata.type\":\"Edm.DateTime\",\"testField\":\"2020-09-17T00:00:00.99999Z\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
-    "etag": "W/\"datetime'2020-10-01T00%3A39%3A10.3128936Z'\"",
+    "date": "Fri, 20 Nov 2020 20:40:14 GMT",
+    "etag": "W/\"datetime'2020-11-20T20%3A40%3A15.2444478Z'\"",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "0aed9917-1936-400b-804c-6eb3f07db142",
-    "x-ms-request-id": "a61af782-3002-0027-468b-9733b0000000",
+    "x-ms-client-request-id": "9b315097-fc06-49c1-aee9-83ae2741a710",
+    "x-ms-request-id": "1af13680-4002-0001-757d-bfa804000000",
     "x-ms-version": "2019-02-02"
    }
   },
@@ -52,11 +52,11 @@
    "responseHeaders": {
     "cache-control": "no-cache",
     "content-length": "0",
-    "date": "Thu, 01 Oct 2020 00:39:09 GMT",
+    "date": "Fri, 20 Nov 2020 20:40:14 GMT",
     "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
     "x-content-type-options": "nosniff",
-    "x-ms-client-request-id": "3a816cb3-b636-41f0-a108-49fbec24c91e",
-    "x-ms-request-id": "a61af787-3002-0027-4a8b-9733b0000000",
+    "x-ms-client-request-id": "9c8569a4-0b0c-427a-a345-40e6d3d7d486",
+    "x-ms-request-id": "1af136c4-4002-0001-377d-bfa804000000",
     "x-ms-version": "2019-02-02"
    }
   }
@@ -65,5 +65,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "ba216f911645c59b1a52f7438e388a5b"
+ "hash": "7fee4db0b19a27922131b4c8a6cee2f7"
 }

--- a/sdk/tables/data-tables/recordings/node/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_date.js
+++ b/sdk/tables/data-tables/recordings/node/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_date.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "6ac9d775672e07f757ba4121a2483e0b";
+module.exports.hash = "863e289a59927f30b076ac8746af91b5";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
-  .post('/tableClientTestnode', {"PartitionKey":"P2_node","RowKey":"R2","testField":"2020-09-17T00:00:00.000Z","testField@odata.type":"Edm.DateTime"})
+  .post('/tableClientTestnode', {"PartitionKey":"P2_node","RowKey":"R2","testField":"2020-09-17T00:00:00.111Z","testField@odata.type":"Edm.DateTime"})
   .query(true)
   .reply(204, "", [
   'Cache-Control',
@@ -13,15 +13,15 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Content-Length',
   '0',
   'ETag',
-  `W/"datetime'2020-10-01T00%3A38%3A37.4486279Z'"`,
+  `W/"datetime'2020-11-20T20%3A53%3A23.1334566Z'"`,
   'Location',
   "https://fakestorageaccount.table.core.windows.net/tableClientTestnode(PartitionKey='P2_node',RowKey='R2')",
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e136f7de-c002-005f-728b-975b07000000',
+  '921386a0-3002-0041-6b7f-bf81ea000000',
   'x-ms-client-request-id',
-  '2dbe5af7-f180-4f65-ade1-2849342d5486',
+  'cdd1359c-2af5-4ebd-9124-11d0b81e87f1',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
@@ -31,13 +31,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'DataServiceId',
   "https://fakestorageaccount.table.core.windows.net/tableClientTestnode(PartitionKey='P2_node',RowKey='R2')",
   'Date',
-  'Thu, 01 Oct 2020 00:38:36 GMT'
+  'Fri, 20 Nov 2020 20:53:22 GMT'
 ]);
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
   .get('/tableClientTestnode(PartitionKey=%27P2_node%27,RowKey=%27R2%27)')
   .query(true)
-  .reply(200, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestnode/@Element","odata.etag":"W/\"datetime'2020-10-01T00%3A38%3A37.4486279Z'\"","PartitionKey":"P2_node","RowKey":"R2","Timestamp":"2020-10-01T00:38:37.4486279Z","testField@odata.type":"Edm.DateTime","testField":"2020-09-17T00:00:00Z"}, [
+  .reply(200, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestnode/@Element","odata.etag":"W/\"datetime'2020-11-20T20%3A53%3A23.1334566Z'\"","PartitionKey":"P2_node","RowKey":"R2","Timestamp":"2020-11-20T20:53:23.1334566Z","testField@odata.type":"Edm.DateTime","testField":"2020-09-17T00:00:00.111Z"}, [
   'Cache-Control',
   'no-cache',
   'Transfer-Encoding',
@@ -45,13 +45,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Content-Type',
   'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
   'ETag',
-  `W/"datetime'2020-10-01T00%3A38%3A37.4486279Z'"`,
+  `W/"datetime'2020-11-20T20%3A53%3A23.1334566Z'"`,
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e136f7e3-c002-005f-758b-975b07000000',
+  '921386a9-3002-0041-727f-bf81ea000000',
   'x-ms-client-request-id',
-  '792c5668-7724-4b89-8ca0-377a49dc37d3',
+  '9257f564-cc35-42ea-9863-382a448d88ef',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
@@ -61,7 +61,7 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 01 Oct 2020 00:38:37 GMT'
+  'Fri, 20 Nov 2020 20:53:22 GMT'
 ]);
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
@@ -75,13 +75,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'e136f7e7-c002-005f-798b-975b07000000',
+  '921386b0-3002-0041-797f-bf81ea000000',
   'x-ms-client-request-id',
-  'ddcf6640-da62-43e6-a17a-69c79282a96f',
+  'e0332ebf-04ce-4175-af69-232062cb1659',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 01 Oct 2020 00:38:37 GMT'
+  'Fri, 20 Nov 2020 20:53:22 GMT'
 ]);

--- a/sdk/tables/data-tables/recordings/node/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_datetime.js
+++ b/sdk/tables/data-tables/recordings/node/tableclient_createentity_getentity_and_delete/recording_should_createentity_with_datetime.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "45a503815008d0a93ed1c23b7485cdfa";
+module.exports.hash = "5ecfde59f77d9fc9785b51fc9d62d08e";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
-  .post('/tableClientTestnode', {"PartitionKey":"P7_node","RowKey":"R7","testField":"2020-09-17T00:00:00.000Z","testField@odata.type":"Edm.DateTime"})
+  .post('/tableClientTestnode', {"PartitionKey":"P7_node","RowKey":"R7","testField":"2020-09-17T00:00:00.99999Z","testField@odata.type":"Edm.DateTime"})
   .query(true)
   .reply(204, "", [
   'Cache-Control',
@@ -13,15 +13,15 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Content-Length',
   '0',
   'ETag',
-  `W/"datetime'2020-10-01T00%3A38%3A38.2994773Z'"`,
+  `W/"datetime'2020-11-20T20%3A39%3A32.4994263Z'"`,
   'Location',
   "https://fakestorageaccount.table.core.windows.net/tableClientTestnode(PartitionKey='P7_node',RowKey='R7')",
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f29ad480-e002-0043-568b-978310000000',
+  'b2eb0e9a-6002-0016-487d-bf6867000000',
   'x-ms-client-request-id',
-  '466a47b1-9a38-4e50-8bf0-376f15608475',
+  '79589036-b885-418f-9c9d-47f90b623959',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
@@ -31,13 +31,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'DataServiceId',
   "https://fakestorageaccount.table.core.windows.net/tableClientTestnode(PartitionKey='P7_node',RowKey='R7')",
   'Date',
-  'Thu, 01 Oct 2020 00:38:38 GMT'
+  'Fri, 20 Nov 2020 20:39:31 GMT'
 ]);
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
   .get('/tableClientTestnode(PartitionKey=%27P7_node%27,RowKey=%27R7%27)')
   .query(true)
-  .reply(200, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestnode/@Element","odata.etag":"W/\"datetime'2020-10-01T00%3A38%3A38.2994773Z'\"","PartitionKey":"P7_node","RowKey":"R7","Timestamp":"2020-10-01T00:38:38.2994773Z","testField@odata.type":"Edm.DateTime","testField":"2020-09-17T00:00:00Z"}, [
+  .reply(200, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#tableClientTestnode/@Element","odata.etag":"W/\"datetime'2020-11-20T20%3A39%3A32.4994263Z'\"","PartitionKey":"P7_node","RowKey":"R7","Timestamp":"2020-11-20T20:39:32.4994263Z","testField@odata.type":"Edm.DateTime","testField":"2020-09-17T00:00:00.99999Z"}, [
   'Cache-Control',
   'no-cache',
   'Transfer-Encoding',
@@ -45,13 +45,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Content-Type',
   'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
   'ETag',
-  `W/"datetime'2020-10-01T00%3A38%3A38.2994773Z'"`,
+  `W/"datetime'2020-11-20T20%3A39%3A32.4994263Z'"`,
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f29ad486-e002-0043-5a8b-978310000000',
+  'b2eb0ebb-6002-0016-677d-bf6867000000',
   'x-ms-client-request-id',
-  '03d98c40-557c-4ea4-a9e4-e53d0b1b6fc1',
+  '09f3b6db-a037-4360-9bbe-eed53b3b3544',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
@@ -61,7 +61,7 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 01 Oct 2020 00:38:38 GMT'
+  'Fri, 20 Nov 2020 20:39:31 GMT'
 ]);
 
 nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
@@ -75,13 +75,13 @@ nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryPara
   'Server',
   'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f29ad489-e002-0043-5d8b-978310000000',
+  'b2eb0ecb-6002-0016-777d-bf6867000000',
   'x-ms-client-request-id',
-  'de84d211-378f-43df-99e0-af754f8201ad',
+  '79e449ee-5b1d-449f-86f9-a92f6f4d46e4',
   'x-ms-version',
   '2019-02-02',
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 01 Oct 2020 00:38:38 GMT'
+  'Fri, 20 Nov 2020 20:39:31 GMT'
 ]);

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -96,7 +96,7 @@ export type DeleteTableResponse = TableDeleteHeaders & {
 // @public
 export interface Edm<T extends EdmTypes> {
     type: T;
-    value: T extends "Binary" ? Uint8Array : T extends "Boolean" ? boolean : T extends "DateTime" ? Date : T extends "Double" ? number : T extends "Int32" ? number : string;
+    value: T extends "Binary" ? Uint8Array : T extends "Boolean" ? boolean : T extends "Double" ? number : T extends "Int32" ? number : string;
 }
 
 // @public

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -398,8 +398,6 @@ export interface Edm<T extends EdmTypes> {
     ? Uint8Array
     : T extends "Boolean"
     ? boolean
-    : T extends "DateTime"
-    ? Date
     : T extends "Double"
     ? number
     : T extends "Int32"

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -113,7 +113,7 @@ function getTypedObject(value: any, type: string): any {
     case Edm.String:
       return value;
     case Edm.DateTime:
-      return new Date(value);
+      return { value, type: "DateTime" };
     case Edm.Int64:
       return { value, type: "Int64" };
     case Edm.Guid:

--- a/sdk/tables/data-tables/test/integration/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/integration/tableclient.spec.ts
@@ -166,12 +166,15 @@ describe("TableClient", () => {
     });
 
     it("should createEntity with Date", async () => {
-      type TestType = { testField: Date };
-      const testDate = new Date(2020, 8, 17);
-      const testEntity: TableEntity<TestType> = {
+      type TestType = {
+        testField: Edm<"DateTime">;
+      };
+
+      const testDate = "2020-09-17T00:00:00.111Z";
+      const testEntity = {
         partitionKey: `P2_${suffix}`,
         rowKey: "R2",
-        testField: testDate
+        testField: new Date(testDate)
       };
       const createResult = await client.createEntity(testEntity);
       const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey);
@@ -181,7 +184,7 @@ describe("TableClient", () => {
       assert.equal(createResult._response.status, 204);
       assert.equal(result.partitionKey, testEntity.partitionKey);
       assert.equal(result.rowKey, testEntity.rowKey);
-      assert.deepEqual(result.testField, testDate);
+      assert.deepEqual(result.testField.value, testDate);
     });
 
     it("should createEntity with Guid", async () => {
@@ -301,11 +304,7 @@ describe("TableClient", () => {
       type TestType = {
         testField: Edm<"DateTime">;
       };
-
-      type ResponseType = {
-        testField: Date;
-      };
-      const testDate = new Date(2020, 8, 17);
+      const testDate = "2020-09-17T00:00:00.99999Z";
       const testDateTime: Edm<"DateTime"> = {
         value: testDate,
         type: "DateTime"
@@ -317,16 +316,13 @@ describe("TableClient", () => {
         testField: testDateTime
       };
       const createResult = await client.createEntity(testEntity, {});
-      const result = await client.getEntity<ResponseType>(
-        testEntity.partitionKey,
-        testEntity.rowKey
-      );
+      const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey);
       const deleteResult = await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey);
 
       assert.equal(deleteResult._response.status, 204);
       assert.equal(createResult._response.status, 204);
       assert.equal(result.rowKey, testEntity.rowKey);
-      assert.deepEqual(result.testField, testDate);
+      assert.deepEqual(result.testField.value, testDate);
     });
 
     it("should createEntity with primitive int and float", async () => {

--- a/sdk/tables/data-tables/test/unit/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/unit/serialization.spec.ts
@@ -175,11 +175,11 @@ describe("Deserializer", () => {
 
   it("should deserialize a Date value", () => {
     const dateValue = new Date();
-    const deserialized: Entity = deserialize<Entity>({
+    const deserialized = deserialize<{ dateProp: Edm<"DateTime"> }>({
       dateProp: dateValue.toJSON(),
       "dateProp@odata.type": "Edm.DateTime"
     });
-    assert.deepEqual(deserialized.dateProp, dateValue);
+    assert.deepEqual(deserialized.dateProp, { type: "DateTime", value: dateValue.toISOString() });
   });
 
   it("should deserialize a Guid value", () => {


### PR DESCRIPTION
Fixes #12646

Tables service supports ns precision DateTime however JavaScript doesn't. As part of entity deserialization, whenever we get a property with type Edm.DateTime we parse it into a JavaScript Date object, which can lead to losing precision.

To fix this we need to disable the default deserialization for Edm.DateTime and give the user an "edm" object, similar to what we do for Guid and Int64

```typescript
{
partitionKey: "p1",
rowKey: "r1",
blahblah: {type: "DateTime", value:"the date"}
}
```