### PR TITLE
[core-tracing] beta version

### DIFF
--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.10 (Unreleased)
+## 1.0.0-beta.1 (Unreleased)
 
 ## 1.0.0-preview.9 (2020-08-04)
 

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Release History
 
-## 1.0.0-preview.10 (Unreleased)
-
+## 1.0.0-beta.10 (Unreleased)
 
 ## 1.0.0-preview.9 (2020-08-04)
 

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.1",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-beta.10",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Updating the version to use `beta` instead of `preview` following our [new semver policy](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releases.md#package-versioning).