### PR TITLE
[ai-form-recognizer] Fixed a broken link in the README.

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -137,7 +137,7 @@ The following section provides several JavaScript code snippets illustrating com
 
 - [Recognize Forms Using a Custom Model](#recognize-forms-using-a-custom-model)
 - [Recognize Content](#recognize-content)
-- [Use Prebuilt Models](#use-prebuilt-models)
+- [Use Prebuilt Models](#using-prebuilt-models)
 - [Train a Model](#train-a-model)
 - [Listing All Models](#listing-all-models)
 


### PR DESCRIPTION
This is something that the docs build found. I patched it there  so that the broken link won't go live, but also have to make the same change in the repo for the future.