### PR TITLE
Fix undeclared var issue in versioning tool

### DIFF
--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -51,7 +51,7 @@ async function main(argv) {
 
   const oldVersion = packageJsonContents.version;
   const newVersion = incrementVersion(packageJsonContents.version);
-  console.log(`${packageName}: ${oldVersion} -> ${newVersion}`);
+  console.log(`${packageJsonContents.name}: ${oldVersion} -> ${newVersion}`);
 
   if (dryRun) {
     console.log("Dry run only, no changes");

--- a/eng/tools/versioning/set-version.js
+++ b/eng/tools/versioning/set-version.js
@@ -36,7 +36,7 @@ async function main(argv) {
   const rushSpec = await packageUtils.getRushSpec(repoRoot);
 
   const targetPackage = rushSpec.projects.find(
-    packageSpec => packageSpec.packageName.replace("@", "").replace("/", "-") == packageName
+    packageSpec => packageSpec.packageName.replace("@", "").replace("/", "-") == artifactName
   );
 
   const targetPackagePath = path.join(repoRoot, targetPackage.projectFolder);
@@ -47,7 +47,7 @@ async function main(argv) {
   );
 
   const oldVersion = packageJsonContents.version;
-  console.log(`${packageName}: ${oldVersion} -> ${newVersion}`);
+  console.log(`${packageJsonContents.name}: ${oldVersion} -> ${newVersion}`);
 
   if (dryRun) {
     console.log("Dry run only, no changes");


### PR DESCRIPTION
Packagename variable is not declared. This was broken after making changes to support monitor package. Updated to refer package name from package.json instead of package name variable. 