### PR TITLE
Align "trigger" with "pr" in core ci.yml

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -10,8 +10,10 @@ trigger:
     include:
       - sdk/core/
       - eng/
-      - common/config/rush/
+      - common/
       - rush.json
+    exclude:
+      - common/smoke-test/
 
 pr:
   branches:


### PR DESCRIPTION
- Continuation of #12636

When I updated core `ci.yml` in #12636, I updated the `pr` section but forgot to update the `trigger` section with the same changes.  In general, both `trigger` and `pr` should use the same path filters.