### PR TITLE
[WIP] Debug Perf test/framework with storage-blob

### DIFF
--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -71,8 +71,10 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/storage-blob": "^12.3.0",
     "@types/node": "^8.0.0",
     "@types/node-fetch": "^2.5.0",
+    "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "karma": "^5.1.0",
     "karma-chrome-launcher": "^3.0.0",

--- a/sdk/test-utils/perfstress/test/index.spec.ts
+++ b/sdk/test-utils/perfstress/test/index.spec.ts
@@ -12,6 +12,7 @@ import { Exception } from "./exception.spec";
 import { PerfStressPolicyTest } from "./perfStressPolicy.spec";
 import { SleepTest } from "./sleep.spec";
 import { NodeFetchTest } from "./nodeFetch.spec";
+import { StorageBlobDownloadTest } from "./storage-blob.spec";
 
 console.log("=== Starting the perfStress test ===");
 
@@ -24,7 +25,8 @@ const perfStressProgram = new PerfStressProgram(
     Exception,
     PerfStressPolicyTest,
     SleepTest,
-    NodeFetchTest
+    NodeFetchTest,
+    StorageBlobDownloadTest
   ])
 );
 

--- a/sdk/test-utils/perfstress/test/storage-blob.spec.ts
+++ b/sdk/test-utils/perfstress/test/storage-blob.spec.ts
@@ -33,29 +33,34 @@ export class StorageBlobDownloadTest extends PerfStressTest<string> {
     `https://${this.account}.blob.core.windows.net`,
     this.sharedKeyCredential
   );
-  containerName = `newcontainer${new Date().getTime()}`;
-  blobName = `newblob${new Date().getTime()}`;
+  protected static containerName = `newcontainer${new Date().getTime()}`;
+  protected static blobName = `newblob${new Date().getTime()}`;
 
   public async globalSetup() {
-    const containerClient = this.blobServiceClient.getContainerClient(this.containerName);
+    const containerClient = this.blobServiceClient.getContainerClient(
+      StorageBlobDownloadTest.containerName
+    );
 
     const createContainerResponse = await containerClient.create();
     console.log(
-      `Create container ${this.containerName} successfully`,
+      `Create container ${StorageBlobDownloadTest.containerName} successfully`,
       createContainerResponse.requestId
     );
 
     // Create a blob
     const content = "hello world";
-    const blockBlobClient = containerClient.getBlockBlobClient(this.blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(StorageBlobDownloadTest.blobName);
     const uploadBlobResponse = await blockBlobClient.upload(content, Buffer.byteLength(content));
-    console.log(`Upload block blob ${this.blobName} successfully`, uploadBlobResponse.requestId);
+    console.log(
+      `Upload block blob ${StorageBlobDownloadTest.blobName} successfully`,
+      uploadBlobResponse.requestId
+    );
   }
 
   async runAsync(): Promise<void> {
     await this.blobServiceClient
-      .getContainerClient(this.containerName)
-      .getBlockBlobClient(this.blobName)
+      .getContainerClient(StorageBlobDownloadTest.containerName)
+      .getBlockBlobClient(StorageBlobDownloadTest.blobName)
       .download(0);
     console.log("success");
   }


### PR DESCRIPTION
### TO REPRO
- Checkout this branch
- Create a storage account
- Add a .env file in `test-utils/perfstress/` folder with `ACCOUNT_NAME` and `ACCOUNT_KEY` variables
- Build - `rush update && rush build -t test-utils-perfstress`
- To run the test (this seems to fail at the fourth request with 404 ContainerNotFound)
   - `rushx build && npm run perfstress-test:node -- StorageBlobDownloadTest --warmup 2 --duration 7 --iterations 2 --parallel 2`
- To run the test without the parallel flag
   - `rushx build && npm run perfstress-test:node -- StorageBlobDownloadTest --warmup 2 --duration 7 --iterations 2`