### PR TITLE
[Docs] Adding docs npm script

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4902,13 +4902,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-  /marked/0.8.2:
+  /marked/0.7.0:
     dev: false
     engines:
-      node: '>= 8.16.2'
+      node: '>=0.10.0'
     hasBin: true
     resolution:
-      integrity: sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+      integrity: sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
   /matched/1.0.2:
     dependencies:
       arr-union: 3.1.0
@@ -7424,25 +7424,32 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==
-  /typedoc/0.15.8:
+  /typedoc/0.15.0:
     dependencies:
       '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
       handlebars: 4.7.6
       highlight.js: 9.18.5
       lodash: 4.17.20
-      marked: 0.8.2
+      marked: 0.7.0
       minimatch: 3.0.4
       progress: 2.0.3
       shelljs: 0.8.4
       typedoc-default-themes: 0.6.3
-      typescript: 3.7.5
+      typescript: 3.5.3
     dev: false
     engines:
       node: '>= 6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==
+      integrity: sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==
+  /typescript/3.5.3:
+    dev: false
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
   /typescript/3.7.5:
     dev: false
     engines:
@@ -7999,11 +8006,12 @@ packages:
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-6I4Mk4uW2jiQCts0Mu6iQgHY4G4aLT8KWx/lsK4v9iuiHpr0CU8GhwKHHSkjDT5+jk+GCReMizlVrf72ZfT7tg==
+      integrity: sha512-/cEoyr7dJ/Fj8Nq0ObDnNCSDaHeuyk9YlmzLmZ1tt8VmiS7j4nbRJ3YZqMEHyDm4Yuyef+GDx3IpvLTPFGl3dQ==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/ai-anomaly-detector.tgz':
@@ -8047,12 +8055,13 @@ packages:
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-RW4L5S5WIdfnKGcH5TQTIEaC+2O1sw/o7klCMUhEHjsKjOMCaqPX33HkIUecwfP2DUziXc6vXmFNABts2aEfaQ==
+      integrity: sha512-b+/YnSED+6D09pqMSRj6eVePgyfaRmCZuF4RMyD764znPYFa8UTO7cV1WroNwnLoIVHKVYUsT0TV6oni5BmYYQ==
       tarball: 'file:projects/ai-anomaly-detector.tgz'
     version: 0.0.0
   'file:projects/ai-form-recognizer.tgz':
@@ -8091,11 +8100,12 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-qs1vs3/sMfvaMcgWin/LfDjaVqoo2ZDL4uaDQ0G6vcDXKp64Nq6osJI3wcacGMOFVIL+ITwPvt7gm6k7YysALg==
+      integrity: sha512-S1FHW/boFLFuUfLdVvK4k6FcZ09uXvv+wv0X1I92XcMXsY+e40V2JZO3podov7Lu92cmdgzjWUNhhJ0KwcWeMw==
       tarball: 'file:projects/ai-form-recognizer.tgz'
     version: 0.0.0
   'file:projects/ai-metrics-advisor.tgz':
@@ -8135,11 +8145,12 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-+nkN0Oz5+Q9uVk+ekojps8bleNS36KPiYpF+Nl0WKyNlBfmNL7J6b5UgF8JCzVm7R+ZXo/kbty8QQbMZFI0rKA==
+      integrity: sha512-56+fLgUKJy9vuid+pXe3AbrJylYsPBuMC+89/FNzhhQ/rpEkVRxHMkyMbffYHuR/Cisoqmppuo2wM1rORgsuCw==
       tarball: 'file:projects/ai-metrics-advisor.tgz'
     version: 0.0.0
   'file:projects/ai-text-analytics.tgz':
@@ -8181,11 +8192,12 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-Y704o0GbkErVcle9eFDUuz6z/g2DlS4HJ+pjNxkDaxmQFtOqFTV6kYP3VvqvKPx82qQ7Pbrt4wV079bTTuMvoQ==
+      integrity: sha512-3Qbc/cf9PYE6le2E64FnKegsIFiIDAsVumlBBnJ65na8GjbHclFwmFXqmmFkB5Ebv3VNVCy4OKuuLGNI5e1lfA==
       tarball: 'file:projects/ai-text-analytics.tgz'
     version: 0.0.0
   'file:projects/app-configuration.tgz':
@@ -8233,12 +8245,13 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-rusj0Bw3XKpZ8Akpncirn95jwlJeSLZJ+99B0vAdpCPyNcRApKHaXUh0ieN65tw2u+VeqNDCDUInCljpbflyQw==
+      integrity: sha512-EOU48HtJCLa8SNSj2mpIixMGvQIz14kM3dBUBRAsyimecbxT68mVkOf3kqBaOej+tLb/vS6Fd48qHhJZMG1fWQ==
       tarball: 'file:projects/app-configuration.tgz'
     version: 0.0.0
   'file:projects/communication-administration.tgz':
@@ -8288,11 +8301,12 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/communication-administration'
     resolution:
-      integrity: sha512-hk/S5Swc0VA4P6czWbrYevG3Bk8RwyyhcbkeX0APXbjGNijcHLQrso7K1+h6K6r1M3ZEUGsE2psjZ4iQ+EXQ/w==
+      integrity: sha512-3A2odrX3u49arfzaaJOy50W3Q2XuAqnh/vhOWPlvYXfaiUgyQtPafS3voI/24XQcdEJhqfklUkcrGCsqpwbahw==
       tarball: 'file:projects/communication-administration.tgz'
     version: 0.0.0
   'file:projects/communication-chat.tgz':
@@ -8342,12 +8356,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-/sOLSdW51ob0kgkd9V0koTPR2zAGEU8kJR+6Ym0wXjGjW/GcO4w8+B1l1D7gPDRoH5MrwiCgc/9CrA3uO2O9Ag==
+      integrity: sha512-2Y5A83cIYj0fCNGcOdoDqL9SZVSih3rFgLCubuuNXH/4r0S9SltqOLMyWtxiUMZdfTEdfUIJIRVke01Qa3h6RA==
       tarball: 'file:projects/communication-chat.tgz'
     version: 0.0.0
   'file:projects/communication-common.tgz':
@@ -8395,12 +8410,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/communication-common'
     resolution:
-      integrity: sha512-q4v4oQk3V1eHfiM7MrgOpP1yrMA5FTCPZEBHuE1ZSe+HXhIEut8nnXdZmZKpf/rsCBiqfWwiBqeayrJsfyVMgg==
+      integrity: sha512-Gh2EuRdRcUC82cH1kNaL7TI+U2e5geXPbbzlVCbgYaembL0NxBAs6+FISVEbp4VqNyi91vgxETjNrW6/W1ynvA==
       tarball: 'file:projects/communication-common.tgz'
     version: 0.0.0
   'file:projects/communication-sms.tgz':
@@ -8447,12 +8463,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-lv8KbY4NtcT1BTIBNMoUC5iWh63xfZJX30ybkQ9MY9UuYQIVZNcyUk9hXIPuGg4Q9CVWcRWddEQpKIUvf2Ceng==
+      integrity: sha512-3dK1J5mkSGx7yF31hFFT8heVu1yomz+yTrWdlMtGVvFxgOypJ+mjIeJhJKwp1OWSOatxeTeB+bp1R84ctRuwhw==
       tarball: 'file:projects/communication-sms.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -8504,6 +8521,7 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       url: 0.11.0
       util: 0.12.3
@@ -8511,7 +8529,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-VeHo/3F64j4xWPeJnzddWax5TQaWq5vkVYeO+xnOV1daotzky4EG0G5seN0MjBv2i1xVgZUCd8pLNmoaud7ijQ==
+      integrity: sha512-Ck2V99gIoHzvZK7KrlLt5loB1Z1rKwGNpH60cw8q5p2G90twPOXRpfj8+aqaJSRWosbn8MzRt4m2b6KkWgi/+Q==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
@@ -8519,11 +8537,12 @@ packages:
       '@types/node': 8.10.66
       eslint: 7.15.0
       prettier: 1.19.1
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/core-asynciterator-polyfill'
     resolution:
-      integrity: sha512-579utL571q1yBrhiW+iUabtk8LM7BO16GSgjReVBGIH0QTqF+QnHz9IGe23PF6HXgStf1ooNWW8/PlFHxhQ12g==
+      integrity: sha512-PSoGMY8rSp+2k+6LRsnHYReRcEmEu446cPynWd81TSgjTLme5oJSToob2lrpyKqmiX8IJpOdb7KYU1BXe4GC9Q==
       tarball: 'file:projects/core-asynciterator-polyfill.tgz'
     version: 0.0.0
   'file:projects/core-auth.tgz':
@@ -8552,12 +8571,13 @@ packages:
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-w+4Njk0cpR1RsS+23OLpjzMsY1uWV0UjSnUkHEPORY2vUjPKpOxIS4+O7tNS/npWx2xmtrOVDNCspYh2m58YUw==
+      integrity: sha512-nbqHULaXmyV0E0HM5thpSI9sJ7NUK6UaeeU6sTbpvvT8n0FxlkP2Fex95beZcpg1Hrwr2MHQ2yI54L+ocLrhvQ==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-client.tgz':
@@ -8600,12 +8620,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-cMUYBG4LnrO8f6L9g7tVPo+sOtW7FZWTdwJuk0Oz3VSZz3qyLe8YLibWPYpDRcKheYoonOs6F6Cd0r6x3BeZYw==
+      integrity: sha512-WKhDsSJUjYwKEaqTXw8UINS5hRS0DF7PN/eTl4Q+H0ONwZBvmsVCo/2Phsi82UHFmS8wjSUxhNVquBJJLWLYvg==
       tarball: 'file:projects/core-client.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -8665,6 +8686,7 @@ packages:
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
       tunnel: 0.0.6
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
       uuid: 8.3.2
@@ -8673,7 +8695,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-EB0195kCwz9FfAwQ4dqaDEIacySepF/VQ1JZepe8oiXRKD0XOlF/0+7kHUqb0QD34bKm+hMAV19Gt7SQa6OL9Q==
+      integrity: sha512-xoK9EAqufrJHugz4CfzW5VA8lM21vej5nMQP0Qxay4mS83uIiO7GtKERjsHZGZHt0AXAO2K0eqqlnXdl8IKnOg==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-https.tgz':
@@ -8720,13 +8742,14 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/core-https'
     resolution:
-      integrity: sha512-uk6vJyJlYzQgazAEA0LwKResq610gKmQ/yiLYalliw7QLOD+fJ0sWZ8bLVn+FVBiPjMSaNQywt3b9LM13S0lNw==
+      integrity: sha512-LsASmLOIS/9450Gz7ZBASKL8Kk8eRMl35C3nK7KnU+G+EpJq3CSxODNt8KBO8K8Dt5BmpwZZazQT7z2FuZnmdQ==
       tarball: 'file:projects/core-https.tgz'
     version: 0.0.0
   'file:projects/core-lro.tgz':
@@ -8768,12 +8791,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
-      integrity: sha512-FaRHwhtBvsvYBg44ERPZ+2JFalVjL12ZC9qbAQilRXDD60UK3a7pE5mhuKluJpIIki7WCxbDR+3O/BHDRtrl+Q==
+      integrity: sha512-5GWrnUKABdlG4eYsDJXLov4WYArxjw7SwaAh8K97dwIwaPVTURLbG1XP94fE+UhUdAW9RnPSTIbycDrRXIx92Q==
       tarball: 'file:projects/core-lro.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -8782,11 +8806,12 @@ packages:
       eslint: 7.15.0
       prettier: 1.19.1
       rimraf: 3.0.2
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/core-paging'
     resolution:
-      integrity: sha512-Z5Fm7ygHiUtMvPDwzTVpcqP2ljhgLX7eh8j6Jt57y7eqAQdUQvc5mmm30PXjQV2hsTuJ1jMvtLreF6N55+YL1g==
+      integrity: sha512-M4RdTnOgHZlIvIAKbwmq1yhSBY5COCi1zNBjHpH4CX3CWWTVFysZIySOG3alcsV9k3GosRdNRVbm31yd4haaRA==
       tarball: 'file:projects/core-paging.tgz'
     version: 0.0.0
   'file:projects/core-tracing.tgz':
@@ -8814,12 +8839,13 @@ packages:
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-DhFq5yiQe3dgAl8wD9FFLfscg+dT5unzHPR8msjTkwZtBWBytwH2TVG81l6Fb3vnVixMBgvzTwZcxSHogF6CYQ==
+      integrity: sha512-6f2EmaILLa2SooiVaXN+AtR1C+4/zeJp52P4UdTqfYTOh6gVYYRW41qDvltBNcArrqejYGYdoEaYkKMmHO5v8g==
       tarball: 'file:projects/core-tracing.tgz'
     version: 0.0.0
   'file:projects/core-xml.tgz':
@@ -8861,13 +8887,14 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
       xml2js: 0.4.23
     dev: false
     name: '@rush-temp/core-xml'
     resolution:
-      integrity: sha512-E6+mGFZU1E0XYk4WhZQ9u2lNgFhWhyX7GbRsgvh1ZKRM8bVcUPO5XxRp4yQTxZZZdjhBzGw7O5GBijzUJh/vAQ==
+      integrity: sha512-YGHMaRMcVP7rSHOkFQMlCBO/JnsrZN/x0HXoCOBrQSaluQYpl8xfXNgmbxwo6qLwJta5FyOGmI4nw71n8mQgcA==
       tarball: 'file:projects/core-xml.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz':
@@ -8915,14 +8942,14 @@ packages:
       tslib: 2.0.3
       tslint: 5.20.1_typescript@4.1.2
       tslint-config-prettier: 1.18.0
-      typedoc: 0.15.8
+      typedoc: 0.15.0
       typescript: 4.1.2
       universal-user-agent: 6.0.0
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-Kqk42hGhwTPyYjOlIdjMxmORm7N2CwdnyVnJyBPAJ0MVU0gTd/3Uw/KJ9QwX31HrJKpY40C4WUdJNkCJswYUnQ==
+      integrity: sha512-f4XvZFRk2B9t8VyvcsRz0avEx5Rbd8IMZjNMJ+R7sKiXiRLYnOHotwOJSIfZvd7nBHDUd5aKeYh9JShr8t44Tg==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/data-tables.tgz':
@@ -8968,12 +8995,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-75ZzbSvGKjvROf6l9StltxmwSqRgN+qt0P5wX9qyZIh2ENqQqkfiFG3dffpHbzzUqtG+KHWEU+jJloiOZT4ApA==
+      integrity: sha512-q7N2kw0AD/INh87gkzzATH88kOQ6/qO78ipb8D0vRin+En7CUV1/fo7jZzl1dM5lGTWeneGYQ7aWOcXrw6pInA==
       tarball: 'file:projects/data-tables.tgz'
     version: 0.0.0
   'file:projects/dev-tool.tgz':
@@ -9004,11 +9032,12 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       ts-node: 8.10.2_typescript@4.1.2
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/dev-tool'
     resolution:
-      integrity: sha512-37QflDS/zEzfOn1wNV785BODIjihU332rsVK8wypf4dJdS2I9nNpVDSzl+UmntasKy9PfHVmGfBK+Mt4DYI/DA==
+      integrity: sha512-QwPKuIWs5rSVmaIdiotAHMq7SgV3krnMkMsgN+NDJUsp4dJzO6SQ8rkLaykLwwOp3yUkaoyEfz0Vu2ruGoPJfw==
       tarball: 'file:projects/dev-tool.tgz'
     version: 0.0.0
   'file:projects/digital-twins-core.tgz':
@@ -9055,12 +9084,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-PY29tnyeE1xo7Tfl4I/6+hCE6PQHW4H47LOK7KcFKW1hw4BwS6WV/11+9mDMCcgQn6AvmI5af/vW6mwhCDIxew==
+      integrity: sha512-ae/j8WVDhVc/e3OhrNsfvzw+GlRxoHordzQS23/xD/LKF3coD0FkGy6f2vxjzhudnl+ViJH5pkpeh7KZkatm1A==
       tarball: 'file:projects/digital-twins-core.tgz'
     version: 0.0.0
   'file:projects/eslint-plugin-azure-sdk.tgz':
@@ -9088,11 +9118,12 @@ packages:
       rimraf: 3.0.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/eslint-plugin-azure-sdk'
     resolution:
-      integrity: sha512-2RtUxF0G9TkwYn+ZCfPc5pcFzpb+20NV+Nibj725uqFgdwuj20B8If1fkG6LaVqYKTEbJKJD837k6XU4EC6eyA==
+      integrity: sha512-NmCxr5BwG6llNiPN2tnOIOQ3s6yungwTUIrG79tJOKe+Z+FA2BZD933217k6pyyUfkAHB7LFn604ZKjpxRZkgg==
       tarball: 'file:projects/eslint-plugin-azure-sdk.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
@@ -9157,13 +9188,14 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uuid: 8.3.2
       ws: 7.4.1
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-NxydVds/CH4YTIbc4aeC11WgGZ/FrQcAPE286RrD0qwd9MMswko4dCiS+q0Ro82pdYDlXEBTEsAwLCXOyFtVYQ==
+      integrity: sha512-3SC0qZD7sdFrMZ1YvNobSOHLdbnuyLT2J8UvNzBttUQanMY1leTdP6wemdx1Ilpl6tdX57wag1rSSoLsrv8e/g==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -9207,13 +9239,14 @@ packages:
       rollup-plugin-uglify: 6.0.4_rollup@1.32.1
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uuid: 8.3.2
       ws: 7.4.1
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-CUEydPsK9Ib12uZOg1uSxu7in1Tctk9K3b+cHt9MGy7+4fi3Y0NwiZ3NBAB2Otqd46Hx7zr6gXpMoMK9H8HZxA==
+      integrity: sha512-VdjvuX62354cTQQjRFfC/zsJ3R2lHwvwhqs/7GNUoUZ/JcDI7U0WT3TEPGtFsWpzuD5eztNIFqAJUaT8BOKcOw==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/eventgrid.tgz':
@@ -9264,11 +9297,12 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/eventgrid'
     resolution:
-      integrity: sha512-eiUZNj6txdZhBfrL0Kn29B5iOSQYI4b8ancxuc++FVIyB0UIaQhlW4ND7lO0VGMmj0vO/mCAPzn2pKXwyYr8yg==
+      integrity: sha512-JhMUPit7XVAdzsKK2AoDCLaKKwYY35seJsvnKT7j8Z0X0Rhlx6mjUo9aVOjxKgRX2wauc0JToBahKyr3p+H9Yg==
       tarball: 'file:projects/eventgrid.tgz'
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
@@ -9322,12 +9356,13 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-XP7kxY48TSXY49Ng9C9KqUxROMX5XAv8K6U+IxsfHFqT9l4ElxlLhAWbKuiS5PGHyjDwG5k/QOxdefKvdfPK0w==
+      integrity: sha512-Khh03c2ZQe4nXYKGnkk4F1NweAwUUlsYV6G7hOx4xD/FBNAqFSICmdZYcVC1nCQszjkgOcUrr5jjBzcSw6Ji5Q==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -9379,6 +9414,7 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       sinon: 9.2.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
       uuid: 8.3.2
@@ -9387,7 +9423,7 @@ packages:
     optionalDependencies:
       keytar: 5.6.0
     resolution:
-      integrity: sha512-W6fiD1kheW4WBLzp6o1DPpgmiYh7ZY+QA972IwLPNEdKfUABdF7ri+CAGTVE3pZiHwfRryqqy6TH2ND4KiQ2XA==
+      integrity: sha512-WJOJ7+HD7LnQmOEszTRNvDTlQq6GfsgMF/5Lga38trgkCYvZziYq3Wpj77zpPXKoijUklAkkPrUQMd6T1OtuwA==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-admin.tgz':
@@ -9438,12 +9474,13 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-+V8gl6Pz5s0RrXxwaoYcD8U3sx0wpAVe+hkkrrbFjKK4RRNNy6XreyAdzkgqvuR5Qfef5U+XoiNECmMG0Bf0fw==
+      integrity: sha512-OzxL/QQmYQZxYJfTDmfg/NqypEti6hl2QSZiZIahOShevxeberBRxTtFHDN7iHEJzBygVbs+7x5N0zbwxZR8rw==
       tarball: 'file:projects/keyvault-admin.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -9497,12 +9534,13 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-DVTjs6v5XBAK9xi6+mFepAB8uRvnMIJTn22lqhl2ZHuiustF0+jfXpEaqOvuqSY8Y1EUKTXVY6yyVq+qMvzK2Q==
+      integrity: sha512-qCqX+6z9ApYpYEgavjiYYPkDIXAtDjr4YFtfT6ty8Z0GebglXyM6/lUHYCZCb/iZ3zl7mcZk6Gr5R9DVornaXg==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-common.tgz':
@@ -9513,11 +9551,12 @@ packages:
       prettier: 1.19.1
       rimraf: 3.0.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/keyvault-common'
     resolution:
-      integrity: sha512-2zFAKDUWUYLbduUtaBOYxIq4aazqkzh3KfJF1MgY6fpYifMMRdaYHqUMng/IGu+MBZfJdzV+Upsi518u4Ldfsg==
+      integrity: sha512-wGsIDNLQxOtmtG36q4jZFT5fe+tIn2u1IJ0eKEOdafLAt4ij8y0T61EYKt0Szy2P/5KPUjXf71L+Gn3YKp1ajg==
       tarball: 'file:projects/keyvault-common.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -9571,12 +9610,13 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-UbHknUtKbp9QE5wqH0BUS47/leJzDa4QDXiajIPFbopKtkmst9X7EFRZwkj2+vaG8IzC3MJA3yhANVMBzefo3Q==
+      integrity: sha512-ih63xJEo0JOW8l0HJJIcmBBEiXPDhSckVD5DHB1ZkvxccmDj9skcCh1wz/OBY+3gv+lRHjJGeMFmBLquoMwdfQ==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -9630,12 +9670,13 @@ packages:
       sinon: 9.2.2
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-BuxLmdfmq5zFde2qwg3Mh1SNyznVjdj2s4DbVwVlm5rp5d06stuUEmn9JeVJwYqcULlso2SS/JC35azgySJziQ==
+      integrity: sha512-HwGe33AehqCmJGocmT5jLrwk9lO3fhAW9Q/eow0Iiasu+Dw5Mecu3Y/q0oBHrpKz9xnn+gphw0/mErq013/EdQ==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
@@ -9678,11 +9719,12 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-TC+91o3vOgfHDaQCYZRbeNyPKl+iTRT7xUG95RFx8338fad017nAaari2M2tKKENdX6Y88/zDhpG7UbRZCZElA==
+      integrity: sha512-d71LHApwoPHvQuygrJsO2LgHXzxCYOUmBjRZI+rEyjZm8b4uAeVMVPZNr8YcB4exsdXh2RNNI6wrAXzYtog4Gw==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/opentelemetry-exporter-azure-monitor.tgz':
@@ -9705,11 +9747,12 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.2
       ts-mocha: 7.0.0_mocha@7.2.0
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/opentelemetry-exporter-azure-monitor'
     resolution:
-      integrity: sha512-RtvAZIQarwqGmOWYNN88wHQf4F9WX6/1TFR6gXNq4odNmbKjtYo6+6VHC8e34QEX3D+Qe1jJBvqzm13uFsVSog==
+      integrity: sha512-2D1De0nKkSxPnE6MpmIIxJlQgBzVhZG0+WV7bH/A+SAEkbPnCaZc4x06S55r1HqHEkaed5jAKAD/w34dcK+lFA==
       tarball: 'file:projects/opentelemetry-exporter-azure-monitor.tgz'
     version: 0.0.0
   'file:projects/schema-registry-avro.tgz':
@@ -9758,11 +9801,12 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-c8aE7fBRADpuNDlIKKHT5uf21gzh+jpulsXD8LjSMijtkftEfv0lFVgXtJAB/19KXUSiIIDq1BnjFk+f9prrOg==
+      integrity: sha512-Qne3J51bXhlxC7fUR2m8MHL4VQYJ05OiFDQEHZfMnlvg/qyoV7HCXdGOPYgkrVg+rrEBeWWHgUeDgUqLnugH7Q==
       tarball: 'file:projects/schema-registry-avro.tgz'
     version: 0.0.0
   'file:projects/schema-registry.tgz':
@@ -9808,11 +9852,12 @@ packages:
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       source-map-support: 0.5.19
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-U5GG/dUlYsjZV2VOSdtfVHCIzLenM9wCBXnAN8JBXHk8L2JiRqoyE0hLRkQH8cJ0by6qs5+LR8lSf33eMUom2w==
+      integrity: sha512-+/4nJITinsQDoAZBg8Z3RgqPvjoaZQXTOa1rMyydqQ1KrDR9Q0rmbQpo2E/FYkLzL9xYroe2hgAMgPuLlYIxtQ==
       tarball: 'file:projects/schema-registry.tgz'
     version: 0.0.0
   'file:projects/search-documents.tgz':
@@ -9861,12 +9906,13 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-LimQPij2WoQKHTvlsYM5wPpeUZomHBAcOC+xNHDOoWBCnnFykq+QuPiCbHuh5oF/LI3BD2pIooHdE2P0CqmQcg==
+      integrity: sha512-yrj5IfpqMHIeJBv5ebCshD6C7ejzyHRgGYm0vv3ESJOC9wdiFKEIrO+xmhNelnXd4OsP6F8nTzKI4/FACCoMpw==
       tarball: 'file:projects/search-documents.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -9936,12 +9982,13 @@ packages:
       sinon: 9.2.2
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       ws: 7.4.1
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-ArnJ1dloEHO3tyszfLbQMLFIuS5oqkiB9d9ML8TsikK+0d1Iq+u8wFNQ6uZ7vTmQoTwdLsvBSNPXewcBTl+PRA==
+      integrity: sha512-NtHFQKVrAKrls6z5YzCcDoyFVyk/mDMqzQM1B0nfUJrdiuBPaDZVZKg7VbWQ4AgRIcOfGXh9zGupespT7nWQqQ==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob-changefeed.tgz':
@@ -9993,12 +10040,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-naRHjtdal8Ba/Xn97GHExcYsPhxUuAoseJrG9x+Z2jVyt5F6aein0BtY25lx2lw8UlW6RYligFu6yXoi0N7dAQ==
+      integrity: sha512-GB6dzwyl55+PUKNR+APLb3pIRehff+qPtexMhX4zbYE64pkkrbrgpmdPwUF4GuuSiMAhgBr2nSCjjQ4F1xWaVQ==
       tarball: 'file:projects/storage-blob-changefeed.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -10049,12 +10097,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-gnapBcY6ytkbUVoRXZX739COWVziMXj3bjwLDSlFQrbyVSE1dGkXfucEA6IqpYwFxBAzvQD4qdE71MSLJ1bv5A==
+      integrity: sha512-GU0THWuthBtLplzUAFUR077fB/XNQLJ+ECACrCRMvYB2hqmM4xHCweTE6cne5WHdIgtdlxA/SzlMAOeMzAvKhg==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file-datalake.tgz':
@@ -10110,12 +10159,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-MUOh8lJ8xCl5bPO4o67JOq0Eob/G8e3GkUrj5/C09zY+Zt7d9Kub8Bvt1o8ugJnbJoJz/2DJDvM/MRDm7V3G8Q==
+      integrity: sha512-7zlsPeM7/anZ5Bm6+2Whssl/mbSTNzmRqeAZh6ibBKxN+Mx9QO1/yUOsrWpphZZqxvpq0NFttpglEJxqNsbkkQ==
       tarball: 'file:projects/storage-file-datalake.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':
@@ -10165,12 +10215,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-9LzI1lf8ygOG/AB4seU6izLUJQWYCseLcB29BQf+ohT8+CyySXLWRRQ3n0NktJv+8/VNMewNVS2OSFbdpL0BdQ==
+      integrity: sha512-nJ/xoJ8obfCUdjcDkGk/biIUR7UxyDkakl/m1gGE/Wsx/XEGqxir+uP4KvTW0ZU/7i5EvXZFuBc03K8XHIs4UQ==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-internal-avro.tgz':
@@ -10216,12 +10267,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-internal-avro'
     resolution:
-      integrity: sha512-dbfd9Yi+PhwWkq+wQglScXEzEwuK57J9ghvGzcLl/YjEb8xiBP9tcCJFuQHiL09kYjjWXo1ovp6YxGDtwTFnmA==
+      integrity: sha512-K2Ewnm3Ca4h8KMWzAEJGQW3JjbkcfH7+WmHQwWPdlO1Juqqu6oHY2aPt6o+1o37SKg9eNxe9Ov1qvewgOvirRA==
       tarball: 'file:projects/storage-internal-avro.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10270,12 +10322,13 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-ObYde6y6YMeFYHDi6X+JQt4bwdrL0/wYbmTQGvFkxmge/iUPgtVfidkSZpBNLeiVQ+umStsZPpjC7uHBtJ/WUQ==
+      integrity: sha512-hSsAaRbDyGjhbbDov7+hfSkKFW8e9mgKnrnC2h65t15GPo7uByAR7lxtCBjBXffy0RWZpsX+2qTF8V/MWxtd0A==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/synapse-access-control.tgz':
@@ -10289,12 +10342,13 @@ packages:
       rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
-      integrity: sha512-8aMndFj3iyUWPmmlJBxq3axpC9R+YSxpvuH3K5QY8CYsBjQwz5SNqoFDfDkBI2YV4MMmZDIvX025CLsiozMS4w==
+      integrity: sha512-JCJstGGX2qovoRiZAad7qgenI60yvsC+3RyEXCq4Py3seDFeO8A7jip0YrQr0/ok6csTr6/QiN9fG7Ih6ANZIg==
       tarball: 'file:projects/synapse-access-control.tgz'
     version: 0.0.0
   'file:projects/synapse-artifacts.tgz':
@@ -10308,12 +10362,13 @@ packages:
       rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
-      integrity: sha512-Is9B3s48BNwjw5AZyFFGNbIl4FwHX4HW3zx7AUg4OHjqH/5QAbdyvZ8SA0rmIIC8+pOjlwpdO3CMKygoCupl7w==
+      integrity: sha512-Wxa9LQfnPOTIq46yC/HY5gH6LOGjCC2T7z3mKgHBYEkeWWsiI6/9OleBqdxR4x+ianFIZLdkei3YW6cCXFVeKg==
       tarball: 'file:projects/synapse-artifacts.tgz'
     version: 0.0.0
   'file:projects/synapse-managed-private-endpoints.tgz':
@@ -10327,12 +10382,13 @@ packages:
       rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
-      integrity: sha512-Ithp/Sd7cZBELTcM82DiS52CiqH2fKRIrBcMclOVNTw3Xqh1C59GhXVhn3CkHD/NfmYe824OPaCJApmI52+UkQ==
+      integrity: sha512-IAZYRnwXHIEkhIWNuX51zj0eJUplSWEnCqvt1GqVSqn4QNyYssEH8biDJWMEZlLyemOF89Aoq/t2WCSdCXLKwQ==
       tarball: 'file:projects/synapse-managed-private-endpoints.tgz'
     version: 0.0.0
   'file:projects/synapse-monitoring.tgz':
@@ -10346,12 +10402,13 @@ packages:
       rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/synapse-monitoring'
     resolution:
-      integrity: sha512-ybHyf6GcYZOin+1W8v70LDGolTZ8mOqXytI3Jn22ayDjAbJ+f8kKOwvat6W8/HG6WfFpYrsBvZKghS6k2oGncQ==
+      integrity: sha512-cc9QELiLOVr/XCwhWv/nnqGISxwYNTijwEe/rnLu2Euj8q/ckn8wINS8Rc2kH3IvePOTWxJn+ohw12i0b1sJKg==
       tarball: 'file:projects/synapse-monitoring.tgz'
     version: 0.0.0
   'file:projects/synapse-spark.tgz':
@@ -10365,12 +10422,13 @@ packages:
       rollup-plugin-node-resolve: 3.4.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uglify-js: 3.12.1
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
-      integrity: sha512-l31Wlv1WeCqBJm+tbD9VN6F1m1ZyHcuUvoGhIr6vKjah2SD1lEd05zck41BIa/jr+QerN7JLBUlcxjN2SCx53g==
+      integrity: sha512-53YhkAXb9Lc8Fp23aaGr2gKr538I1VRubKcRt+nuFg9ERRP2i9eqsrvl3CNcyYf5wz2vnHKMs1Sa+zRaA+irWQ==
       tarball: 'file:projects/synapse-spark.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10407,12 +10465,13 @@ packages:
       rimraf: 3.0.2
       rollup: 1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       util: 0.12.3
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-n3qPB1N4SkIiBDNfhKvEMr6DV4AerViAx11XZwUfgxpmkp3IGnqCGpCQZDfdUFm3uPJkxEEVH1mxPTd5BxqBSA==
+      integrity: sha512-zh48644QwvahtrV3xRbBlFSkkKCBB84FoAQG8e7P+Fn9RvPJhmUwFfwlgACjNO1EupnfCwkWYww9BT3nFzSlJw==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/test-utils-perfstress.tgz':
@@ -10431,11 +10490,12 @@ packages:
       prettier: 1.19.1
       rimraf: 3.0.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
     dev: false
     name: '@rush-temp/test-utils-perfstress'
     resolution:
-      integrity: sha512-sm36kIhCNYBbbMAWgDDyE0pUlOyFhC3q5fbvFkAVoQVowfZ8IJK//1jQsEI3z0yB5bNHJR+rw+QaWgldrkB46w==
+      integrity: sha512-gMGFoDklp2uuxwqIPE+qmYDHS/rjhhkQA7tsMlLuLAcoCApMXUJa51w8Am+hF8XWgQmPne9RcMghBHGFTnkWHQ==
       tarball: 'file:projects/test-utils-perfstress.tgz'
     version: 0.0.0
   'file:projects/test-utils-recorder.tgz':
@@ -10487,12 +10547,13 @@ packages:
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       rollup-plugin-visualizer: 4.2.0_rollup@1.32.1
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       xhr-mock: 2.5.1
     dev: false
     name: '@rush-temp/test-utils-recorder'
     resolution:
-      integrity: sha512-WEfRyUxdNUxn8+8eedpTcgdFv7ARQ2N/Y+ILJQuHjEJY1mY11+CAbTOXMod2r76fmJs6KkeIunHWpU6Y95X8Xg==
+      integrity: sha512-djCe32KpPT8TTJ7k/W/bdzDJ4UEo0Rz5bJtsNQOlqaD+MVwedY6Bi+HkKcdyCTlUZ5voabCQwixJAuIvsGxOTw==
       tarball: 'file:projects/test-utils-recorder.tgz'
     version: 0.0.0
   'file:projects/testhub.tgz':
@@ -10508,13 +10569,14 @@ packages:
       rhea: 1.0.24
       rimraf: 3.0.2
       tslib: 2.0.3
+      typedoc: 0.15.0
       typescript: 4.1.2
       uuid: 8.3.2
       yargs: 15.4.1
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-o7zYyw6/QJHBg2/e3mbbeOe+ohKdRse2FU1aX4i7AdO+1337l44mWy1DwVWhcFUy5aSzahd194/6nrgp7Sj6JQ==
+      integrity: sha512-H+vYaFnYiRChkB0tGH5+DP/KFMLNXsogMJbkDFRbZccdMPKexg+zRX35PWzwNyWiOQ7K4SNXNRzaGJGbOjcRxg==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
 registry: ''

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -21,7 +21,8 @@
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "unit-test": "mocha --require ts-node/register test/**/*.spec.ts",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "repository": "github:Azure/azure-sdk-for-js",
   "author": "Microsoft Corporation",
@@ -63,6 +64,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-visualizer": "^4.0.4"
+    "rollup-plugin-visualizer": "^4.0.4",
+    "typedoc": "0.15.0"
   }
 }

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -51,7 +51,8 @@
     "unit-test:node": "mocha --require source-map-support/register --timeout 10000 --full-trace --recursive dist/tests",
     "unit-test:browser": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "test": "npm run clean && npm run build:test && npm run unit-test"
+    "test": "npm run clean && npm run build:test && npm run unit-test",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -89,6 +90,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "mocha-junit-reporter": "^1.18.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -110,7 +111,8 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "typescript": "4.1.2",
     "util": "^0.12.1",
-    "@azure/test-utils-recorder": "^1.0.0"
+    "@azure/test-utils-recorder": "^1.0.0",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -67,7 +67,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 180000 --full-trace test-dist/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -133,6 +134,7 @@
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
     "uglify-js": "^3.4.9",
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -38,7 +38,8 @@
     "test:watch": "npm run test -- --watch --reporter min",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -119,6 +120,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -31,7 +31,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -121,6 +122,7 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -112,6 +113,7 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -37,7 +37,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -119,7 +120,8 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -30,7 +30,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --no-timeouts test/*.spec.ts",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "types": "./types/src/index.d.ts",
   "engine": {
@@ -102,6 +103,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -56,7 +56,8 @@
     "test": "npm run test:node && npm run test:browser",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register -t 50000 --reporter ../../../common/tools/mocha-multi-reporter.js ./test/**/*.spec.ts",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -124,6 +125,7 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "ws": "^7.1.1"
+    "ws": "^7.1.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -50,7 +50,8 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": true,
   "private": false,
@@ -59,6 +60,7 @@
     "@types/node": "^8.0.0",
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -38,7 +38,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "mocha test-dist/**/*.js --reporter ../../../common/tools/mocha-multi-reporter.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -94,6 +95,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -48,7 +48,8 @@
     "test": "npm run clean && npm run build:ts && npm run bundle:test:node && npm run unit-test:node && npm run bundle:test:browser && npm run unit-test:browser && npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true mocha -r esm -r ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude \"test/**/*.browser.ts\" \"test/**/*.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -121,6 +122,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -101,7 +101,8 @@
     "publish-preview": "mocha --no-colors && shx rm -rf dist/test && node ./.scripts/publish",
     "local": "ts-node ./.scripts/local.ts",
     "latest": "ts-node ./.scripts/latest.ts",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "nyc": {
@@ -194,6 +195,7 @@
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
     "uglify-js": "^3.4.9",
-    "xhr-mock": "^2.4.1"
+    "xhr-mock": "^2.4.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -53,7 +53,8 @@
     "test": "npm run clean && npm run build:ts && npm run bundle:test:node && npm run unit-test:node && npm run bundle:test:browser && npm run unit-test:browser && npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -137,6 +138,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -87,7 +87,8 @@
     "unit-test:browser": "npm run build:test && karma start --single-run",
     "unit-test:node": "npm run build:test && nyc mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-test/index.node.js",
     "pack": "npm pack 2>&1",
-    "prebuild": "npm run clean"
+    "prebuild": "npm run clean",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "dependencies": {
@@ -134,6 +135,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "uglify-js": "^3.4.9"
+    "uglify-js": "^3.4.9",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -62,7 +62,8 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": true,
   "private": false,
@@ -75,6 +76,7 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "mocha test-dist/**/*.js --reporter ../../../common/tools/mocha-multi-reporter.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -86,6 +87,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -47,7 +47,8 @@
     "test": "npm run clean && npm run build:ts && npm run bundle:test:node && npm run unit-test:node && npm run bundle:test:browser && npm run unit-test:browser && npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -117,6 +118,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -37,7 +37,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --no-timeouts test/*.spec.ts",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "types": "./types/logger.d.ts",
   "engine": {
@@ -111,6 +112,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -131,7 +131,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.0.0",
     "tslint-config-prettier": "^1.14.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "0.15.0",
     "typescript": "4.1.2"
   }
 }

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -36,7 +36,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 180000 --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -116,7 +117,8 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   },
   "sideEffects": false
 }

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -73,7 +73,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -131,6 +132,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -69,7 +69,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "//metadata": {
     "constantPaths": [
@@ -159,6 +160,7 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "ws": "^7.1.1"
+    "ws": "^7.1.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -55,7 +55,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "//metadata": {
     "constantPaths": [
@@ -111,6 +112,7 @@
     "rollup-plugin-uglify": "^6.0.0",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "ws": "^7.1.1"
+    "ws": "^7.1.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -56,7 +56,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "dependencies": {
     "@azure/event-hubs": "^5.0.0",
@@ -115,7 +116,8 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -32,7 +32,7 @@
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "build:samples": "echo Skipped.",
-    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
+    "docs": "echo Skipped."
   },
   "dependencies": {
     "@azure/event-hubs": "^2.1.4",
@@ -51,7 +51,6 @@
     "yargs": "^15.0.0"
   },
   "devDependencies": {
-    "eslint": "^7.15.0",
-    "typedoc": "0.15.0"
+    "eslint": "^7.15.0"
   }
 }

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -31,7 +31,8 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "dependencies": {
     "@azure/event-hubs": "^2.1.4",
@@ -50,6 +51,7 @@
     "yargs": "^15.0.0"
   },
   "devDependencies": {
-    "eslint": "^7.15.0"
+    "eslint": "^7.15.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -71,7 +71,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/*/{,!(browser)/**/}*.spec.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -122,7 +123,8 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skip": [

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -44,7 +44,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start",
     "unit-test:node": "mocha test-dist/**/*.js --reporter ../../../common/tools/mocha-multi-reporter.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -137,6 +138,7 @@
     "util": "^0.12.1",
     "sinon": "^9.0.2",
     "@types/sinon": "^9.0.4",
-    "mock-fs": "^4.10.4"
+    "mock-fs": "^4.10.4",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -135,6 +135,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -72,7 +72,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "dependencies": {

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -65,7 +65,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 250000 --full-trace dist-test/index.node.js",
     "unit-test:node:no-timeout": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --no-timeouts --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "//metadata": {
@@ -152,6 +153,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -66,6 +66,7 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -53,7 +53,8 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "echo skipped",
     "unit-test:node:no-timeout": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "echo Skipped."
   },
   "dependencies": {
     "@azure/core-http": "^1.2.0",
@@ -66,7 +67,6 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2",
-    "typedoc": "0.15.0"
+    "typescript": "4.1.2"
   }
 }

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -67,7 +67,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 180000 --full-trace dist-test/index.node.js",
     "unit-test:node:no-timeout": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --no-timeouts --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "//metadata": {
@@ -144,6 +145,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -68,7 +68,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 180000 --full-trace dist-test/index.node.js",
     "unit-test:node:no-timeout": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --no-timeouts --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "//metadata": {
@@ -150,6 +151,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -70,7 +70,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 120000 --full-trace \"test/{,!(browser)/**/}*.spec.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -122,7 +123,8 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skip": [

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
@@ -31,7 +31,8 @@
     "test-opentelemetry-versions": "node test-opentelemetry-versions.js 2>&1",
     "prepare": "npm run build",
     "pack": "npm pack 2>&1",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "engines": {
     "node": ">=8.3.0"
@@ -76,7 +77,8 @@
     "rimraf": "^3.0.0",
     "sinon": "^9.0.2",
     "ts-mocha": "^7.0.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   },
   "dependencies": {
     "@azure/core-http": "^1.2.0",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -113,6 +114,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -125,6 +126,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -30,7 +30,8 @@
     "test": "npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js --harmony",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -128,6 +129,7 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -73,7 +73,8 @@
     "test": "npm run test:node && npm run test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "npm run build:test:node && nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 120000 --full-trace dist-esm/test/internal/**/*.spec.js dist-esm/test/node/*.spec.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "//metadata": {
@@ -171,6 +172,7 @@
     "ws": "^7.1.1",
     "sinon": "^9.0.2",
     "@types/sinon": "^9.0.4",
-    "events": "^3.0.0"
+    "events": "^3.0.0",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -51,7 +51,8 @@
     "unit-test:browser": "echo 'browser not supported yet.'",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "BreakingChanges.md",
@@ -155,7 +156,8 @@
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
     "util": "^0.12.1",
-    "sinon": "^9.0.2"
+    "sinon": "^9.0.2",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -59,7 +59,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "BreakingChanges.md",
@@ -175,6 +176,7 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -54,7 +54,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "BreakingChanges.md",
@@ -160,6 +161,7 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -54,7 +54,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "BreakingChanges.md",
@@ -165,6 +166,7 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -46,7 +46,7 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
+    "docs": "echo Skipped."
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
@@ -97,7 +97,6 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1",
-    "typedoc": "0.15.0"
+    "util": "^0.12.1"
   }
 }

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -96,6 +96,7 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -45,7 +45,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -52,7 +52,8 @@
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 120000 dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "BreakingChanges.md",
@@ -161,6 +162,7 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -41,7 +41,8 @@
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
     "@opentelemetry/api": "^0.10.2",
-    "@microsoft/api-extractor": "7.7.11"
+    "@microsoft/api-extractor": "7.7.11",
+    "typedoc": "0.15.0"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -73,7 +74,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "extract-api": "api-extractor run --local",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -42,7 +42,8 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11"
+    "@microsoft/api-extractor": "7.7.11",
+    "typedoc": "0.15.0"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -74,7 +75,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "extract-api": "api-extractor run --local",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -41,7 +41,8 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11"
+    "@microsoft/api-extractor": "7.7.11",
+    "typedoc": "0.15.0"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -73,7 +74,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "extract-api": "api-extractor run --local",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -40,7 +40,8 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11"
+    "@microsoft/api-extractor": "7.7.11",
+    "typedoc": "0.15.0"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -72,7 +73,8 @@
     "test": "echo skipped",
     "extract-api": "api-extractor run --local",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -40,7 +40,8 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "@rollup/plugin-commonjs": "11.0.2",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "7.7.11"
+    "@microsoft/api-extractor": "7.7.11",
+    "typedoc": "0.15.0"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
@@ -72,7 +73,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "extract-api": "api-extractor run --local",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -38,7 +38,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run --testMode=unit && npm run integration-test:browser",
     "unit-test:node": "mocha --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/unit.index.node.js && npm run integration-test:node",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -115,7 +116,8 @@
     "dotenv": "^8.2.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "rollup-plugin-shim": "^1.0.0",
-    "@rollup/plugin-inject": "^4.0.0"
+    "@rollup/plugin-inject": "^4.0.0",
+    "typedoc": "0.15.0"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -33,7 +33,8 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/{,!(browser)/**/}/*.spec.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -100,7 +101,8 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typescript": "4.1.2",
-    "util": "^0.12.1"
+    "util": "^0.12.1",
+    "typedoc": "0.15.0"
   },
   "//smokeTestConfiguration": {
     "skipFolder": true

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -32,7 +32,7 @@
     "test:node": "npm run clean && npm run build && npm run unit-test:node",
     "test": "npm run clean && npm run build && npm run unit-test",
     "build:samples": "echo Skipped.",
-    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
+    "docs": "echo Skipped."
   },
   "files": [
     "dist/",
@@ -82,7 +82,6 @@
     "karma-env-preprocessor": "^0.1.1",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2",
-    "typedoc": "0.15.0"
+    "typescript": "4.1.2"
   }
 }

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -31,7 +31,8 @@
     "test:browser": "npm run clean && npm run build npm run unit-test:browser",
     "test:node": "npm run clean && npm run build && npm run unit-test:node",
     "test": "npm run clean && npm run build && npm run unit-test",
-    "build:samples": "echo Skipped."
+    "build:samples": "echo Skipped.",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -81,6 +82,7 @@
     "karma-env-preprocessor": "^0.1.1",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -34,7 +34,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser",
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
-    "test": "npm run clean && npm run build:test && npm run unit-test"
+    "test": "npm run clean && npm run build:test && npm run unit-test",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "files": [
     "dist/",
@@ -115,6 +116,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "typescript": "4.1.2",
-    "xhr-mock": "^2.4.1"
+    "xhr-mock": "^2.4.1",
+    "typedoc": "0.15.0"
   }
 }

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -35,7 +35,7 @@
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser",
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
     "test": "npm run clean && npm run build:test && npm run unit-test",
-    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
+    "docs": "echo Skipped."
   },
   "files": [
     "dist/",
@@ -116,7 +116,6 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "typescript": "4.1.2",
-    "xhr-mock": "^2.4.1",
-    "typedoc": "0.15.0"
+    "xhr-mock": "^2.4.1"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -74,7 +74,8 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/{,!(browser)/**/}*.spec.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -128,6 +129,7 @@
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
     "ts-node": "^8.3.0",
-    "karma-source-map-support": "~1.4.0"
+    "karma-source-map-support": "~1.4.0",
+    "typedoc": "0.15.0"
   }
 }


### PR DESCRIPTION
This newly added command `docs` can help increase the quality of our documentation comments. It enables us to have a tight feedback loop on what is being generated as a documentation of our packages. I am pinning `typedoc` to v0.15.0 for now because this is the version being used for generating docs at `docs.microsoft.com`. This version should be updated when that team updates theirs.

Fixes https://github.com/Azure/azure-sdk-for-js/issues/12928