### PR TITLE
 [core-amqp] bugfix: updates retry function to return immediately once attempts are exhausted

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.1 (Unreleased)
 
+- Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
+  Previously, `retry` would still sleep one more time after all retry attempts were exhausted before returning.
+  Now, `retry` will return immediately after all retry attempts are completed as necessary.
 
 ## 2.0.0 (2020-11-12)
 

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -229,7 +229,7 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
         targetDelayInMs = Math.min(incrementDelta, config.retryOptions.maxRetryDelayInMs);
       }
 
-      if (lastError && lastError.retryable) {
+      if (lastError && lastError.retryable && totalNumberOfAttempts > i) {
         logger.verbose(
           "[%s] Sleeping for %d milliseconds for '%s'.",
           config.connectionId,

--- a/sdk/core/core-amqp/test/retry.spec.ts
+++ b/sdk/core/core-amqp/test/retry.spec.ts
@@ -203,6 +203,41 @@ dotenv.config();
       }
     });
 
+    it("should not sleep after final failure if all attempts return a retryable error", async function() {
+      let counter = 0;
+      // Create an abort controller so we can clean up the delay's setTimeout ASAP after the race.
+      const delayAbortController = new AbortController();
+      try {
+        const config: RetryConfig<any> = {
+          operation: async () => {
+            debug("counter: %d", ++counter);
+            await delay(0);
+            const e = new MessagingError("I would always like to fail, keep retrying.");
+            e.retryable = true;
+            throw e;
+          },
+          connectionId: "connection-1",
+          operationType: RetryOperationType.session,
+          retryOptions: {
+            maxRetries: 0,
+            retryDelayInMs: 60000,
+            mode: mode
+          }
+        };
+        // Since retry should not sleep since maxRetries is 0, `retry` should beat `delay`.
+        await Promise.race([retry(config), delay(10000, delayAbortController.signal)]);
+        // If we get here, `delay` won :-(
+        throw new Error("TestFailure: 'retry' took longer than expected to return.");
+      } catch (err) {
+        should.exist(err);
+        err.message.should.equal("I would always like to fail, keep retrying.");
+        should.equal(true, err instanceof MessagingError);
+        counter.should.equal(1);
+        // Clear delay's setTimeout...we don't need it anymore.
+        delayAbortController.abort();
+      }
+    });
+
     it("should stop retries when aborted", async function() {
       let counter = 0;
       const controller = new AbortController();

--- a/sdk/core/core-amqp/test/retry.spec.ts
+++ b/sdk/core/core-amqp/test/retry.spec.ts
@@ -210,8 +210,7 @@ dotenv.config();
       try {
         const config: RetryConfig<any> = {
           operation: async () => {
-            debug("counter: %d", ++counter);
-            await delay(0);
+            counter++;
             const e = new MessagingError("I would always like to fail, keep retrying.");
             e.retryable = true;
             throw e;
@@ -245,8 +244,7 @@ dotenv.config();
       try {
         const config: RetryConfig<any> = {
           operation: async () => {
-            debug("counter: %d", ++counter);
-            await delay(0);
+            counter++;
             const e = new MessagingError("I would always like to fail, keep retrying.");
             e.retryable = true;
             throw e;


### PR DESCRIPTION
Fixes #12610 

This change is pretty straightforward.

### Expected `retry` behavior:
If the operation passed to `retry` fails with a `retryable` error __and__ the maximum number of retries allowed has not been reached, `retry` should 'sleep' between operation attempts.

### Actual `retry` behavior pre-change:
If the operation passed to `retry` fails with a `retryable` error `retry` adds a 'sleep'.

This means that even if the final 'attempt' results in a retryable error being thrown, `retry` still sleeps before yielding the error to the calling code.

### Actual `retry` behavior post-change:
Matches the expected `retry` behavior. There is a 'sleep` only _between_ operation attempts, but not after all attempts have been exhausted.
