### PR TITLE
[Synapse] Add back missing Spark example

### DIFF
--- a/sdk/synapse/synapse-spark/README.md
+++ b/sdk/synapse/synapse-spark/README.md
@@ -21,7 +21,18 @@ npm install @azure/synapse-spark
 
 ## Examples
 
-In the future, we will share samples here.
+```ts
+import { SparkClient } from "@azure/synapse-spark";
+import { DefaultAzureCredential } from "@azure/identity";
+
+export async function main(): Promise<void> {
+  const credential = new DefaultAzureCredential();
+
+  let client = new SparkClient(credential, "https://mysynapse.dev.azuresynapse.net", "mysparkpool");
+  let output = await client.sparkBatch.getSparkBatchJobs();
+  console.log("output:", output);
+}
+```
 
 ## Related projects
 


### PR DESCRIPTION
Looks like the sample in the README for Spark was missing an example. Adding one.