### PR TITLE
[Text Analytics] adding @azure/core-asynciterator-polyfill as a dep

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -79,6 +79,7 @@
   "sideEffects": false,
   "autoPublish": false,
   "dependencies": {
+    "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",


### PR DESCRIPTION
This apparently is needed for node8 tests to succeed in https://github.com/Azure/azure-sdk-for-js/pull/12713/.