### PR TITLE
[Service Bus] Update migration guide to follow template

### DIFF
--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -4,35 +4,36 @@ This guide is intended to assist in the migration from version 1 of the Service 
 
 Familiarity with the version 1 of the `@azure/service-bus` library is assumed. For those new to the Service Bus client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md) and [Service Bus samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples) for the `@azure/service-bus` library rather than this guide.
 
+## Table of contents
+* [Migration benefits](#migration-benefits)
+  * [Cross Service SDK improvements](#cross-service-sdk-improvements)
+  * [New features](#new-features)
+  * [Performance improvements](#performance-improvements)
+* [Important changes](#important-changes)
+  * [Client hierarchy](#client-hierarchy)
+  * [Client constructors](#client-constructors)
+  * [Creating senders and receivers](#creating-senders-and-receivers)
+  * [Message format changes](#message-format-changes)
+  * [Receiving messages](#receiving-messages)
+  * [Rule management](#rule-management)
+* [Upcoming features](#upcoming-features)
+* [Additional samples](#additional-samples)
+
 ## Migration benefits
 
 A natural question to ask when considering whether or not to adopt a new version or library is what the benefits of doing so would be. As Azure has matured and been embraced by a more diverse group of developers, we have been focused on learning the patterns and practices to best support developer productivity and to understand the gaps that the JavaScript client libraries have.
 
 There were several areas of consistent feedback expressed across the Azure client library ecosystem. One of the most important is that the client libraries for different Azure services have not had a consistent approach to organization, naming, and API structure. Additionally, many developers have felt that the learning curve was difficult, and the APIs did not offer a good, approachable, and consistent onboarding story for those learning Azure or exploring a specific Azure service.
 
-To try and improve the development experience across Azure services, including Service Bus, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript specific guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that these libraries have a natural and idiomatic feel. Further details are available in the guidelines for those interested.
+To try and improve the development experience across Azure services, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [TypeScript & JavaScript specific guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html) was also introduced to ensure that these libraries have a natural and idiomatic feel. Further details are available in the guidelines for those interested.
 
-The new version 7 of the Service Bus library provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as using the new `@azure/identity` library to share a single authentication between clients and a unified diagnostics pipeline offering a common view of the activities across each of the client libraries.
+### Cross Service SDK improvements
 
-## Changes in version 7 of the Service Bus library
-
-### Message format changes
-
-Some key fields have been renamed in the ServiceBusMessage and ServiceBusReceivedMessage to better align with [AMQP](https://www.amqp.org/sites/amqp.org/files/amqp.pdf):
-- `label` has been renamed to `subject`
-- `userProperties` has been renamed to `applicationProperties`
-
-### Client hierarchy
-
-In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, and subscription. This acts as the single entry point in contrast with multiple entry points from before. You can create senders and receivers from this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
-
-#### Approachability
-
-By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods from a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, using sessions or not, you will start your applications by constructing the same client.
-
-#### Consistency
-
-We now have methods with similar names, signature and location to create senders and receivers. This provides consistency and predictability on the various features of the library.
+The new version of the Service Bus library also shares some of the cross-service improvements made to the Azure development experience, such as:
+- Using the new `@azure/identity` library to share a single authentication approach between clients.
+- A unified logging and diagnostics pipeline that offers a common view of the activities across each of the client libraries.
+- The use of promises rather than callbacks for a simplified programming experience.
+- The use of async iterators in paging APIs.
 
 ### New features
 
@@ -51,6 +52,20 @@ Notable performance improvements:
 
 - Number of messages that can be sent in a certain duration using a single sender has been improved 4-5 times from v1.x (excluding the effects of batch message API).
 - Memory usage for message lock renewals, session lock renewals and peeking has been made more efficient.
+
+## Important changes
+
+### Client hierarchy
+
+In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, and subscription. This acts as the single entry point in contrast with multiple entry points from before. You can create senders and receivers from this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
+
+#### Approachability
+
+By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods from a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, using sessions or not, you will start your applications by constructing the same client.
+
+#### Consistency
+
+We now have methods with similar names, signature and location to create senders and receivers. This provides consistency and predictability on the various features of the library.
 
 ### Client constructors
 
@@ -146,6 +161,20 @@ const serviceBusClient = new ServiceBusClient("my-namespace.servicebus.windows.n
     receiver link to the session was only initialized when the async methods on the `ServiceBusSessionReceiver`
     were first called.
 
+### Message format changes
+
+In version 1 of this library, we had the below to represent a Service Bus message
+- `SendableMessageInfo` - An interface representing the message when you need to send it. 
+- `ReceivedMessageInfo` - An interface representing the message when you use the peek operation. This extends the `SendableMessageInfo` with data set by the service.
+- `ServiceBusMessage` - A class representing the message when receive it using the receiver. This extends the `ReceivedMessageInfo` with methods on it to settle the message.
+
+In version 7 of this library, we simplified this as below:
+- `ServiceBusMessage` is now the name of the interface representing the message when you need to send it with the below changes to better align with the [AMQP spec](https://www.amqp.org/sites/amqp.org/files/amqp.pdf):
+  - `label` has been renamed to `subject`
+  - `userProperties` has been renamed to `applicationProperties`
+- `ServiceBusReceivedMessage` is the name of the interface representing the message when you get it from the service, regardless of whether you used the peek operation or receivied it using the receiver.
+- The methods to settle the message have been moved from the message to the recevier to better represent the nature of the message settlement feature which is an attribute of the receiver.
+
 ### Receiving messages
 
 - `peek()` and `peekBySequenceNumber()` methods are collapsed into a single method `peekMessages()`.
@@ -222,10 +251,14 @@ Additionally, since a message cannot be settled if the receiver that was used to
   await serviceBusAdministrationClient.deleteRule();
   ```
 
-### Upcoming features
+## Upcoming features
 
 - [Transactions](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-transactions#transactions-in-service-bus) to group two or more operations together into an execution scope to ensure that all operations belonging to a given group of operations either succeed or fail jointly.
 - Optional [prefetch](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-prefetch) support to speed up the message flow by having a message readily available for local retrieval when and before the application asks for one.
 - An optional method on `ServiceBusSender` to allow pre-initializing the sender link to remove the upfront cost from the first send operation.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fservicebus%2Fservice-bus%2FMIGRATIONGUIDE.png)
+
+## Additional samples
+
+More examples can be found at [Samples for @azure/service-bus](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples/)

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -5,19 +5,20 @@ This guide is intended to assist in the migration from version 1 of the Service 
 Familiarity with the version 1 of the `@azure/service-bus` library is assumed. For those new to the Service Bus client library for JavaScript, please refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md) and [Service Bus samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples) for the `@azure/service-bus` library rather than this guide.
 
 ## Table of contents
-* [Migration benefits](#migration-benefits)
-  * [Cross Service SDK improvements](#cross-service-sdk-improvements)
-  * [New features](#new-features)
-  * [Performance improvements](#performance-improvements)
-* [Important changes](#important-changes)
-  * [Client hierarchy](#client-hierarchy)
-  * [Client constructors](#client-constructors)
-  * [Creating senders and receivers](#creating-senders-and-receivers)
-  * [Message format changes](#message-format-changes)
-  * [Receiving messages](#receiving-messages)
-  * [Rule management](#rule-management)
-* [Upcoming features](#upcoming-features)
-* [Additional samples](#additional-samples)
+
+- [Migration benefits](#migration-benefits)
+  - [Cross Service SDK improvements](#cross-service-sdk-improvements)
+  - [New features](#new-features)
+  - [Performance improvements](#performance-improvements)
+- [Important changes](#important-changes)
+  - [Client hierarchy](#client-hierarchy)
+  - [Client constructors](#client-constructors)
+  - [Creating senders and receivers](#creating-senders-and-receivers)
+  - [Message format changes](#message-format-changes)
+  - [Receiving messages](#receiving-messages)
+  - [Rule management](#rule-management)
+- [Upcoming features](#upcoming-features)
+- [Additional samples](#additional-samples)
 
 ## Migration benefits
 
@@ -30,6 +31,7 @@ To try and improve the development experience across Azure services, a set of un
 ### Cross Service SDK improvements
 
 The new version of the Service Bus library also shares some of the cross-service improvements made to the Azure development experience, such as:
+
 - Using the new `@azure/identity` library to share a single authentication approach between clients.
 - A unified logging and diagnostics pipeline that offers a common view of the activities across each of the client libraries.
 - The use of promises rather than callbacks for a simplified programming experience.
@@ -164,11 +166,13 @@ const serviceBusClient = new ServiceBusClient("my-namespace.servicebus.windows.n
 ### Message format changes
 
 In version 1 of this library, we had the below to represent a Service Bus message
-- `SendableMessageInfo` - An interface representing the message when you need to send it. 
+
+- `SendableMessageInfo` - An interface representing the message when you need to send it.
 - `ReceivedMessageInfo` - An interface representing the message when you use the peek operation. This extends the `SendableMessageInfo` with data set by the service.
 - `ServiceBusMessage` - A class representing the message when receive it using the receiver. This extends the `ReceivedMessageInfo` with methods on it to settle the message.
 
 In version 7 of this library, we simplified this as below:
+
 - `ServiceBusMessage` is now the name of the interface representing the message when you need to send it with the below changes to better align with the [AMQP spec](https://www.amqp.org/sites/amqp.org/files/amqp.pdf):
   - `label` has been renamed to `subject`
   - `userProperties` has been renamed to `applicationProperties`
@@ -219,7 +223,7 @@ These have been moved to the receiver in the new version, take the message as in
 
 ```typescript
 // current
-const serviceBusReceivedMessage: ServiceBusReceivedMessage
+const serviceBusReceivedMessage: ServiceBusReceivedMessage;
 const serviceBusReceiver: ServiceBusReceiver;
 
 serviceBusReceiver.completeMessage(serviceBusReceivedMessage);

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -177,7 +177,7 @@ In version 7 of this library, we simplified this as below:
   - `label` has been renamed to `subject`
   - `userProperties` has been renamed to `applicationProperties`
 - `ServiceBusReceivedMessage` is the name of the interface representing the message when you get it from the service, regardless of whether you used the peek operation or receivied it using the receiver.
-- The methods to settle the message have been moved from the message to the recevier to better represent the nature of the message settlement feature which is an attribute of the receiver.
+- The methods to settle the message have been moved from the message to the receiver to better represent the nature of the message settlement feature which is an attribute of the receiver.
 
 ### Receiving messages
 


### PR DESCRIPTION
This PR updates the Service Bus migration guide to follow the [template](https://github.com/Azure/azure-sdk/pull/2132) to fix #12366