### PR TITLE
[Event Hubs] Remove @constructor tags

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -107,7 +107,6 @@ export class EventHubConsumerClient {
   }
 
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
@@ -126,7 +125,6 @@ export class EventHubConsumerClient {
     options?: EventHubConsumerClientOptions
   ); // #1
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
@@ -149,7 +147,6 @@ export class EventHubConsumerClient {
     options?: EventHubConsumerClientOptions
   ); // #1.1
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
@@ -170,7 +167,6 @@ export class EventHubConsumerClient {
     options?: EventHubConsumerClientOptions
   ); // #2
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
@@ -195,7 +191,6 @@ export class EventHubConsumerClient {
     options?: EventHubConsumerClientOptions
   ); // #2.1
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
@@ -218,7 +213,6 @@ export class EventHubConsumerClient {
     options?: EventHubConsumerClientOptions
   ); // #3
   /**
-   * @constructor
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -69,7 +69,6 @@ export class EventHubProducerClient {
   }
 
   /**
-   * @constructor
    * The `EventHubProducerClient` class is used to send events to an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
@@ -83,7 +82,6 @@ export class EventHubProducerClient {
    */
   constructor(connectionString: string, options?: EventHubClientOptions);
   /**
-   * @constructor
    * The `EventHubProducerClient` class is used to send events to an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
@@ -98,7 +96,6 @@ export class EventHubProducerClient {
    */
   constructor(connectionString: string, eventHubName: string, options?: EventHubClientOptions);
   /**
-   * @constructor
    * The `EventHubProducerClient` class is used to send events to an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to


### PR DESCRIPTION
The API reference docs for [EventHubConsumerClient ](https://docs.microsoft.com/en-us/javascript/api/%40azure/event-hubs/eventhubconsumerclient?view=azure-node-latest)and [EventHubProducerClient ](https://docs.microsoft.com/en-us/javascript/api/%40azure/event-hubs/eventhubproducerclient?view=azure-node-latest)dont show the description we have in the source code for their constructors. My guess is that the `@constructor` tag causes the doc generating tool (typedoc v0.15.0) to ignore what comes next. It does so for tags like `@member` as well. While #12912 takes us closer to a long term fix, this PR does a quick fix for now

Found during https://github.com/azure/azure-sdk-for-js/issues/12374 by @richardpark-msft 