### PR TITLE
[core-http(s)] Expose setClientRequestIdPolicy options

### DIFF
--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -353,7 +353,6 @@ export interface HttpResponse {
 
 // @public
 export interface InternalPipelineOptions extends PipelineOptions {
-    clientRequestIdOptions?: ClientRequestIdOptions;
     decompressResponse?: boolean;
     deserializationOptions?: DeserializationOptions;
     loggingOptions?: LogPolicyOptions;
@@ -532,6 +531,7 @@ export function parseXML(str: string, opts?: SerializerOptions): Promise<any>;
 
 // @public
 export interface PipelineOptions {
+    clientRequestIdOptions?: ClientRequestIdOptions;
     httpClient?: HttpClient;
     // (undocumented)
     keepAliveOptions?: KeepAliveOptions;

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -101,8 +101,8 @@ export function bearerTokenAuthenticationPolicy(credential: TokenCredential, sco
 
 // @public
 export interface ClientRequestIdOptions {
+    disable?: boolean;
     requestIdHeaderName?: string;
-    shouldGenerateClientRequestId?: boolean;
 }
 
 // @public (undocumented)
@@ -353,6 +353,7 @@ export interface HttpResponse {
 
 // @public
 export interface InternalPipelineOptions extends PipelineOptions {
+    clientRequestIdOptions?: ClientRequestIdOptions;
     decompressResponse?: boolean;
     deserializationOptions?: DeserializationOptions;
     loggingOptions?: LogPolicyOptions;
@@ -531,7 +532,6 @@ export function parseXML(str: string, opts?: SerializerOptions): Promise<any>;
 
 // @public
 export interface PipelineOptions {
-    clientRequestIdOptions?: ClientRequestIdOptions;
     httpClient?: HttpClient;
     // (undocumented)
     keepAliveOptions?: KeepAliveOptions;

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -99,6 +99,12 @@ export class BasicAuthenticationCredentials implements ServiceClientCredentials 
 // @public
 export function bearerTokenAuthenticationPolicy(credential: TokenCredential, scopes: string | string[]): RequestPolicyFactory;
 
+// @public
+export interface ClientRequestIdOptions {
+    requestIdHeaderName?: string;
+    shouldGenerateClientRequestId?: boolean;
+}
+
 // @public (undocumented)
 export interface CompositeMapper extends BaseMapper {
     // (undocumented)
@@ -347,6 +353,7 @@ export interface HttpResponse {
 
 // @public
 export interface InternalPipelineOptions extends PipelineOptions {
+    clientRequestIdOptions?: ClientRequestIdOptions;
     decompressResponse?: boolean;
     deserializationOptions?: DeserializationOptions;
     loggingOptions?: LogPolicyOptions;

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -55,7 +55,10 @@ export {
   RequestPolicyOptions,
   RequestPolicyOptionsLike
 } from "./policies/requestPolicy";
-export { generateClientRequestIdPolicy } from "./policies/generateClientRequestIdPolicy";
+export {
+  generateClientRequestIdPolicy,
+  ClientRequestIdOptions
+} from "./policies/generateClientRequestIdPolicy";
 export { exponentialRetryPolicy, RetryOptions, RetryMode } from "./policies/exponentialRetryPolicy";
 export { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
 export { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";

--- a/sdk/core/core-http/src/pipelineOptions.ts
+++ b/sdk/core/core-http/src/pipelineOptions.ts
@@ -9,6 +9,7 @@ import { ProxyOptions } from "./serviceClient";
 import { UserAgentOptions } from "./policies/userAgentPolicy";
 import { DeserializationOptions } from "./policies/deserializationPolicy";
 import { LogPolicyOptions } from "./policies/logPolicy";
+import { ClientRequestIdOptions } from "./policies/generateClientRequestIdPolicy";
 
 /**
  * Defines options that are used to configure the HTTP pipeline for
@@ -46,6 +47,10 @@ export interface PipelineOptions {
    * Options for adding user agent details to outgoing requests.
    */
   userAgentOptions?: UserAgentOptions;
+  /**
+   * Configure the header to use for the client request id
+   */
+  clientRequestIdOptions?: ClientRequestIdOptions;
 }
 
 /**

--- a/sdk/core/core-http/src/pipelineOptions.ts
+++ b/sdk/core/core-http/src/pipelineOptions.ts
@@ -47,10 +47,6 @@ export interface PipelineOptions {
    * Options for adding user agent details to outgoing requests.
    */
   userAgentOptions?: UserAgentOptions;
-  /**
-   * Configure the header to use for the client request id
-   */
-  clientRequestIdOptions?: ClientRequestIdOptions;
 }
 
 /**
@@ -77,4 +73,8 @@ export interface InternalPipelineOptions extends PipelineOptions {
    * Send JSON Array payloads as NDJSON.
    */
   sendStreamingJson?: boolean;
+  /**
+   * Configure the header to use for the client request id
+   */
+  clientRequestIdOptions?: ClientRequestIdOptions;
 }

--- a/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
+++ b/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
@@ -22,7 +22,7 @@ export interface ClientRequestIdOptions {
   /**
    * Whether or not to include a the generateClientRequestPolicyId pipeline
    */
-  shouldGenerateClientRequestId?: boolean;
+  disable?: boolean;
 }
 
 /**
@@ -30,7 +30,7 @@ export interface ClientRequestIdOptions {
  */
 export const DefaultClientRequestIdOptions: ClientRequestIdOptions = {
   requestIdHeaderName: "x-ms-client-request-id",
-  shouldGenerateClientRequestId: true
+  disable: false
 };
 
 export function generateClientRequestIdPolicy(

--- a/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
+++ b/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
@@ -10,6 +10,29 @@ import {
   RequestPolicyOptions
 } from "./requestPolicy";
 
+/**
+ * Options for how HTTP connections generate the client request id header
+ * requests.
+ */
+export interface ClientRequestIdOptions {
+  /**
+   * The header name to use for the client request id
+   */
+  requestIdHeaderName?: string;
+  /**
+   * Whether or not to include a the generateClientRequestPolicyId pipeline
+   */
+  shouldGenerateClientRequestId?: boolean;
+}
+
+/**
+ * Default options for ClientRequestId policy
+ */
+export const DefaultClientRequestIdOptions: ClientRequestIdOptions = {
+  requestIdHeaderName: "x-ms-client-request-id",
+  shouldGenerateClientRequestId: true
+};
+
 export function generateClientRequestIdPolicy(
   requestIdHeaderName = "x-ms-client-request-id"
 ): RequestPolicyFactory {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -797,9 +797,10 @@ export function createPipelineFromOptions(
     requestPolicyFactories.push(proxyPolicy(pipelineOptions.proxyOptions));
   }
 
-  if (clientRequestIdOptions.shouldGenerateClientRequestId) {
-    requestPolicyFactories.push(
-      generateClientRequestIdPolicy(pipelineOptions.clientRequestIdOptions?.requestIdHeaderName)
+  let clientRequestIdPolicy: RequestPolicyFactory | undefined;
+  if (!clientRequestIdOptions.disable) {
+    clientRequestIdPolicy = generateClientRequestIdPolicy(
+      pipelineOptions.clientRequestIdOptions?.requestIdHeaderName
     );
   }
 
@@ -816,6 +817,7 @@ export function createPipelineFromOptions(
     tracingPolicy({ userAgent: userAgentValue }),
     keepAlivePolicy(keepAliveOptions),
     userAgentPolicy({ value: userAgentValue }),
+    ...(clientRequestIdPolicy ? [clientRequestIdPolicy] : []),
     deserializationPolicy(deserializationOptions.expectedContentTypes),
     throttlingRetryPolicy(),
     systemErrorRetryPolicy(),

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -20,7 +20,10 @@ import {
   DefaultDeserializationOptions
 } from "./policies/deserializationPolicy";
 import { exponentialRetryPolicy, DefaultRetryOptions } from "./policies/exponentialRetryPolicy";
-import { generateClientRequestIdPolicy } from "./policies/generateClientRequestIdPolicy";
+import {
+  DefaultClientRequestIdOptions,
+  generateClientRequestIdPolicy
+} from "./policies/generateClientRequestIdPolicy";
 import {
   userAgentPolicy,
   getDefaultUserAgentHeaderName,
@@ -770,6 +773,11 @@ export function createPipelineFromOptions(
     userAgentValue = userAgentInfo.join(" ");
   }
 
+  const clientRequestIdOptions = {
+    ...DefaultClientRequestIdOptions,
+    ...pipelineOptions.clientRequestIdOptions
+  };
+
   const keepAliveOptions = {
     ...DefaultKeepAliveOptions,
     ...pipelineOptions.keepAliveOptions
@@ -789,6 +797,12 @@ export function createPipelineFromOptions(
     requestPolicyFactories.push(proxyPolicy(pipelineOptions.proxyOptions));
   }
 
+  if (clientRequestIdOptions.shouldGenerateClientRequestId) {
+    requestPolicyFactories.push(
+      generateClientRequestIdPolicy(pipelineOptions.clientRequestIdOptions?.requestIdHeaderName)
+    );
+  }
+
   const deserializationOptions = {
     ...DefaultDeserializationOptions,
     ...pipelineOptions.deserializationOptions
@@ -802,7 +816,6 @@ export function createPipelineFromOptions(
     tracingPolicy({ userAgent: userAgentValue }),
     keepAlivePolicy(keepAliveOptions),
     userAgentPolicy({ value: userAgentValue }),
-    generateClientRequestIdPolicy(),
     deserializationPolicy(deserializationOptions.expectedContentTypes),
     throttlingRetryPolicy(),
     systemErrorRetryPolicy(),

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -297,7 +297,7 @@ describe("ServiceClient", function() {
         }
       },
       clientRequestIdOptions: {
-        shouldGenerateClientRequestId: false
+        disable: true
       }
     };
 
@@ -331,7 +331,6 @@ describe("ServiceClient", function() {
         }
       },
       clientRequestIdOptions: {
-        shouldGenerateClientRequestId: true,
         requestIdHeaderName: fooRequestId
       }
     };

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -147,6 +147,7 @@ export interface PipelineOptions {
     proxyOptions?: ProxySettings;
     redirectOptions?: RedirectPolicyOptions;
     retryOptions?: ExponentialRetryPolicyOptions;
+    setClientRequestIdPolicyOptions?: SetClientRequestIdPolicyOptions;
     userAgentOptions?: UserAgentPolicyOptions;
 }
 
@@ -271,6 +272,12 @@ export function setClientRequestIdPolicy(requestIdHeaderName?: string): Pipeline
 
 // @public
 export const setClientRequestIdPolicyName = "setClientRequestIdPolicy";
+
+// @public
+export interface SetClientRequestIdPolicyOptions {
+    requestIdHeaderName?: string;
+    shouldSetClientRequestId?: boolean;
+}
 
 // @public
 export function systemErrorRetryPolicy(options?: SystemErrorRetryPolicyOptions): PipelinePolicy;

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -109,6 +109,7 @@ export type HttpMethods = "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "HEAD" |
 // @public
 export interface InternalPipelineOptions extends PipelineOptions {
     loggingOptions?: LogPolicyOptions;
+    setClientRequestIdPolicyOptions?: SetClientRequestIdPolicyOptions;
 }
 
 // @public
@@ -147,7 +148,6 @@ export interface PipelineOptions {
     proxyOptions?: ProxySettings;
     redirectOptions?: RedirectPolicyOptions;
     retryOptions?: ExponentialRetryPolicyOptions;
-    setClientRequestIdPolicyOptions?: SetClientRequestIdPolicyOptions;
     userAgentOptions?: UserAgentPolicyOptions;
 }
 
@@ -275,8 +275,8 @@ export const setClientRequestIdPolicyName = "setClientRequestIdPolicy";
 
 // @public
 export interface SetClientRequestIdPolicyOptions {
+    disable?: boolean;
     requestIdHeaderName?: string;
-    shouldSetClientRequestId?: boolean;
 }
 
 // @public

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -41,7 +41,8 @@ export {
 } from "./policies/exponentialRetryPolicy";
 export {
   setClientRequestIdPolicy,
-  setClientRequestIdPolicyName
+  setClientRequestIdPolicyName,
+  SetClientRequestIdPolicyOptions
 } from "./policies/setClientRequestIdPolicy";
 export { logPolicy, logPolicyName, LogPolicyOptions } from "./policies/logPolicy";
 export { proxyPolicy, proxyPolicyName, getDefaultProxySettings } from "./policies/proxyPolicy";

--- a/sdk/core/core-rest-pipeline/src/policies/setClientRequestIdPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/setClientRequestIdPolicy.ts
@@ -10,6 +10,29 @@ import { PipelinePolicy } from "../pipeline";
 export const setClientRequestIdPolicyName = "setClientRequestIdPolicy";
 
 /**
+ * Options for how HTTP connections generate the client request id header
+ * requests.
+ */
+export interface SetClientRequestIdPolicyOptions {
+  /**
+   * The header name to use for the client request id
+   */
+  requestIdHeaderName?: string;
+  /**
+   * Whether or not to include a the generateClientRequestPolicyId pipeline
+   */
+  shouldSetClientRequestId?: boolean;
+}
+
+/**
+ * Default options for ClientRequestId policy
+ */
+export const DefaultSetClientRequestIdPolicyOptions: SetClientRequestIdPolicyOptions = {
+  requestIdHeaderName: "x-ms-client-request-id",
+  shouldSetClientRequestId: true
+};
+
+/**
  * Each PipelineRequest gets a unique id upon creation.
  * This policy passes that unique id along via an HTTP header to enable better
  * telemetry and tracing.

--- a/sdk/core/core-rest-pipeline/src/policies/setClientRequestIdPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/setClientRequestIdPolicy.ts
@@ -21,7 +21,7 @@ export interface SetClientRequestIdPolicyOptions {
   /**
    * Whether or not to include a the generateClientRequestPolicyId pipeline
    */
-  shouldSetClientRequestId?: boolean;
+  disable?: boolean;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface SetClientRequestIdPolicyOptions {
  */
 export const DefaultSetClientRequestIdPolicyOptions: SetClientRequestIdPolicyOptions = {
   requestIdHeaderName: "x-ms-client-request-id",
-  shouldSetClientRequestId: true
+  disable: false
 };
 
 /**

--- a/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
@@ -388,5 +388,66 @@ describe("HttpsPipeline", function() {
       const response = await pipeline.sendRequest(testHttpClient, request);
       assert.strictEqual(response.status, 200);
     });
+
+    it("sets client request id by default", async function() {
+      const clientRequestIdHeaderName = "x-ms-client-request-id";
+      const testHttpsClient: HttpsClient = {
+        sendRequest: async (request) => {
+          assert.strictEqual(request.url, "https://example.com");
+          return {
+            request,
+            headers: createHttpHeaders(),
+            status: 200
+          };
+        }
+      };
+
+      const pipeline = createPipelineFromOptions({});
+      const request = createPipelineRequest({ url: "https://example.com" });
+      const response = await pipeline.sendRequest(testHttpsClient, request);
+      assert.isTrue(response.request.headers.has(clientRequestIdHeaderName));
+    });
+
+    it("doesn't set client request id", async function() {
+      const clientRequestIdHeaderName = "x-ms-client-request-id";
+      const testHttpsClient: HttpsClient = {
+        sendRequest: async (request) => {
+          assert.strictEqual(request.url, "https://example.com");
+          return {
+            request,
+            headers: createHttpHeaders(),
+            status: 200
+          };
+        }
+      };
+
+      const pipeline = createPipelineFromOptions({
+        setClientRequestIdPolicyOptions: { shouldSetClientRequestId: false }
+      });
+      const request = createPipelineRequest({ url: "https://example.com" });
+      const response = await pipeline.sendRequest(testHttpsClient, request);
+      assert.isFalse(response.request.headers.has(clientRequestIdHeaderName));
+    });
+
+    it("sets client request id with custom header name", async function() {
+      const clientRequestIdHeaderName = "x-ms-foo-request-id";
+      const testHttpsClient: HttpsClient = {
+        sendRequest: async (request) => {
+          assert.strictEqual(request.url, "https://example.com");
+          return {
+            request,
+            headers: createHttpHeaders(),
+            status: 200
+          };
+        }
+      };
+
+      const pipeline = createPipelineFromOptions({
+        setClientRequestIdPolicyOptions: { requestIdHeaderName: clientRequestIdHeaderName }
+      });
+      const request = createPipelineRequest({ url: "https://example.com" });
+      const response = await pipeline.sendRequest(testHttpsClient, request);
+      assert.isTrue(response.request.headers.has(clientRequestIdHeaderName));
+    });
   });
 });

--- a/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/pipeline.spec.ts
@@ -391,7 +391,7 @@ describe("HttpsPipeline", function() {
 
     it("sets client request id by default", async function() {
       const clientRequestIdHeaderName = "x-ms-client-request-id";
-      const testHttpsClient: HttpsClient = {
+      const testHttpClient: HttpClient = {
         sendRequest: async (request) => {
           assert.strictEqual(request.url, "https://example.com");
           return {
@@ -404,13 +404,13 @@ describe("HttpsPipeline", function() {
 
       const pipeline = createPipelineFromOptions({});
       const request = createPipelineRequest({ url: "https://example.com" });
-      const response = await pipeline.sendRequest(testHttpsClient, request);
+      const response = await pipeline.sendRequest(testHttpClient, request);
       assert.isTrue(response.request.headers.has(clientRequestIdHeaderName));
     });
 
     it("doesn't set client request id", async function() {
       const clientRequestIdHeaderName = "x-ms-client-request-id";
-      const testHttpsClient: HttpsClient = {
+      const testHttpClient: HttpClient = {
         sendRequest: async (request) => {
           assert.strictEqual(request.url, "https://example.com");
           return {
@@ -422,16 +422,16 @@ describe("HttpsPipeline", function() {
       };
 
       const pipeline = createPipelineFromOptions({
-        setClientRequestIdPolicyOptions: { shouldSetClientRequestId: false }
+        setClientRequestIdPolicyOptions: { disable: true }
       });
       const request = createPipelineRequest({ url: "https://example.com" });
-      const response = await pipeline.sendRequest(testHttpsClient, request);
+      const response = await pipeline.sendRequest(testHttpClient, request);
       assert.isFalse(response.request.headers.has(clientRequestIdHeaderName));
     });
 
     it("sets client request id with custom header name", async function() {
       const clientRequestIdHeaderName = "x-ms-foo-request-id";
-      const testHttpsClient: HttpsClient = {
+      const testHttpClient: HttpClient = {
         sendRequest: async (request) => {
           assert.strictEqual(request.url, "https://example.com");
           return {
@@ -446,7 +446,7 @@ describe("HttpsPipeline", function() {
         setClientRequestIdPolicyOptions: { requestIdHeaderName: clientRequestIdHeaderName }
       });
       const request = createPipelineRequest({ url: "https://example.com" });
-      const response = await pipeline.sendRequest(testHttpsClient, request);
+      const response = await pipeline.sendRequest(testHttpClient, request);
       assert.isTrue(response.request.headers.has(clientRequestIdHeaderName));
     });
   });


### PR DESCRIPTION
Allow setting `Client Request Id` preferences through pipeline options. This PR enables the user to:

1) Choose to turn off automatically setting `x-ms-client-request-id`
2) Choose a different header name for the ClientRequestId

This is already available to users when sending requests with raw `ServiceClientOptions` instead of `Pipeline`