### PR TITLE
[core] prepare for December release

### DIFF
--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.2 (2020-12-09)
+
+Updates the `tslib` dependency to version 2.x.
+
 ## 1.0.1 (2019-12-04)
 
 Fixes the [bug 6271](https://github.com/Azure/azure-sdk-for-js/issues/6271) that can occur with angular prod builds due to triple-slash directives.

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/abort-controller",
   "sdk-type": "client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microsoft Azure SDK for JavaScript - Aborter",
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.0.1 (2020-12-09)
 
 - Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
   Previously, `retry` would still sleep one more time after all retry attempts were exhausted before returning.

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.4 (Unreleased)
+## 1.1.4 (2020-12-09)
 
 - Updated to use OpenTelemetry 0.10.2 via `@azure/core-tracing`
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.9",
+    "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.9",
-    "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Release History
 
-## 1.0.3 (Unreleased)
+## 1.0.3 (2020-12-09)
 
+- Updates the `tslib` dependency to version 2.x.
 
 ## 1.0.2 (2020-04-28)
+
 - Moved `@opentelemetry/types` to the `devDependencies`.
 
 ## 1.0.1 (2020-02-28)

--- a/sdk/core/logger/CHANGELOG.md
+++ b/sdk/core/logger/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2020-12-09)
+
+- Updates the `tslib` dependency to version 2.x.
 
 ## 1.0.0 (2019-10-29)
 


### PR DESCRIPTION
This prepares core packages for release.

Note that all of the core packages except core-amqp are just being released so that the published version pulls in tslib 2.x instead of tslib 1.x. This fixes #12631, where it was discovered that using a bundler (e.g. webpack) to generate an application bundle that includes our SDK also pulled in multiple copies of tslib 1.x.

Multiple copies of tslib were pulled in because due to the way node_modules were being resolved, tslib 2.x would be at the root of a package's node_modules directory, and every package that used tslib 1.x had its own copy of tslib that would then be included in the bundle.

core-amqp does include a bug fix this release that improves performance in one scenario:
> - Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
  Previously, `retry` would still sleep one more time after all retry attempts were exhausted before returning.
  Now, `retry` will return immediately after all retry attempts are completed as necessary.

