### PR TITLE
[Text Analytics] Tests read env vars only after they were read by the recorder

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -47,7 +47,8 @@
     "skipFolder": true
   },
   "browser": {
-    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js"
+    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
+    "./dist-esm/test/utils/env.js": "./dist-esm/test/utils/env.browser.js"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -7,8 +7,8 @@ chaiUse(chaiPromises);
 
 import { isLiveMode, isRecordMode, Recorder } from "@azure/test-utils-recorder";
 
-import { createRecordedClient, testEnv } from "../utils/recordedClient";
-import { TextAnalyticsClient, AzureKeyCredential } from "../../src";
+import { createClient, createRecorder } from "../utils/recordedClient";
+import { TextAnalyticsClient } from "../../src";
 import { assertAllSuccess } from "../utils/resultHelper";
 
 const testDataEn = [
@@ -22,14 +22,13 @@ describe("[API Key] TextAnalyticsClient", function() {
   let recorder: Recorder;
   let client: TextAnalyticsClient;
 
-  const apiKey = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
-
   // eslint-disable-next-line no-invalid-this
   this.timeout(100000);
 
   beforeEach(function() {
+    client = createClient("APIKey");
     // eslint-disable-next-line no-invalid-this
-    ({ client, recorder } = createRecordedClient(this, apiKey));
+    recorder = createRecorder(this);
   });
 
   afterEach(async function() {

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -26,9 +26,9 @@ describe("[API Key] TextAnalyticsClient", function() {
   this.timeout(100000);
 
   beforeEach(function() {
-    client = createClient("APIKey");
     // eslint-disable-next-line no-invalid-this
     recorder = createRecorder(this);
+    client = createClient("APIKey");
   });
 
   afterEach(async function() {

--- a/sdk/textanalytics/ai-text-analytics/test/public/pipelineOptions.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/pipelineOptions.spec.ts
@@ -2,23 +2,21 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
+import * as dotenv from "dotenv";
 
-import {
-  TextAnalyticsClient,
-  DetectLanguageResultArray,
-  DetectLanguageSuccessResult,
-  AzureKeyCredential
-} from "../../src";
-import { testEnv } from "../utils/recordedClient";
+import { DetectLanguageResultArray, DetectLanguageSuccessResult } from "../../src";
 
-import { WebResource, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
+import { WebResource, HttpOperationResponse, HttpHeaders, isNode } from "@azure/core-http";
+import { createClient } from "../utils/recordedClient";
+
+if (isNode) {
+  dotenv.config();
+}
 
 describe("TextAnalyticsClient Custom PipelineOptions", function() {
-  const credential = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
-
   it("use custom HTTPClient", async () => {
     const pipelineTester = new Promise<DetectLanguageResultArray>((resolve) => {
-      const client = new TextAnalyticsClient(testEnv.ENDPOINT, credential, {
+      const client = createClient("APIKey", {
         httpClient: {
           sendRequest: async (request: WebResource): Promise<HttpOperationResponse> => ({
             status: 200,

--- a/sdk/textanalytics/ai-text-analytics/test/public/pipelineOptions.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/pipelineOptions.spec.ts
@@ -2,16 +2,12 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import * as dotenv from "dotenv";
 
 import { DetectLanguageResultArray, DetectLanguageSuccessResult } from "../../src";
-
-import { WebResource, HttpOperationResponse, HttpHeaders, isNode } from "@azure/core-http";
 import { createClient } from "../utils/recordedClient";
 
-if (isNode) {
-  dotenv.config();
-}
+import { WebResource, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
+
 
 describe("TextAnalyticsClient Custom PipelineOptions", function() {
   it("use custom HTTPClient", async () => {

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -7,7 +7,7 @@ import { assert } from "chai";
 
 import { isLiveMode, isRecordMode, Recorder } from "@azure/test-utils-recorder";
 
-import { createRecordedClient } from "../utils/recordedClient";
+import { createClient, createRecorder } from "../utils/recordedClient";
 import {
   TextAnalyticsClient,
   TextDocumentInput,
@@ -45,7 +45,9 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   beforeEach(function() {
     // eslint-disable-next-line no-invalid-this
-    ({ client, recorder } = createRecordedClient(this));
+    client = createClient("AAD");
+    // eslint-disable-next-line no-invalid-this
+    recorder = createRecorder(this);
     let nextId = 0;
     getId = () => {
       nextId += 1;

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -45,9 +45,8 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   beforeEach(function() {
     // eslint-disable-next-line no-invalid-this
-    client = createClient("AAD");
-    // eslint-disable-next-line no-invalid-this
     recorder = createRecorder(this);
+    client = createClient("AAD");
     let nextId = 0;
     getId = () => {
       nextId += 1;

--- a/sdk/textanalytics/ai-text-analytics/test/utils/env.browser.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/env.browser.ts
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.

--- a/sdk/textanalytics/ai-text-analytics/test/utils/env.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/env.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as dotenv from "dotenv";
+
+dotenv.config();

--- a/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
@@ -62,6 +62,11 @@ export function createClient(
   return new TextAnalyticsClient(env.ENDPOINT, credential, options);
 }
 
+/**
+ * creates the recorder and reads the environment variables from the `.env` file.
+ * Should be called first in the test suite to make sure environment variables are
+ * read before they are being used.
+ */
 export function createRecorder(context: Context): Recorder {
   return record(context, environmentSetup);
 }

--- a/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 import { TokenCredential, ClientSecretCredential } from "@azure/identity";
 
-import { AzureKeyCredential, TextAnalyticsClient } from "../../src/";
+import { AzureKeyCredential, TextAnalyticsClient, TextAnalyticsClientOptions } from "../../src/";
 
 const replaceableVariables: { [k: string]: string } = {
   AZURE_CLIENT_ID: "azure_client_id",
@@ -17,12 +17,6 @@ const replaceableVariables: { [k: string]: string } = {
   TEXT_ANALYTICS_API_KEY_ALT: "api_key_alt",
   ENDPOINT: "https://endpoint/"
 };
-
-export const testEnv = new Proxy(replaceableVariables, {
-  get: (target, key: string) => {
-    return env[key] || target[key];
-  }
-});
 
 export const environmentSetup: RecorderEnvironmentSetup = {
   replaceableVariables,
@@ -43,18 +37,21 @@ export const environmentSetup: RecorderEnvironmentSetup = {
 
 export type AuthMethod = "APIKey" | "AAD";
 
-export function createClient(authMethod: AuthMethod): TextAnalyticsClient {
+export function createClient(
+  authMethod: AuthMethod,
+  options?: TextAnalyticsClientOptions
+): TextAnalyticsClient {
   let credential: AzureKeyCredential | TokenCredential;
   switch (authMethod) {
     case "APIKey": {
-      credential = new AzureKeyCredential(testEnv.TEXT_ANALYTICS_API_KEY);
+      credential = new AzureKeyCredential(env.TEXT_ANALYTICS_API_KEY);
       break;
     }
     case "AAD": {
       credential = new ClientSecretCredential(
-        testEnv.AZURE_TENANT_ID,
-        testEnv.AZURE_CLIENT_ID,
-        testEnv.AZURE_CLIENT_SECRET
+        env.AZURE_TENANT_ID,
+        env.AZURE_CLIENT_ID,
+        env.AZURE_CLIENT_SECRET
       );
       break;
     }
@@ -62,7 +59,7 @@ export function createClient(authMethod: AuthMethod): TextAnalyticsClient {
       throw Error(`Unsupported authentication method: ${authMethod}`);
     }
   }
-  return new TextAnalyticsClient(testEnv.ENDPOINT, credential);
+  return new TextAnalyticsClient(env.ENDPOINT, credential, options);
 }
 
 export function createRecorder(context: Context): Recorder {

--- a/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/utils/recordedClient.ts
@@ -7,6 +7,7 @@ import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure/test-uti
 import { TokenCredential, ClientSecretCredential } from "@azure/identity";
 
 import { AzureKeyCredential, TextAnalyticsClient, TextAnalyticsClientOptions } from "../../src/";
+import "./env";
 
 const replaceableVariables: { [k: string]: string } = {
   AZURE_CLIENT_ID: "azure_client_id",


### PR DESCRIPTION
Use the API Key from the corresponding environment var only after it was read by the recorder. 
Also does the following:
- split `createRecordedClient` into `createRecorder` and `createClient` with better arguments.
- get rid of `testEnv`.
- use `createClient` everywhere.

Fixes #12990 and part of https://github.com/Azure/azure-sdk-for-js/issues/12819.