### PR TITLE
[event-hubs][service-bus] updates (EventData|ServiceBusMessage).body documentation

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.3.2 (Unreleased)
 
+- Updates documentation for `EventData` to call out that the `body` field
+  should be set to a `Buffer` when cross-language compatibility while
+  receiving events is required.
 
 ## 5.3.1 (2020-11-12)
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 5.3.2 (Unreleased)
 
 - Updates documentation for `EventData` to call out that the `body` field
-  should be set to a `Buffer` when cross-language compatibility while
-  receiving events is required.
+  must be converted to a byte array or `Buffer` when cross-language
+  compatibility while receiving events is required.
 
 ## 5.3.1 (2020-11-12)
 

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -229,6 +229,9 @@ export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessa
 export interface EventData {
   /**
    * @property The message body that needs to be sent.
+   * If the application reading the events is not using this SDK,
+   * consider setting the `body` to a `Buffer` for better cross-language
+   * compatibility.
    */
   body: any;
   /**

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -230,8 +230,8 @@ export interface EventData {
   /**
    * @property The message body that needs to be sent.
    * If the application reading the events is not using this SDK,
-   * consider setting the `body` to a `Buffer` for better cross-language
-   * compatibility.
+   * convert your body payload to a byte array or Buffer for better
+   * cross-language compatibility.
    */
   body: any;
   /**

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Release History
 
+## 7.0.1 (Unreleased)
+
+- Updates documentation for `ServiceBusMessage` to call out that the `body` field
+  must be converted to a byte array or `Buffer` when cross-language
+  compatibility while receiving events is required.
+
 ## 7.0.0 (2020-11-23)
 
 - This release marks the general availability of the `@azure/service-bus` package.
 - If you are using version 1.1.10 or lower and want to migrate to the latest version
-of this package please look at our [migration guide to move from Service Bus V1 to Service Bus V7](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/migrationguide.md)
+  of this package please look at our [migration guide to move from Service Bus V1 to Service Bus V7](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/migrationguide.md)
 
 ### Breaking changes
+
 **Note:** The following breaking changes are with respect to version `7.0.0-preview.8`.
 If migrating from version 1.1.10 or lower, look at our [migration guide to move from Service Bus V1 to Service Bus V7](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/migrationguide.md).
 

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "license": "MIT",
   "description": "Azure Service Bus SDK for JavaScript",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -104,6 +104,9 @@ export interface DeadLetterOptions {
 export interface ServiceBusMessage {
   /**
    * @property The message body that needs to be sent or is received.
+   * If the application receiving the message is not using this SDK,
+   * convert your body payload to a byte array or Buffer for better
+   * cross-language compatibility.
    */
   body: any;
   /**

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -7,7 +7,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "7.0.0"
+  version: "7.0.1"
 };
 
 /**


### PR DESCRIPTION
Partly addresses #12701 by recommending setting `EventData.body` to a `Buffer` when the user needs cross-language compatibility between sending and receiving events.

### Context
The `@azure/event-hubs` producer will do one of two things to the body depending on the body's type:

- If the body is a buffer, it will send it as is.
- If the body is not a buffer, it will JSON.stringify it before sending the message. When receiving the message using the SDK, the body will be parsed using JSON.parse.

When sending events with this SDK and receiving events using a different solution, we see that the event body is parsed differently. In this type of scenario, event bodies should be sent as Buffers since these will be sent as is rather than have any transformations (in our case, JSON encoding) performed on them.
