### PR TITLE
[Synapse] Remove duplicate clean command

### DIFF
--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "tslib": "^2.0.0",
-    "rimraf": "^3.0.0"
+    "tslib": "^2.0.0"
   },
   "keywords": [
     "node",
@@ -62,7 +61,6 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify && npm run extract-api",
-    "clean": "rimraf ./dist* types *.log",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "pack": "npm pack 2>&1",
     "test": "echo skip",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -11,8 +11,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
-    "tslib": "^2.0.0",
-    "rimraf": "^3.0.0"
+    "tslib": "^2.0.0"
   },
   "keywords": [
     "node",
@@ -63,7 +62,6 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify && npm run extract-api",
-    "clean": "rimraf ./dist* types *.log",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "pack": "npm pack 2>&1",
     "build:test": "echo skip",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -10,8 +10,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
-    "tslib": "^2.0.0",
-    "rimraf": "^3.0.0"
+    "tslib": "^2.0.0"
   },
   "keywords": [
     "node",
@@ -62,7 +61,6 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify && npm run extract-api",
-    "clean": "rimraf ./dist* types *.log",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "test": "echo skip",
     "build:test": "echo skip",

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
-    "tslib": "^2.0.0",
-    "rimraf": "^3.0.0"
+    "tslib": "^2.0.0"
   },
   "keywords": [
     "node",
@@ -61,7 +60,6 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify && npm run extract-api",
-    "clean": "rimraf ./dist* types *.log",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "pack": "npm pack 2>&1",
     "build:test": "echo skipped",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
-    "tslib": "^2.0.0",
-    "rimraf": "^3.0.0"
+    "tslib": "^2.0.0"
   },
   "keywords": [
     "node",
@@ -61,7 +60,6 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify && npm run extract-api",
-    "clean": "rimraf ./dist* types *.log",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "pack": "npm pack 2>&1",
     "build:test": "echo skipped",


### PR DESCRIPTION
Two `clean` commands were added by two different PRs https://github.com/Azure/azure-sdk-for-js/pull/12870 and https://github.com/Azure/azure-sdk-for-js/pull/12770. This PR removes the addition done by the former.