### PR TITLE
[Cosmos] Return undefined for sum aggregate when one partition is undefined

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/SumAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/SumAggregator.ts
@@ -16,7 +16,7 @@ export class SumAggregator implements Aggregator {
       return;
     }
     if (this.sum === undefined) {
-      this.sum = other;
+      this.sum = undefined;
     } else {
       this.sum += other;
     }

--- a/sdk/cosmosdb/cosmos/test/public/functional/query.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/query.spec.ts
@@ -124,5 +124,30 @@ describe("Queries", function() {
         "second batch element should be doc3"
       );
     });
+
+    describe("SUM query iterator", function() {
+      this.timeout(process.env.MOCHA_TIMEOUT || 30000);
+
+      it("returns undefined sum with undefined value in aggregator", async function() {
+        const container = await getTestContainer(
+          "Validate QueryIterator Functionality",
+          undefined,
+          {
+            throughput: 11100,
+            partitionKey: "/id"
+          }
+        );
+        await container.items.create({ id: "5eded6f8asdfasdfasdfaa21be0109ae34e29", age: 22 });
+        await container.items.create({ id: "5eded6f8a21be0109ae34e29", age: 22 });
+        await container.items.create({ id: "5edasdfasdfed6f8a21be0109ae34e29", age: null });
+        await container.items.create({ id: "5eded6f8a2dd1be0109ae34e29", age: 22 });
+        await container.items.create({ id: "AndersenFamily" });
+        await container.items.create({ id: "1" });
+
+        const queryIterator = container.items.query("SELECT VALUE SUM(c.age) FROM c");
+        const { resources: sum } = await queryIterator.fetchAll();
+        assert.equal(sum.length, 0);
+      });
+    });
   });
 });


### PR DESCRIPTION
We had an issue noticed in the portal where we were returning seemingly correct values for queries like

```
SELECT VALUE SUM(c.age) from c
``` 

for cross-partition queries, even when age had null or undefined values. For example, with the following items, we were returning the value 44

```
{ id: id1, age: 22 },
{ id: id2, age: 22 },
{ id: id3, age: null },
{ id: id4, age: 22 },
{ id: id5 },
{ id: id6 }
```

which is inconsistent with other SDKs

Remake of https://github.com/Azure/azure-sdk-for-js/pull/12926