### PR TITLE
[keyvault] MQ docs: minor fixes to the readmes for samples

### DIFF
--- a/sdk/keyvault/keyvault-keys/samples/javascript/README.md
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/README.md
@@ -12,11 +12,11 @@ urlFragment: keyvault-keys-javascript
 
 These sample programs show how to use the JavaScript client libraries for Azure Key Vault Keys in some common scenarios.
 
-| **File Name**                  | **Description**                                                 |
+| **File Name**                   | **Description**                                                  |
 | ------------------------------- | ---------------------------------------------------------------- |
 | [cryptography.js][cryptography] | uses a key to sign/verify, encrypt/decrypt, and wrap/unwrap data |
 | [helloWorld.js][helloworld]     | creates, reads, lists, and deletes keys                          |
-| [purgeAllKeys.js][purgeAllKeys] | purges all the keys of a Key Vault (useful for repeated tests)    |
+| [purgeAllKeys.js][purgeallkeys] | purges all the keys of a Key Vault (useful for repeated tests)   |
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ The samples are compatible with Node.js >= 8.0.0.
 
 You need [an Azure subscription][freesub] and [an Azure Key Vault][azkeyvault] to run these sample programs. To quickly create the needed Key Vault resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Ftests-resources.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Ftest-resources.json)
 
 If creating the Key Vault manually using the Azure Portal, be aware that the samples require that the soft-delete feature be enabled. Our template above will enable this feature automatically, but it is possible to enable it manually using the Azure CLI. See [this page][kvsoftdelete] for more information.
 
@@ -62,7 +62,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 
 [cryptography]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/javascript/cryptography.js
 [helloworld]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/javascript/helloWorld.js
-[purgeAllKeys]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/javascript/purgeAllKeys.js
+[purgeallkeys]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/javascript/purgeAllKeys.js
 [apiref]: https://docs.microsoft.com/javascript/api/@azure/keyvault-keys
 [azkeyvault]: https://docs.microsoft.com/azure/key-vault/quick-create-portal
 [kvsoftdelete]: https://docs.microsoft.com/azure/key-vault/key-vault-soft-delete-cli

--- a/sdk/keyvault/keyvault-keys/samples/typescript/README.md
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/README.md
@@ -16,7 +16,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 | ------------------------------- | ---------------------------------------------------------------- |
 | [cryptography.ts][cryptography] | uses a key to sign/verify, encrypt/decrypt, and wrap/unwrap data |
 | [helloWorld.ts][helloworld]     | creates, reads, lists, and deletes keys                          |
-| [purgeAllKeys.ts][purgeAllKeys] | purges all the keys of a Key Vault (useful for repeated tests)    |
+| [purgeAllKeys.ts][purgeallkeys] | purges all the keys of a Key Vault (useful for repeated tests)   |
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ npm install -g typescript
 
 You need [an Azure subscription][freesub] and [an Azure Key Vault][azkeyvault] to run these sample programs. To quickly create the needed Key Vault resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Ftests-resources.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Ftest-resources.json)
 
 If creating the Key Vault manually using the Azure Portal, be aware that the samples require that the soft-delete feature be enabled. Our template above will enable this feature automatically, but it is possible to enable it manually using the Azure CLI. See [this page][kvsoftdelete] for more information.
 
@@ -74,7 +74,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 
 [cryptography]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
 [helloworld]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/typescript/src/helloWorld.ts
-[purgeAllKeys]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/typescript/src/purgeAllKeys.ts
+[purgeallkeys]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/typescript/src/purgeAllKeys.ts
 [apiref]: https://docs.microsoft.com/javascript/api/@azure/keyvault-keys
 [azkeyvault]: https://docs.microsoft.com/azure/key-vault/quick-create-portal
 [kvsoftdelete]: https://docs.microsoft.com/azure/key-vault/key-vault-soft-delete-cli

--- a/sdk/keyvault/keyvault-secrets/samples/javascript/README.md
+++ b/sdk/keyvault/keyvault-secrets/samples/javascript/README.md
@@ -26,7 +26,7 @@ The samples are compatible with Node.js >= 8.0.0.
 
 You need [an Azure subscription][freesub] and [an Azure Key Vault][azkeyvault] to run these sample programs. To quickly create the needed Key Vault resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Fkeyvault-secrets%2Ftests-resources.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Fkeyvault-secrets%2Ftest-resources.json)
 
 If creating the Key Vault manually using the Azure Portal, be aware that the samples require that the soft-delete feature be enabled. Our template above will enable this feature automatically, but it is possible to enable it manually using the Azure CLI. See [this page][kvsoftdelete] for more information.
 

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/README.md
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/README.md
@@ -12,13 +12,13 @@ urlFragment: keyvault-secrets-typescript
 
 These sample programs show how to use the TypeScript client libraries for Azure Key Vault Secrets in some common scenarios.
 
-| **File Name**                          | **Description**                                                                                                                                                                      |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [backupAndRestore.ts][backupandrestore] | creates a secret, then makes a backup from it, then deletes it and purges it, and finally restores it                                                                                 |
+| **File Name**                           | **Description**                                                                                                                                                                 |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [backupAndRestore.ts][backupandrestore] | creates a secret, then makes a backup from it, then deletes it and purges it, and finally restores it                                                                           |
 | [deleteAndRecover.ts][deleteandrecover] | creates a secret, then deletes it, then recovers it (soft-delete is required for this sample to run, see: https://docs.microsoft.com/azure/key-vault/key-vault-ovw-soft-delete) |
-| [helloWorld.ts][helloworld]             | creates, reads, updates, and deletes a secret                                                                                                                                         |
-| [listOperations.ts][listoperations]     | creates a secret and shows various ways to iterate over the secret and its versions                                                                                                   |
-| [purgeAllSecrets.ts][purgeAllSecrets]   | purges all the secrets of a Key Vault (useful for repeated tests)                                                                                                                      |
+| [helloWorld.ts][helloworld]             | creates, reads, updates, and deletes a secret                                                                                                                                   |
+| [listOperations.ts][listoperations]     | creates a secret and shows various ways to iterate over the secret and its versions                                                                                             |
+| [purgeAllSecrets.ts][purgeallsecrets]   | purges all the secrets of a Key Vault (useful for repeated tests)                                                                                                               |
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ npm install -g typescript
 
 You need [an Azure subscription][freesub] and [an Azure Key Vault][azkeyvault] to run these sample programs. To quickly create the needed Key Vault resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Fkeyvault-secrets%2Ftests-resources.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Fkeyvault-secrets%2Ftest-resources.json)
 
 If creating the Key Vault manually using the Azure Portal, be aware that the samples require that the soft-delete feature be enabled. Our template above will enable this feature automatically, but it is possible to enable it manually using the Azure CLI. See [this page][kvsoftdelete] for more information.
 
@@ -78,7 +78,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [deleteandrecover]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript/src/deleteAndRecover.ts
 [helloworld]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript/src/helloWorld.ts
 [listoperations]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript/src/listOperations.ts
-[purgeAllSecrets]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript/src/purgeAllSecrets.ts
+[purgeallsecrets]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript/src/purgeAllSecrets.ts
 [apiref]: https://docs.microsoft.com/javascript/api/@azure/keyvault-secrets
 [azkeyvault]: https://docs.microsoft.com/azure/key-vault/quick-create-portal
 [kvsoftdelete]: https://docs.microsoft.com/azure/key-vault/key-vault-soft-delete-cli


### PR DESCRIPTION
* deploy buttons were referring to 'tests-resources.json' rather than 'test-resources.json' (ie, no 's')
* prettier auto-lowercased the purgeAllKeys ref in the md. Cosmetic and harmless.