### PR TITLE
[Communication] - Common - Adding Identifier suffix

### DIFF
--- a/sdk/communication/communication-administration/review/communication-administration.api.md
+++ b/sdk/communication/communication-administration/review/communication-administration.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { CommunicationUser } from '@azure/communication-common';
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import * as coreHttp from '@azure/core-http';
 import { HttpResponse } from '@azure/core-http';
 import { KeyCredential } from '@azure/core-auth';
@@ -79,9 +79,9 @@ export class CommunicationIdentityClient {
     constructor(connectionString: string, options?: CommunicationIdentityOptions);
     constructor(url: string, credential: KeyCredential, options?: CommunicationIdentityOptions);
     createUser(options?: OperationOptions): Promise<CreateUserResponse>;
-    deleteUser(user: CommunicationUser, options?: OperationOptions): Promise<VoidResponse>;
-    issueToken(user: CommunicationUser, scopes: TokenScope[], options?: OperationOptions): Promise<IssueTokenResponse>;
-    revokeTokens(user: CommunicationUser, tokensValidFrom?: Date, options?: OperationOptions): Promise<VoidResponse>;
+    deleteUser(user: CommunicationUserIdentifier, options?: OperationOptions): Promise<VoidResponse>;
+    issueToken(user: CommunicationUserIdentifier, scopes: TokenScope[], options?: OperationOptions): Promise<IssueTokenResponse>;
+    revokeTokens(user: CommunicationUserIdentifier, tokensValidFrom?: Date, options?: OperationOptions): Promise<VoidResponse>;
 }
 
 // @public
@@ -102,7 +102,7 @@ export interface CommunicationTokenRequest {
 
 // @public
 export interface CommunicationUserToken extends Pick<CommunicationIdentityToken, "token" | "expiresOn"> {
-    user: CommunicationUser;
+    user: CommunicationUserIdentifier;
 }
 
 // @public
@@ -141,7 +141,7 @@ export interface CreateReservationResponse {
 }
 
 // @public
-export type CreateUserResponse = WithResponse<CommunicationUser>;
+export type CreateUserResponse = WithResponse<CommunicationUserIdentifier>;
 
 // @public
 export type GetAreaCodesOptions = OperationOptions;

--- a/sdk/communication/communication-administration/src/communicationIdentity/communicationIdentityClient.ts
+++ b/sdk/communication/communication-administration/src/communicationIdentity/communicationIdentityClient.ts
@@ -5,7 +5,7 @@ import {
   createCommunicationAccessKeyCredentialPolicy,
   parseClientArguments,
   isKeyCredential,
-  CommunicationUser
+  CommunicationUserIdentifier
 } from "@azure/communication-common";
 import { KeyCredential } from "@azure/core-auth";
 import {
@@ -107,12 +107,12 @@ export class CommunicationIdentityClient {
   /**
    * Creates a scoped user token.
    *
-   * @param {CommunicationUser} user The user whose tokens are being revoked.
+   * @param {CommunicationUserIdentifier} user The user whose tokens are being revoked.
    * @param {TokenScope[]} scopes Scopes to include in the token.
    * @param {OperationOptions} [options={}] Additional options for the request.
    */
   public async issueToken(
-    user: CommunicationUser,
+    user: CommunicationUserIdentifier,
     scopes: TokenScope[],
     options: OperationOptions = {}
   ): Promise<IssueTokenResponse> {
@@ -148,7 +148,7 @@ export class CommunicationIdentityClient {
    * @param {OperationOptions} [options={}] Additional options for the request.
    */
   public async revokeTokens(
-    user: CommunicationUser,
+    user: CommunicationUserIdentifier,
     tokensValidFrom: Date = new Date(),
     options: OperationOptions = {}
   ): Promise<VoidResponse> {
@@ -184,7 +184,7 @@ export class CommunicationIdentityClient {
       const { id, _response } = await this.client.create(
         operationOptionsToRequestOptionsBase(updatedOptions)
       );
-      const user: CommunicationUser = { communicationUserId: id };
+      const user: CommunicationUserIdentifier = { communicationUserId: id };
       return attachHttpResponse(user, _response);
     } catch (e) {
       span.setStatus({
@@ -200,11 +200,11 @@ export class CommunicationIdentityClient {
   /**
    * Triggers revocation event for user and deletes all its data.
    *
-   * @param {CommunicationUser} user The user being deleted.
+   * @param {CommunicationUserIdentifier} user The user being deleted.
    * @param {OperationOptions} [options={}] Additional options for the request.
    */
   public async deleteUser(
-    user: CommunicationUser,
+    user: CommunicationUserIdentifier,
     options: OperationOptions = {}
   ): Promise<VoidResponse> {
     const { span, updatedOptions } = createSpan("CommunicationIdentity-deleteUser", options);

--- a/sdk/communication/communication-administration/src/communicationIdentity/models.ts
+++ b/sdk/communication/communication-administration/src/communicationIdentity/models.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { PipelineOptions } from "@azure/core-http";
-import { CommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier } from "@azure/communication-common";
 import { CommunicationIdentityToken } from "./generated/src/models";
 import { WithResponse } from "../common/models";
 
@@ -24,13 +24,13 @@ export interface CommunicationUserToken
   /**
    * Represents the user the token was issued for
    */
-  user: CommunicationUser;
+  user: CommunicationUserIdentifier;
 }
 
 /**
  * Represents the response from creating a user
  */
-export type CreateUserResponse = WithResponse<CommunicationUser>;
+export type CreateUserResponse = WithResponse<CommunicationUserIdentifier>;
 
 /**
  * Represents the response from issuing a token

--- a/sdk/communication/communication-administration/test/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-administration/test/communicationIdentityClient.mocked.spec.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { isNode } from "@azure/core-http";
-import { CommunicationUserIdentifier, isCommunicationUserIdentifier } from "@azure/communication-common";
+import {
+  CommunicationUserIdentifier,
+  isCommunicationUserIdentifier
+} from "@azure/communication-common";
 import { assert } from "chai";
 import sinon from "sinon";
 import { CommunicationIdentityClient } from "../src";

--- a/sdk/communication/communication-administration/test/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-administration/test/communicationIdentityClient.mocked.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { isNode } from "@azure/core-http";
-import { CommunicationUser, isCommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier, isCommunicationUserIdentifier } from "@azure/communication-common";
 import { assert } from "chai";
 import sinon from "sinon";
 import { CommunicationIdentityClient } from "../src";
@@ -11,7 +11,7 @@ import { issueTokenHttpClient, revokeTokensHttpClient } from "./utils/mockHttpCl
 
 describe("CommunicationIdentityClient [Mocked]", () => {
   const dateHeader = isNode ? "date" : "x-ms-date";
-  const user: CommunicationUser = { communicationUserId: "ACS_ID" };
+  const user: CommunicationUserIdentifier = { communicationUserId: "ACS_ID" };
 
   afterEach(() => {
     sinon.restore();
@@ -72,7 +72,7 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     const client = new TestCommunicationIdentityClient();
     const user = await client.createUserTest();
 
-    assert.isTrue(isCommunicationUser(user));
+    assert.isTrue(isCommunicationUserIdentifier(user));
     assert.equal(user.communicationUserId, "identity");
     assert.isDefined(user._response);
     assert.isTrue(JSON.stringify(user).indexOf("id") > -1);

--- a/sdk/communication/communication-administration/test/communicationIdentityClient.spec.ts
+++ b/sdk/communication/communication-administration/test/communicationIdentityClient.spec.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier } from "@azure/communication-common";
 import { assert } from "chai";
 import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 import { CommunicationIdentityClient } from "../src";
 import { createRecordedCommunicationIdentityClient } from "./utils/recordedClient";
 
 describe("CommunicationIdentityClient [Playback/Live]", function() {
-  let user: CommunicationUser;
+  let user: CommunicationUserIdentifier;
   let recorder: Recorder;
   let client: CommunicationIdentityClient;
 

--- a/sdk/communication/communication-administration/test/utils/testCommunicationIdentityClient.ts
+++ b/sdk/communication/communication-administration/test/utils/testCommunicationIdentityClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { OperationOptions, RestResponse } from "@azure/core-http";
-import { CommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier } from "@azure/communication-common";
 import {
   CommunicationIdentityClient,
   TokenScope,
@@ -19,7 +19,7 @@ export class TestCommunicationIdentityClient {
   private connectionString: string = "endpoint=https://contoso.spool.azure.local;accesskey=banana";
 
   public async issueTokenTest(
-    user: CommunicationUser,
+    user: CommunicationUserIdentifier,
     scopes: TokenScope[],
     options: OperationOptions = {}
   ): Promise<IssueTokenResponse> {
@@ -30,7 +30,7 @@ export class TestCommunicationIdentityClient {
   }
 
   public async revokeTokensTest(
-    user: CommunicationUser,
+    user: CommunicationUserIdentifier,
     revocationTime?: Date,
     options: OperationOptions = {}
   ): Promise<RestResponse> {

--- a/sdk/communication/communication-chat/review/communication-chat.api.md
+++ b/sdk/communication/communication-chat/review/communication-chat.api.md
@@ -7,8 +7,8 @@
 import { ChatMessageDeletedEvent } from '@azure/communication-signaling';
 import { ChatMessageEditedEvent } from '@azure/communication-signaling';
 import { ChatMessageReceivedEvent } from '@azure/communication-signaling';
-import { CommunicationUser } from '@azure/communication-common';
 import { CommunicationUserCredential } from '@azure/communication-common';
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import * as coreHttp from '@azure/core-http';
 import { HttpResponse } from '@azure/core-http';
 import { OperationOptions } from '@azure/core-http';
@@ -53,7 +53,7 @@ export interface ChatClientOptions extends PipelineOptions {
 
 // @public
 export interface ChatMessage extends Omit<RestChatMessage, "senderId"> {
-    sender?: CommunicationUser;
+    sender?: CommunicationUserIdentifier;
 }
 
 // @public
@@ -61,7 +61,7 @@ export type ChatMessagePriority = "Normal" | "High";
 
 // @public
 export interface ChatThread extends Omit<RestChatThread, "createdBy" | "members"> {
-    readonly createdBy?: CommunicationUser;
+    readonly createdBy?: CommunicationUserIdentifier;
     members?: ChatThreadMember[];
 }
 
@@ -75,7 +75,7 @@ export class ChatThreadClient {
     listMembers(options?: ListMembersOptions): PagedAsyncIterableIterator<ChatThreadMember>;
     listMessages(options?: ListMessagesOptions): PagedAsyncIterableIterator<ChatMessage>;
     listReadReceipts(options?: ListReadReceiptsOptions): PagedAsyncIterableIterator<ReadReceipt>;
-    removeMember(member: CommunicationUser, options?: RemoveMemberOptions): Promise<OperationResponse>;
+    removeMember(member: CommunicationUserIdentifier, options?: RemoveMemberOptions): Promise<OperationResponse>;
     sendMessage(request: SendMessageRequest, options?: SendMessageOptions): Promise<SendChatMessageResponse>;
     sendReadReceipt(request: SendReadReceiptRequest, options?: SendReadReceiptOptions): Promise<OperationResponse>;
     sendTypingNotification(options?: SendTypingNotificationOptions): Promise<boolean>;
@@ -98,7 +98,7 @@ export interface ChatThreadInfo {
 
 // @public
 export interface ChatThreadMember extends Omit<RestChatThreadMember, "id"> {
-    user: CommunicationUser;
+    user: CommunicationUserIdentifier;
 }
 
 // @public
@@ -151,7 +151,7 @@ export interface OperationResponse {
 
 // @public
 export interface ReadReceipt extends Omit<RestReadReceipt, "senderId"> {
-    readonly sender?: CommunicationUser;
+    readonly sender?: CommunicationUserIdentifier;
 }
 
 // @public

--- a/sdk/communication/communication-chat/src/chatThreadClient.ts
+++ b/sdk/communication/communication-chat/src/chatThreadClient.ts
@@ -3,7 +3,7 @@
 
 import { logger } from "./models/logger";
 import { SDK_VERSION } from "./constants";
-import { CommunicationUser, CommunicationUserCredential } from "@azure/communication-common";
+import { CommunicationUserIdentifier, CommunicationUserCredential } from "@azure/communication-common";
 import { createCommunicationUserCredentialPolicy } from "./credential/communicationUserCredentialPolicy";
 import { ChatApiClient } from "./generated/src/chatApiClient";
 import {
@@ -421,7 +421,7 @@ export class ChatThreadClient {
    * @param options Operation options.
    */
   public async removeMember(
-    member: CommunicationUser,
+    member: CommunicationUserIdentifier,
     options: RemoveMemberOptions = {}
   ): Promise<OperationResponse> {
     const { span, updatedOptions } = createSpan("ChatThreadClient-RemoveMembers", options);

--- a/sdk/communication/communication-chat/src/chatThreadClient.ts
+++ b/sdk/communication/communication-chat/src/chatThreadClient.ts
@@ -3,7 +3,10 @@
 
 import { logger } from "./models/logger";
 import { SDK_VERSION } from "./constants";
-import { CommunicationUserIdentifier, CommunicationUserCredential } from "@azure/communication-common";
+import {
+  CommunicationUserIdentifier,
+  CommunicationUserCredential
+} from "@azure/communication-common";
 import { createCommunicationUserCredentialPolicy } from "./credential/communicationUserCredentialPolicy";
 import { ChatApiClient } from "./generated/src/chatApiClient";
 import {

--- a/sdk/communication/communication-chat/src/models/models.ts
+++ b/sdk/communication/communication-chat/src/models/models.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier } from "@azure/communication-common";
 import { HttpResponse } from "@azure/core-http";
 import {
   SendChatMessageResult,
@@ -24,9 +24,9 @@ export {
  */
 export interface ChatMessage extends Omit<RestChatMessage, "senderId"> {
   /**
-   * The CommunicationUser that identifies this chat message sender.
+   * The CommunicationUserIdentifier that identifies this chat message sender.
    */
-  sender?: CommunicationUser;
+  sender?: CommunicationUserIdentifier;
 }
 
 /**
@@ -34,9 +34,9 @@ export interface ChatMessage extends Omit<RestChatMessage, "senderId"> {
  */
 export interface ChatThread extends Omit<RestChatThread, "createdBy" | "members"> {
   /**
-   * The CommunicationUser that identifies this chat thread owner.
+   * The CommunicationUserIdentifier that identifies this chat thread owner.
    */
-  readonly createdBy?: CommunicationUser;
+  readonly createdBy?: CommunicationUserIdentifier;
   /**
    * Chat thread members.
    */
@@ -48,9 +48,9 @@ export interface ChatThread extends Omit<RestChatThread, "createdBy" | "members"
  */
 export interface ChatThreadMember extends Omit<RestChatThreadMember, "id"> {
   /**
-   * The CommunicationUser that identifies this chat thread member.
+   * The CommunicationUserIdentifier that identifies this chat thread member.
    */
-  user: CommunicationUser;
+  user: CommunicationUserIdentifier;
 }
 
 /**
@@ -58,9 +58,9 @@ export interface ChatThreadMember extends Omit<RestChatThreadMember, "id"> {
  */
 export interface ReadReceipt extends Omit<RestReadReceipt, "senderId"> {
   /**
-   * The CommunicationUser that identifies this Read receipt sender.
+   * The CommunicationUserIdentifier that identifies this Read receipt sender.
    */
-  readonly sender?: CommunicationUser;
+  readonly sender?: CommunicationUserIdentifier;
 }
 
 /**

--- a/sdk/communication/communication-chat/test/chatClient.spec.ts
+++ b/sdk/communication/communication-chat/test/chatClient.spec.ts
@@ -5,7 +5,7 @@ import { Recorder } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import { ChatClient, ChatThreadClient } from "../src";
 import { createTestUser, createRecorder, createChatClient } from "./utils/recordedClient";
-import { CommunicationUser } from "@azure/communication-common";
+import { CommunicationUserIdentifier } from "@azure/communication-common";
 
 describe("ChatClient", function() {
   let threadId: string;
@@ -14,9 +14,9 @@ describe("ChatClient", function() {
   let chatClient: ChatClient;
   let chatThreadClient: ChatThreadClient;
 
-  let testUser: CommunicationUser;
-  let testUser2: CommunicationUser;
-  let testUser3: CommunicationUser;
+  let testUser: CommunicationUserIdentifier;
+  let testUser2: CommunicationUserIdentifier;
+  let testUser3: CommunicationUserIdentifier;
 
   this.afterAll(async function() {
     // await deleteTestUser(testUser);

--- a/sdk/communication/communication-chat/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/utils/recordedClient.ts
@@ -8,7 +8,7 @@ import { env, Recorder, record, RecorderEnvironmentSetup } from "@azure/test-uti
 import { isNode } from "@azure/core-http";
 import { ChatClient } from "../../src";
 import {
-  CommunicationUser,
+  CommunicationUserIdentifier,
   AzureCommunicationUserCredential,
   parseClientArguments
 } from "@azure/communication-common";
@@ -47,7 +47,7 @@ export async function createTestUser(): Promise<CommunicationUserToken> {
   return await identityClient.issueToken(testUser, ["chat"]);
 }
 
-export async function deleteTestUser(testUser: CommunicationUser) {
+export async function deleteTestUser(testUser: CommunicationUserIdentifier) {
   if (testUser) {
     const identityClient = new CommunicationIdentityClient(env.COMMUNICATION_CONNECTION_STRING);
     await identityClient.deleteUser(testUser);

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -19,7 +19,6 @@
 - Renamed `CallingApplicationKind` to `CallingApplicationIdentifierKind`.
 - Renamed `isCallingApplication` to `isCallingApplicationIdentifier`.
 
-
 ## 1.0.0-beta.3 (2020-11-16)
 
 Updated `@azure/communication-common` version.

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 1.0.0-beta.4 (Unreleased)
 
+### Breaking Changes
+
+- Renamed `Identifier` to `CommunicationIdentifier`.
+- Renamed `IdentifierKind` to `CommunicationIdentifierKind`.
+
+- Renamed `CommunicationUser` to `CommunicationUserIdentifier`.
+- Renamed `CommunicationUserKind` to `CommunicationUserIdentifierKind`.
+- Renamed `isCommunicationUser` to `isCommunicationUserIdentifier`.
+
+- Renamed `PhoneNumber` to `PhoneNumberIdentifier`.
+- Renamed `PhoneNumberKind` to `PhoneNumberIdentifierKind`.
+- Renamed `isPhoneNumber` to `isPhoneNumberIdentifier`.
+
+- Renamed `CallingApplication` to `CallingApplicationIdentifier`.
+- Renamed `CallingApplicationKind` to `CallingApplicationIdentifierKind`.
+- Renamed `isCallingApplication` to `isCallingApplicationIdentifier`.
+
 
 ## 1.0.0-beta.3 (2020-11-16)
 

--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -31,6 +31,9 @@ export interface CallingApplicationIdentifierKind extends CallingApplicationIden
 export type CommunicationIdentifier = CommunicationUserIdentifier | PhoneNumberIdentifier | CallingApplicationIdentifier | UnknownIdentifier;
 
 // @public
+export type CommunicationIdentifierKind = CommunicationUserIdentifierKind | PhoneNumberIdentifierKind | CallingApplicationIdentifierKind | UnknownIdentifierKind;
+
+// @public
 export interface CommunicationUserCredential {
     dispose(): void;
     getToken(abortSignal?: AbortSignalLike): Promise<AccessToken>;
@@ -50,10 +53,7 @@ export interface CommunicationUserIdentifierKind extends CommunicationUserIdenti
 export const createCommunicationAccessKeyCredentialPolicy: (credential: KeyCredential) => RequestPolicyFactory;
 
 // @public
-export const getIdentifierKind: (identifier: CommunicationIdentifier) => IdentifierKind;
-
-// @public
-export type IdentifierKind = CommunicationUserIdentifierKind | PhoneNumberIdentifierKind | CallingApplicationIdentifierKind | UnknownIdentifierKind;
+export const getIdentifierKind: (identifier: CommunicationIdentifier) => CommunicationIdentifierKind;
 
 // @public
 export const isCallingApplicationIdentifier: (identifier: CommunicationIdentifier) => identifier is CallingApplicationIdentifier;

--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -18,19 +18,17 @@ export class AzureCommunicationUserCredential implements CommunicationUserCreden
     }
 
 // @public
-export interface CallingApplication {
+export interface CallingApplicationIdentifier {
     callingApplicationId: string;
 }
 
 // @public
-export interface CallingApplicationKind extends CallingApplication {
+export interface CallingApplicationIdentifierKind extends CallingApplicationIdentifier {
     kind: "CallingApplication";
 }
 
 // @public
-export interface CommunicationUser {
-    communicationUserId: string;
-}
+export type CommunicationIdentifier = CommunicationUserIdentifier | PhoneNumberIdentifier | CallingApplicationIdentifier | UnknownIdentifier;
 
 // @public
 export interface CommunicationUserCredential {
@@ -39,7 +37,12 @@ export interface CommunicationUserCredential {
 }
 
 // @public
-export interface CommunicationUserKind extends CommunicationUser {
+export interface CommunicationUserIdentifier {
+    communicationUserId: string;
+}
+
+// @public
+export interface CommunicationUserIdentifierKind extends CommunicationUserIdentifier {
     kind: "CommunicationUser";
 }
 
@@ -47,39 +50,36 @@ export interface CommunicationUserKind extends CommunicationUser {
 export const createCommunicationAccessKeyCredentialPolicy: (credential: KeyCredential) => RequestPolicyFactory;
 
 // @public
-export const getIdentifierKind: (identifier: Identifier) => IdentifierKind;
+export const getIdentifierKind: (identifier: CommunicationIdentifier) => IdentifierKind;
 
 // @public
-export type Identifier = CommunicationUser | PhoneNumber | CallingApplication | UnknownIdentifier;
+export type IdentifierKind = CommunicationUserIdentifierKind | PhoneNumberIdentifierKind | CallingApplicationIdentifierKind | UnknownIdentifierKind;
 
 // @public
-export type IdentifierKind = CommunicationUserKind | PhoneNumberKind | CallingApplicationKind | UnknownIdentifierKind;
+export const isCallingApplicationIdentifier: (identifier: CommunicationIdentifier) => identifier is CallingApplicationIdentifier;
 
 // @public
-export const isCallingApplication: (identifier: Identifier) => identifier is CallingApplication;
-
-// @public
-export const isCommunicationUser: (identifier: Identifier) => identifier is CommunicationUser;
+export const isCommunicationUserIdentifier: (identifier: CommunicationIdentifier) => identifier is CommunicationUserIdentifier;
 
 // @public
 export const isKeyCredential: (credential: any) => credential is KeyCredential;
 
 // @public
-export const isPhoneNumber: (identifier: Identifier) => identifier is PhoneNumber;
+export const isPhoneNumberIdentifier: (identifier: CommunicationIdentifier) => identifier is PhoneNumberIdentifier;
 
 // @public
-export const isUnknownIdentifier: (identifier: Identifier) => identifier is UnknownIdentifier;
+export const isUnknownIdentifier: (identifier: CommunicationIdentifier) => identifier is UnknownIdentifier;
 
 // @public
 export const parseClientArguments: (connectionStringOrUrl: string, credentialOrOptions?: any) => UrlWithCredential;
 
 // @public
-export interface PhoneNumber {
+export interface PhoneNumberIdentifier {
     phoneNumber: string;
 }
 
 // @public
-export interface PhoneNumberKind extends PhoneNumber {
+export interface PhoneNumberIdentifierKind extends PhoneNumberIdentifier {
     kind: "PhoneNumber";
 }
 

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -4,14 +4,14 @@
 /**
  * Identifies a communication user.
  */
-export type Identifier = CommunicationUser | PhoneNumber | CallingApplication | UnknownIdentifier;
+export type CommunicationIdentifier = CommunicationUserIdentifier | PhoneNumberIdentifier | CallingApplicationIdentifier | UnknownIdentifier;
 
 /**
  * An Azure Communication user.
  */
-export interface CommunicationUser {
+export interface CommunicationUserIdentifier {
   /**
-   * Id of the CommunicationUser as returned from the Communication Service.
+   * Id of the CommunicationUserIdentifier as returned from the Communication Service.
    */
   communicationUserId: string;
 }
@@ -19,7 +19,7 @@ export interface CommunicationUser {
 /**
  * A phone number.
  */
-export interface PhoneNumber {
+export interface PhoneNumberIdentifier {
   /**
    * The phone number in E.164 format.
    */
@@ -29,9 +29,9 @@ export interface PhoneNumber {
 /**
  * A calling application, i.e. a non-human participant in communication.
  */
-export interface CallingApplication {
+export interface CallingApplicationIdentifier {
   /**
-   * Id of the CallingApplication.
+   * Id of the CallingApplicationIdentifier.
    */
   callingApplicationId: string;
 }
@@ -51,7 +51,7 @@ export interface UnknownIdentifier {
  *
  * @param identifier The assumed CommunicationUser to be tested.
  */
-export const isCommunicationUser = (identifier: Identifier): identifier is CommunicationUser => {
+export const isCommunicationUserIdentifier = (identifier: CommunicationIdentifier): identifier is CommunicationUserIdentifier => {
   return typeof (identifier as any).communicationUserId === "string";
 };
 
@@ -60,7 +60,7 @@ export const isCommunicationUser = (identifier: Identifier): identifier is Commu
  *
  * @param identifier The assumed PhoneNumber to be tested.
  */
-export const isPhoneNumber = (identifier: Identifier): identifier is PhoneNumber => {
+export const isPhoneNumberIdentifier = (identifier: CommunicationIdentifier): identifier is PhoneNumberIdentifier => {
   return typeof (identifier as any).phoneNumber === "string";
 };
 
@@ -69,7 +69,7 @@ export const isPhoneNumber = (identifier: Identifier): identifier is PhoneNumber
  *
  * @param identifier The assumed CallingApplication to be tested.
  */
-export const isCallingApplication = (identifier: Identifier): identifier is CallingApplication => {
+export const isCallingApplicationIdentifier = (identifier: CommunicationIdentifier): identifier is CallingApplicationIdentifier => {
   return typeof (identifier as any).callingApplicationId === "string";
 };
 
@@ -78,23 +78,23 @@ export const isCallingApplication = (identifier: Identifier): identifier is Call
  *
  * @param identifier The assumed UnknownIdentifier to be tested.
  */
-export const isUnknownIdentifier = (identifier: Identifier): identifier is UnknownIdentifier => {
+export const isUnknownIdentifier = (identifier: CommunicationIdentifier): identifier is UnknownIdentifier => {
   return typeof (identifier as any).id === "string";
 };
 
 /**
  * The IdentifierKind is a discriminated union that adds a property `kind` to an Identifier.
  */
-export type IdentifierKind =
-  | CommunicationUserKind
-  | PhoneNumberKind
-  | CallingApplicationKind
+export type CommunicationIdentifierKind =
+  | CommunicationUserIdentifierKind
+  | PhoneNumberIdentifierKind
+  | CallingApplicationIdentifierKind
   | UnknownIdentifierKind;
 
 /**
  * IdentifierKind for a CommunicationUser identifier.
  */
-export interface CommunicationUserKind extends CommunicationUser {
+export interface CommunicationUserIdentifierKind extends CommunicationUserIdentifier {
   /**
    * The identifier kind.
    */
@@ -104,7 +104,7 @@ export interface CommunicationUserKind extends CommunicationUser {
 /**
  * IdentifierKind for a PhoneNumber identifier.
  */
-export interface PhoneNumberKind extends PhoneNumber {
+export interface PhoneNumberIdentifierKind extends PhoneNumberIdentifier {
   /**
    * The identifier kind.
    */
@@ -114,7 +114,7 @@ export interface PhoneNumberKind extends PhoneNumber {
 /**
  * IdentifierKind for a CallingApplication identifier.
  */
-export interface CallingApplicationKind extends CallingApplication {
+export interface CallingApplicationIdentifierKind extends CallingApplicationIdentifier {
   /**
    * The identifier kind.
    */
@@ -136,14 +136,14 @@ export interface UnknownIdentifierKind extends UnknownIdentifier {
  *
  * @param identifier The identifier whose kind is to be inferred.
  */
-export const getIdentifierKind = (identifier: Identifier): IdentifierKind => {
-  if (isCommunicationUser(identifier)) {
+export const getIdentifierKind = (identifier: CommunicationIdentifier): CommunicationIdentifierKind => {
+  if (isCommunicationUserIdentifier(identifier)) {
     return { ...identifier, kind: "CommunicationUser" };
   }
-  if (isPhoneNumber(identifier)) {
+  if (isPhoneNumberIdentifier(identifier)) {
     return { ...identifier, kind: "PhoneNumber" };
   }
-  if (isCallingApplication(identifier)) {
+  if (isCallingApplicationIdentifier(identifier)) {
     return { ...identifier, kind: "CallingApplication" };
   }
   return { ...identifier, kind: "Unknown" };

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -4,7 +4,11 @@
 /**
  * Identifies a communication user.
  */
-export type CommunicationIdentifier = CommunicationUserIdentifier | PhoneNumberIdentifier | CallingApplicationIdentifier | UnknownIdentifier;
+export type CommunicationIdentifier =
+  | CommunicationUserIdentifier
+  | PhoneNumberIdentifier
+  | CallingApplicationIdentifier
+  | UnknownIdentifier;
 
 /**
  * An Azure Communication user.
@@ -51,7 +55,9 @@ export interface UnknownIdentifier {
  *
  * @param identifier The assumed CommunicationUser to be tested.
  */
-export const isCommunicationUserIdentifier = (identifier: CommunicationIdentifier): identifier is CommunicationUserIdentifier => {
+export const isCommunicationUserIdentifier = (
+  identifier: CommunicationIdentifier
+): identifier is CommunicationUserIdentifier => {
   return typeof (identifier as any).communicationUserId === "string";
 };
 
@@ -60,7 +66,9 @@ export const isCommunicationUserIdentifier = (identifier: CommunicationIdentifie
  *
  * @param identifier The assumed PhoneNumber to be tested.
  */
-export const isPhoneNumberIdentifier = (identifier: CommunicationIdentifier): identifier is PhoneNumberIdentifier => {
+export const isPhoneNumberIdentifier = (
+  identifier: CommunicationIdentifier
+): identifier is PhoneNumberIdentifier => {
   return typeof (identifier as any).phoneNumber === "string";
 };
 
@@ -69,7 +77,9 @@ export const isPhoneNumberIdentifier = (identifier: CommunicationIdentifier): id
  *
  * @param identifier The assumed CallingApplication to be tested.
  */
-export const isCallingApplicationIdentifier = (identifier: CommunicationIdentifier): identifier is CallingApplicationIdentifier => {
+export const isCallingApplicationIdentifier = (
+  identifier: CommunicationIdentifier
+): identifier is CallingApplicationIdentifier => {
   return typeof (identifier as any).callingApplicationId === "string";
 };
 
@@ -78,7 +88,9 @@ export const isCallingApplicationIdentifier = (identifier: CommunicationIdentifi
  *
  * @param identifier The assumed UnknownIdentifier to be tested.
  */
-export const isUnknownIdentifier = (identifier: CommunicationIdentifier): identifier is UnknownIdentifier => {
+export const isUnknownIdentifier = (
+  identifier: CommunicationIdentifier
+): identifier is UnknownIdentifier => {
   return typeof (identifier as any).id === "string";
 };
 
@@ -136,7 +148,9 @@ export interface UnknownIdentifierKind extends UnknownIdentifier {
  *
  * @param identifier The identifier whose kind is to be inferred.
  */
-export const getIdentifierKind = (identifier: CommunicationIdentifier): CommunicationIdentifierKind => {
+export const getIdentifierKind = (
+  identifier: CommunicationIdentifier
+): CommunicationIdentifierKind => {
   if (isCommunicationUserIdentifier(identifier)) {
     return { ...identifier, kind: "CommunicationUser" };
   }

--- a/sdk/communication/communication-common/test/identifierModels.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModels.spec.ts
@@ -24,6 +24,9 @@ describe("Identifier models", () => {
     const phoneNumber = { phoneNumber: "123" };
     const identifierKind = getIdentifierKind(phoneNumber);
     assert.strictEqual(identifierKind.kind, "PhoneNumber");
-    assert.strictEqual((identifierKind as PhoneNumberIdentifier).phoneNumber, phoneNumber.phoneNumber);
+    assert.strictEqual(
+      (identifierKind as PhoneNumberIdentifier).phoneNumber,
+      phoneNumber.phoneNumber
+    );
   });
 });

--- a/sdk/communication/communication-common/test/identifierModels.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModels.spec.ts
@@ -3,20 +3,20 @@
 
 import { assert } from "chai";
 import {
-  isCommunicationUser,
-  isCallingApplication,
-  isPhoneNumber,
+  isCommunicationUserIdentifier,
+  isCallingApplicationIdentifier,
+  isPhoneNumberIdentifier,
   getIdentifierKind,
-  PhoneNumber,
+  PhoneNumberIdentifier,
   isUnknownIdentifier
 } from "../src";
 
 describe("Identifier models", () => {
   it("type guards", () => {
     const communicationUser = { communicationUserId: "alice" };
-    assert.isTrue(isCommunicationUser(communicationUser));
-    assert.isFalse(isCallingApplication(communicationUser));
-    assert.isFalse(isPhoneNumber(communicationUser));
+    assert.isTrue(isCommunicationUserIdentifier(communicationUser));
+    assert.isFalse(isCallingApplicationIdentifier(communicationUser));
+    assert.isFalse(isPhoneNumberIdentifier(communicationUser));
     assert.isFalse(isUnknownIdentifier(communicationUser));
   });
 
@@ -24,6 +24,6 @@ describe("Identifier models", () => {
     const phoneNumber = { phoneNumber: "123" };
     const identifierKind = getIdentifierKind(phoneNumber);
     assert.strictEqual(identifierKind.kind, "PhoneNumber");
-    assert.strictEqual((identifierKind as PhoneNumber).phoneNumber, phoneNumber.phoneNumber);
+    assert.strictEqual((identifierKind as PhoneNumberIdentifier).phoneNumber, phoneNumber.phoneNumber);
   });
 });


### PR DESCRIPTION
Two changes included in this PR:
1. Adding `Identifier` suffix to all Identifier types
2. Rename `Identifier` rename to `CommunicationIdentifier`