### PR TITLE
[core-http] Support custom auth scopes

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -38,7 +38,7 @@ export interface BaseMapper {
 // @public
 export interface ClientPipelineOptions extends InternalPipelineOptions {
     credentialOptions?: {
-        baseUri?: string;
+        scope?: string;
         credential?: TokenCredential;
     };
     deserializationOptions?: DeserializationPolicyOptions;
@@ -339,6 +339,7 @@ export class ServiceClient {
 
 // @public
 export interface ServiceClientOptions {
+    authScope?: string;
     baseUri?: string;
     credential?: TokenCredential;
     httpsClient?: HttpsClient;

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -38,7 +38,7 @@ export interface BaseMapper {
 // @public
 export interface ClientPipelineOptions extends InternalPipelineOptions {
     credentialOptions?: {
-        scope?: string;
+        credentialScopes?: string | string[];
         credential?: TokenCredential;
     };
     deserializationOptions?: DeserializationPolicyOptions;
@@ -339,9 +339,9 @@ export class ServiceClient {
 
 // @public
 export interface ServiceClientOptions {
-    authScope?: string;
     baseUri?: string;
     credential?: TokenCredential;
+    credentialScopes?: string | string[];
     httpsClient?: HttpsClient;
     parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
     pipeline?: Pipeline;

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -38,8 +38,8 @@ export interface BaseMapper {
 // @public
 export interface ClientPipelineOptions extends InternalPipelineOptions {
     credentialOptions?: {
-        credentialScopes?: string | string[];
-        credential?: TokenCredential;
+        credentialScopes: string | string[];
+        credential: TokenCredential;
     };
     deserializationOptions?: DeserializationPolicyOptions;
 }

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -33,6 +33,7 @@ import { getRequestUrl } from "./urlHelpers";
 import { isPrimitiveType } from "./utils";
 import { getOperationArgumentValueFromParameter } from "./operationHelpers";
 import { deserializationPolicy, DeserializationPolicyOptions } from "./deserializationPolicy";
+import { URL } from "./url";
 
 /**
  * Options to be provided while creating the client.

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -400,8 +400,13 @@ function createDefaultPipeline(
     parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
   } = {}
 ): Pipeline {
+  const credentialOptions =
+    options.credential && options.credentialScopes
+      ? { credentialScopes: options.credentialScopes, credential: options.credential }
+      : undefined;
+
   return createClientPipeline({
-    credentialOptions: options,
+    credentialOptions,
     deserializationOptions: {
       parseXML: options.parseXML
     }
@@ -417,7 +422,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
   /**
    * Options to customize bearerTokenAuthenticationPolicy.
    */
-  credentialOptions?: { credentialScopes?: string | string[]; credential?: TokenCredential };
+  credentialOptions?: { credentialScopes: string | string[]; credential: TokenCredential };
   /**
    * Options to customize deserializationPolicy.
    */
@@ -432,13 +437,11 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
  */
 export function createClientPipeline(options: ClientPipelineOptions = {}): Pipeline {
   const pipeline = createPipelineFromOptions(options ?? {});
-  const credential = options.credentialOptions?.credential;
-  const scopes = options.credentialOptions?.credentialScopes;
-  if (credential && scopes) {
+  if (options.credentialOptions) {
     pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
-        credential,
-        scopes
+        credential: options.credentialOptions.credential,
+        scopes: options.credentialOptions.credentialScopes
       })
     );
   }

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -543,7 +543,10 @@ function flattenResponse(
 
 function getCredentialScopes(options: ServiceClientOptions): string | string[] | undefined {
   if (options.credentialScopes) {
-    return options.credentialScopes;
+    const scopes = options.credentialScopes;
+    return Array.isArray(scopes)
+      ? scopes.map((scope) => new URL(scope).toString())
+      : new URL(scopes).toString();
   }
 
   if (options.baseUri) {

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -72,6 +72,32 @@ describe("ServiceClient", function() {
       }
     };
 
+    it("should throw if scopes contain an invalid url", async function() {
+      const credential: TokenCredential = {
+        getToken: async (_scopes) => {
+          return { token: "testToken", expiresOnTimestamp: 11111 };
+        }
+      };
+      try {
+        let request: OperationRequest;
+        const client = new ServiceClient({
+          httpsClient: {
+            sendRequest: (req) => {
+              request = req;
+              return Promise.resolve({ request, status: 200, headers: createHttpHeaders() });
+            }
+          },
+          credential,
+          credentialScopes: ["https://microsoft.com", "lalala"]
+        });
+
+        await client.sendOperationRequest(testOperationArgs, testOperationSpec);
+        assert.fail();
+      } catch (error) {
+        assert.include(error.message, `Invalid URL`);
+      }
+    });
+
     it("should throw is no scope or baseUri are defined", async function() {
       const credential: TokenCredential = {
         getToken: async (_scopes) => {

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -55,7 +55,8 @@
     "./es/src/util/base64.js": "./es/src/util/base64.browser.js",
     "./es/src/util/xml.js": "./es/src/util/xml.browser.js",
     "./es/src/defaultHttpClient.js": "./es/src/defaultHttpClient.browser.js",
-    "./es/src/util/inspect.js": "./es/src/util/inspect.browser.js"
+    "./es/src/util/inspect.js": "./es/src/util/inspect.browser.js",
+    "./es/src/util/url.js": "./es/src/util/url.browser.js"
   },
   "license": "MIT",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-http/README.md",

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -774,6 +774,7 @@ export interface ServiceClientCredentials {
 
 // @public
 export interface ServiceClientOptions {
+    authScope?: string;
     clientRequestIdHeaderName?: string;
     deserializationContentTypes?: DeserializationContentTypes;
     generateClientRequestIdHeader?: boolean;

--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -774,8 +774,8 @@ export interface ServiceClientCredentials {
 
 // @public
 export interface ServiceClientOptions {
-    authScope?: string;
     clientRequestIdHeaderName?: string;
+    credentialScopes?: string | string[];
     deserializationContentTypes?: DeserializationContentTypes;
     generateClientRequestIdHeader?: boolean;
     httpClient?: HttpClient;

--- a/sdk/core/core-http/rollup.base.config.js
+++ b/sdk/core/core-http/rollup.base.config.js
@@ -14,7 +14,7 @@ const input = "./es/src/coreHttp.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["http", "https", "util", "os", "stream", "crypto"];
+  const externalNodeBuiltins = ["http", "https", "util", "os", "stream", "crypto", "url"];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -150,6 +150,10 @@ export interface ServiceClientOptions {
    * Proxy settings which will be used for every HTTP request (Node.js only).
    */
   proxySettings?: ProxySettings;
+  /**
+   * If specified, will be used to build the BearerTokenAuthenticationPolicy.
+   */
+  authScope?: string;
 }
 
 /**
@@ -217,13 +221,12 @@ export class ServiceClient {
           let bearerTokenPolicyFactory: RequestPolicyFactory | undefined = undefined;
           // eslint-disable-next-line @typescript-eslint/no-this-alias
           const serviceClient = this;
+          let scope = options?.authScope;
           return {
             create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): RequestPolicy {
               if (bearerTokenPolicyFactory === undefined || bearerTokenPolicyFactory === null) {
-                bearerTokenPolicyFactory = bearerTokenAuthenticationPolicy(
-                  credentials,
-                  `${serviceClient.baseUri || ""}/.default`
-                );
+                scope = scope || `${serviceClient.baseUri || ""}/.default`;
+                bearerTokenPolicyFactory = bearerTokenAuthenticationPolicy(credentials, scope);
               }
 
               return bearerTokenPolicyFactory.create(nextPolicy, options);

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -61,6 +61,7 @@ import { tracingPolicy } from "./policies/tracingPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 import { ndJsonPolicy } from "./policies/ndJsonPolicy";
 import { XML_ATTRKEY, SerializerOptions, XML_CHARKEY } from "./util/serializer.common";
+import { URL } from "./util/url";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -61,7 +61,7 @@ import { tracingPolicy } from "./policies/tracingPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 import { ndJsonPolicy } from "./policies/ndJsonPolicy";
 import { XML_ATTRKEY, SerializerOptions, XML_CHARKEY } from "./util/serializer.common";
-import { URL } from "./util/url";
+import { URL } from "./url";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -1051,7 +1051,10 @@ function getCredentialScopes(
   baseUri?: string
 ): string | string[] | undefined {
   if (options?.credentialScopes) {
-    return options.credentialScopes;
+    const scopes = options.credentialScopes;
+    return Array.isArray(scopes)
+      ? scopes.map((scope) => new URL(scope).toString())
+      : new URL(scopes).toString();
   }
 
   if (baseUri) {

--- a/sdk/core/core-http/src/url.ts
+++ b/sdk/core/core-http/src/url.ts
@@ -3,6 +3,8 @@
 
 import { replaceAll } from "./util/utils";
 
+export { URL, URLSearchParams } from "./util/url";
+
 type URLQueryParseState = "ParameterName" | "ParameterValue";
 
 /**

--- a/sdk/core/core-http/src/util/url.browser.ts
+++ b/sdk/core/core-http/src/util/url.browser.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+const url = URL;
+const urlSearchParams = URLSearchParams;
+
+export { url as URL, urlSearchParams as URLSearchParams };

--- a/sdk/core/core-http/src/util/url.ts
+++ b/sdk/core/core-http/src/util/url.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { URL, URLSearchParams } from "url";

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -33,75 +33,74 @@ import * as Mappers from "./testMappers";
 
 describe("ServiceClient", function() {
   describe("Auth scopes", () => {
-    it("should use default scope", async () => {
+    const testArgs = {
+      metadata: {
+        alpha: "hello",
+        beta: "world"
+      },
+      unrelated: 42
+    };
+
+    const testOperationSpec: OperationSpec = {
+      httpMethod: "GET",
+      baseUrl: "httpbin.org",
+      serializer: new Serializer(),
+      headerParameters: [
+        {
+          parameterPath: "metadata",
+          mapper: {
+            serializedName: "metadata",
+            type: {
+              name: "Dictionary",
+              value: {
+                type: {
+                  name: "String"
+                }
+              }
+            },
+            headerCollectionPrefix: "foo-bar-"
+          } as DictionaryMapper
+        },
+        {
+          parameterPath: "unrelated",
+          mapper: {
+            serializedName: "unrelated",
+            type: {
+              name: "Number"
+            }
+          }
+        }
+      ],
+      responses: {
+        200: {}
+      }
+    };
+
+    it("should throw when there is no credentialScopes or baseUri", async () => {
       const cred: TokenCredential = {
-        getToken: async (scopes) => {
-          assert.equal(scopes, "/.default");
+        getToken: async (_scopes) => {
           return { token: "testToken", expiresOnTimestamp: 11111 };
         }
       };
-      const expected = {
-        "foo-bar-alpha": "hello",
-        "foo-bar-beta": "world",
-        unrelated: "42",
-        authorization: "Bearer testToken",
-        "user-agent": "core-http/1.2.1 Node/v12.18.2 OS/(x64-Linux-5.4.0-1031-azure)"
-      };
       let request: WebResource;
-      const client = new ServiceClient(cred, {
-        httpClient: {
-          sendRequest: (req) => {
-            request = req;
-            return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
-          }
-        }
-      });
-      await client.sendOperationRequest(
-        {
-          metadata: {
-            alpha: "hello",
-            beta: "world"
-          },
-          unrelated: 42
-        },
-        {
-          httpMethod: "GET",
-          baseUrl: "httpbin.org",
-          serializer: new Serializer(),
-          headerParameters: [
-            {
-              parameterPath: "metadata",
-              mapper: {
-                serializedName: "metadata",
-                type: {
-                  name: "Dictionary",
-                  value: {
-                    type: {
-                      name: "String"
-                    }
-                  }
-                },
-                headerCollectionPrefix: "foo-bar-"
-              } as DictionaryMapper
-            },
-            {
-              parameterPath: "unrelated",
-              mapper: {
-                serializedName: "unrelated",
-                type: {
-                  name: "Number"
-                }
-              }
+      try {
+        const client = new ServiceClient(cred, {
+          httpClient: {
+            sendRequest: (req) => {
+              request = req;
+              return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
             }
-          ],
-          responses: {
-            200: {}
           }
-        }
-      );
+        });
 
-      assert(request!);
-      assert.deepEqual(request!.headers.toJson(), expected);
+        await client.sendOperationRequest(testArgs, testOperationSpec);
+        assert.fail("Expected to throw");
+      } catch (error) {
+        assert.equal(
+          error.message,
+          `When using credential, the ServiceClient must contain a baseUri or a credentialScopes in ServiceClientOptions. Unable to create a bearerTokenAuthenticationPolicy`
+        );
+      }
     });
 
     it("should use the provided scope", async () => {
@@ -112,13 +111,6 @@ describe("ServiceClient", function() {
           return { token: "testToken", expiresOnTimestamp: 11111 };
         }
       };
-      const expected = {
-        "foo-bar-alpha": "hello",
-        "foo-bar-beta": "world",
-        unrelated: "42",
-        authorization: "Bearer testToken",
-        "user-agent": "core-http/1.2.1 Node/v12.18.2 OS/(x64-Linux-5.4.0-1031-azure)"
-      };
       let request: WebResource;
       const client = new ServiceClient(cred, {
         httpClient: {
@@ -127,54 +119,13 @@ describe("ServiceClient", function() {
             return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
           }
         },
-        authScope: scope
+        credentialScopes: scope
       });
-      await client.sendOperationRequest(
-        {
-          metadata: {
-            alpha: "hello",
-            beta: "world"
-          },
-          unrelated: 42
-        },
-        {
-          httpMethod: "GET",
-          baseUrl: "httpbin.org",
-          serializer: new Serializer(),
-          headerParameters: [
-            {
-              parameterPath: "metadata",
-              mapper: {
-                serializedName: "metadata",
-                type: {
-                  name: "Dictionary",
-                  value: {
-                    type: {
-                      name: "String"
-                    }
-                  }
-                },
-                headerCollectionPrefix: "foo-bar-"
-              } as DictionaryMapper
-            },
-            {
-              parameterPath: "unrelated",
-              mapper: {
-                serializedName: "unrelated",
-                type: {
-                  name: "Number"
-                }
-              }
-            }
-          ],
-          responses: {
-            200: {}
-          }
-        }
-      );
+
+      await client.sendOperationRequest(testArgs, testOperationSpec);
 
       assert(request!);
-      assert.deepEqual(request!.headers.toJson(), expected);
+      assert.deepEqual(request!.headers.get("authorization"), "Bearer testToken");
     });
 
     it("should use the baseUri to build scope", async () => {
@@ -197,13 +148,6 @@ describe("ServiceClient", function() {
         }
       };
 
-      const expected = {
-        "foo-bar-alpha": "hello",
-        "foo-bar-beta": "world",
-        unrelated: "42",
-        authorization: "Bearer testToken",
-        "user-agent": "core-http/1.2.1 Node/v12.18.2 OS/(x64-Linux-5.4.0-1031-azure)"
-      };
       let request: WebResource;
       const client = new MockService(cred, {
         httpClient: {
@@ -213,52 +157,11 @@ describe("ServiceClient", function() {
           }
         }
       });
-      await client.sendOperationRequest(
-        {
-          metadata: {
-            alpha: "hello",
-            beta: "world"
-          },
-          unrelated: 42
-        },
-        {
-          httpMethod: "GET",
-          baseUrl: "httpbin.org",
-          serializer: new Serializer(),
-          headerParameters: [
-            {
-              parameterPath: "metadata",
-              mapper: {
-                serializedName: "metadata",
-                type: {
-                  name: "Dictionary",
-                  value: {
-                    type: {
-                      name: "String"
-                    }
-                  }
-                },
-                headerCollectionPrefix: "foo-bar-"
-              } as DictionaryMapper
-            },
-            {
-              parameterPath: "unrelated",
-              mapper: {
-                serializedName: "unrelated",
-                type: {
-                  name: "Number"
-                }
-              }
-            }
-          ],
-          responses: {
-            200: {}
-          }
-        }
-      );
+
+      await client.sendOperationRequest(testArgs, testOperationSpec);
 
       assert(request!);
-      assert.deepEqual(request!.headers.toJson(), expected);
+      assert.deepEqual(request!.headers.get("authorization"), "Bearer testToken");
     });
   });
 

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -76,6 +76,30 @@ describe("ServiceClient", function() {
       }
     };
 
+    it("should throw when there is a non fqdm as credentialScopes", async () => {
+      const cred: TokenCredential = {
+        getToken: async (_scopes) => {
+          return { token: "testToken", expiresOnTimestamp: 11111 };
+        }
+      };
+      let request: WebResource;
+      try {
+        const client = new ServiceClient(cred, {
+          httpClient: {
+            sendRequest: (req) => {
+              request = req;
+              return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
+            }
+          },
+          credentialScopes: ["/lalala//", "https://microsoft.com"]
+        });
+        await client.sendOperationRequest(testArgs, testOperationSpec);
+        assert.fail("Expected to throw");
+      } catch (error) {
+        assert.include(error.message, `Invalid URL`);
+      }
+    });
+
     it("should throw when there is no credentialScopes or baseUri", async () => {
       const cred: TokenCredential = {
         getToken: async (_scopes) => {
@@ -92,7 +116,6 @@ describe("ServiceClient", function() {
             }
           }
         });
-
         await client.sendOperationRequest(testArgs, testOperationSpec);
         assert.fail("Expected to throw");
       } catch (error) {


### PR DESCRIPTION
Currently, there is no way to specify a custom scope to build the BearerTokenAuthenticationPolicy. So far `core-http` has been using the baseUri to build this scope. This generally works well for management plane libraries. However there are other scenarios where we may need to set a custom scope value, for example Synapse.

This PR introduces a new optional property to `ServiceClientOptions` called `authScope` which if present we'll use it as is for the scope, otherwise we fall back to the current behavior.