### PR TITLE
[Attestation] Adding sample.env

### DIFF
--- a/sdk/attestation/attestation/sample.env
+++ b/sdk/attestation/attestation/sample.env
@@ -1,0 +1,7 @@
+AAD_ATTESTATION_URL="<AAD attestation URL>"
+ISOLATED_ATTESTATION_URL="<Isolated attestaion URL>"
+policySigningCertificate2=""
+isolatedSigningCertificate=""
+policySigningCertificate1=""
+policySigningCertificate0=""
+TEST_MODE=playback

--- a/sdk/attestation/attestation/sample.env
+++ b/sdk/attestation/attestation/sample.env
@@ -4,4 +4,6 @@ policySigningCertificate2=""
 isolatedSigningCertificate=""
 policySigningCertificate1=""
 policySigningCertificate0=""
+# Our tests assume that TEST_MODE is "playback" by default. You can
+# change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.
 TEST_MODE=playback


### PR DESCRIPTION
This file can serve as a guideline for attestation developers on how to configure various environment variables. Simply copy the `sample.env` file into `.env` file with the configurations you want.