### PR TITLE
[Key Vault] Excluding dist-browser from the artifacts

### DIFF
--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -35,7 +35,6 @@
   "files": [
     "types/keyvault-admin.d.ts",
     "dist/",
-    "dist-browser/",
     "dist-esm/keyvault-admin/src",
     "dist-esm/keyvault-common/src",
     "README.md",

--- a/sdk/keyvault/keyvault-admin/rollup.config.js
+++ b/sdk/keyvault/keyvault-admin/rollup.config.js
@@ -1,14 +1,3 @@
 import * as base from "./rollup.base.config";
 
-const inputs = [];
-
-if (!process.env.ONLY_BROWSER) {
-  inputs.push(base.nodeConfig());
-}
-
-// Disable this until we are ready to run rollup for the browser.
-if (!process.env.ONLY_NODE) {
-  inputs.push(base.browserConfig());
-}
-
-export default inputs;
+export default [base.nodeConfig()];

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -28,7 +28,6 @@
   "files": [
     "types/keyvault-certificates.d.ts",
     "dist/",
-    "dist-browser/",
     "dist-esm/keyvault-certificates/src",
     "dist-esm/keyvault-common/src",
     "README.md",

--- a/sdk/keyvault/keyvault-certificates/rollup.config.js
+++ b/sdk/keyvault/keyvault-certificates/rollup.config.js
@@ -1,14 +1,3 @@
 import * as base from "./rollup.base.config";
 
-const inputs = [];
-
-if (!process.env.ONLY_BROWSER) {
-  inputs.push(base.nodeConfig());
-}
-
-// Disable this until we are ready to run rollup for the browser.
-if (!process.env.ONLY_NODE) {
-  inputs.push(base.browserConfig());
-}
-
-export default inputs;
+export default [base.nodeConfig()];

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -57,7 +57,9 @@
   },
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "@azure/core-tracing": "1.0.0-preview.9",
+    "@opentelemetry/api": "^0.10.2"
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -28,7 +28,6 @@
   "files": [
     "types/keyvault-keys.d.ts",
     "dist/",
-    "dist-browser/",
     "dist-esm/keyvault-keys/src",
     "dist-esm/keyvault-common/src",
     "README.md",

--- a/sdk/keyvault/keyvault-keys/rollup.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.config.js
@@ -1,14 +1,3 @@
 import * as base from "./rollup.base.config";
 
-const inputs = [];
-
-if (!process.env.ONLY_BROWSER) {
-  inputs.push(base.nodeConfig());
-}
-
-// Disable this until we are ready to run rollup for the browser.
-if (!process.env.ONLY_NODE) {
-  inputs.push(base.browserConfig());
-}
-
-export default inputs;
+export default [base.nodeConfig()];

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -31,7 +31,6 @@
   "files": [
     "types/keyvault-secrets.d.ts",
     "dist/",
-    "dist-browser/",
     "dist-esm/keyvault-secrets/src",
     "dist-esm/keyvault-common/src",
     "README.md",

--- a/sdk/keyvault/keyvault-secrets/rollup.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.config.js
@@ -1,14 +1,3 @@
 import * as base from "./rollup.base.config";
 
-const inputs = [];
-
-if (!process.env.ONLY_BROWSER) {
-  inputs.push(base.nodeConfig());
-}
-
-// Disable this until we are ready to run rollup for the browser.
-if (!process.env.ONLY_NODE) {
-  inputs.push(base.browserConfig());
-}
-
-export default inputs;
+export default [base.nodeConfig()];


### PR DESCRIPTION
Fixes #12224

These changes effectively exclude the dist-browser folder from our artifacts. Is this all that is needed?

Since we still run browser tests, I'm thinking I should not actively remove every other use case of dist-browser (like in rollups)