### PR TITLE
[core-amqp][event-hubs] support specifying a custom endpoint

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -96,6 +96,28 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-xxlGwbbTkEZAline8wrP75FLaOsT23nMukzIg5X/Cs6cQSQ/JKj7Uxq5Idxp9GgAYT+g+PAj+BJ929/jaselBQ==
+  /@azure/core-amqp/2.0.0:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/logger': 1.0.0
+      '@types/async-lock': 1.1.2
+      '@types/is-buffer': 2.0.0
+      async-lock: 1.2.6
+      buffer: 5.7.1
+      events: 3.2.0
+      is-buffer: 2.0.5
+      jssha: 3.2.0
+      process: 0.11.10
+      rhea: 1.0.24
+      rhea-promise: 1.0.0
+      tslib: 2.0.3
+      url: 0.11.0
+      util: 0.12.3
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-DUsxzHqpaTkSWIIInjNe5YZ8vEampE31MkjrkFAIfKL5SGPRT/LdPq9ipMxo0m1YjmYwAZNcEgSBSM4tbmMNYA==
   /@azure/core-asynciterator-polyfill/1.0.0:
     dev: false
     resolution:
@@ -182,6 +204,25 @@ packages:
     dev: false
     resolution:
       integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==
+  /@azure/event-hubs/5.3.1:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/core-amqp': 2.0.0
+      '@azure/core-asynciterator-polyfill': 1.0.0
+      '@azure/core-auth': 1.1.3
+      '@azure/core-tracing': 1.0.0-preview.9
+      '@azure/logger': 1.0.0
+      '@opentelemetry/api': 0.10.2
+      buffer: 5.7.1
+      is-buffer: 2.0.5
+      jssha: 3.2.0
+      process: 0.11.10
+      rhea-promise: 1.0.0
+      tslib: 2.0.3
+      uuid: 8.3.2
+    dev: false
+    resolution:
+      integrity: sha512-WcLu2DPt/1RwuSnpoLFxkOakBsyByXWuvzOKfHOCzhVGRBuRFJ+MZbLjZgHYvHbzTD+wxP08AXDpUFeGq8Rr+A==
   /@azure/keyvault-keys/4.1.0:
     dependencies:
       '@azure/core-http': 1.2.1
@@ -9209,7 +9250,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-3SC0qZD7sdFrMZ1YvNobSOHLdbnuyLT2J8UvNzBttUQanMY1leTdP6wemdx1Ilpl6tdX57wag1rSSoLsrv8e/g==
+      integrity: sha512-5KZnVq69wtqP4Q3UOxSYjrS6G1WGcIReGvgjgR/kD7XYUv+2jOvZmX/1Z8nHWAZrfjF+8/pQWpiO9QJsQ2Ds8A==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -9321,6 +9362,7 @@ packages:
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
+      '@azure/event-hubs': 5.3.1
       '@azure/storage-blob': 12.3.0
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -9376,7 +9418,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-Khh03c2ZQe4nXYKGnkk4F1NweAwUUlsYV6G7hOx4xD/FBNAqFSICmdZYcVC1nCQszjkgOcUrr5jjBzcSw6Ji5Q==
+      integrity: sha512-sX8X7q6Kg7zrmNaqZG1YiPbY5rAWx1babUki0vRwJbcr1JnNySYjRTgTI/4l0T2tcHTxChwWseTc+BLdUIAtlg==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -9438,7 +9480,7 @@ packages:
     optionalDependencies:
       keytar: 5.6.0
     resolution:
-      integrity: sha512-ZCzaGxJsU3n67T2O+8DtrTWeuFg6gBOwA64vLE07BgvTuLYeJL2KPawcSq1EUgaVAJz/yfOsOSSy6voyC7ORvw==
+      integrity: sha512-gDqAgKO9IiU3fs1ndBcG862UQXuswjFTKIotljAb1lgW/GAEQvtw0FcqZOvIVhWeYGznlCeD0lYclCUxpXNHsA==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-admin.tgz':
@@ -10003,7 +10045,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-NtHFQKVrAKrls6z5YzCcDoyFVyk/mDMqzQM1B0nfUJrdiuBPaDZVZKg7VbWQ4AgRIcOfGXh9zGupespT7nWQqQ==
+      integrity: sha512-H1+AAiX5xT5M3M6zxkbB3btkRHd2YjJLa76b3fy/R7nsp8vQB0OBD4V6ybRI1PqOuR6LnDQjGFL9bVUnTwTCsQ==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob-changefeed.tgz':

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.1 (Unreleased)
 
+- Adds the ability to configure the `hostname` and `port` that a `ConnectionContextBase` will use
+  when connecting to a service.
+
 - Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
   Previously, `retry` would still sleep one more time after all retry attempts were exhausted before returning.
   Now, `retry` will return immediately after all retry attempts are completed as necessary.

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 2.1.0 (Unreleased)
 
-- Adds the ability to configure the `hostname` and `port` that a `ConnectionContextBase` will use
-  when connecting to a service.
+- Adds the ability to configure the `amqpHostname` and `port` that a `ConnectionContextBase` will use when connecting to a service.
+  The `host` field refers to the DNS host or IP address of the service, whereas the `amqpHostname`
+  is the fully qualified host name of the service. Normally `host` and `amqpHostname` will be the same.
+  However if your network does not allow connecting to the service via the public host,
+  you can specify a custom host (e.g. an application gateway) via the `host` field and continue
+  using the public host as the `amqpHostname`.
 
-- Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
+* Fixes the bug reported in issue [12610](https://github.com/Azure/azure-sdk-for-js/issues/12610).
   Previously, `retry` would still sleep one more time after all retry attempts were exhausted before returning.
   Now, `retry` will return immediately after all retry attempts are completed as necessary.
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.1.0 (Unreleased)
 
 - Adds the ability to configure the `hostname` and `port` that a `ConnectionContextBase` will use
   when connecting to a service.

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -163,6 +163,8 @@ export interface ConnectionConfig {
     endpoint: string;
     entityPath?: string;
     host: string;
+    hostname?: string;
+    port?: number;
     sharedAccessKey: string;
     sharedAccessKeyName: string;
     webSocket?: WebSocketImpl;

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -159,11 +159,11 @@ export enum ConditionErrorNameMapper {
 
 // @public
 export interface ConnectionConfig {
+    amqpHostname?: string;
     connectionString: string;
     endpoint: string;
     entityPath?: string;
     host: string;
-    hostname?: string;
     port?: number;
     sharedAccessKey: string;
     sharedAccessKeyName: string;

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -122,7 +122,7 @@ export const ConnectionContextBase = {
     const connectionOptions: ConnectionOptions = {
       transport: Constants.TLS,
       host: parameters.config.host,
-      hostname: parameters.config.hostname ?? parameters.config.host,
+      hostname: parameters.config.amqpHostname ?? parameters.config.host,
       username: parameters.config.sharedAccessKeyName,
       port: parameters.config.port ?? 5671,
       reconnect: false,

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -144,7 +144,7 @@ export const ConnectionContextBase = {
       (!isNode && typeof window !== "undefined" && (window as any).WebSocket)
     ) {
       const socket = parameters.config.webSocket || (window as any).WebSocket;
-      const host = connectionOptions.host;
+      const host = parameters.config.host;
       const endpoint = parameters.config.webSocketEndpointPath || "";
       const socketOptions = parameters.config.webSocketConstructorOptions || {};
       const port = parameters.config.port ?? 443;

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -122,9 +122,9 @@ export const ConnectionContextBase = {
     const connectionOptions: ConnectionOptions = {
       transport: Constants.TLS,
       host: parameters.config.host,
-      hostname: parameters.config.host,
+      hostname: parameters.config.hostname ?? parameters.config.host,
       username: parameters.config.sharedAccessKeyName,
-      port: 5671,
+      port: parameters.config.port ?? 5671,
       reconnect: false,
       properties: {
         product: parameters.connectionProperties.product,
@@ -144,7 +144,7 @@ export const ConnectionContextBase = {
       (!isNode && typeof window !== "undefined" && (window as any).WebSocket)
     ) {
       const socket = parameters.config.webSocket || (window as any).WebSocket;
-      const host = parameters.config.host;
+      const host = connectionOptions.host;
       const endpoint = parameters.config.webSocketEndpointPath || "";
       const socketOptions = parameters.config.webSocketConstructorOptions || {};
 

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -147,10 +147,11 @@ export const ConnectionContextBase = {
       const host = connectionOptions.host;
       const endpoint = parameters.config.webSocketEndpointPath || "";
       const socketOptions = parameters.config.webSocketConstructorOptions || {};
+      const port = parameters.config.port ?? 443;
 
       connectionOptions.webSocketOptions = {
         webSocket: socket,
-        url: `wss://${host}:443/${endpoint}`,
+        url: `wss://${host}:${port}/${endpoint}`,
         protocol: ["AMQPWSB10"],
         options: socketOptions
       };

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -26,13 +26,18 @@ export interface ConnectionConfig {
    */
   endpoint: string;
   /**
-   * @property {string} host - The host "<yournamespace>.servicebus.windows.net".
+   * The DNS hostname or IP address of the service.
+   * Typically of the form "<yournamespace>.servicebus.windows.net" unless connecting
+   * to the service through an intermediary.
    */
   host: string;
   /**
-   * @property {string} hostname - The hostname "<yournamespace>.servicebus.windows.net".
+   * The fully qualified name of the host to connect to.
+   * This field can be used by AMQP proxies to determine the correct back-end service to
+   * connect the client to.
+   * Typically of the form "<yournamespace>.servicebus.windows.net".
    */
-  hostname?: string;
+  amqpHostname?: string;
   /**
    * The port number.
    */

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -30,6 +30,14 @@ export interface ConnectionConfig {
    */
   host: string;
   /**
+   * @property {string} hostname - The hostname "<yournamespace>.servicebus.windows.net".
+   */
+  hostname?: string;
+  /**
+   * The port number.
+   */
+  port?: number;
+  /**
    * @property {string} connectionString - The connection string.
    */
   connectionString: string;
@@ -135,7 +143,7 @@ export const ConnectionConfig = {
       throw new TypeError("Missing 'entityPath' in configuration");
     }
     if (config.entityPath != undefined) {
-       config.entityPath = String(config.entityPath);
+      config.entityPath = String(config.entityPath);
     }
 
     if (!isSharedAccessSignature(config.connectionString)) {

--- a/sdk/core/core-amqp/test/context.spec.ts
+++ b/sdk/core/core-amqp/test/context.spec.ts
@@ -35,6 +35,118 @@ describe("ConnectionContextBase", function() {
     done();
   });
 
+  it("should set host and hostname to the same value by default", function() {
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.hostname!.should.equal("hostname.servicebus.windows.net");
+    context.connection.options.host!.should.equal("hostname.servicebus.windows.net");
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
+  it("should allow setting host and hostname to different values", function() {
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    config.hostname = "127.0.0.1";
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.hostname!.should.equal("127.0.0.1");
+    context.connection.options.host!.should.equal("hostname.servicebus.windows.net");
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
+  it("should allow specifying a port", function() {
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    config.port = 1111;
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.port!.should.equal(1111);
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
+  it("should have a default port (5671)", function() {
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.port!.should.equal(5671);
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
   if (isNode) {
     it("should accept a websocket constructor in Node", async () => {
       const connectionString =

--- a/sdk/core/core-amqp/test/context.spec.ts
+++ b/sdk/core/core-amqp/test/context.spec.ts
@@ -147,6 +147,103 @@ describe("ConnectionContextBase", function() {
     context.cbsSession.should.instanceOf(CbsClient);
   });
 
+  it("should allow setting host and hostname to different values when using websockets", function() {
+    const websockets: any = () => {};
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    config.webSocket = websockets;
+    config.hostname = config.host;
+    config.host = "127.0.0.1";
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.host!.should.equal("127.0.0.1");
+    context.connection.options.hostname!.should.equal("hostname.servicebus.windows.net");
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.connection.options.webSocketOptions!.url.should.equal(`wss://127.0.0.1:443/`);
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
+  it("should have a default port when using websockets (443)", function() {
+    const websockets: any = () => {};
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    config.webSocket = websockets;
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.connection.options.webSocketOptions!.url.should.equal(
+      `wss://hostname.servicebus.windows.net:443/`
+    );
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
+  it("should allow specifying a port when using websockets", function() {
+    const websockets: any = () => {};
+    const connectionString =
+      "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+    config.webSocket = websockets;
+    config.port = 1111;
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+    should.exist(context.config);
+    should.exist(context.connection);
+    should.exist(context.connectionId);
+    should.exist(context.connectionLock);
+    should.exist(context.negotiateClaimLock);
+    context.connection.options.port!.should.equal(1111);
+    context.wasConnectionCloseCalled.should.equal(false);
+    context.connection.should.instanceOf(Connection);
+    context.connection.options.properties!.product.should.equal("MSJSClient");
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
+    context.connection.options.properties!.version.should.equal("1.0.0");
+    context.connection.options.webSocketOptions!.url.should.equal(
+      `wss://hostname.servicebus.windows.net:1111/`
+    );
+    context.cbsSession.should.instanceOf(CbsClient);
+  });
+
   if (isNode) {
     it("should accept a websocket constructor in Node", async () => {
       const connectionString =

--- a/sdk/core/core-amqp/test/context.spec.ts
+++ b/sdk/core/core-amqp/test/context.spec.ts
@@ -68,7 +68,7 @@ describe("ConnectionContextBase", function() {
       "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
     const path = "mypath";
     const config = ConnectionConfig.create(connectionString, path);
-    config.hostname = "127.0.0.1";
+    config.amqpHostname = "127.0.0.1";
     const context = ConnectionContextBase.create({
       config: config,
       connectionProperties: {
@@ -154,7 +154,7 @@ describe("ConnectionContextBase", function() {
     const path = "mypath";
     const config = ConnectionConfig.create(connectionString, path);
     config.webSocket = websockets;
-    config.hostname = config.host;
+    config.amqpHostname = config.host;
     config.host = "127.0.0.1";
     const context = ConnectionContextBase.create({
       config: config,

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
-## 5.3.2 (Unreleased)
+## 5.4.0-beta.1 (Unreleased)
+
+- Adds the `customEndpointAddress` field to `EventHubClientOptions`.
+  This allows for specifying a custom endpoint to use when communicating
+  with the Event Hubs service, which is useful when your network does not
+  allow communicating to the standard Event Hubs endpoint.
+  Resolves [#12901](https://github.com/Azure/azure-sdk-for-js/issues/12901).
 
 - Updates documentation for `EventData` to call out that the `body` field
   must be converted to a byte array or `Buffer` when cross-language

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.3.2",
+  "version": "5.4.0-beta.1",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -29,7 +29,8 @@
     }
   },
   "browser": {
-    "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js"
+    "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js",
+    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },
   "engine": {
     "node": ">=8.0.0"
@@ -89,7 +90,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.0.0",
+    "@azure/core-amqp": "^2.0.1",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/core-auth": "^1.1.3",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -29,8 +29,7 @@
     }
   },
   "browser": {
-    "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js",
-    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
+    "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js"
   },
   "engine": {
     "node": ">=8.0.0"

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.0.1",
+    "@azure/core-amqp": "^2.1.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/core-auth": "^1.1.3",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -74,6 +74,7 @@ export interface EventDataBatch {
 
 // @public
 export interface EventHubClientOptions {
+    customEndpointAddress?: string;
     retryOptions?: RetryOptions;
     userAgent?: string;
     webSocketOptions?: WebSocketOptions;

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -19,7 +19,7 @@ const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["events", "util", "os"];
+  const externalNodeBuiltins = ["events", "util", "os", "url"];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -501,6 +501,10 @@ export function createConnectionContext(
     config = EventHubConnectionConfig.create(connectionString);
   }
 
+  if (options?.customEndpointAddress) {
+    EventHubConnectionConfig.setCustomEndpointAddress(config, options.customEndpointAddress);
+  }
+
   ConnectionConfig.validate(config);
 
   return ConnectionContext.create(config, credential, options);

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -3,11 +3,14 @@
 /* eslint-disable eqeqeq */
 
 import { ConnectionConfig } from "@azure/core-amqp";
+import { URL } from "./util/url";
 
 /**
  * Describes the connection config object that is created after parsing an EventHub connection
  * string. It also provides some convenience methods for getting the address and audience for
  * different entities.
+ * @internal
+ * @ignore
  */
 export interface EventHubConnectionConfig extends ConnectionConfig {
   /**
@@ -65,7 +68,8 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
  * Describes the connection config object that is created after parsing an EventHub connection
  * string. It also provides some convenience methods for getting the address and audience for
  * different entities.
- * @module EventHubConnectionConfig
+ * @internal
+ * @ignore
  */
 export const EventHubConnectionConfig = {
   /**
@@ -139,6 +143,21 @@ export const EventHubConnectionConfig = {
       return `${config.entityPath}/ConsumerGroups/${consumergroup}/Partitions/${partitionId}`;
     };
     return config as EventHubConnectionConfig;
+  },
+
+  /**
+   * Updates the provided EventHubConnectionConfig to use the custom endpoint address.
+   * @param config An existing connection configuration to be updated.
+   * @param customEndpointAddress The custom endpoint address to use.
+   */
+  setCustomEndpointAddress(config: EventHubConnectionConfig, customEndpointAddress: string): void {
+    // The hostname should match the host prior to using the custom endpoint.
+    config.hostname = config.host;
+    const { host, port } = new URL(customEndpointAddress);
+    config.host = host;
+    if (port) {
+      config.port = parseInt(port, 10);
+    }
   },
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -3,7 +3,7 @@
 /* eslint-disable eqeqeq */
 
 import { ConnectionConfig } from "@azure/core-amqp";
-import { URL } from "./util/url";
+import { parseEndpoint } from "./util/parseEndpoint";
 
 /**
  * Describes the connection config object that is created after parsing an EventHub connection
@@ -153,7 +153,7 @@ export const EventHubConnectionConfig = {
   setCustomEndpointAddress(config: EventHubConnectionConfig, customEndpointAddress: string): void {
     // The amqpHostname should match the host prior to using the custom endpoint.
     config.amqpHostname = config.host;
-    const { hostname, port } = new URL(customEndpointAddress);
+    const { hostname, port } = parseEndpoint(customEndpointAddress);
     // Since we specify the port separately, set host to the customEndpointAddress hostname.
     config.host = hostname;
     if (port) {

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -151,8 +151,8 @@ export const EventHubConnectionConfig = {
    * @param customEndpointAddress The custom endpoint address to use.
    */
   setCustomEndpointAddress(config: EventHubConnectionConfig, customEndpointAddress: string): void {
-    // The hostname should match the host prior to using the custom endpoint.
-    config.hostname = config.host;
+    // The amqpHostname should match the host prior to using the custom endpoint.
+    config.amqpHostname = config.host;
     const { hostname, port } = new URL(customEndpointAddress);
     // Since we specify the port separately, set host to the customEndpointAddress hostname.
     config.host = hostname;

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -153,8 +153,9 @@ export const EventHubConnectionConfig = {
   setCustomEndpointAddress(config: EventHubConnectionConfig, customEndpointAddress: string): void {
     // The hostname should match the host prior to using the custom endpoint.
     config.hostname = config.host;
-    const { host, port } = new URL(customEndpointAddress);
-    config.host = host;
+    const { hostname, port } = new URL(customEndpointAddress);
+    // Since we specify the port separately, set host to the customEndpointAddress hostname.
+    config.host = hostname;
     if (port) {
       config.port = parseInt(port, 10);
     }

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -111,7 +111,7 @@ export enum CloseReason {
  */
 export interface EventHubClientOptions {
   /**
-   * A custom endpoint to use when connection to the Event Hubs service.
+   * A custom endpoint to use when connecting to the Event Hubs service.
    * This can be useful when your network does not allow connecting to the
    * standard Azure Event Hubs endpoint address, but does allow connecting
    * through an intermediary.

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -111,18 +111,22 @@ export enum CloseReason {
  */
 export interface EventHubClientOptions {
   /**
-   * @property
+   * A custom endpoint to use when connectin to the Event Hubs service.
+   * This can be useful when your network does not allow connecting to the
+   * standard Azure Event Hubs endpoint address, but does allow connecting
+   * through an intermediary.
+   */
+  customEndpointAddress?: string;
+  /**
    * Options to configure the retry policy for all the operations on the client.
    * For example, `{ "maxRetries": 4 }` or `{ "maxRetries": 4, "retryDelayInMs": 30000 }`.
    */
   retryOptions?: RetryOptions;
   /**
-   * @property
    * Options to configure the channelling of the AMQP connection over Web Sockets.
    */
   webSocketOptions?: WebSocketOptions;
   /**
-   * @property
    * Value that is appended to the built in user agent string that is passed to the Event Hubs service.
    */
   userAgent?: string;

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -115,6 +115,8 @@ export interface EventHubClientOptions {
    * This can be useful when your network does not allow connecting to the
    * standard Azure Event Hubs endpoint address, but does allow connecting
    * through an intermediary.
+   *
+   * Example: "https://my.custom.endpoint:100/"
    */
   customEndpointAddress?: string;
   /**

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -111,7 +111,7 @@ export enum CloseReason {
  */
 export interface EventHubClientOptions {
   /**
-   * A custom endpoint to use when connectin to the Event Hubs service.
+   * A custom endpoint to use when connection to the Event Hubs service.
    * This can be useful when your network does not allow connecting to the
    * standard Azure Event Hubs endpoint address, but does allow connecting
    * through an intermediary.

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.3.2"
+  version: "5.4.0-beta.1"
 };

--- a/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
+++ b/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Parses the host, hostname, and port from an endpoint.
+ * @param endpoint And endpoint to parse.
+ * @hidden
+ * @internal
+ */
+export function parseEndpoint(endpoint: string): { host: string; hostname: string; port?: string } {
+  const hostMatch = endpoint.match(/.*:\/\/([^\/]*)/i);
+  if (!hostMatch) {
+    throw new TypeError(`Invalid endpoint missing host: ${endpoint}`);
+  }
+
+  const [, host] = hostMatch;
+  const [hostname, port] = host.split(":");
+
+  return { host, hostname, port };
+}

--- a/sdk/eventhub/event-hubs/src/util/url.browser.ts
+++ b/sdk/eventhub/event-hubs/src/util/url.browser.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// <reference lib="DOM" />
+
+const url = URL;
+
+export { url as URL };

--- a/sdk/eventhub/event-hubs/src/util/url.browser.ts
+++ b/sdk/eventhub/event-hubs/src/util/url.browser.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-/// <reference lib="DOM" />
-
-const url = URL;
-
-export { url as URL };

--- a/sdk/eventhub/event-hubs/src/util/url.ts
+++ b/sdk/eventhub/event-hubs/src/util/url.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { URL } from "url";

--- a/sdk/eventhub/event-hubs/src/util/url.ts
+++ b/sdk/eventhub/event-hubs/src/util/url.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export { URL } from "url";

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -97,7 +97,7 @@ describe("Create EventHubConsumerClient", function(): void {
       { customEndpointAddress: "sb://foo.private.bar:111" }
     );
     client.should.be.an.instanceof(EventHubConsumerClient);
-    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.host.should.equal("foo.private.bar");
     client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
@@ -119,7 +119,7 @@ describe("Create EventHubConsumerClient", function(): void {
       { customEndpointAddress: "sb://foo.private.bar:111" }
     );
     client.should.be.an.instanceof(EventHubConsumerClient);
-    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.host.should.equal("foo.private.bar");
     client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
@@ -196,7 +196,7 @@ describe("Create EventHubProducerClient", function(): void {
       { customEndpointAddress: "sb://foo.private.bar:111" }
     );
     client.should.be.an.instanceof(EventHubProducerClient);
-    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.host.should.equal("foo.private.bar");
     client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
@@ -217,7 +217,7 @@ describe("Create EventHubProducerClient", function(): void {
       { customEndpointAddress: "sb://foo.private.bar:111" }
     );
     client.should.be.an.instanceof(EventHubProducerClient);
-    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.host.should.equal("foo.private.bar");
     client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -98,7 +98,7 @@ describe("Create EventHubConsumerClient", function(): void {
     );
     client.should.be.an.instanceof(EventHubConsumerClient);
     client["_context"].config.host.should.equal("foo.private.bar");
-    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
 
@@ -120,7 +120,7 @@ describe("Create EventHubConsumerClient", function(): void {
     );
     client.should.be.an.instanceof(EventHubConsumerClient);
     client["_context"].config.host.should.equal("foo.private.bar");
-    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
 });
@@ -197,7 +197,7 @@ describe("Create EventHubProducerClient", function(): void {
     );
     client.should.be.an.instanceof(EventHubProducerClient);
     client["_context"].config.host.should.equal("foo.private.bar");
-    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
 
@@ -218,7 +218,7 @@ describe("Create EventHubProducerClient", function(): void {
     );
     client.should.be.an.instanceof(EventHubProducerClient);
     client["_context"].config.host.should.equal("foo.private.bar");
-    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.amqpHostname!.should.equal("test.servicebus.windows.net");
     client["_context"].config.port!.should.equal(111);
   });
 });

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -89,6 +89,40 @@ describe("Create EventHubConsumerClient", function(): void {
     should.equal(client.eventHubName, "my-event-hub-name");
     should.equal(client.fullyQualifiedNamespace, "test.servicebus.windows.net");
   });
+
+  it("respects customEndpointAddress when using connection string", () => {
+    const client = new EventHubConsumerClient(
+      "dummy",
+      "Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-name",
+      { customEndpointAddress: "sb://foo.private.bar:111" }
+    );
+    client.should.be.an.instanceof(EventHubConsumerClient);
+    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.port!.should.equal(111);
+  });
+
+  it("respects customEndpointAddress when using credentials", () => {
+    const dummyCredential: TokenCredential = {
+      getToken: async () => {
+        return {
+          token: "boo",
+          expiresOnTimestamp: 12324
+        };
+      }
+    };
+    const client = new EventHubConsumerClient(
+      "dummy",
+      "test.servicebus.windows.net",
+      "my-event-hub-name",
+      dummyCredential,
+      { customEndpointAddress: "sb://foo.private.bar:111" }
+    );
+    client.should.be.an.instanceof(EventHubConsumerClient);
+    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.port!.should.equal(111);
+  });
 });
 
 describe("Create EventHubProducerClient", function(): void {
@@ -154,6 +188,38 @@ describe("Create EventHubProducerClient", function(): void {
     client.should.be.an.instanceof(EventHubProducerClient);
     should.equal(client.eventHubName, "my-event-hub-name");
     should.equal(client.fullyQualifiedNamespace, "test.servicebus.windows.net");
+  });
+
+  it("respects customEndpointAddress when using connection string", () => {
+    const client = new EventHubProducerClient(
+      "Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-name",
+      { customEndpointAddress: "sb://foo.private.bar:111" }
+    );
+    client.should.be.an.instanceof(EventHubProducerClient);
+    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.port!.should.equal(111);
+  });
+
+  it("respects customEndpointAddress when using credentials", () => {
+    const dummyCredential: TokenCredential = {
+      getToken: async () => {
+        return {
+          token: "boo",
+          expiresOnTimestamp: 12324
+        };
+      }
+    };
+    const client = new EventHubProducerClient(
+      "test.servicebus.windows.net",
+      "my-event-hub-name",
+      dummyCredential,
+      { customEndpointAddress: "sb://foo.private.bar:111" }
+    );
+    client.should.be.an.instanceof(EventHubProducerClient);
+    client["_context"].config.host.should.equal("foo.private.bar:111");
+    client["_context"].config.hostname!.should.equal("test.servicebus.windows.net");
+    client["_context"].config.port!.should.equal(111);
   });
 });
 

--- a/sdk/eventhub/event-hubs/test/config.spec.ts
+++ b/sdk/eventhub/event-hubs/test/config.spec.ts
@@ -75,5 +75,112 @@ describe("ConnectionConfig", function() {
 
       done();
     });
+
+    describe("setCustomEndpointAddress", () => {
+      it("overwrites host", () => {
+        const config = EventHubConnectionConfig.create(
+          "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep"
+        );
+        config.should.have.property("host").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("sharedAccessKeyName").that.equals("sakName");
+        config.should.have.property("sharedAccessKey").that.equals("sak");
+        config.should.have.property("entityPath").that.equals("ep");
+
+        config.getManagementAddress().should.equal("ep/$management");
+        config.getSenderAddress().should.equal("ep");
+        config.getSenderAddress("0").should.equal("ep/Partitions/0");
+        config.getSenderAddress(0).should.equal("ep/Partitions/0");
+        config.getReceiverAddress("0").should.equal("ep/ConsumerGroups/$default/Partitions/0");
+        config.getReceiverAddress(0).should.equal("ep/ConsumerGroups/$default/Partitions/0");
+        config.getReceiverAddress("0", "cg").should.equal("ep/ConsumerGroups/cg/Partitions/0");
+        config.getReceiverAddress(0, "cg").should.equal("ep/ConsumerGroups/cg/Partitions/0");
+
+        config
+          .getManagementAudience()
+          .should.equal("sb://hostname.servicebus.windows.net/ep/$management");
+        config.getSenderAudience().should.equal("sb://hostname.servicebus.windows.net/ep");
+        config
+          .getSenderAudience("0")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/Partitions/0");
+        config
+          .getSenderAudience(0)
+          .should.equal("sb://hostname.servicebus.windows.net/ep/Partitions/0");
+        config
+          .getReceiverAudience("0")
+          .should.equal(
+            "sb://hostname.servicebus.windows.net/ep/ConsumerGroups/$default/Partitions/0"
+          );
+        config
+          .getReceiverAudience(0)
+          .should.equal(
+            "sb://hostname.servicebus.windows.net/ep/ConsumerGroups/$default/Partitions/0"
+          );
+        config
+          .getReceiverAudience("0", "cg")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/ConsumerGroups/cg/Partitions/0");
+        config
+          .getReceiverAudience(0, "cg")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/ConsumerGroups/cg/Partitions/0");
+
+        EventHubConnectionConfig.setCustomEndpointAddress(config, "https://foo.private.endpoint");
+        config.should.have.property("hostname").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("host").that.equals("foo.private.endpoint");
+        config.should.not.have.property("port");
+      });
+
+      it("overwrites host and port", () => {
+        const config = EventHubConnectionConfig.create(
+          "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep"
+        );
+        config.should.have.property("host").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("sharedAccessKeyName").that.equals("sakName");
+        config.should.have.property("sharedAccessKey").that.equals("sak");
+        config.should.have.property("entityPath").that.equals("ep");
+
+        config.getManagementAddress().should.equal("ep/$management");
+        config.getSenderAddress().should.equal("ep");
+        config.getSenderAddress("0").should.equal("ep/Partitions/0");
+        config.getSenderAddress(0).should.equal("ep/Partitions/0");
+        config.getReceiverAddress("0").should.equal("ep/ConsumerGroups/$default/Partitions/0");
+        config.getReceiverAddress(0).should.equal("ep/ConsumerGroups/$default/Partitions/0");
+        config.getReceiverAddress("0", "cg").should.equal("ep/ConsumerGroups/cg/Partitions/0");
+        config.getReceiverAddress(0, "cg").should.equal("ep/ConsumerGroups/cg/Partitions/0");
+
+        config
+          .getManagementAudience()
+          .should.equal("sb://hostname.servicebus.windows.net/ep/$management");
+        config.getSenderAudience().should.equal("sb://hostname.servicebus.windows.net/ep");
+        config
+          .getSenderAudience("0")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/Partitions/0");
+        config
+          .getSenderAudience(0)
+          .should.equal("sb://hostname.servicebus.windows.net/ep/Partitions/0");
+        config
+          .getReceiverAudience("0")
+          .should.equal(
+            "sb://hostname.servicebus.windows.net/ep/ConsumerGroups/$default/Partitions/0"
+          );
+        config
+          .getReceiverAudience(0)
+          .should.equal(
+            "sb://hostname.servicebus.windows.net/ep/ConsumerGroups/$default/Partitions/0"
+          );
+        config
+          .getReceiverAudience("0", "cg")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/ConsumerGroups/cg/Partitions/0");
+        config
+          .getReceiverAudience(0, "cg")
+          .should.equal("sb://hostname.servicebus.windows.net/ep/ConsumerGroups/cg/Partitions/0");
+
+        EventHubConnectionConfig.setCustomEndpointAddress(
+          config,
+          "https://foo.private.endpoint:1111"
+        );
+        config.should.have.property("hostname").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("host").that.equals("foo.private.endpoint:1111");
+        config.should.have.property("port").that.equals(1111);
+      });
+    });
   });
 });

--- a/sdk/eventhub/event-hubs/test/config.spec.ts
+++ b/sdk/eventhub/event-hubs/test/config.spec.ts
@@ -178,7 +178,7 @@ describe("ConnectionConfig", function() {
           "https://foo.private.endpoint:1111"
         );
         config.should.have.property("hostname").that.equals("hostname.servicebus.windows.net");
-        config.should.have.property("host").that.equals("foo.private.endpoint:1111");
+        config.should.have.property("host").that.equals("foo.private.endpoint");
         config.should.have.property("port").that.equals(1111);
       });
     });

--- a/sdk/eventhub/event-hubs/test/config.spec.ts
+++ b/sdk/eventhub/event-hubs/test/config.spec.ts
@@ -123,7 +123,7 @@ describe("ConnectionConfig", function() {
           .should.equal("sb://hostname.servicebus.windows.net/ep/ConsumerGroups/cg/Partitions/0");
 
         EventHubConnectionConfig.setCustomEndpointAddress(config, "https://foo.private.endpoint");
-        config.should.have.property("hostname").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("amqpHostname").that.equals("hostname.servicebus.windows.net");
         config.should.have.property("host").that.equals("foo.private.endpoint");
         config.should.not.have.property("port");
       });
@@ -177,7 +177,7 @@ describe("ConnectionConfig", function() {
           config,
           "https://foo.private.endpoint:1111"
         );
-        config.should.have.property("hostname").that.equals("hostname.servicebus.windows.net");
+        config.should.have.property("amqpHostname").that.equals("hostname.servicebus.windows.net");
         config.should.have.property("host").that.equals("foo.private.endpoint");
         config.should.have.property("port").that.equals(1111);
       });

--- a/sdk/eventhub/event-hubs/test/impl/parseEndpoint.spec.ts
+++ b/sdk/eventhub/event-hubs/test/impl/parseEndpoint.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { parseEndpoint } from "../../src/util/parseEndpoint";
+import chai from "chai";
+const should = chai.should();
+
+describe("parseEndpoint", () => {
+  it("throws an error for invalid inputs", () => {
+    should.throw(() => parseEndpoint(""), /Invalid endpoint/);
+    should.throw(() => parseEndpoint("missing-protocol"), /Invalid endpoint/);
+    should.throw(() => parseEndpoint("//missing-protocol"), /Invalid endpoint/);
+  });
+
+  it("extracts host, hostname, and port", () => {
+    parseEndpoint("sb://test.servicebus.windows.net:5671").should.eql({
+      host: "test.servicebus.windows.net:5671",
+      hostname: "test.servicebus.windows.net",
+      port: "5671"
+    } as ReturnType<typeof parseEndpoint>);
+
+    parseEndpoint("https://127.0.0.1:5671").should.eql({
+      host: "127.0.0.1:5671",
+      hostname: "127.0.0.1",
+      port: "5671"
+    } as ReturnType<typeof parseEndpoint>);
+
+    parseEndpoint("amqps://127.0.0.1:5671/path/?query=foo").should.eql({
+      host: "127.0.0.1:5671",
+      hostname: "127.0.0.1",
+      port: "5671"
+    } as ReturnType<typeof parseEndpoint>);
+
+    parseEndpoint("wss://127.0.0.1/path/?query=foo").should.eql({
+      host: "127.0.0.1",
+      hostname: "127.0.0.1",
+      port: undefined
+    } as ReturnType<typeof parseEndpoint>);
+  });
+});

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.0.1",
+    "@azure/core-amqp": "^2.1.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.0.0",
+    "@azure/core-amqp": "^2.0.1",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",


### PR DESCRIPTION
Fixes #12901 

### Purpose of change

Some users run their applications in a private network that lacks access to public endpoints, such as <namespace>.servicebus.windows.net. Due to these restrictions, these applications are unable to create direct connections to the Azure Event Hubs service using the standard endpoint address and require the ability to specify a custom host name to ensure they route through the proper intermediary for the connection to be made.

### Testing

I've added tests that verify the connection has been configured with the custom endpoint correctly.

I also manually ran these changes by setting up an Application Gateway in Azure with:
- backend pool with a backend target that points to the FQDN of my Event Hubs Namespace (`<namespace>.servicebus.windows.net`)
- A front-end listener using a HTTPS and a nonstandard port (200).
- HTTP settings with the following:
   - backend port: 443
   - Override with new host name: set to 'Yes'
- A rule that maps the front-end listener to the back-end target and uses the HTTP settings above.

I then had a test script that sent events, received events, and called operations on the $management link setting the `customEndpointAddress` to the public IP address from my application gateway.

Here's a simplified version of that script:
```js
const { EventHubProducerClient } = require('@azure/event-hubs');
const ws = require('ws');
const connectionString = `Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=sakn;SharedAccessKey=key`;
const eventHubName = `my-hub`;

async function run() {
  const client = new EventHubProducerClient(connectionString, eventHubName, {
    customEndpointAddress: `https://my.ip.address:200`,
    webSocketOptions: {
      webSocket: ws
    }
  });

  const props = await client.getEventHubProperties();
  console.log(props);
  return client.close();
}
run().catch(console.error);
```

Note that in my application gateway I also used self-signed certs so needed to do some additional work so node.js would recognize my certificate, but that's separate from the customEndpointAddress work and doesn't require changes from our SDK.