### PR TITLE
[communication-administration] fix option passing for LROs and slow playback tests

### DIFF
--- a/sdk/communication/communication-administration/CHANGELOG.md
+++ b/sdk/communication/communication-administration/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Key bug fixes
 
+- Fixed a bug where poller options were ignored for `beginReleasePhoneNumbers`, `beginReservePhoneNumbers` and `beginPurchaseReservation`.
 - Fixed paging for `listPhoneNumbers`, `listPhonePlanGroups`, `listPhonePlans`, `listReleases`, `listSearches`, `listSupportedCountries`.
 
 ## 1.0.0-beta.3 (2020-11-16)

--- a/sdk/communication/communication-administration/src/phoneNumber/phoneNumberAdministrationClient.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/phoneNumberAdministrationClient.ts
@@ -974,10 +974,13 @@ export class PhoneNumberAdministrationClient {
     phoneNumbers: string[],
     options: BeginReleasePhoneNumbersOptions = {}
   ): Promise<PollerLike<PollOperationState<PhoneNumberRelease>, PhoneNumberRelease>> {
+    const { pollInterval, resumeFrom, ...requestOptions } = options;
     const poller = new ReleasePhoneNumbersPoller({
       phoneNumbers,
       client: this.client,
-      requestOptions: options
+      pollInterval,
+      resumeFrom,
+      requestOptions
     });
 
     await poller.poll();
@@ -1010,10 +1013,13 @@ export class PhoneNumberAdministrationClient {
     reservationRequest: CreateReservationRequest,
     options: BeginReservePhoneNumbersOptions = {}
   ): Promise<PollerLike<PollOperationState<PhoneNumberReservation>, PhoneNumberReservation>> {
+    const { pollInterval, resumeFrom, ...requestOptions } = options;
     const poller = new ReservePhoneNumbersPoller({
       reservationRequest,
       client: this.client,
-      requestOptions: options
+      pollInterval,
+      resumeFrom,
+      requestOptions
     });
 
     await poller.poll();
@@ -1045,10 +1051,13 @@ export class PhoneNumberAdministrationClient {
     reservationId: string,
     options: BeginPurchaseReservationOptions = {}
   ): Promise<PollerLike<PollOperationState<void>, void>> {
+    const { pollInterval, resumeFrom, ...requestOptions } = options;
     const poller = new PurchaseReservationPoller({
       reservationId,
       client: this.client,
-      requestOptions: options
+      pollInterval,
+      resumeFrom,
+      requestOptions
     });
 
     await poller.poll();

--- a/sdk/communication/communication-administration/test/lro.purchase.spec.ts
+++ b/sdk/communication/communication-administration/test/lro.purchase.spec.ts
@@ -9,7 +9,10 @@ import {
   PhoneNumberAdministrationClient,
   PhoneNumberReservation
 } from "../src";
-import { createRecordedPhoneNumberAdministrationClient } from "./utils/recordedClient";
+import {
+  createRecordedPhoneNumberAdministrationClient,
+  testPollerOptions
+} from "./utils/recordedClient";
 
 describe("PhoneNumber - LROs - Purchase Reservation [Playback/Live]", function() {
   let recorder: Recorder;
@@ -90,7 +93,10 @@ describe("PhoneNumber - LROs - Purchase Reservation [Playback/Live]", function()
       areaCode,
       quantity: 1
     };
-    const reservePoller = await client.beginReservePhoneNumbers(reservationRequest);
+    const reservePoller = await client.beginReservePhoneNumbers(
+      reservationRequest,
+      testPollerOptions
+    );
     assert.ok(reservePoller.getOperationState().isStarted);
 
     const reservation: PhoneNumberReservation = await reservePoller.pollUntilDone();
@@ -100,7 +106,7 @@ describe("PhoneNumber - LROs - Purchase Reservation [Playback/Live]", function()
     assert.equal(reservation.status, "Reserved");
     assert.equal(reservation.phoneNumbers?.length, 1);
 
-    const purchasePoller = await client.beginPurchaseReservation(reservationId);
+    const purchasePoller = await client.beginPurchaseReservation(reservationId, testPollerOptions);
     assert.ok(purchasePoller.getOperationState().isStarted);
 
     await purchasePoller.pollUntilDone();

--- a/sdk/communication/communication-administration/test/lro.release.spec.ts
+++ b/sdk/communication/communication-administration/test/lro.release.spec.ts
@@ -4,7 +4,10 @@
 import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import { PhoneNumberAdministrationClient, PhoneNumberRelease } from "../src";
-import { createRecordedPhoneNumberAdministrationClient } from "./utils/recordedClient";
+import {
+  createRecordedPhoneNumberAdministrationClient,
+  testPollerOptions
+} from "./utils/recordedClient";
 
 describe("PhoneNumber - LROs - Release [Playback/Live]", function() {
   let recorder: Recorder;
@@ -42,7 +45,7 @@ describe("PhoneNumber - LROs - Release [Playback/Live]", function() {
       this.skip();
     }
 
-    const poller = await client.beginReleasePhoneNumbers([phoneNumberToRelease]);
+    const poller = await client.beginReleasePhoneNumbers([phoneNumberToRelease], testPollerOptions);
     assert.ok(poller.getOperationState().isStarted);
 
     const release: PhoneNumberRelease = await poller.pollUntilDone();

--- a/sdk/communication/communication-administration/test/lro.reserve.spec.ts
+++ b/sdk/communication/communication-administration/test/lro.reserve.spec.ts
@@ -10,7 +10,10 @@ import {
   PhoneNumberAdministrationClient,
   PhoneNumberReservation
 } from "../src";
-import { createRecordedPhoneNumberAdministrationClient } from "./utils/recordedClient";
+import {
+  createRecordedPhoneNumberAdministrationClient,
+  testPollerOptions
+} from "./utils/recordedClient";
 
 describe("PhoneNumber - LROs - Phone Number Reservations [Playback/Live]", function() {
   let recorder: Recorder;
@@ -93,7 +96,7 @@ describe("PhoneNumber - LROs - Phone Number Reservations [Playback/Live]", funct
       areaCode,
       quantity: 1
     };
-    poller = await client.beginReservePhoneNumbers(reservationRequest);
+    poller = await client.beginReservePhoneNumbers(reservationRequest, testPollerOptions);
     assert.ok(poller.getOperationState().isStarted);
 
     const reservation: PhoneNumberReservation = await poller.pollUntilDone();

--- a/sdk/communication/communication-administration/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-administration/test/utils/recordedClient.ts
@@ -4,7 +4,13 @@
 import { Context } from "mocha";
 import * as dotenv from "dotenv";
 
-import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
+import {
+  env,
+  Recorder,
+  record,
+  RecorderEnvironmentSetup,
+  isPlaybackMode
+} from "@azure/test-utils-recorder";
 import { isNode } from "@azure/core-http";
 import { CommunicationIdentityClient, PhoneNumberAdministrationClient } from "../../src";
 
@@ -78,3 +84,7 @@ export function createRecordedPhoneNumberAdministrationClient(
     includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS == "true"
   };
 }
+
+export const testPollerOptions = {
+  pollInterval: isPlaybackMode() ? 0 : undefined
+};


### PR DESCRIPTION
We had ignored the `pollInterval` and `resumeFrom` options by accident. Now passing them correctly, and setting pollInterval to 0 in test playback mode.

This brings down our playback LRO tests from ~20sec to 200ms and unblocks #12770 