### PR TITLE
[MQ: build reliability] Export the SERVICE_BUS_ENDPOINT output value for usingAadAuth.js

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -126,6 +126,7 @@
   },
   "//smokeTestConfiguration": {
     "skip": [
+      "createComposedModel.js",
       "customModelManagement.js",
       "differentiateLabeledUnlabeled.js",
       "getBoundingBoxes.js",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeBusinessCard.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeBusinessCard.js
@@ -73,6 +73,10 @@ async function main() {
  * processing.
  */
 function printSimpleArrayField(businessCard, fieldName) {
+  if (businessCard.fields[fieldName] == null) {
+    return;
+  }
+
   const fieldValues = businessCard.fields[fieldName].value;
   if (Array.isArray(fieldValues)) {
     console.log(`${fieldName}:`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeBusinessCard.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeBusinessCard.ts
@@ -77,6 +77,10 @@ export async function main() {
  * processing.
  */
 function printSimpleArrayField(businessCard: RecognizedForm, fieldName: string) {
+  if (businessCard.fields[fieldName] == null) {
+    return;
+  }
+
   const fieldValues = businessCard.fields[fieldName]?.value;
   if (Array.isArray(fieldValues)) {
     console.log(`${fieldName}:`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeBusinessCard.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeBusinessCard.ts
@@ -77,10 +77,6 @@ export async function main() {
  * processing.
  */
 function printSimpleArrayField(businessCard: RecognizedForm, fieldName: string) {
-  if (businessCard.fields[fieldName] == null) {
-    return;
-  }
-
   const fieldValues = businessCard.fields[fieldName]?.value;
   if (Array.isArray(fieldValues)) {
     console.log(`${fieldName}:`);

--- a/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
@@ -205,7 +205,9 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
   public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
     // Ensure that we're about to use a secure connection.
     if (!webResource.url.startsWith("https:")) {
-      throw new Error("The resource address for authorization must use the 'https' protocol.");
+      throw new Error(
+        `The resource address for authorization must use the 'https' protocol.: url:'${webResource.url}'`
+      );
     }
 
     // The next request will happen differently whether we have a challenge or not.

--- a/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
@@ -205,9 +205,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
   public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
     // Ensure that we're about to use a secure connection.
     if (!webResource.url.startsWith("https:")) {
-      throw new Error(
-        `The resource address for authorization must use the 'https' protocol.: url:'${webResource.url}'`
-      );
+      throw new Error("The resource address for authorization must use the 'https' protocol.");
     }
 
     // The next request will happen differently whether we have a challenge or not.

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -88,7 +88,8 @@
     "skip": [
       "receiveMessagesLoop.js",
       "receiveMessagesStreaming.js",
-      "useProxy.js"
+      "useProxy.js",
+      "usingAadAuth.js"
     ]
   },
   "dependencies": {

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -90,7 +90,6 @@
       "receiveMessagesLoop.js",
       "receiveMessagesStreaming.js",
       "scheduledMessages.js",
-      "sendMessages.js",
       "session.js",
       "useProxy.js"
     ]

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -86,11 +86,8 @@
   },
   "//smokeTestConfiguration": {
     "skip": [
-      "browseMessages.js",
       "receiveMessagesLoop.js",
       "receiveMessagesStreaming.js",
-      "scheduledMessages.js",
-      "session.js",
       "useProxy.js"
     ]
   },

--- a/sdk/servicebus/service-bus/sample.env
+++ b/sdk/servicebus/service-bus/sample.env
@@ -1,6 +1,6 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
 SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
-SERVICE_BUS_CONNECTION_STRING="<connection string>"
+SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.
 QUEUE_NAME="<queue name>"

--- a/sdk/servicebus/service-bus/sample.env
+++ b/sdk/servicebus/service-bus/sample.env
@@ -1,5 +1,5 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
-SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
+SERVICEBUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
 SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.

--- a/sdk/servicebus/service-bus/samples/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/javascript/README.md
@@ -59,7 +59,7 @@ node sendMessages.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
+npx cross-env SERVICEBUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
 ```
 
 ## Next Steps

--- a/sdk/servicebus/service-bus/samples/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/javascript/README.md
@@ -59,7 +59,7 @@ node sendMessages.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICE_BUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
+npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
 ```
 
 ## Next Steps

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/administrationClient.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/administrationClient.js
@@ -13,7 +13,7 @@ const { ServiceBusAdministrationClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -17,7 +17,7 @@ const { ServiceBusClient, delay } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/listingEntities.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/listingEntities.js
@@ -13,7 +13,7 @@ const { ServiceBusAdministrationClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 
 async function main() {
   const serviceBusAdministrationClient = new ServiceBusAdministrationClient(connectionString);

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -15,7 +15,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 const sbClient = new ServiceBusClient(connectionString);
 

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
@@ -15,7 +15,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -15,7 +15,7 @@ const { AbortController } = require("@azure/abort-controller");
 dotenv.config();
 
 const serviceBusConnectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+  process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a session enabled queue but would also work a session enabled subscription.
 const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
@@ -23,7 +23,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const userEventsQueueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 const sbClient = new ServiceBusClient(connectionString);
 

--- a/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
@@ -16,7 +16,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/javascript/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/identity": "^1.0.2",
-    "@azure/service-bus": "next",
+    "@azure/service-bus": "latest",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^5.0.0",
     "ws": "^7.0.0"

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
@@ -11,7 +11,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 // Load the .env file if it exists
 require("dotenv").config();
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -13,7 +13,7 @@ const { delay, isServiceBusError, ServiceBusClient } = require("@azure/service-b
 // Load the .env file if it exists
 require("dotenv").config();
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/sample.env
+++ b/sdk/servicebus/service-bus/samples/javascript/sample.env
@@ -1,6 +1,6 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
 SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
-SERVICE_BUS_CONNECTION_STRING="<connection string>"
+SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.
 QUEUE_NAME="<queue name>"

--- a/sdk/servicebus/service-bus/samples/javascript/sample.env
+++ b/sdk/servicebus/service-bus/samples/javascript/sample.env
@@ -1,5 +1,5 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
-SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
+SERVICEBUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
 SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -15,7 +15,7 @@ const { delay, ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const listOfScientists = [

--- a/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
@@ -16,7 +16,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const messages = [
@@ -59,6 +59,7 @@ async function main() {
         }
       }
     }
+
     // Send the batch
     await sender.sendMessages(batch);
 

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -18,7 +18,7 @@ require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
 // Ensure on portal.azure.com that queue/topic has Sessions feature enabled
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 
 const listOfScientists = [

--- a/sdk/servicebus/service-bus/samples/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/javascript/useProxy.js
@@ -14,7 +14,7 @@ const HttpsProxyAgent = require("https-proxy-agent");
 require("dotenv").config();
 
 // Define connection string for your Service Bus instance here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {

--- a/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
@@ -26,7 +26,7 @@ require("dotenv").config();
 
 // Define Service Bus Endpoint here and related entity names here
 const serviceBusEndpoint =
-  process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
+  process.env.SERVICEBUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here

--- a/sdk/servicebus/service-bus/samples/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/typescript/README.md
@@ -71,7 +71,7 @@ node dist/sendMessages.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
+npx cross-env SERVICEBUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
 ```
 
 ## Next Steps

--- a/sdk/servicebus/service-bus/samples/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/typescript/README.md
@@ -71,7 +71,7 @@ node dist/sendMessages.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICE_BUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
+npx cross-env SERVICE_BUS_ENDPOINT="<endpoint>" SERVICEBUS_CONNECTION_STRING="<connection string>" QUEUE_NAME="<queue name>" node dist/basic.js
 ```
 
 ## Next Steps

--- a/sdk/servicebus/service-bus/samples/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/typescript/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/identity": "^1.0.2",
-    "@azure/service-bus": "next",
+    "@azure/service-bus": "latest",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^5.0.0",
     "ws": "^7.0.0"

--- a/sdk/servicebus/service-bus/samples/typescript/sample.env
+++ b/sdk/servicebus/service-bus/samples/typescript/sample.env
@@ -1,6 +1,6 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
 SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
-SERVICE_BUS_CONNECTION_STRING="<connection string>"
+SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.
 QUEUE_NAME="<queue name>"

--- a/sdk/servicebus/service-bus/samples/typescript/sample.env
+++ b/sdk/servicebus/service-bus/samples/typescript/sample.env
@@ -1,5 +1,5 @@
 # Used in most samples. Retrieve these values from a storage account in the Azure Portal.
-SERVICE_BUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
+SERVICEBUS_ENDPOINT="<service bus namespace>.servicebus.windows.net"
 SERVICEBUS_CONNECTION_STRING="<connection string>"
 
 # Used in most samples. Provide the name of a queue within the service bus namespace above.

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/administrationClient.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/administrationClient.ts
@@ -14,7 +14,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -23,7 +23,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/listingEntities.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/listingEntities.ts
@@ -14,7 +14,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 
 export async function main() {
   const serviceBusAdministrationClient = new ServiceBusAdministrationClient(connectionString);

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -16,7 +16,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 const sbClient: ServiceBusClient = new ServiceBusClient(connectionString);
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
@@ -16,7 +16,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const sbClient: ServiceBusClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -21,7 +21,7 @@ import { AbortController } from "@azure/abort-controller";
 dotenv.config();
 
 const serviceBusConnectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+  process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a session enabled queue but would also work a session enabled subscription.
 const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
@@ -26,7 +26,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const userEventsQueueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 const sbClient = new ServiceBusClient(connectionString);
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
@@ -17,7 +17,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
@@ -15,7 +15,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -21,7 +21,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -22,7 +22,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const listOfScientists = [

--- a/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
@@ -17,7 +17,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const messages: ServiceBusMessage[] = [

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -19,7 +19,7 @@ dotenv.config();
 
 // Define connection string and related Service Bus entity names here
 // Ensure on portal.azure.com that queue/topic has Sessions feature enabled
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME_WITH_SESSIONS || "<queue name>";
 
 const listOfScientists = [

--- a/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
@@ -15,7 +15,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string for your Service Bus instance here
-const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {

--- a/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
@@ -27,7 +27,7 @@ dotenv.config();
 
 // Define Service Bus Endpoint here and related entity names here
 const serviceBusEndpoint =
-  process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
+  process.env.SERVICEBUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here

--- a/sdk/servicebus/service-bus/test/perf/azure-sb-package/receive.ts
+++ b/sdk/servicebus/service-bus/test/perf/azure-sb-package/receive.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `receiver.receive()` in package `azure-sb`.
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. This test presumes that there are messages in the queue.
 5. `ts-node receive.ts [totalMessages]`
 6. Example: `ts-node receive.ts 1000000`
@@ -21,7 +21,7 @@ let _messages = 0;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
 
   const maxConcurrentCalls = process.argv.length > 2 ? parseInt(process.argv[2]) : 10;

--- a/sdk/servicebus/service-bus/test/perf/azure-sb-package/send.ts
+++ b/sdk/servicebus/service-bus/test/perf/azure-sb-package/send.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `sender.send()` in package `azure-sb`.
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. Run `npm install azure-sb @types/azure-sb` to install `azure-sb` package for this test.
 5. `ts-node send.ts [maxInflightMessages] [totalMessages]`
 6. Example: `ts-node send.ts 1000 1000000`
@@ -24,7 +24,7 @@ let _rejected = 0;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
 
   const maxInflight = process.argv.length > 2 ? parseInt(process.argv[2]) : 1;

--- a/sdk/servicebus/service-bus/test/perf/rhea-promise/receive.ts
+++ b/sdk/servicebus/service-bus/test/perf/rhea-promise/receive.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `receiver.receive()` in package `rhea-promise
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. This test presumes that there are messages in the queue.
 5. `ts-node receive.ts [maxConcurrentCalls] [totalMessages]`
 6. Example: `ts-node receive.ts 1000 1000000`
@@ -28,7 +28,7 @@ let _credit = -1;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
   const allowUnauthorized = process.env.SERVICE_BUS_ALLOW_UNAUTHORIZED ? true : false;
 

--- a/sdk/servicebus/service-bus/test/perf/rhea-promise/send.ts
+++ b/sdk/servicebus/service-bus/test/perf/rhea-promise/send.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `sender.send()` in package `rhea-promise`.
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. `ts-node send.ts [maxInflightMessages] [totalMessages]`
 5. Example: `ts-node send.ts 1000 1000000`
  */
@@ -23,7 +23,7 @@ let _rejected = 0;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
   const allowUnauthorized = process.env.SERVICE_BUS_ALLOW_UNAUTHORIZED ? true : false;
 

--- a/sdk/servicebus/service-bus/test/perf/service-bus/receive.ts
+++ b/sdk/servicebus/service-bus/test/perf/service-bus/receive.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `receiver.receive()` in package `@azure/servi
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. This test presumes that there are messages in the queue.
 4. `ts-node receive.ts [totalMessages]`
 5. Example: `ts-node receive.ts 1000000`
@@ -22,7 +22,7 @@ let _messages = 0;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
 
   const maxConcurrentCalls = process.argv.length > 2 ? parseInt(process.argv[2]) : 10;

--- a/sdk/servicebus/service-bus/test/perf/service-bus/send.ts
+++ b/sdk/servicebus/service-bus/test/perf/service-bus/send.ts
@@ -5,7 +5,7 @@ Measures the maximum throughput of `sender.send()` in package `@azure/service-bu
 # Instructions
 1. Create a Service Bus namespace with `Tier=Premium` and `Messaging Units=4`.  It is recommended to use the largest possible namespace to allow maximum client throughput.
 2. Create a queue inside the namespace.
-3. Set env vars `SERVICE_BUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
+3. Set env vars `SERVICEBUS_CONNECTION_STRING` and `SERVICE_BUS_QUEUE_NAME`.
 4. `ts-node app.ts [maxInflightMessages] [totalMessages]`
 5. Example: `ts-node app.ts 1000 1000000`
  */
@@ -22,7 +22,7 @@ let _messages = 0;
 
 async function main(): Promise<void> {
   // Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<shared-access-key>
-  const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING as string;
+  const connectionString = process.env.SERVICEBUS_CONNECTION_STRING as string;
   const entityPath = process.env.SERVICE_BUS_QUEUE_NAME as string;
 
   const maxInflight = process.argv.length > 2 ? parseInt(process.argv[2]) : 1;

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "baseName": {
@@ -41,19 +41,48 @@
       "apiVersion": "2015-08-01",
       "name": "[variables('authorizationRuleName')]",
       "location": "[variables('location')]",
-      "dependsOn": ["[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"],
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
+      ],
       "properties": {
-        "rights": ["Listen", "Manage", "Send"]
+        "rights": [
+          "Listen",
+          "Manage",
+          "Send"
+        ]
       }
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2018-01-01-preview",
       "name": "[guid(concat('dataOwnerRoleId', parameters('baseName')))]",
-      "dependsOn": ["[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"],
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[variables('serviceBusDataOwnerRoleId')]",
         "principalId": "[parameters('testApplicationOid')]"
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('baseName'), '/testQueue')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
+      ],
+      "properties": {
+        "lockDuration": "PT5M",
+        "maxSizeInMegabytes": "1024",
+        "requiresDuplicateDetection": "false",
+        "requiresSession": "false",
+        "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+        "deadLetteringOnMessageExpiration": "false",
+        "duplicateDetectionHistoryTimeWindow": "PT10M",
+        "maxDeliveryCount": "10",
+        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+        "enablePartitioning": "false",
+        "enableExpress": "false"
       }
     }
   ],
@@ -65,6 +94,10 @@
     "SERVICE_BUS_ENDPOINT": {
       "type": "string",
       "value": "[replace(reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint, ':443/', '')]"
+    },
+    "QUEUE_NAME": {
+      "type": "string",
+      "value": "testQueue"
     }
   }
 }

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -64,7 +64,7 @@
     },
     "SERVICE_BUS_ENDPOINT": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint]"
+      "value": "[replace(reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint, ':443/', '')]"
     }
   }
 }

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -84,10 +84,35 @@
         "enablePartitioning": "false",
         "enableExpress": "false"
       }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('baseName'), '/testQueueWithSessions')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))]"
+      ],
+      "properties": {
+        "lockDuration": "PT5M",
+        "maxSizeInMegabytes": "1024",
+        "requiresDuplicateDetection": "false",
+        "requiresSession": "true",
+        "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+        "deadLetteringOnMessageExpiration": "false",
+        "duplicateDetectionHistoryTimeWindow": "PT10M",
+        "maxDeliveryCount": "10",
+        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+        "enablePartitioning": "false",
+        "enableExpress": "false"
+      }
     }
   ],
   "outputs": {
     "SERVICEBUS_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "SERVICE_BUS_CONNECTION_STRING": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
     },
@@ -98,6 +123,10 @@
     "QUEUE_NAME": {
       "type": "string",
       "value": "testQueue"
+    },
+    "QUEUE_NAME_WITH_SESSIONS": {
+      "type": "string",
+      "value": "testQueueWithSessions"
     }
   }
 }

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -61,6 +61,10 @@
     "SERVICEBUS_CONNECTION_STRING": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "SERVICE_BUS_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint]"
     }
   }
 }

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -112,10 +112,6 @@
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
     },
-    "SERVICE_BUS_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
-    },
     "SERVICE_BUS_ENDPOINT": {
       "type": "string",
       "value": "[replace(reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint, ':443/', '')]"

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -112,7 +112,7 @@
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('baseName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
     },
-    "SERVICE_BUS_ENDPOINT": {
+    "SERVICEBUS_ENDPOINT": {
       "type": "string",
       "value": "[replace(reference(resourceId('Microsoft.ServiceBus/namespaces', parameters('baseName'))).serviceBusEndpoint, ':443/', '')]"
     },


### PR DESCRIPTION
There were several issues causing the smoke tests to not be a useful signal - this PR improves on the situation and gets us back to green. There are still some issues that require followup which I'll be filing soon.

Fixes:
* ServiceBus was only whitelisting a single sample (usingAadAuth.js) which _used_ to pass but only because it wasn't doing any real work. When we changed it awhile back to actually attempt to use it's connection it failed. This still needs some investigation but in the meantime I've swapped it out and brought in some more useful samples like sendMessages.js, browseMessages.js and sessions.js, which should give us some coverage. This also required altering the test-resources.json so it properly created the sample queues as well as outputting them so they'd get set in the environment.
* FormRecognizer had some failing samples. After talking with @willmtemple I ignored one of them that will require some actual test data to be bootstrapped reasonably (so not necessarily a good candidate for this). I fixed another one that appeared to just not handle some data being empty (seems legitimate, but perhaps it's a bug).d up in the sample's environment.

Fixes #12803