### PR TITLE
[Monitor] Fix incorrect log message when connection string is valid

### DIFF
--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/connectionStringParser.ts
@@ -61,12 +61,14 @@ export class ConnectionStringParser {
           `Connection String contains an unsupported 'Authorization' value: ${result.authorization!}. Defaulting to 'Authorization=ikey'. Instrumentation Key ${result.instrumentationkey!}`
         );
       }
+    } else {
+      logger.error(
+        "An invalid connection string was passed in. There may be telemetry loss",
+        connectionString
+      );
     }
 
-    logger.error(
-      "An invalid connection string was passed in. There may be telemetry loss",
-      connectionString
-    );
+    
     return result;
   }
 }


### PR DESCRIPTION
Since this package got ported to the repo, it's had a small bug where we'd always log about the connection string being invalid. This PR adjusts the code slightly to only log when there is an invalid connection string.