### PR TITLE
[core-http] enable no-prototype-builtins

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -82,7 +82,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o core-http-lintReport.html",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -82,7 +82,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o core-http-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o core-http-lintReport.html",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -82,8 +82,11 @@ export abstract class FetchHttpClient implements HttpClient {
         if (typeof value === "function") {
           value = value();
         }
-        // eslint-disable-next-line no-prototype-builtins
-        if (value && value.hasOwnProperty("value") && value.hasOwnProperty("options")) {
+        if (
+          value &&
+          Object.prototype.hasOwnProperty.call(value, "value") &&
+          Object.prototype.hasOwnProperty.call(value, "options")
+        ) {
           requestForm.append(key, value.value, value.options);
         } else {
           requestForm.append(key, value);

--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -16,6 +16,13 @@ import { AccessTokenCache, ExpiringAccessTokenCache } from "../credentials/acces
 import { AccessTokenRefresher } from "../credentials/accessTokenRefresher";
 
 /**
+ * The automated token refresh will only start to happen at the
+ * expiration date minus the value of timeBetweenRefreshAttemptsInMs,
+ * which is by default 30 seconds.
+ */
+const timeBetweenRefreshAttemptsInMs = 30000;
+
+/**
  * Creates a new BearerTokenAuthenticationPolicy factory.
  *
  * @param credential The TokenCredential implementation that can supply the bearer token.
@@ -38,13 +45,6 @@ export function bearerTokenAuthenticationPolicy(
     }
   };
 }
-
-/**
- * The automated token refresh will only start to happen at the
- * expiration date minus the value of timeBetweenRefreshAttemptsInMs,
- * which is by default 30 seconds.
- */
-const timeBetweenRefreshAttemptsInMs = 30000;
 
 /**
  *

--- a/sdk/core/core-http/src/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.ts
@@ -16,7 +16,7 @@ import { getEnvironmentValue } from "../util/utils";
 
 let noProxyList: string[] = [];
 let isNoProxyInitalized = false;
-let byPassedList = new Map();
+const byPassedList = new Map();
 
 function loadEnvironmentProxyValue(): string | undefined {
   if (!process) {
@@ -37,7 +37,7 @@ function isBypassed(uri: string) {
   }
   loadNoProxy();
   let isBypassed = false;
-  let host = URLBuilder.parse(uri).getHost()!;
+  const host = URLBuilder.parse(uri).getHost()!;
   for (const proxyString of noProxyList) {
     if (proxyString[0] === ".") {
       if (uri.endsWith(proxyString)) {
@@ -63,7 +63,7 @@ function loadNoProxy() {
   }
   const noProxy = getEnvironmentValue(Constants.NO_PROXY);
   if (noProxy) {
-    let list = noProxy.split(",");
+    const list = noProxy.split(",");
     noProxyList = list.map((item) => item.trim()).filter((item) => item.length);
   }
   isNoProxyInitalized = true;

--- a/sdk/core/core-http/src/util/serializer.common.ts
+++ b/sdk/core/core-http/src/util/serializer.common.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * Default key used to access the XML attributes.

--- a/sdk/core/core-http/src/xhrHttpClient.ts
+++ b/sdk/core/core-http/src/xhrHttpClient.ts
@@ -43,8 +43,11 @@ export class XhrHttpClient implements HttpClient {
       const formData = request.formData;
       const requestForm = new FormData();
       const appendFormValue = (key: string, value: any): void => {
-        // eslint-disable-next-line no-prototype-builtins
-        if (value && value.hasOwnProperty("value") && value.hasOwnProperty("options")) {
+        if (
+          value &&
+          Object.prototype.hasOwnProperty.call(value, "value") &&
+          Object.prototype.hasOwnProperty.call(value, "options")
+        ) {
           requestForm.append(key, value.value, value.options);
         } else {
           requestForm.append(key, value);

--- a/sdk/core/core-http/test/mockHttp.ts
+++ b/sdk/core/core-http/test/mockHttp.ts
@@ -49,8 +49,7 @@ class FetchHttpMock implements HttpMockFacade {
 
   // returns the locally mocked fetch instance
   getFetch(): typeof node_fetch {
-    /// @ts-ignore
-    return this._fetch as typeof node_fetch;
+    return (this._fetch as unknown) as typeof node_fetch;
   }
 
   setup(): void {

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -66,8 +66,8 @@ describe("ProxyPolicy (node)", function() {
     });
 
     it("should not assign proxy settings to the web request when noProxyList contain request url", async () => {
-      let request = new WebResource();
-      let policy = new ProxyPolicy(emptyRequestPolicy, emptyPolicyOptions, proxySettings);
+      const request = new WebResource();
+      const policy = new ProxyPolicy(emptyRequestPolicy, emptyPolicyOptions, proxySettings);
       request.url = "http://foo.com";
       await policy.sendRequest(request);
       should().not.exist(request.proxySettings);

--- a/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/transforms.ts
@@ -280,8 +280,7 @@ export function toFieldsFromFieldValue(
 ): { [propertyName: string]: FormField } {
   const result: { [propertyName: string]: FormField } = {};
   for (const key in original) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (original.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(original, key)) {
       if (!original[key]) {
         result[key] = { name: key };
         continue;


### PR DESCRIPTION
## What

- Enable "no-prototype-builtins" and fix the errors
- Fix any errors found in core-http lint report
- Fail on lint errors

## Why

- Fixing the no-prototype rule was punted to a future commit to limit scope
- In passing, I noticed other errors in the lint report
- When all were fixed, I figured it would be helpful to fail with an error so the user can tell where to find the lint report. Otherwise I had to figure out why the lint errors weren't showing up like they do in other projects

- [x] Ran unit tests 
- [x] Ensure the lint report is clean of errors (but not warnings to limit changes)

Fixes #8972