### PR TITLE
Add empty build:samples scripts to all packages missing them.

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint src test --ext .ts -f html -o template-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "unit-test": "mocha --require ts-node/register test/**/*.spec.ts"
+    "unit-test": "mocha --require ts-node/register test/**/*.spec.ts",
+    "build:samples": "echo Skipped."
   },
   "repository": "github:Azure/azure-sdk-for-js",
   "author": "Microsoft Corporation",

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -50,7 +50,8 @@
     "unit-test:node": "mocha --require source-map-support/register --timeout 10000 --full-trace --recursive dist/tests",
     "unit-test:browser": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "test": "npm run clean && npm run build:test && npm run unit-test"
+    "test": "npm run clean && npm run build:test && npm run unit-test",
+    "build:samples": "echo Skipped."
   },
   "engines": {
     "node": ">=8.0.0"

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -29,7 +29,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --no-timeouts test/*.spec.ts",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "build:samples": "echo Skipped."
   },
   "types": "./types/src/index.d.ts",
   "engine": {

--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -49,7 +49,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "build:samples": "echo Skipped."
   },
   "sideEffects": true,
   "private": false,

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -100,7 +100,8 @@
     "dep:ms-rest-azure-js": "npx ts-node .scripts/testDependentProjects.ts ms-rest-azure-js",
     "publish-preview": "mocha --no-colors && shx rm -rf dist/test && node ./.scripts/publish",
     "local": "ts-node ./.scripts/local.ts",
-    "latest": "ts-node ./.scripts/latest.ts"
+    "latest": "ts-node ./.scripts/latest.ts",
+    "build:samples": "echo Skipped."
   },
   "sideEffects": false,
   "nyc": {

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -61,7 +61,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "build:samples": "echo Skipped."
   },
   "sideEffects": true,
   "private": false,

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -36,7 +36,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --no-timeouts test/*.spec.ts",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "build:samples": "echo Skipped."
   },
   "types": "./types/logger.d.ts",
   "engine": {

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -30,7 +30,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "build:samples": "echo Skipped."
   },
   "dependencies": {
     "@azure/event-hubs": "^2.1.4",

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
@@ -30,7 +30,8 @@
     "report": "nyc report --reporter=json",
     "test-opentelemetry-versions": "node test-opentelemetry-versions.js 2>&1",
     "prepare": "npm run build",
-    "pack": "npm pack 2>&1"
+    "pack": "npm pack 2>&1",
+    "build:samples": "echo Skipped."
   },
   "engines": {
     "node": ">=8.3.0"

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -30,7 +30,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test:browser": "npm run clean && npm run build npm run unit-test:browser",
     "test:node": "npm run clean && npm run build && npm run unit-test:node",
-    "test": "npm run clean && npm run build && npm run unit-test"
+    "test": "npm run clean && npm run build && npm run unit-test",
+    "build:samples": "echo Skipped."
   },
   "files": [
     "dist/",


### PR DESCRIPTION
This PR adds `"echo Skipped."` script placeholders for `build:samples` commands in all packages where they are missing. It will almost always be the case that packages should have a `build:samples` command, so in my opinion using `echo Skipped.` as a placeholder where it is not required is preferable to making this command optional in the rush configuration.