### PR TITLE
[Identity] Feedback after #10337 (2)

### DIFF
--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -35,7 +35,11 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = ["dist-esm/test/public/*.spec.js", "dist-esm/test/internal/**/*.spec.js"];
+    baseConfig.input = [
+      "dist-esm/test/public/*.spec.js",
+      "dist-esm/test/public/node/*.spec.js",
+      "dist-esm/test/internal/*.spec.js"
+    ];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
@@ -89,7 +93,11 @@ export function browserConfig(test = false) {
   };
 
   if (test) {
-    baseConfig.input = "dist-esm/test/internal/*.spec.js";
+    baseConfig.input = [
+      "dist-esm/test/public/*.spec.js",
+      "dist-esm/test/public/browser/*.spec.js",
+      "dist-esm/test/internal/*.spec.js"
+    ];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "test-browser/index.js";
 

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -2,11 +2,9 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { assertRejects } from "../authTestUtils";
-import { MockAuthHttpClient } from "../authTestUtils";
-import { AuthenticationError } from "../../src";
+import { assertRejects, MockAuthHttpClient } from "../authTestUtils";
 import { IdentityClient } from "../../src/client/identityClient";
-import { ClientSecretCredential } from "../../src";
+import { ClientSecretCredential, AuthenticationError } from "../../src";
 import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel } from "@azure/logger";
 import { isNode } from "@azure/core-http";
 

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -17,7 +17,7 @@ interface AuthRequestDetails {
   token: AccessToken | null;
 }
 
-describe("ManagedIdentityCredential", function () {
+describe("ManagedIdentityCredential", function() {
   afterEach(() => {
     delete process.env.IDENTITY_ENDPOINT;
     delete process.env.IDENTITY_HEADER;
@@ -26,7 +26,7 @@ describe("ManagedIdentityCredential", function () {
     delete process.env.IDENTITY_SERVER_THUMBPRINT;
   });
 
-  it("sends an authorization request with a modified resource name", async function () {
+  it("sends an authorization request with a modified resource name", async function() {
     const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client", {
       authResponse: [
         { status: 200 }, // Respond to IMDS isAvailable
@@ -83,7 +83,7 @@ describe("ManagedIdentityCredential", function () {
     }
   });
 
-  it("returns error when ManagedIdentityCredential authentication failed", async function () {
+  it("returns error when ManagedIdentityCredential authentication failed", async function() {
     process.env.AZURE_CLIENT_ID = "errclient";
 
     const errResponse: OAuthErrorResponse = {

--- a/sdk/identity/identity/test/public/node/authorizationCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/authorizationCodeCredential.spec.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { AuthorizationCodeCredential } from "../../src";
+import { AuthorizationCodeCredential } from "../../../src";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
-import { MockAuthHttpClient, assertClientCredentials } from "../authTestUtils";
+import { MockAuthHttpClient, assertClientCredentials } from "../../authTestUtils";
 
 describe("AuthorizationCodeCredential", function() {
   it("sends an authorization request with the given credentials and authorization code", async () => {

--- a/sdk/identity/identity/test/public/node/azureCliCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/azureCliCredential.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { MockAzureCliCredentialClient } from "../mockAzureCliCredentialClient";
+import { MockAzureCliCredentialClient } from "../../mockAzureCliCredentialClient";
 
 describe("AzureCliCredential", function() {
   it("get access token without error", async function() {

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -5,8 +5,8 @@ import qs from "qs";
 import jws from "jws";
 import path from "path";
 import assert from "assert";
-import { ClientCertificateCredential } from "../../src";
-import { MockAuthHttpClient } from "../authTestUtils";
+import { ClientCertificateCredential } from "../../../src";
+import { MockAuthHttpClient } from "../../authTestUtils";
 import { setTracer, TestTracer, SpanGraph } from "@azure/core-tracing";
 
 describe("ClientCertificateCredential", function() {

--- a/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
@@ -3,13 +3,13 @@
 
 import assert from "assert";
 import path from "path";
-import { EnvironmentCredential, AuthenticationError, CredentialUnavailable } from "../../src";
+import { EnvironmentCredential, AuthenticationError, CredentialUnavailable } from "../../../src";
 import {
   MockAuthHttpClient,
   assertClientCredentials,
   assertClientUsernamePassword,
   assertRejects
-} from "../authTestUtils";
+} from "../../authTestUtils";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 
 interface OAuthErrorResponse {


### PR DESCRIPTION
Got some good feedback after #10337 was approved and merged.
I had a first approach here: https://github.com/Azure/azure-sdk-for-js/pull/10968
But I'm closing this since master has changed considerably since I made that PR.

This PR includes:

- Browser tests now run internal and public tests. For tests that could only run in one environment, I'm following Will's guidelines and moving them into a sub-folder called either "node" or "browser" (so, for example: "public/node/test.spec.ts").
- Combined multiple imports from `../../src`, from feedback: https://github.com/Azure/azure-sdk-for-js/pull/10337#discussion_r481345299 (Note that I couldn't find other tests with separate multiple imports from the same file).

The rest of the original feedback is no longer applicable.
In any case, more feedback appreciated!