### PR TITLE
[Core AMQP] - Fix debug log output for Retries

### DIFF
--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -175,7 +175,12 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
   let success = false;
   const totalNumberOfAttempts = config.retryOptions.maxRetries + 1;
   for (let i = 1; i <= totalNumberOfAttempts; i++) {
-    logger.verbose("[%s] Attempt number: %d", config.connectionId, config.operationType, i);
+    logger.verbose(
+      "[%s] Attempt number for '%s': %d.",
+      config.connectionId,
+      config.operationType,
+      i
+    );
     try {
       result = await config.operation();
       success = true;


### PR DESCRIPTION
## What

- Add the operationType format specifier for debug logs

## Why

The mismatch between the number of format specifiers and the variables
passed in causes `NaN` to show up in the debug output. 

Before: 

```
azure:core-amqp:verbose [connection-1] Attempt number: NaN 1
...
azure:core-amqp:verbose [connection-1] Success for 'sendMessage', after attempt number: 1.
```

After:

```
azure:core-amqp:verbose [connection-1] Attempt number for 'sendMessage': 1.
...
azure:core-amqp:verbose [connection-1] Success for 'sendMessage', after attempt number: 1.
```

Fixes #11798