### PR TITLE
Add export to sample main functions where missing

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_change_point.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_change_point.ts
@@ -36,7 +36,7 @@ function read_series_from_file(path: string): Array<TimeSeriesPoint> {
   return result;
 }
 
-async function main() {
+export async function main() {
   // create client
   const client = new AnomalyDetectorClient(endpoint, new AzureKeyCredential(apiKey));
 

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_entire_series_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_entire_series_anomaly.ts
@@ -36,7 +36,7 @@ function read_series_from_file(path: string): Array<TimeSeriesPoint> {
   return result;
 }
 
-async function main() {
+export async function main() {
   // create client
   const client = new AnomalyDetectorClient(endpoint, new AzureKeyCredential(apiKey));
 

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_last_point_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/typescript/src/sample_detect_last_point_anomaly.ts
@@ -36,7 +36,7 @@ function read_series_from_file(path: string): Array<TimeSeriesPoint> {
   return result;
 }
 
-async function main() {
+export async function main() {
   // create client
   const client = new AnomalyDetectorClient(endpoint, new AzureKeyCredential(apiKey));
 

--- a/sdk/core/core-lro/samples/typescript/samplesClient.ts
+++ b/sdk/core/core-lro/samples/typescript/samplesClient.ts
@@ -215,7 +215,7 @@ class Client {
 
 // Now let's see how the client is used.
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const client = new Client();
   let poller = await client.beginLongOperation();
   console.log(poller.getResult()); // Should show: { value: 1 }

--- a/sdk/eventgrid/eventgrid/samples/typescript/src/sendCloudEvent.ts
+++ b/sdk/eventgrid/eventgrid/samples/typescript/src/sendCloudEvent.ts
@@ -14,7 +14,7 @@ const endpoint = process.env["EVENT_GRID_ENDPOINT"] || "";
 // Navigate to Settings > Access keys in your Event Grid topic's menu blade to see both access keys (you may use either).
 const accessKey = process.env["EVENT_GRID_ACCESS_KEY"] || "";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   // Create the client used to publish events to the Event Grid Service
   const client = new EventGridPublisherClient(endpoint, new AzureKeyCredential(accessKey));
 

--- a/sdk/eventgrid/eventgrid/samples/typescript/src/sendEventGridEvent.ts
+++ b/sdk/eventgrid/eventgrid/samples/typescript/src/sendEventGridEvent.ts
@@ -7,14 +7,14 @@ import * as dotenv from "dotenv";
 // Load the .env file if it exists
 dotenv.config();
 
-// The URL of the endpoint of the Event Grid topic. 
+// The URL of the endpoint of the Event Grid topic.
 const endpoint = process.env["EVENT_GRID_ENDPOINT"] || "";
 
 // You can find the access keys in the Azure portal.
 // Navigate to Settings > Access keys in your Event Grid topic's menu blade to see both access keys (you may use either).
 const accessKey = process.env["EVENT_GRID_ACCESS_KEY"] || "";
 
-async function main(): Promise<void> {    
+export async function main(): Promise<void> {
   // Create the client used to publish events to the Event Grid Service
   const client = new EventGridPublisherClient(endpoint, new AzureKeyCredential(accessKey));
 
@@ -26,7 +26,7 @@ async function main(): Promise<void> {
       subject: "azure/sdk/eventgrid/samples/sendEventSample",
       dataVersion: "1.0",
       data: {
-        message: "this is a sample event",
+        message: "this is a sample event"
       }
     }
   ]);

--- a/sdk/eventhub/event-processor-host/samples/iothubEph.ts
+++ b/sdk/eventhub/event-processor-host/samples/iothubEph.ts
@@ -24,7 +24,7 @@ const storageConnectionString = "";
 const storageContainerName = EventProcessorHost.createHostName("iothub-container");
 const ephName = "my-iothub-eph";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   // Start eph.
   const eph = await startEph(ephName);
   // Sleeeping for 90 seconds. This will give time for eph to receive messages.

--- a/sdk/eventhub/event-processor-host/samples/multiEph.ts
+++ b/sdk/eventhub/event-processor-host/samples/multiEph.ts
@@ -32,7 +32,7 @@ const ephName2 = "eph-2";
 // Use `createHostName` to create a unique name based on given prefix to use different storage containers on each run if needed.
 const storageContainerName = EventProcessorHost.createHostName("test-container");
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   // Start eph-1.
   const eph1 = await startEph(ephName1);
   await delay(20000);

--- a/sdk/eventhub/event-processor-host/samples/sendBatch.ts
+++ b/sdk/eventhub/event-processor-host/samples/sendBatch.ts
@@ -12,7 +12,7 @@ import { EventHubClient, EventData } from "@azure/event-hubs";
 const connectionString = "";
 const eventHubName = "";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
   const messageCount = 300;

--- a/sdk/eventhub/event-processor-host/samples/singleEph.ts
+++ b/sdk/eventhub/event-processor-host/samples/singleEph.ts
@@ -33,7 +33,7 @@ const storageConnectionString = "";
 const storageContainerName = EventProcessorHost.createHostName("test-container");
 const ephName = "my-eph";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   // Start eph.
   const eph = await startEph(ephName);
   // Sleeeping for 90 seconds. This will give time for eph to receive messages.

--- a/sdk/eventhub/event-processor-host/samples/websockets.ts
+++ b/sdk/eventhub/event-processor-host/samples/websockets.ts
@@ -33,7 +33,7 @@ const urlParts = url.parse("http://localhost:3128");
 urlParts.auth = "username:password"; // Skip this if proxy server does not need authentication.
 const proxyAgent = new httpsProxyAgent(urlParts);
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const eph = EventProcessorHost.createFromConnectionString(
     EventProcessorHost.createHostName(ephName),
     storageConnectionString,

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/typescript/src/receiveEventsUsingCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/typescript/src/receiveEventsUsingCheckpointStore.ts
@@ -27,7 +27,7 @@ const storageConnectionString = "";
 const containerName = "";
 const consumerGroup = "";
 
-async function main() {
+export async function main() {
   // this client will be used by our eventhubs-checkpointstore-blob, which
   // persists any checkpoints from this session in Azure Storage
   const containerClient = new ContainerClient(storageConnectionString, containerName);

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/typescript/src/receiveEventsWithApiSpecificStorage.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/typescript/src/receiveEventsWithApiSpecificStorage.ts
@@ -35,7 +35,7 @@ const storageContainerUrl =
 const storageAccountName = process.env["STORAGE_ACCOUNT_NAME"] || "<storageaccount>";
 const storageAccountKey = process.env["STORAGE_ACCOUNT_KEY"] || "<key>";
 
-async function main() {
+export async function main() {
   // The `containerClient` will be used by our eventhubs-checkpointstore-blob, which
   // persists any checkpoints from this session in Azure Storage.
   const storageCredential = new StorageSharedKeyCredential(storageAccountName, storageAccountKey);

--- a/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  TableServiceClient,
-  TablesSharedKeyCredential,
-} from "@azure/data-tables";
+import { TableServiceClient, TablesSharedKeyCredential } from "@azure/data-tables";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -47,9 +44,7 @@ async function tableServiceClientWithSasToken() {
  * and it is not available for browsers
  */
 async function tableServiceClientWithAccountConnectionString() {
-  const client = TableServiceClient.fromConnectionString(
-    accountConnectionString
-  );
+  const client = TableServiceClient.fromConnectionString(accountConnectionString);
   countTablesWithClient(client);
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/authenticationMethods.ts
@@ -74,7 +74,7 @@ async function countTablesWithClient(client: TableServiceClient) {
   console.log(`Listed ${count} tables`);
 }
 
-async function main() {
+export async function main() {
   console.log("== Client Authentication Methods Sample ==");
 
   await tableServiceClientWithSasConnectionString();

--- a/sdk/tables/data-tables/samples/typescript/src/createAndDeleteEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/createAndDeleteEntities.ts
@@ -44,7 +44,7 @@ interface Entity {
   quantity: number;
 }
 
-async function main() {
+export async function main() {
   await createAndDeleteEntities();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
@@ -44,7 +44,7 @@ async function createAndDeleteTableWithTableClient() {
   await client.delete();
 }
 
-async function main() {
+export async function main() {
   await createAndDeleteTable();
   await createAndDeleteTableWithTableClient();
 }

--- a/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/createAndDeleteTable.ts
@@ -13,9 +13,7 @@ async function createAndDeleteTable() {
   console.log("== Delete and create table Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client
-  const serviceClient = TableServiceClient.fromConnectionString(
-    sasConnectionString
-  );
+  const serviceClient = TableServiceClient.fromConnectionString(sasConnectionString);
 
   // Create a new table
   const tableName = "SampleCreateAndDeleteTable";
@@ -32,10 +30,7 @@ async function createAndDeleteTableWithTableClient() {
   const tableName = "SampleCreateAndDeleteTable2";
 
   // Creating a new table client doesn't do a network call
-  const client = TableClient.fromConnectionString(
-    sasConnectionString,
-    tableName
-  );
+  const client = TableClient.fromConnectionString(sasConnectionString, tableName);
 
   // Will attempt to create a table with the tableName specified above
   await client.create();

--- a/sdk/tables/data-tables/samples/typescript/src/queryEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/queryEntities.ts
@@ -68,7 +68,7 @@ interface Entity {
   quantity: number;
 }
 
-async function main() {
+export async function main() {
   await createAndDeleteEntities();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
@@ -37,7 +37,7 @@ async function queryTables() {
   await serviceClient.deleteTable(tableName);
 }
 
-async function main() {
+export async function main() {
   await queryTables();
 }
 

--- a/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/queryTables.ts
@@ -13,9 +13,7 @@ async function queryTables() {
   console.log("== Query tables Sample ==");
 
   // See authenticationMethods sample for other options of creating a new client
-  const serviceClient = TableServiceClient.fromConnectionString(
-    accountConnectionString
-  );
+  const serviceClient = TableServiceClient.fromConnectionString(accountConnectionString);
 
   // Create a new table
   const tableName = "OfficeSupplies3p1";
@@ -25,7 +23,7 @@ async function queryTables() {
   // odata is a helper function that takes care of encoding the query
   // filter, in this sample it will add quotes around tableName
   const queryTableResults = serviceClient.listTables({
-    queryOptions: { filter: odata`TableName eq ${tableName}` },
+    queryOptions: { filter: odata`TableName eq ${tableName}` }
   });
 
   // Iterate the results

--- a/sdk/tables/data-tables/samples/typescript/src/updateAndUpsertEntities.ts
+++ b/sdk/tables/data-tables/samples/typescript/src/updateAndUpsertEntities.ts
@@ -57,7 +57,7 @@ interface Entity {
   brand?: string;
 }
 
-async function main() {
+export async function main() {
   await createAndDeleteEntities();
 }
 


### PR DESCRIPTION
TypeScript samples always need to `export` their main function so that it can be used in the sample harness, which will import and run the `main` function. This PR adds it in the few places it was missing.

The commit formatting hook also ran, changing the appearance of a few lines in the same files.