### PR TITLE
OT Exporter retry when there are network issues

### DIFF
--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-beta.1 (Unreleased)
 
+- OT Exporter retry when there are network issues
+- OpenTelemetry Exporter using Resources API to get service properties
 - Rename package to `@azure/opentelemetry-exporter-azure-monitor`
 - [BREAKING] Deprecate all configuration options except for `connectionString`
 - [BREAKING] Removed support for `TelemetryProcessor`

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
@@ -4,6 +4,7 @@
 import { Logger } from "@opentelemetry/api";
 import { ConsoleLogger, LogLevel, ExportResult } from "@opentelemetry/core";
 import { ReadableSpan, SpanExporter } from "@opentelemetry/tracing";
+import { RestError } from "@azure/core-http";
 import { ConnectionStringParser } from "../utils/connectionStringParser";
 import { HttpSender, FileSystemPersist } from "../platform";
 import {
@@ -105,12 +106,20 @@ export class AzureMonitorTraceExporter implements SpanExporter {
         return ExportResult.FAILED_NOT_RETRYABLE;
       }
     } catch (senderErr) {
-      // Request failed -- always retry
-      this._logger.error(
-        "Retrying due to transient client side error. Error message:",
-        senderErr.message
-      );
-      return ExportResult.FAILED_RETRYABLE;
+      if (this._isNetworkError(senderErr)) {
+        this._logger.error(
+          "Retrying due to transient client side error. Error message:",
+          senderErr.message
+        );
+        return ExportResult.FAILED_RETRYABLE;
+      }
+      else {
+        this._logger.error(
+          "Envelopes could not be exported and are not retriable. Error message:",
+          senderErr.message
+        );
+        return ExportResult.FAILED_NOT_RETRYABLE;
+      }
     }
   }
 
@@ -139,5 +148,22 @@ export class AzureMonitorTraceExporter implements SpanExporter {
     } catch (err) {
       this._logger.warn(`Failed to fetch persisted file`, err);
     }
+  }
+
+  private _isNetworkError(error: Error): boolean {
+    if (error instanceof RestError) {
+      if (
+        error &&
+        error.code &&
+        (error.code === "ETIMEDOUT" ||
+          error.code === "ESOCKETTIMEDOUT" ||
+          error.code === "ECONNREFUSED" ||
+          error.code === "ECONNRESET" ||
+          error.code === "ENOENT")
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
@@ -107,10 +107,10 @@ export class AzureMonitorTraceExporter implements SpanExporter {
     } catch (senderErr) {
       // Request failed -- always retry
       this._logger.error(
-        "Envelopes could not be exported and are not retriable. Error message:",
+        "Retrying due to transient client side error. Error message:",
         senderErr.message
       );
-      return ExportResult.FAILED_NOT_RETRYABLE;
+      return ExportResult.FAILED_RETRYABLE;
     }
   }
 

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
@@ -52,7 +52,9 @@ describe("#AzureMonitorBaseExporter", () => {
 
   describe("Sender/Persister Controller", () => {
     describe("#exportEnvelopes()", () => {
-      const scope = nock(DEFAULT_BREEZE_ENDPOINT).post("/v2/track");
+      const scope = nock(DEFAULT_BREEZE_ENDPOINT)
+        .log(console.log)
+        .post("/v2/track");
       const envelope = {
         name: "Name",
         time: new Date()
@@ -103,12 +105,12 @@ describe("#AzureMonitorBaseExporter", () => {
         assert.strictEqual(persistedEnvelopes, null);
       });
 
-      it("should persist when an error is caught", async () => {
+      it("should not persist when an error is caught", async () => {
         const exporter = new TestExporter();
-        scope.reply(1, ""); // httpSender will throw
+        scope.replyWithError("Error");
 
         const result = await exporter.exportEnvelopesPrivate([envelope]);
-        assert.strictEqual(result, ExportResult.FAILED_RETRYABLE);
+        assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
 
         const persistedEnvelopes = await exporter["_persister"].shift();
         assert.strictEqual(persistedEnvelopes, null);

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
@@ -52,9 +52,7 @@ describe("#AzureMonitorBaseExporter", () => {
 
   describe("Sender/Persister Controller", () => {
     describe("#exportEnvelopes()", () => {
-      const scope = nock(DEFAULT_BREEZE_ENDPOINT)
-        .log(console.log)
-        .post("/v2/track");
+      const scope = nock(DEFAULT_BREEZE_ENDPOINT).post("/v2/track");
       const envelope = {
         name: "Name",
         time: new Date()

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
@@ -103,12 +103,12 @@ describe("#AzureMonitorBaseExporter", () => {
         assert.strictEqual(persistedEnvelopes, null);
       });
 
-      it("should not persist when an error is caught", async () => {
+      it("should persist when an error is caught", async () => {
         const exporter = new TestExporter();
         scope.reply(1, ""); // httpSender will throw
 
         const result = await exporter.exportEnvelopesPrivate([envelope]);
-        assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
+        assert.strictEqual(result, ExportResult.FAILED_RETRYABLE);
 
         const persistedEnvelopes = await exporter["_persister"].shift();
         assert.strictEqual(persistedEnvelopes, null);

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/test/unit/export/trace.test.ts
@@ -107,7 +107,7 @@ describe("#AzureMonitorBaseExporter", () => {
 
       it("should not persist when an error is caught", async () => {
         const exporter = new TestExporter();
-        scope.replyWithError("Error");
+        scope.reply(1, ""); // httpSender will throw
 
         const result = await exporter.exportEnvelopesPrivate([envelope]);
         assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);


### PR DESCRIPTION
Fixes #12904


Python exporter currently retry when there is any exception with HTTP call
https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/monitor/microsoft-opentelemetry-exporter-azuremonitor/microsoft/opentelemetry/exporter/azuremonitor/export/_base.py#L134

Same behavior is in ApplicationInsights Node.js SDK
https://github.com/microsoft/ApplicationInsights-node.js/blob/develop/Library/Sender.ts#L164