### PR TITLE
[dev-tool] Removed repo checkout directory assumption

### DIFF
--- a/common/tools/dev-tool/src/util/printer.ts
+++ b/common/tools/dev-tool/src/util/printer.ts
@@ -4,12 +4,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import chalk from "chalk";
-import path from "path";
 
 const printModes = ["info", "warn", "error", "success", "debug"] as const;
 
 export type Fn<T = void> = (...values: any[]) => T;
 export type ModeMap<T> = { [k in typeof printModes[number]]: T };
+
+const DEV_TOOL_PATH = __dirname.split("dev-tool")[0];
 
 /**
  * The interface that describes the Printer produced by {@link createPrinter}
@@ -99,11 +100,9 @@ const finalLogger: ModeMap<Fn> = {
   debug(...values: string[]) {
     if (process.env.DEBUG) {
       const caller = getCaller();
-      const fileName = caller
-        ?.getFileName()
-        ?.split(path.join("azure-sdk-for-js", "common", "tools", "dev-tool"));
+      const fileName = caller?.getFileName()?.split(DEV_TOOL_PATH)?.[1];
       const callerInfo = `(@ ${fileName ? fileName : "<unknown>"}#${caller?.getFunctionName() ??
-        "<unknown>"}:${caller?.getLineNumber()}:${caller?.getColumnNumber()})`;
+        "<anonymous>"}:${caller?.getLineNumber()}:${caller?.getColumnNumber()})`;
       backend.error(values[0], colors.debug(callerInfo), ...values.slice(1));
     }
   },

--- a/common/tools/dev-tool/test/resolveProject.spec.ts
+++ b/common/tools/dev-tool/test/resolveProject.spec.ts
@@ -24,7 +24,7 @@ describe("Project Resolution", async () => {
     assert.equal(packageInfo.name, "@azure/dev-tool");
     assert.match(
       packageInfo.path,
-      new RegExp(`.*${path.sep}${path.join("azure-sdk-for-js", "common", "tools", "dev-tool")}`)
+      new RegExp(`.*${path.sep}${path.join("common", "tools", "dev-tool")}`)
     );
   });
 });


### PR DESCRIPTION
Closes #12287 
("Windows" in the linked issue is a red herring, the same bug would apply to Linux and macOS)

dev-tool had a couple of places where it assumed the repository was cloned into a directory named "azure-sdk-for-js", of course that isn't necessarily true. This fixes that.