### PR TITLE
[@azure/service-bus] Fix invalid check for Node

### DIFF
--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -8,7 +8,7 @@ import isBuffer from "is-buffer";
 import { Buffer } from "buffer";
 import * as Constants from "../util/constants";
 import { AbortError, AbortSignalLike } from "@azure/abort-controller";
-import { HttpOperationResponse, HttpResponse } from "@azure/core-http";
+import { HttpOperationResponse, HttpResponse, isNode } from "@azure/core-http";
 
 // This is the only dependency we have on DOM types, so rather than require
 // the DOM lib we can just shim this in.
@@ -24,13 +24,6 @@ interface Navigator {
  * @internal
  */
 declare const navigator: Navigator;
-
-/**
- * @internal
- * @ignore
- * A constant that indicates whether the environment is node.js or browser based.
- */
-export const isNode = typeof navigator === "undefined" && typeof process !== "undefined";
 
 /**
  * @internal

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isNode } from "@azure/core-http";
 import { PageSettings } from "@azure/core-paging";
 import { DefaultAzureCredential } from "@azure/identity";
 import chai from "chai";
@@ -19,7 +20,7 @@ import {
   ServiceBusAdministrationClient,
   WithResponse
 } from "../src/serviceBusAtomManagementClient";
-import { EntityStatus, EntityAvailabilityStatus, isNode } from "../src/util/utils";
+import { EntityStatus, EntityAvailabilityStatus } from "../src/util/utils";
 import { EnvVarNames, getEnvVars } from "./utils/envVarUtils";
 import { recreateQueue, recreateSubscription, recreateTopic } from "./utils/managementUtils";
 import { EntityNames } from "./utils/testUtils";

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -18,9 +18,9 @@ import {
   getRandomTestClientTypeWithNoSessions
 } from "./utils/testutils2";
 import { getDeliveryProperty } from "./utils/misc";
-import { isNode } from "../src/util/utils";
 import { verifyMessageCount } from "./utils/managementUtils";
 import sinon from "sinon";
+import { isNode } from "@azure/core-http";
 
 const should = chai.should();
 chai.use(chaiAsPromised);


### PR DESCRIPTION
Moved the @azure/service-bus library over to the isNode check defined in @azure/core-http to fix an invalid check for Node.

fixes: #12983