### PR TITLE
[Cosmos] fix strictness issue in src/extractPartitionKey.ts

### DIFF
--- a/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
@@ -12,29 +12,26 @@ export function extractPartitionKey(
   document: any,
   partitionKeyDefinition: PartitionKeyDefinition
 ): PartitionKey[] {
-  if (
-    partitionKeyDefinition &&
-    partitionKeyDefinition.paths &&
-    partitionKeyDefinition.paths.length > 0
-  ) {
-    const partitionKey: PartitionKey[] = [];
-    partitionKeyDefinition.paths.forEach((path: string) => {
-      const pathParts = parsePath(path);
-      let obj = document;
-      for (const part of pathParts) {
-        if (!(typeof obj === "object" && part in obj)) {
-          obj = undefined;
-          break;
-        }
-        obj = obj[part];
-      }
-      partitionKey.push(obj);
-    });
-    if (partitionKey.length === 1 && partitionKey[0] === undefined) {
-      return undefinedPartitionKey(partitionKeyDefinition);
-    }
-    return partitionKey;
+  if (partitionKeyDefinition.paths.length === 0) {
+    throw new Error("Expects a non empty array of paths");
   }
+  const partitionKey: PartitionKey[] = [];
+  partitionKeyDefinition.paths.forEach((path: string) => {
+    const pathParts = parsePath(path);
+    let obj = document;
+    for (const part of pathParts) {
+      if (!(typeof obj === "object" && part in obj)) {
+        obj = undefined;
+        break;
+      }
+      obj = obj[part];
+    }
+    partitionKey.push(obj);
+  });
+  if (partitionKey.length === 1 && partitionKey[0] === undefined) {
+    return undefinedPartitionKey(partitionKeyDefinition);
+  }
+  return partitionKey;
 }
 /**
  * @ignore

--- a/sdk/cosmosdb/cosmos/test/integration/extractPartitionKey.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/extractPartitionKey.spec.ts
@@ -4,14 +4,6 @@ import assert from "assert";
 import { extractPartitionKey } from "../../src/extractPartitionKey";
 
 describe("extractPartitionKey", function() {
-  describe("With undefined partitionKeyDefinition", function() {
-    it("should return undefined", function() {
-      const document: any = {};
-      const result = extractPartitionKey(document, undefined);
-      assert.equal(result, undefined);
-    });
-  });
-
   describe("With a defined partitionKeyDefinition", function() {
     const partitionKeyDefinition = { paths: ["/a/b"] };
     const migratedPartitionKeyDefinition = { paths: ["/_partitionKey"], isSystemKey: true };


### PR DESCRIPTION
Our goal is to remove `strict: false` from `tsconfig.json` in order to fulfill https://github.com/Azure/azure-sdk-for-js/issues/5276. I plan to do so by opening a PR with fixes per file.