### PR TITLE
[cosmos] modify package.json with the test scripts

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -62,7 +62,7 @@
     "extract-api": "npm run check:src:strict && npm run build:src && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/common/setup.ts \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\"  --timeout 100000",
+    "integration-test:node": "mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/public/common/setup.ts \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\"  --timeout 100000",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json src test samples --ext .ts -f html -o cosmos-lintReport.html || exit 0",
@@ -72,7 +72,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test-consumer": "node consumer-test.js 2>&1",
     "test": "npm run unit-test && npm run integration-test",
-    "test:signoff": "mocha -r esm -r dotenv/config -r ./test/common/setup.js \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\" --timeout 100000 --grep \"#nosignoff\" --invert",
+    "test:signoff": "mocha -r esm -r dotenv/config -r ./test/public/common/setup.js \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\" --timeout 100000 --grep \"#nosignoff\" --invert",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -62,7 +62,7 @@
     "extract-api": "npm run check:src:strict && npm run build:src && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/common/setup.ts \"./test/**/*.spec.ts\" --timeout 100000",
+    "integration-test:node": "mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/common/setup.ts \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\"  --timeout 100000",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json src test samples --ext .ts -f html -o cosmos-lintReport.html || exit 0",
@@ -72,7 +72,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test-consumer": "node consumer-test.js 2>&1",
     "test": "npm run unit-test && npm run integration-test",
-    "test:signoff": "mocha -r esm -r dotenv/config -r ./test/common/setup.js \"./test/**/*.spec.js\" --timeout 100000 --grep \"#nosignoff\" --invert",
+    "test:signoff": "mocha -r esm -r dotenv/config -r ./test/common/setup.js \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\" --timeout 100000 --grep \"#nosignoff\" --invert",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"

--- a/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/session.spec.ts
@@ -10,7 +10,7 @@ import { SessionContainer } from "../../src/session/sessionContainer";
 import { VectorSessionToken } from "../../src/session/VectorSessionToken";
 import { endpoint, masterKey } from "../public/common/_testConfig";
 import { getTestDatabase, removeAllDatabases } from "../public/common/TestHelpers";
-import * as RequestHandler from "../../src";
+import * as RequestHandler from "../../src/request/RequestHandler";
 import { RequestContext } from "../../src";
 
 // TODO: there is alot of "any" types for tokens here

--- a/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v1.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v1.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { hashV1PartitionKey } from "../../../src/utils/hashing/v1";
+import { hashV1PartitionKey } from "../../../../src/utils/hashing/v1";
 
 describe("effectivePartitionKey", function() {
   describe("computes v1 key", function() {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v2.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v2.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { hashV2PartitionKey } from "../../../src/utils/hashing/v2";
+import { hashV2PartitionKey } from "../../../../src/utils/hashing/v2";
 
 describe("effectivePartitionKey", function() {
   describe("computes v2 key", function() {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
@@ -4,7 +4,7 @@ import assert from "assert";
 import { Constants } from "../../../src";
 import { getUserAgent } from "../../../src/common";
 
-const packageJson = require("../../package.json");
+const packageJson = require("../../../package.json");
 const packageVersion = packageJson["version"];
 const constantVersion = Constants.SDKVersion;
 

--- a/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/platform.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import assert from "assert";
-import { Constants } from "../../../src";
-import { getUserAgent } from "../../../src/common";
+import { Constants } from "../../../dist-esm/index";
+import { getUserAgent } from "../../../dist-esm/common";
 
 const packageJson = require("../../../package.json");
 const packageVersion = packageJson["version"];

--- a/sdk/cosmosdb/cosmos/test/public/integration/aggregates/groupBy.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/aggregates/groupBy.spec.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Container, ContainerDefinition } from "../../../src";
+import { Container, ContainerDefinition } from "../../../../src";
 import { bulkInsertItems, getTestContainer, removeAllDatabases } from "../../common/TestHelpers";
 import snapshot from "snap-shot-it";
 import assert from "assert";


### PR DESCRIPTION
- I noticed that the cosmos tests are not actually running any test files after the previous PR merge - https://github.com/Azure/azure-sdk-for-js/pull/12764
- Since the folder structure for tests have been altered, we need to update the test scripts with the correct paths to test files