### PR TITLE
[core-http] Update changelog for December release

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 (2020-12-08)
 
-- Support custom auth scopes [PR 12752](https://github.com/Azure/azure-sdk-for-js/pull/12752)
+- Support custom auth scopes. Scope is a mechanism in OAuth 2.0 to limit an application's access to a user's account [PR 12752](https://github.com/Azure/azure-sdk-for-js/pull/12752)
 - Add helper function `createSpan` to help in the creation of tracing spans in Track2 libraries [PR 12525](https://github.com/Azure/azure-sdk-for-js/pull/12525)
 
 ## 1.2.0 (2020-11-05)

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
-## 1.2.1 (Unreleased)
+## 1.2.1 (2020-12-08)
 
+- Support custom auth scopes [PR 12752](https://github.com/Azure/azure-sdk-for-js/pull/12752)
+- Add helper function `createSpan` to help in the creation of tracing spans in Track2 libraries [PR 12525](https://github.com/Azure/azure-sdk-for-js/pull/12525)
 
 ## 1.2.0 (2020-11-05)
 


### PR DESCRIPTION
Updating the changelog for the December release with 2 changes going into the next release:
- Support custom auth scopes [PR 12752](https://github.com/Azure/azure-sdk-for-js/pull/12752)
- Add helper function `createSpan` to help in the creation of tracing spans in Track2 libraries [PR 12525](https://github.com/Azure/azure-sdk-for-js/pull/12525)