### PR TITLE
[event-hubs] fix eslint errors (round 1)

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -5,7 +5,7 @@
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "sideEffects": false,
   "keywords": [
@@ -31,7 +31,7 @@
   "browser": {
     "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js"
   },
-  "engine": {
+  "engines": {
     "node": ">=8.0.0"
   },
   "files": [

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -397,10 +397,7 @@ export namespace ConnectionContext {
 
     function cleanConnectionContext(context: ConnectionContext): Promise<void> {
       // Remove listeners from the connection object.
-      context.connection.removeListener(
-        ConnectionEvents.connectionOpen,
-        onConnectionOpen
-      );
+      context.connection.removeListener(ConnectionEvents.connectionOpen, onConnectionOpen);
       context.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
       context.connection.removeListener(ConnectionEvents.protocolError, protocolError);
       context.connection.removeListener(ConnectionEvents.error, error);

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -111,7 +111,7 @@ export interface ConnectionContextOptions extends EventHubClientOptions {
 /**
  * Helper type to get the names of all the functions on an object.
  */
-type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]; // eslint-disable-line @typescript-eslint/ban-types
 /**
  * Helper type to get the types of all the functions on an object.
  */
@@ -387,7 +387,7 @@ export namespace ConnectionContext {
       }
     };
 
-    function addConnectionListeners(connection: Connection) {
+    function addConnectionListeners(connection: Connection): void {
       // Add listeners on the connection object.
       connection.on(ConnectionEvents.connectionOpen, onConnectionOpen);
       connection.on(ConnectionEvents.disconnected, onDisconnected);
@@ -395,35 +395,35 @@ export namespace ConnectionContext {
       connection.on(ConnectionEvents.error, error);
     }
 
-    function cleanConnectionContext(connectionContext: ConnectionContext) {
+    function cleanConnectionContext(context: ConnectionContext): Promise<void> {
       // Remove listeners from the connection object.
-      connectionContext.connection.removeListener(
+      context.connection.removeListener(
         ConnectionEvents.connectionOpen,
         onConnectionOpen
       );
-      connectionContext.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-      connectionContext.connection.removeListener(ConnectionEvents.protocolError, protocolError);
-      connectionContext.connection.removeListener(ConnectionEvents.error, error);
+      context.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
+      context.connection.removeListener(ConnectionEvents.protocolError, protocolError);
+      context.connection.removeListener(ConnectionEvents.error, error);
       // Close the connection
-      return connectionContext.connection.close();
+      return context.connection.close();
     }
 
-    async function refreshConnection(connectionContext: ConnectionContext) {
-      const originalConnectionId = connectionContext.connectionId;
+    async function refreshConnection(context: ConnectionContext): Promise<void> {
+      const originalConnectionId = context.connectionId;
       try {
-        await cleanConnectionContext(connectionContext);
+        await cleanConnectionContext(context);
       } catch (err) {
         logger.verbose(
-          `[${connectionContext.connectionId}] There was an error closing the connection before reconnecting: %O`,
+          `[${context.connectionId}] There was an error closing the connection before reconnecting: %O`,
           err
         );
       }
 
       // Create a new connection, id, locks, and cbs client.
-      connectionContext.refreshConnection();
-      addConnectionListeners(connectionContext.connection);
+      context.refreshConnection();
+      addConnectionListeners(context.connection);
       logger.verbose(
-        `The connection "${originalConnectionId}" has been updated to "${connectionContext.connectionId}".`
+        `The connection "${originalConnectionId}" has been updated to "${context.connectionId}".`
       );
     }
 

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -23,7 +23,7 @@ export const defaultDataTransformer = {
    * - content: The given AMQP message body as a Buffer.
    * - multiple: true | undefined.
    */
-  encode(body: any): any {
+  encode(body: any): any { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     let result: any;
     if (isBuffer(body)) {
       result = message.data_section(body);
@@ -31,7 +31,7 @@ export const defaultDataTransformer = {
       // string, undefined, null, boolean, array, object, number should end up here
       // coercing undefined to null as that will ensure that null value will be given to the
       // customer on receive.
-      if (body === undefined) body = null; // tslint:disable-line
+      if (body === undefined) body = null;
       try {
         const bodyStr = JSON.stringify(body);
         result = message.data_section(Buffer.from(bodyStr, "utf8"));
@@ -56,7 +56,7 @@ export const defaultDataTransformer = {
    * @param {DataSection} body The AMQP message body
    * @return {*} decoded body or the given body as-is.
    */
-  decode(body: any): any {
+  decode(body: any): any { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     let processedBody: any = body;
     try {
       if (body.content && isBuffer(body.content)) {

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -23,7 +23,8 @@ export const defaultDataTransformer = {
    * - content: The given AMQP message body as a Buffer.
    * - multiple: true | undefined.
    */
-  encode(body: any): any { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
+  encode(body: any): any {
+    // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     let result: any;
     if (isBuffer(body)) {
       result = message.data_section(body);
@@ -56,7 +57,8 @@ export const defaultDataTransformer = {
    * @param {DataSection} body The AMQP message body
    * @return {*} decoded body or the given body as-is.
    */
-  decode(body: any): any { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
+  decode(body: any): any {
+    // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     let processedBody: any = body;
     try {
       if (body.content && isBuffer(body.content)) {

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -203,7 +203,7 @@ export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessa
   if (data.properties) {
     msg.application_properties = data.properties;
   }
-  if (partitionKey != undefined) {
+  if (partitionKey !== null && partitionKey !== undefined) {
     msg.message_annotations[Constants.partitionKey] = partitionKey;
     // Event Hub service cannot route messages to a specific partition based on the partition key
     // if AMQP message header is an empty object. Hence we make sure that header is always present

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -3,7 +3,7 @@
 
 import { DeliveryAnnotations, Message as RheaMessage, MessageAnnotations } from "rhea-promise";
 import { Constants } from "@azure/core-amqp";
-import { isDefined } from './util/isDefined';
+import { isDefined } from "./util/isDefined";
 
 /**
  * Describes the delivery annotations.

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -3,6 +3,7 @@
 
 import { DeliveryAnnotations, Message as RheaMessage, MessageAnnotations } from "rhea-promise";
 import { Constants } from "@azure/core-amqp";
+import { isDefined } from './util/isDefined';
 
 /**
  * Describes the delivery annotations.
@@ -203,7 +204,7 @@ export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessa
   if (data.properties) {
     msg.application_properties = data.properties;
   }
-  if (partitionKey !== null && partitionKey !== undefined) {
+  if (isDefined(partitionKey)) {
     msg.message_annotations[Constants.partitionKey] = partitionKey;
     // Event Hub service cannot route messages to a specific partition based on the partition key
     // if AMQP message header is an empty object. Hence we make sure that header is always present

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -9,6 +9,7 @@ import { Span, SpanContext } from "@opentelemetry/api";
 import { TRACEPARENT_PROPERTY, instrumentEventData } from "./diagnostics/instrumentEventData";
 import { createMessageSpan } from "./diagnostics/messageSpan";
 import { defaultDataTransformer } from "./dataTransformer";
+import { isDefined } from './util/isDefined';
 
 /**
  * The amount of bytes to reserve as overhead for a small message.
@@ -29,7 +30,7 @@ const smallMessageMaxBytes = 255;
  * @internal
  * @ignore
  */
-export function isEventDataBatch(eventDataBatch: any): eventDataBatch is EventDataBatch {
+export function isEventDataBatch(eventDataBatch: any): eventDataBatch is EventDataBatch { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
   return (
     eventDataBatch &&
     typeof eventDataBatch.tryAdd === "function" &&
@@ -192,8 +193,8 @@ export class EventDataBatchImpl implements EventDataBatch {
   ) {
     this._context = context;
     this._maxSizeInBytes = maxSizeInBytes;
-    this._partitionKey = partitionKey != undefined ? String(partitionKey) : partitionKey;
-    this._partitionId = partitionId != undefined ? String(partitionId) : partitionId;
+    this._partitionKey = isDefined(partitionKey) ? String(partitionKey) : partitionKey;
+    this._partitionId = isDefined(partitionId) ? String(partitionId) : partitionId;
     this._sizeInBytes = 0;
     this._count = 0;
   }

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -9,7 +9,7 @@ import { Span, SpanContext } from "@opentelemetry/api";
 import { TRACEPARENT_PROPERTY, instrumentEventData } from "./diagnostics/instrumentEventData";
 import { createMessageSpan } from "./diagnostics/messageSpan";
 import { defaultDataTransformer } from "./dataTransformer";
-import { isDefined } from './util/isDefined';
+import { isDefined } from "./util/isDefined";
 
 /**
  * The amount of bytes to reserve as overhead for a small message.
@@ -30,7 +30,8 @@ const smallMessageMaxBytes = 255;
  * @internal
  * @ignore
  */
-export function isEventDataBatch(eventDataBatch: any): eventDataBatch is EventDataBatch { // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
+export function isEventDataBatch(eventDataBatch: any): eventDataBatch is EventDataBatch {
+  // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
   return (
     eventDataBatch &&
     typeof eventDataBatch.tryAdd === "function" &&

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -21,7 +21,7 @@ import {
   SendBatchOptions
 } from "./models/public";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
-import { isDefined } from './util/isDefined';
+import { isDefined } from "./util/isDefined";
 import { getParentSpan, OperationOptions } from "./util/operationOptions";
 
 /**

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -21,6 +21,7 @@ import {
   SendBatchOptions
 } from "./models/public";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { isDefined } from './util/isDefined';
 import { getParentSpan, OperationOptions } from "./util/operationOptions";
 
 /**
@@ -174,7 +175,7 @@ export class EventHubProducerClient {
   async createBatch(options: CreateBatchOptions = {}): Promise<EventDataBatch> {
     throwErrorIfConnectionClosed(this._context);
 
-    if (options.partitionId != undefined && options.partitionKey != undefined) {
+    if (isDefined(options.partitionId) && isDefined(options.partitionKey)) {
       throw new Error("partitionId and partitionKey cannot both be set when creating a batch");
     }
 
@@ -316,16 +317,16 @@ export class EventHubProducerClient {
         }
       }
     }
-    if (partitionId != undefined && partitionKey != undefined) {
+    if (isDefined(partitionId) && isDefined(partitionKey)) {
       throw new Error(
         `The partitionId (${partitionId}) and partitionKey (${partitionKey}) cannot both be specified.`
       );
     }
 
-    if (partitionId != undefined) {
+    if (isDefined(partitionId)) {
       partitionId = String(partitionId);
     }
-    if (partitionKey != undefined) {
+    if (isDefined(partitionKey)) {
       partitionKey = String(partitionKey);
     }
 

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -462,7 +462,10 @@ export class EventHubReceiver extends LinkEntity {
               await this.abort();
             }
           } catch (err) {
-            return this._onError === onError && onError(err);
+            if (this._onError === onError) {
+              onError(err);
+            }
+            return;
           }
         } else {
           logger.verbose(
@@ -478,6 +481,7 @@ export class EventHubReceiver extends LinkEntity {
           0
         );
         this._addCredit(creditsToAdd);
+        return;
       })
       .catch((err) => {
         // something really unexpected happened, so attempt to call user's error handler
@@ -700,13 +704,13 @@ export class EventHubReceiver extends LinkEntity {
           try {
             await this.close();
           } finally {
-            return reject(new AbortError("The receive operation has been cancelled by the user."));
+            reject(new AbortError("The receive operation has been cancelled by the user."));
           }
         };
 
         // operation has been cancelled, so exit immediately
         if (abortSignal && abortSignal.aborted) {
-          return await rejectOnAbort();
+          return rejectOnAbort();
         }
 
         // updates the prefetch count so that the baseConsumer adds

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -89,8 +89,8 @@ export class EventHubSender extends LinkEntity {
     this.address = context.config.getSenderAddress(partitionId);
     this.audience = context.config.getSenderAudience(partitionId);
 
-    this._onAmqpError = (context: EventContext) => {
-      const senderError = context.sender && context.sender.error;
+    this._onAmqpError = (eventContext: EventContext) => {
+      const senderError = eventContext.sender && eventContext.sender.error;
       logger.verbose(
         "[%s] 'sender_error' event occurred on the sender '%s' with address '%s'. " +
           "The associated error is: %O",
@@ -102,8 +102,8 @@ export class EventHubSender extends LinkEntity {
       // TODO: Consider rejecting promise in trySendBatch() or createBatch()
     };
 
-    this._onSessionError = (context: EventContext) => {
-      const sessionError = context.session && context.session.error;
+    this._onSessionError = (eventContext: EventContext) => {
+      const sessionError = eventContext.session && eventContext.session.error;
       logger.verbose(
         "[%s] 'session_error' event occurred on the session of sender '%s' with address '%s'. " +
           "The associated error is: %O",
@@ -115,8 +115,8 @@ export class EventHubSender extends LinkEntity {
       // TODO: Consider rejecting promise in trySendBatch() or createBatch()
     };
 
-    this._onAmqpClose = async (context: EventContext) => {
-      const sender = this._sender || context.sender!;
+    this._onAmqpClose = async (eventContext: EventContext) => {
+      const sender = this._sender || eventContext.sender!;
       logger.verbose(
         "[%s] 'sender_close' event occurred on the sender '%s' with address '%s'. " +
           "Value for isItselfClosed on the receiver is: '%s' " +
@@ -140,8 +140,8 @@ export class EventHubSender extends LinkEntity {
       }
     };
 
-    this._onSessionClose = async (context: EventContext) => {
-      const sender = this._sender || context.sender!;
+    this._onSessionClose = async (eventContext: EventContext) => {
+      const sender = this._sender || eventContext.sender!;
       logger.verbose(
         "[%s] 'session_close' event occurred on the session of sender '%s' with address '%s'. " +
           "Value for isSessionItselfClosed on the session is: '%s' " +
@@ -322,9 +322,9 @@ export class EventHubSender extends LinkEntity {
         const messages: RheaMessage[] = [];
         // Convert EventData to RheaMessage.
         for (let i = 0; i < events.length; i++) {
-          const message = toRheaMessage(events[i], partitionKey);
-          message.body = defaultDataTransformer.encode(events[i].body);
-          messages[i] = message;
+          const rheaMessage = toRheaMessage(events[i], partitionKey);
+          rheaMessage.body = defaultDataTransformer.encode(events[i].body);
+          messages[i] = rheaMessage;
         }
         // Encode every amqp message and then convert every encoded message to amqp data section
         const batchMessage: RheaMessage = {
@@ -391,11 +391,11 @@ export class EventHubSender extends LinkEntity {
    * We have implemented a synchronous send over here in the sense that we shall be waiting
    * for the message to be accepted or rejected and accordingly resolve or reject the promise.
    * @ignore
-   * @param message The message to be sent to EventHub.
+   * @param rheaMessage The message to be sent to EventHub.
    * @returns Promise<void>
    */
   private _trySendBatch(
-    message: RheaMessage | Buffer,
+    rheaMessage: RheaMessage | Buffer,
     options: SendOptions & EventHubProducerOptions = {}
   ): Promise<void> {
     const abortSignal: AbortSignalLike | undefined = options.abortSignal;
@@ -464,15 +464,15 @@ export class EventHubSender extends LinkEntity {
             });
           } catch (err) {
             removeListeners();
-            err = translate(err);
+            const translatedError = translate(err);
             logger.warning(
               "[%s] An error occurred while creating the sender %s: %s",
               this._context.connectionId,
               this.name,
-              `${err?.name}: ${err?.message}`
+              `${translatedError?.name}: ${translatedError?.message}`
             );
-            logErrorStackTrace(err);
-            return reject(err);
+            logErrorStackTrace(translatedError);
+            return reject(translatedError);
           }
         }
         const timeTakenByInit = Date.now() - initStartTime;
@@ -496,7 +496,7 @@ export class EventHubSender extends LinkEntity {
           }
           try {
             this._sender!.sendTimeoutInSeconds = (timeoutInMs - timeTakenByInit) / 1000;
-            const delivery = await this._sender!.send(message, undefined, 0x80013700);
+            const delivery = await this._sender!.send(rheaMessage, undefined, 0x80013700);
             logger.info(
               "[%s] Sender '%s', sent message with delivery id: %d",
               this._context.connectionId,
@@ -505,14 +505,14 @@ export class EventHubSender extends LinkEntity {
             );
             return resolve();
           } catch (err) {
-            err = translate(err.innerError || err);
+            const translatedError = translate(err.innerError || err);
             logger.warning(
               "[%s] An error occurred while sending the message %s",
               this._context.connectionId,
-              `${err?.name}: ${err?.message}`
+              `${translatedError?.name}: ${translatedError?.message}`
             );
-            logErrorStackTrace(err);
-            return reject(err);
+            logErrorStackTrace(translatedError);
+            return reject(translatedError);
           } finally {
             removeListeners();
           }
@@ -586,15 +586,15 @@ export class EventHubSender extends LinkEntity {
       }
     } catch (err) {
       this.isConnecting = false;
-      err = translate(err);
+      const translatedError = translate(err);
       logger.warning(
         "[%s] An error occurred while creating the sender %s: %s",
         this._context.connectionId,
         this.name,
-        `${err?.name}: ${err?.message}`
+        `${translatedError?.name}: ${translatedError?.message}`
       );
-      logErrorStackTrace(err);
-      throw err;
+      logErrorStackTrace(translatedError);
+      throw translatedError;
     }
   }
 

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { Constants, ErrorNameConditionMapper, translate } from "@azure/core-amqp";
+import { isDefined } from './util/isDefined';
 
 /**
  * Represents the position of an event in an Event Hub partition, typically used when calling the `subscribe()`
@@ -51,15 +52,15 @@ export interface EventPosition {
 export function getEventPositionFilter(eventPosition: EventPosition): string {
   let result;
   // order of preference
-  if (eventPosition.offset != undefined) {
+  if (isDefined(eventPosition.offset)) {
     result = eventPosition.isInclusive
       ? `${Constants.offsetAnnotation} >= '${eventPosition.offset}'`
       : `${Constants.offsetAnnotation} > '${eventPosition.offset}'`;
-  } else if (eventPosition.sequenceNumber != undefined) {
+  } else if (isDefined(eventPosition.sequenceNumber)) {
     result = eventPosition.isInclusive
       ? `${Constants.sequenceNumberAnnotation} >= '${eventPosition.sequenceNumber}'`
       : `${Constants.sequenceNumberAnnotation} > '${eventPosition.sequenceNumber}'`;
-  } else if (eventPosition.enqueuedOn != undefined) {
+  } else if (isDefined(eventPosition.enqueuedOn)) {
     const time =
       eventPosition.enqueuedOn instanceof Date
         ? eventPosition.enqueuedOn.getTime()
@@ -113,8 +114,8 @@ export const latestEventPosition: EventPosition = {
  */
 export function validateEventPositions(
   position: EventPosition | { [partitionId: string]: EventPosition }
-) {
-  if (position == undefined) {
+): void {
+  if (!isDefined(position)) {
     return;
   }
 
@@ -151,15 +152,15 @@ export function isEventPosition(position: any): position is EventPosition {
     return false;
   }
 
-  if (position.offset != undefined) {
+  if (isDefined(position.offset)) {
     return true;
   }
 
-  if (position.sequenceNumber != undefined) {
+  if (isDefined(position.sequenceNumber)) {
     return true;
   }
 
-  if (position.enqueuedOn != undefined) {
+  if (isDefined(position.enqueuedOn)) {
     return true;
   }
 
@@ -167,12 +168,12 @@ export function isEventPosition(position: any): position is EventPosition {
 }
 
 function validateEventPosition(position: EventPosition) {
-  if (position == undefined) {
+  if (!isDefined(position)) {
     return;
   }
-  const offsetPresent = position.offset != undefined;
-  const sequenceNumberPresent = position.sequenceNumber != undefined;
-  const enqueuedOnPresent = position.enqueuedOn != undefined;
+  const offsetPresent = isDefined(position.offset);
+  const sequenceNumberPresent = isDefined(position.sequenceNumber);
+  const enqueuedOnPresent = isDefined(position.enqueuedOn);
 
   if (
     (offsetPresent && sequenceNumberPresent) ||

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Constants, ErrorNameConditionMapper, translate } from "@azure/core-amqp";
-import { isDefined } from './util/isDefined';
+import { isDefined } from "./util/isDefined";
 
 /**
  * Represents the position of an event in an Event Hub partition, typically used when calling the `subscribe()`

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -500,9 +500,7 @@ export class EventProcessor {
 
     const uniquePartitionsToClaim = new Set(partitionsToClaim);
     for (const partitionToClaim of uniquePartitionsToClaim) {
-      let partitionOwnershipRequest: PartitionOwnership;
-
-      partitionOwnershipRequest = this._createPartitionOwnershipRequest(
+      const partitionOwnershipRequest = this._createPartitionOwnershipRequest(
         partitionOwnershipMap,
         partitionToClaim
       );
@@ -527,11 +525,11 @@ export class EventProcessor {
           eventHubName: this._eventHubName,
           consumerGroup: this._consumerGroup,
           partitionId: "",
-          updateCheckpoint: async () => {}
+          updateCheckpoint: async () => { /* no-op */ }
         });
-      } catch (err) {
+      } catch (errorFromUser) {
         logger.verbose(
-          `[${this._id}] An error was thrown from the user's processError handler: ${err}`
+          `[${this._id}] An error was thrown from the user's processError handler: ${errorFromUser}`
         );
       }
     }
@@ -573,7 +571,7 @@ export class EventProcessor {
     }
   }
 
-  isRunning() {
+  isRunning(): boolean {
     return this._isRunning;
   }
 

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -525,7 +525,9 @@ export class EventProcessor {
           eventHubName: this._eventHubName,
           consumerGroup: this._consumerGroup,
           partitionId: "",
-          updateCheckpoint: async () => { /* no-op */ }
+          updateCheckpoint: async () => {
+            /* no-op */
+          }
         });
       } catch (errorFromUser) {
         logger.verbose(

--- a/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
+++ b/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
@@ -21,7 +21,7 @@ export class PartitionGate {
    *
    * @param partitionId A partition ID or the constant "all"
    */
-  add(partitionId: string | "all") {
+  add(partitionId: string | "all"): void {
     if (
       (partitionId === "all" && this._partitions.size > 0) ||
       this._partitions.has(partitionId) ||
@@ -38,7 +38,7 @@ export class PartitionGate {
    *
    * @param partitionId A partition ID or the constant "all"
    */
-  remove(partitionId: string | "all") {
+  remove(partitionId: string | "all"): void {
     this._partitions.delete(partitionId);
   }
 }

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -235,7 +235,7 @@ export class LinkEntity {
     clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
     if (link) {
       try {
-        // Closing the link and its underlying session if the link is open. This should also
+        // Closing the link and its underlying session if the link is open. This should also
         // remove them from the internal map.
         await link.close();
         logger.verbose(

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
 import { createClientLogger } from "@azure/logger";
 
 /**
@@ -14,7 +16,7 @@ export const logger = createClientLogger("event-hubs");
  * @param error Error containing a stack trace.
  * @ignore
  */
-export function logErrorStackTrace(error: any) {
+export function logErrorStackTrace(error: any): void {
   if (error && error.stack) {
     logger.verbose(error.stack);
   }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -33,7 +33,7 @@ import { Span, SpanContext, SpanKind, CanonicalCode } from "@opentelemetry/api";
 import { getParentSpan, OperationOptions } from "./util/operationOptions";
 import { getTracer } from "@azure/core-tracing";
 import { SharedKeyCredential } from "../src/eventhubSharedKeyCredential";
-import { AccessToken } from '@azure/core-auth';
+import { AccessToken } from "@azure/core-auth";
 
 /**
  * Describes the runtime information of an Event Hub.

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -96,7 +96,7 @@ export class PartitionProcessor implements PartitionContext {
    * @property The fully qualified namespace from where the current partition is being processed. It is set by the `EventProcessor`
    * @readonly
    */
-  public get fullyQualifiedNamespace() {
+  public get fullyQualifiedNamespace(): string {
     return this._context.fullyQualifiedNamespace;
   }
 
@@ -104,7 +104,7 @@ export class PartitionProcessor implements PartitionContext {
    * @property The name of the consumer group from where the current partition is being processed. It is set by the `EventProcessor`
    * @readonly
    */
-  public get consumerGroup() {
+  public get consumerGroup(): string {
     return this._context.consumerGroup!;
   }
 
@@ -112,7 +112,7 @@ export class PartitionProcessor implements PartitionContext {
    * @property The name of the event hub to which the current partition belongs. It is set by the `EventProcessor`
    * @readonly
    */
-  public get eventHubName() {
+  public get eventHubName(): string {
     return this._context.eventHubName;
   }
 
@@ -120,14 +120,14 @@ export class PartitionProcessor implements PartitionContext {
    * @property The identifier of the Event Hub partition that is being processed. It is set by the `EventProcessor`
    * @readonly
    */
-  public get partitionId() {
+  public get partitionId(): string {
     return this._context.partitionId;
   }
 
   /**
    * @property The unique identifier of the `EventProcessor` that has spawned the current instance of `PartitionProcessor`. This is set by the `EventProcessor`
    */
-  public get eventProcessorId() {
+  public get eventProcessorId(): string {
     return this._context.eventProcessorId;
   }
 

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -155,9 +155,9 @@ export class PartitionPump {
         // forward error to user's processError and swallow errors they may throw
         try {
           await this._partitionProcessor.processError(err);
-        } catch (err) {
+        } catch (errorFromUser) {
           // Using verbose over warning because this error is swallowed.
-          logger.verbose("An error was thrown by user's processError method: ", err);
+          logger.verbose("An error was thrown by user's processError method: ", errorFromUser);
         }
 
         // close the partition processor if a non-retryable error was encountered
@@ -170,11 +170,11 @@ export class PartitionPump {
             }
             // this will close the pump and will break us out of the while loop
             return await this.stop(CloseReason.Shutdown);
-          } catch (err) {
+          } catch (errorFromStop) {
             // Using verbose over warning because this error is swallowed.
             logger.verbose(
               `An error occurred while closing the receiver with reason ${CloseReason.Shutdown}: `,
-              err
+              errorFromStop
             );
           }
         }

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -16,5 +16,5 @@ export async function delayWithoutThrow(
 ): Promise<void> {
   try {
     await delay(delayInMs, abortSignal);
-  } catch {} // swallow AbortError
+  } catch { /* swallow AbortError */ } 
 }

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -16,5 +16,7 @@ export async function delayWithoutThrow(
 ): Promise<void> {
   try {
     await delay(delayInMs, abortSignal);
-  } catch { /* swallow AbortError */ } 
+  } catch {
+    /* swallow AbortError */
+  }
 }

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// Disable eslint rule since these functions aren't part of the public API.
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
 import { logErrorStackTrace, logger } from "../log";
 import { ConnectionContext } from "../connectionContext";
 

--- a/sdk/eventhub/event-hubs/src/util/isDefined.ts
+++ b/sdk/eventhub/event-hubs/src/util/isDefined.ts
@@ -8,5 +8,5 @@
  * @hidden
  */
 export function isDefined<T>(thing: T | undefined | null): thing is T {
-  return typeof thing !== 'undefined' && thing !== null;
+  return typeof thing !== "undefined" && thing !== null;
 }

--- a/sdk/eventhub/event-hubs/src/util/isDefined.ts
+++ b/sdk/eventhub/event-hubs/src/util/isDefined.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Helper TypeGuard that checks if something is defined or not.
+ * @param thing Anything
+ * @internal
+ * @hidden
+ */
+export function isDefined<T>(thing: T | undefined | null): thing is T {
+  return typeof thing !== 'undefined' && thing !== null;
+}

--- a/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
+++ b/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
@@ -8,7 +8,7 @@
  * @internal
  */
 export function parseEndpoint(endpoint: string): { host: string; hostname: string; port?: string } {
-  const hostMatch = endpoint.match(/.*:\/\/([^\/]*)/i);
+  const hostMatch = endpoint.match(/.*:\/\/([^/]*)/i);
   if (!hostMatch) {
     throw new TypeError(`Invalid endpoint missing host: ${endpoint}`);
   }

--- a/sdk/eventhub/event-hubs/src/util/retries.ts
+++ b/sdk/eventhub/event-hubs/src/util/retries.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Constants, RetryOptions } from "@azure/core-amqp";
-import { isDefined } from './isDefined';
+import { isDefined } from "./isDefined";
 
 /**
  * @internal

--- a/sdk/eventhub/event-hubs/src/util/retries.ts
+++ b/sdk/eventhub/event-hubs/src/util/retries.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { Constants, RetryOptions } from "@azure/core-amqp";
+import { isDefined } from './isDefined';
 
 /**
  * @internal
@@ -9,7 +10,7 @@ import { Constants, RetryOptions } from "@azure/core-amqp";
  */
 export function getRetryAttemptTimeoutInMs(retryOptions: RetryOptions | undefined): number {
   const timeoutInMs =
-    retryOptions == undefined ||
+    !isDefined(retryOptions) ||
     typeof retryOptions.timeoutInMs !== "number" ||
     !isFinite(retryOptions.timeoutInMs) ||
     retryOptions.timeoutInMs < Constants.defaultOperationTimeoutInMs

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -275,7 +275,9 @@ describe("EventHubConsumerClient with non existent namespace", function(): void 
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => { /* no-op */ },
+        processEvents: async () => {
+          /* no-op */
+        },
         processError: async (err) => {
           resolve(err);
         }
@@ -419,7 +421,9 @@ describe("EventHubConsumerClient with non existent event hub", function(): void 
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => { /* no-op */ },
+        processEvents: async () => {
+          /* no-op */
+        },
         processError: async (err) => {
           resolve(err);
         }
@@ -666,7 +670,9 @@ describe("EventHubConsumerClient after close()", function(): void {
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => { /* no-op */ },
+        processEvents: async () => {
+          /* no-op */
+        },
         processError: async (err) => {
           resolve(err);
         }

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -275,7 +275,7 @@ describe("EventHubConsumerClient with non existent namespace", function(): void 
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => {},
+        processEvents: async () => { /* no-op */ },
         processError: async (err) => {
           resolve(err);
         }
@@ -419,7 +419,7 @@ describe("EventHubConsumerClient with non existent event hub", function(): void 
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => {},
+        processEvents: async () => { /* no-op */ },
         processError: async (err) => {
           resolve(err);
         }
@@ -579,7 +579,7 @@ describe("EventHubProducerClient User Agent String", function(): void {
   });
 });
 
-function testUserAgentString(context: ConnectionContext, customValue?: string) {
+function testUserAgentString(context: ConnectionContext, customValue?: string): void {
   const packageVersion = packageJsonInfo.version;
   const properties = context.connection.options.properties;
   properties!["user-agent"].should.startWith(
@@ -666,7 +666,7 @@ describe("EventHubConsumerClient after close()", function(): void {
     let subscription: Subscription | undefined;
     const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
       subscription = client.subscribe({
-        processEvents: async () => {},
+        processEvents: async () => { /* no-op */ },
         processError: async (err) => {
           resolve(err);
         }

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -45,8 +45,12 @@ describe("EventHubConsumerClient", () => {
   describe("unit tests", () => {
     it("isCheckpointStore", () => {
       isCheckpointStore({
-        processEvents: async () => { /* no-op */ },
-        processClose: async () => { /* no-op */ }
+        processEvents: async () => {
+          /* no-op */
+        },
+        processClose: async () => {
+          /* no-op */
+        }
       }).should.not.equal(true);
 
       isCheckpointStore("hello").should.not.equal(true);
@@ -75,8 +79,6 @@ describe("EventHubConsumerClient", () => {
         return fakeEventProcessor;
       };
 
-      
-
       beforeEach(() => {
         fakeEventProcessor = createStubInstance(EventProcessor);
 
@@ -95,8 +97,12 @@ describe("EventHubConsumerClient", () => {
         );
 
         subscriptionHandlers = {
-          processEvents: async () => { /* no-op */ },
-          processError: async () => { /* no-op */ }
+          processEvents: async () => {
+            /* no-op */
+          },
+          processError: async () => {
+            /* no-op */
+          }
         };
 
         (client as any)["_createEventProcessor"] = fakeEventProcessorConstructor;
@@ -104,7 +110,9 @@ describe("EventHubConsumerClient", () => {
       });
 
       it("conflicting subscribes", () => {
-        validateOptions = () => { /* no-op */ };
+        validateOptions = () => {
+          /* no-op */
+        };
 
         client.subscribe(subscriptionHandlers);
         // invalid - we're already subscribed to a conflicting partition
@@ -635,7 +643,9 @@ describe("EventHubConsumerClient", () => {
         clients.push(consumerClient1, consumerClient2);
         let subscription2: Subscription | undefined;
         const subscriptionHandlers2: SubscriptionEventHandlers = {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents() {
             // stop this subscription since it already should have forced the 1st subscription to have an error.
             await subscription2!.close();
@@ -648,7 +658,9 @@ describe("EventHubConsumerClient", () => {
           close: 0
         };
         const subscriptionHandlers1: SubscriptionEventHandlers = {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents() {
             if (!handlerCalls.close) {
               // start the 2nd subscription that will kick the 1st subscription off
@@ -669,7 +681,7 @@ describe("EventHubConsumerClient", () => {
             handlerCalls.initialize++;
           }
         };
-        
+
         const subscription1 = consumerClient1.subscribe(partitionId, subscriptionHandlers1, {
           maxBatchSize: 1,
           maxWaitTimeInSeconds: 1
@@ -719,7 +731,9 @@ describe("EventHubConsumerClient", () => {
         }
 
         const subscriptionHandlers1: SubscriptionEventHandlers = {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(_, context) {
             partitionHandlerCalls[context.partitionId].processEvents = true;
           },
@@ -754,7 +768,9 @@ describe("EventHubConsumerClient", () => {
 
         const partitionsReadFromSub2 = new Set<string>();
         const subscriptionHandlers2: SubscriptionEventHandlers = {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(_, context) {
             partitionsReadFromSub2.add(context.partitionId);
           }
@@ -1071,8 +1087,12 @@ describe("EventHubConsumerClient", () => {
       let closeCalled = 0;
 
       const subscription = client.subscribe(partitionId, {
-        async processError() { /* no-op */ },
-        async processEvents() { /* no-op */ },
+        async processError() {
+          /* no-op */
+        },
+        async processEvents() {
+          /* no-op */
+        },
         async processClose() {
           closeCalled++;
         },
@@ -1115,8 +1135,12 @@ describe("EventHubConsumerClient", () => {
       let closeCalled = 0;
 
       const subscription = client.subscribe({
-        async processError() { /* no-op */ },
-        async processEvents() { /* no-op */ },
+        async processError() {
+          /* no-op */
+        },
+        async processEvents() {
+          /* no-op */
+        },
         async processClose() {
           closeCalled++;
         },
@@ -1158,7 +1182,9 @@ describe("EventHubConsumerClient", () => {
         let subscription: Subscription;
         const caughtErr: Error = await new Promise((resolve) => {
           subscription = client.subscribe({
-            processEvents: async () => { /* no-op */ },
+            processEvents: async () => {
+              /* no-op */
+            },
             processError: async (err, context) => {
               if (!context.partitionId) {
                 await subscription.close();
@@ -1187,7 +1213,9 @@ describe("EventHubConsumerClient", () => {
         const caughtErr: Error = await new Promise((resolve) => {
           // Subscribe to an invalid partition id to trigger a partition-specific error.
           subscription = client.subscribe("-1", {
-            processEvents: async () => { /* no-op */ },
+            processEvents: async () => {
+              /* no-op */
+            },
             processError: async (err, context) => {
               if (context.partitionId) {
                 await subscription.close();

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -91,8 +91,12 @@ describe("Event Processor", function(): void {
           EventHubConsumerClient.defaultConsumerGroupName,
           consumerClient["_context"],
           {
-            processEvents: async () => { /* no-op */ },
-            processError: async () => { /* no-op */ }
+            processEvents: async () => {
+              /* no-op */
+            },
+            processError: async () => {
+              /* no-op */
+            }
           },
           checkpointStore,
           {
@@ -129,7 +133,9 @@ describe("Event Processor", function(): void {
           listOwnership: async () => {
             return [];
           },
-          updateCheckpoint: async () => { /* no-op */ }
+          updateCheckpoint: async () => {
+            /* no-op */
+          }
         };
       }
 
@@ -229,7 +235,9 @@ describe("Event Processor", function(): void {
           EventHubConsumerClient.defaultConsumerGroupName,
           consumerClient["_context"],
           {
-            processEvents: async () => { /* no-op */ },
+            processEvents: async () => {
+              /* no-op */
+            },
             processError: async (err, context) => {
               // simulate the user messing up and accidentally throwing an error
               // we should just log it and not kill anything.
@@ -284,7 +292,9 @@ describe("Event Processor", function(): void {
         async listOwnership(): Promise<PartitionOwnership[]> {
           return [];
         },
-        async updateCheckpoint(): Promise<void> { /* no-op */ },
+        async updateCheckpoint(): Promise<void> {
+          /* no-op */
+        },
         async listCheckpoints(): Promise<Checkpoint[]> {
           return [];
         }
@@ -297,7 +307,9 @@ describe("Event Processor", function(): void {
           pumpManager.createPumpCalled = true;
         },
 
-        async removeAllPumps() { /* no-op */ },
+        async removeAllPumps() {
+          /* no-op */
+        },
 
         isReceivingFromPartition() {
           return false;
@@ -312,8 +324,12 @@ describe("Event Processor", function(): void {
         EventHubConsumerClient.defaultConsumerGroupName,
         consumerClient["_context"],
         {
-          processEvents: async () => { /* no-op */ },
-          processError: async () => { /* no-op */ }
+          processEvents: async () => {
+            /* no-op */
+          },
+          processError: async () => {
+            /* no-op */
+          }
         },
         checkpointStore,
         {
@@ -335,7 +351,7 @@ describe("Event Processor", function(): void {
 
       // when we fail to claim a partition we should _definitely_
       // not attempt to start a pump.
-      should.equal(pumpManager.createPumpCalled, false)
+      should.equal(pumpManager.createPumpCalled, false);
 
       // we'll attempt to claim a partition (but won't succeed)
       should.equal(checkpointStore.claimOwnershipCalled, true);
@@ -387,8 +403,12 @@ describe("Event Processor", function(): void {
           loopIntervalInMs: 1,
           maxWaitTimeInSeconds: 1,
           pumpManager: {
-            async createPump() { /* no-op */ },
-            async removeAllPumps(): Promise<void> { /* no-op */ },
+            async createPump() {
+              /* no-op */
+            },
+            async removeAllPumps(): Promise<void> {
+              /* no-op */
+            },
             isReceivingFromPartition() {
               return false;
             }
@@ -505,7 +525,9 @@ describe("Event Processor", function(): void {
       claimOwnership: async () => {
         throw new Error("Some random failure!");
       },
-      updateCheckpoint: async () => { /* no-op */ },
+      updateCheckpoint: async () => {
+        /* no-op */
+      },
       listCheckpoints: async () => []
     };
 
@@ -513,7 +535,9 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => { /* no-op */ },
+        processEvents: async () => {
+          /* no-op */
+        },
         processError: async (err, _) => {
           errors.push(err);
         }
@@ -617,8 +641,12 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => { /* no-op */ },
-        processError: async () => { /* no-op */ }
+        processEvents: async () => {
+          /* no-op */
+        },
+        processError: async () => {
+          /* no-op */
+        }
       },
       new InMemoryCheckpointStore(),
       {
@@ -636,8 +664,12 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => { /* no-op */ },
-        processError: async () => { /* no-op */ }
+        processEvents: async () => {
+          /* no-op */
+        },
+        processError: async () => {
+          /* no-op */
+        }
       },
       new InMemoryCheckpointStore(),
       { ...defaultOptions, ownerId: "hello", startPosition: latestEventPosition }
@@ -694,8 +726,12 @@ describe("Event Processor", function(): void {
         processInitialize: async () => {
           didPartitionProcessorStart = true;
         },
-        processEvents: async () => { /* no-op */ },
-        processError: async () => { /* no-op */ }
+        processEvents: async () => {
+          /* no-op */
+        },
+        processError: async () => {
+          /* no-op */
+        }
       },
       new InMemoryCheckpointStore(),
       {
@@ -760,7 +796,7 @@ describe("Event Processor", function(): void {
     await processor.stop();
 
     subscriptionEventHandler.hasErrors(partitionIds).should.equal(false);
-    subscriptionEventHandler.allShutdown(partitionIds).should.equal(true)
+    subscriptionEventHandler.allShutdown(partitionIds).should.equal(true);
   });
 
   describe("Partition processor", function(): void {
@@ -875,7 +911,7 @@ describe("Event Processor", function(): void {
           processedAtLeastOneEvent.add(context.partitionId);
 
           if (!partionCount[context.partitionId]) {
-            partionCount[context.partitionId] = 0
+            partionCount[context.partitionId] = 0;
           }
           partionCount[context.partitionId]++;
 
@@ -1491,7 +1527,9 @@ describe("Event Processor", function(): void {
         async processEvents(_events: ReceivedEventData[], context: PartitionContext) {
           partitionOwnershipArr.add(context.partitionId);
         }
-        async processError() { /* no-op */ }
+        async processError() {
+          /* no-op */
+        }
       }
 
       // create messages
@@ -1583,8 +1621,12 @@ describe("Event Processor", function(): void {
           claimedPartitions.add(partitionId);
           claimedPartitionsMap[eventProcessorId] = claimedPartitions;
         },
-        async processEvents() { /* no-op */ },
-        async processError() { /* no-op */ },
+        async processEvents() {
+          /* no-op */
+        },
+        async processError() {
+          /* no-op */
+        },
         async processClose(reason, context) {
           const eventProcessorId: string = (context as any).eventProcessorId;
           const partitionId = context.partitionId;
@@ -1745,8 +1787,12 @@ describe("Event Processor", function(): void {
           claimedPartitions.add(partitionId);
           claimedPartitionsMap[eventProcessorId] = claimedPartitions;
         },
-        async processEvents() { /* no-op */ },
-        async processError() { /* no-op */ },
+        async processEvents() {
+          /* no-op */
+        },
+        async processError() {
+          /* no-op */
+        },
         async processClose(reason, context) {
           const eventProcessorId: string = (context as any).eventProcessorId;
           const partitionId = context.partitionId;
@@ -1910,9 +1956,15 @@ function triggerAbortedSignalAfterNumCalls(maxCalls: number): AbortSignal {
 
       return false;
     },
-    addEventListener: () => { /* no-op */ },
-    removeEventListener: () => { /* no-op */ },
-    onabort: () => { /* no-op */ },
+    addEventListener: () => {
+      /* no-op */
+    },
+    removeEventListener: () => {
+      /* no-op */
+    },
+    onabort: () => {
+      /* no-op */
+    },
     dispatchEvent: () => true
   };
 

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -83,6 +83,56 @@ describe("Event Processor", function(): void {
 
   describe("unit tests", () => {
     describe("_getStartingPosition", () => {
+      function createEventProcessor(
+        checkpointStore: CheckpointStore,
+        startPosition?: FullEventProcessorOptions["startPosition"]
+      ) {
+        return new EventProcessor(
+          EventHubConsumerClient.defaultConsumerGroupName,
+          consumerClient["_context"],
+          {
+            processEvents: async () => { /* no-op */ },
+            processError: async () => { /* no-op */ }
+          },
+          checkpointStore,
+          {
+            startPosition,
+            maxBatchSize: 1,
+            maxWaitTimeInSeconds: 1,
+            loadBalancingStrategy: defaultOptions.loadBalancingStrategy,
+            loopIntervalInMs: defaultOptions.loopIntervalInMs
+          }
+        );
+      }
+
+      const emptyCheckpointStore = createCheckpointStore([]);
+
+      function createCheckpointStore(
+        checkpointsForTest: Pick<Checkpoint, "offset" | "sequenceNumber" | "partitionId">[]
+      ): CheckpointStore {
+        return {
+          claimOwnership: async () => {
+            return [];
+          },
+          listCheckpoints: async () => {
+            return checkpointsForTest.map((cp) => {
+              return {
+                fullyQualifiedNamespace: "not-used-for-this-test",
+                consumerGroup: "not-used-for-this-test",
+                eventHubName: "not-used-for-this-test",
+                offset: cp.offset,
+                sequenceNumber: cp.sequenceNumber,
+                partitionId: cp.partitionId
+              };
+            });
+          },
+          listOwnership: async () => {
+            return [];
+          },
+          updateCheckpoint: async () => { /* no-op */ }
+        };
+      }
+
       before(() => {
         consumerClient["_context"].managementSession!.getEventHubProperties = async () => {
           return Promise.resolve({
@@ -97,7 +147,7 @@ describe("Event Processor", function(): void {
         const processor = createEventProcessor(emptyCheckpointStore);
 
         const eventPosition = await processor["_getStartingPosition"]("0");
-        isLatestPosition(eventPosition).should.be.ok;
+        should.equal(isLatestPosition(eventPosition), true);
       });
 
       it("has a checkpoint", async () => {
@@ -158,58 +208,8 @@ describe("Event Processor", function(): void {
         should.not.exist(eventPositionForPartitionZero!.sequenceNumber);
 
         const eventPositionForPartitionOne = await processor["_getStartingPosition"]("1");
-        isLatestPosition(eventPositionForPartitionOne).should.be.ok;
+        should.equal(isLatestPosition(eventPositionForPartitionOne), true);
       });
-
-      function createEventProcessor(
-        checkpointStore: CheckpointStore,
-        startPosition?: FullEventProcessorOptions["startPosition"]
-      ) {
-        return new EventProcessor(
-          EventHubConsumerClient.defaultConsumerGroupName,
-          consumerClient["_context"],
-          {
-            processEvents: async () => {},
-            processError: async () => {}
-          },
-          checkpointStore,
-          {
-            startPosition,
-            maxBatchSize: 1,
-            maxWaitTimeInSeconds: 1,
-            loadBalancingStrategy: defaultOptions.loadBalancingStrategy,
-            loopIntervalInMs: defaultOptions.loopIntervalInMs
-          }
-        );
-      }
-
-      const emptyCheckpointStore = createCheckpointStore([]);
-
-      function createCheckpointStore(
-        checkpointsForTest: Pick<Checkpoint, "offset" | "sequenceNumber" | "partitionId">[]
-      ): CheckpointStore {
-        return {
-          claimOwnership: async () => {
-            return [];
-          },
-          listCheckpoints: async () => {
-            return checkpointsForTest.map((cp) => {
-              return {
-                fullyQualifiedNamespace: "not-used-for-this-test",
-                consumerGroup: "not-used-for-this-test",
-                eventHubName: "not-used-for-this-test",
-                offset: cp.offset,
-                sequenceNumber: cp.sequenceNumber,
-                partitionId: cp.partitionId
-              };
-            });
-          },
-          listOwnership: async () => {
-            return [];
-          },
-          updateCheckpoint: async () => {}
-        };
-      }
     });
 
     describe("_handleSubscriptionError", () => {
@@ -229,7 +229,7 @@ describe("Event Processor", function(): void {
           EventHubConsumerClient.defaultConsumerGroupName,
           consumerClient["_context"],
           {
-            processEvents: async () => {},
+            processEvents: async () => { /* no-op */ },
             processError: async (err, context) => {
               // simulate the user messing up and accidentally throwing an error
               // we should just log it and not kill anything.
@@ -284,7 +284,7 @@ describe("Event Processor", function(): void {
         async listOwnership(): Promise<PartitionOwnership[]> {
           return [];
         },
-        async updateCheckpoint(): Promise<void> {},
+        async updateCheckpoint(): Promise<void> { /* no-op */ },
         async listCheckpoints(): Promise<Checkpoint[]> {
           return [];
         }
@@ -297,7 +297,7 @@ describe("Event Processor", function(): void {
           pumpManager.createPumpCalled = true;
         },
 
-        async removeAllPumps() {},
+        async removeAllPumps() { /* no-op */ },
 
         isReceivingFromPartition() {
           return false;
@@ -312,8 +312,8 @@ describe("Event Processor", function(): void {
         EventHubConsumerClient.defaultConsumerGroupName,
         consumerClient["_context"],
         {
-          processEvents: async () => {},
-          processError: async () => {}
+          processEvents: async () => { /* no-op */ },
+          processError: async () => { /* no-op */ }
         },
         checkpointStore,
         {
@@ -335,10 +335,10 @@ describe("Event Processor", function(): void {
 
       // when we fail to claim a partition we should _definitely_
       // not attempt to start a pump.
-      pumpManager.createPumpCalled.should.be.false;
+      should.equal(pumpManager.createPumpCalled, false)
 
       // we'll attempt to claim a partition (but won't succeed)
-      checkpointStore.claimOwnershipCalled.should.be.true;
+      should.equal(checkpointStore.claimOwnershipCalled, true);
     });
 
     it("abandoned claims are treated as unowned claims", async () => {
@@ -387,8 +387,8 @@ describe("Event Processor", function(): void {
           loopIntervalInMs: 1,
           maxWaitTimeInSeconds: 1,
           pumpManager: {
-            async createPump() {},
-            async removeAllPumps(): Promise<void> {},
+            async createPump() { /* no-op */ },
+            async removeAllPumps(): Promise<void> { /* no-op */ },
             isReceivingFromPartition() {
               return false;
             }
@@ -416,7 +416,7 @@ describe("Event Processor", function(): void {
         triggerAbortedSignalAfterNumCalls(partitionIds.length * numTimesAbortedIsCheckedInLoop)
       );
 
-      handlers.errors.should.be.empty;
+      handlers.errors.should.deep.equal([]);
 
       const currentOwnerships = await checkpointStore.listOwnership(
         commonFields.fullyQualifiedNamespace,
@@ -505,7 +505,7 @@ describe("Event Processor", function(): void {
       claimOwnership: async () => {
         throw new Error("Some random failure!");
       },
-      updateCheckpoint: async () => {},
+      updateCheckpoint: async () => { /* no-op */ },
       listCheckpoints: async () => []
     };
 
@@ -513,7 +513,7 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => {},
+        processEvents: async () => { /* no-op */ },
         processError: async (err, _) => {
           errors.push(err);
         }
@@ -617,8 +617,8 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => {},
-        processError: async () => {}
+        processEvents: async () => { /* no-op */ },
+        processError: async () => { /* no-op */ }
       },
       new InMemoryCheckpointStore(),
       {
@@ -636,8 +636,8 @@ describe("Event Processor", function(): void {
       EventHubConsumerClient.defaultConsumerGroupName,
       consumerClient["_context"],
       {
-        processEvents: async () => {},
-        processError: async () => {}
+        processEvents: async () => { /* no-op */ },
+        processError: async () => { /* no-op */ }
       },
       new InMemoryCheckpointStore(),
       { ...defaultOptions, ownerId: "hello", startPosition: latestEventPosition }
@@ -680,8 +680,8 @@ describe("Event Processor", function(): void {
 
     receivedEvents.should.deep.equal(expectedMessages);
 
-    subscriptionEventHandler.hasErrors(partitionIds).should.be.false;
-    subscriptionEventHandler.allShutdown(partitionIds).should.be.true;
+    subscriptionEventHandler.hasErrors(partitionIds).should.equal(false);
+    subscriptionEventHandler.allShutdown(partitionIds).should.equal(true);
   });
 
   it("should not throw if stop is called without start", async function(): Promise<void> {
@@ -694,8 +694,8 @@ describe("Event Processor", function(): void {
         processInitialize: async () => {
           didPartitionProcessorStart = true;
         },
-        processEvents: async () => {},
-        processError: async () => {}
+        processEvents: async () => { /* no-op */ },
+        processError: async () => { /* no-op */ }
       },
       new InMemoryCheckpointStore(),
       {
@@ -707,7 +707,7 @@ describe("Event Processor", function(): void {
     // shutdown the processor
     await processor.stop();
 
-    didPartitionProcessorStart.should.be.false;
+    didPartitionProcessorStart.should.equal(false);
   });
 
   it("should support start after stopping", async function(): Promise<void> {
@@ -743,8 +743,8 @@ describe("Event Processor", function(): void {
 
     receivedEvents.should.deep.equal(expectedMessages);
 
-    subscriptionEventHandler.hasErrors(partitionIds).should.be.false;
-    subscriptionEventHandler.allShutdown(partitionIds).should.be.true;
+    subscriptionEventHandler.hasErrors(partitionIds).should.equal(false);
+    subscriptionEventHandler.allShutdown(partitionIds).should.equal(true);
 
     // validate correct events captured for each partition
 
@@ -759,8 +759,8 @@ describe("Event Processor", function(): void {
     loggerForTest(`Stopping processor again`);
     await processor.stop();
 
-    subscriptionEventHandler.hasErrors(partitionIds).should.be.false;
-    subscriptionEventHandler.allShutdown(partitionIds).should.be.true;
+    subscriptionEventHandler.hasErrors(partitionIds).should.equal(false);
+    subscriptionEventHandler.allShutdown(partitionIds).should.equal(true)
   });
 
   describe("Partition processor", function(): void {
@@ -792,8 +792,8 @@ describe("Event Processor", function(): void {
       // shutdown the processor
       await processor.stop();
 
-      subscriptionEventHandler.hasErrors(partitionIds).should.be.false;
-      subscriptionEventHandler.allShutdown(partitionIds).should.be.true;
+      subscriptionEventHandler.hasErrors(partitionIds).should.equal(false);
+      subscriptionEventHandler.allShutdown(partitionIds).should.equal(true);
 
       receivedEvents.should.deep.equal(expectedMessages);
     });
@@ -874,9 +874,10 @@ describe("Event Processor", function(): void {
         async processEvents(events: ReceivedEventData[], context: PartitionContext) {
           processedAtLeastOneEvent.add(context.partitionId);
 
-          !partionCount[context.partitionId]
-            ? (partionCount[context.partitionId] = 1)
-            : partionCount[context.partitionId]++;
+          if (!partionCount[context.partitionId]) {
+            partionCount[context.partitionId] = 0
+          }
+          partionCount[context.partitionId]++;
 
           const existingEvents = checkpointMap.get(context.partitionId)!;
 
@@ -983,7 +984,7 @@ describe("Event Processor", function(): void {
         firstEventsReceivedFromProcessor2[index++] = receivedEvents[0];
       }
 
-      didError.should.be.false;
+      didError.should.equal(false);
       index = 0;
       // validate correct events captured for each partition using checkpoint
       for (const partitionId of partitionIds) {
@@ -1211,7 +1212,7 @@ describe("Event Processor", function(): void {
             const n = Math.floor(partitionIds.length / 2);
             const numPartitions = partitionOwnershipMap.get(processorByName[friendlyName].id)!
               .length;
-            return numPartitions == n || numPartitions == n + 1;
+            return numPartitions === n || numPartitions === n + 1;
           };
 
           if (!isBalanced(`processor-1`) || !isBalanced(`processor-2`)) {
@@ -1234,8 +1235,8 @@ describe("Event Processor", function(): void {
       for (const partitionId of partitionIds) {
         const results = partitionResultsMap.get(partitionId)!;
         results.events.length.should.be.gte(1);
-        results.initialized.should.be.true;
-        (results.closeReason === CloseReason.Shutdown).should.be.true;
+        results.initialized.should.equal(true);
+        (results.closeReason === CloseReason.Shutdown).should.equal(true);
       }
     });
 
@@ -1368,7 +1369,7 @@ describe("Event Processor", function(): void {
             const n = Math.floor(partitionIds.length / 2);
             const numPartitions = partitionOwnershipMap.get(processorByName[friendlyName].id)!
               .length;
-            return numPartitions == n || numPartitions == n + 1;
+            return numPartitions === n || numPartitions === n + 1;
           };
 
           if (!isBalanced(`processor-1`) || !isBalanced(`processor-2`)) {
@@ -1391,8 +1392,8 @@ describe("Event Processor", function(): void {
       for (const partitionId of partitionIds) {
         const results = partitionResultsMap.get(partitionId)!;
         results.events.length.should.be.gte(1);
-        results.initialized.should.be.true;
-        (results.closeReason === CloseReason.Shutdown).should.be.true;
+        results.initialized.should.equal(true);
+        (results.closeReason === CloseReason.Shutdown).should.equal(true);
       }
     });
 
@@ -1471,7 +1472,7 @@ describe("Event Processor", function(): void {
         }
       }
 
-      didError.should.be.false;
+      didError.should.equal(false);
       const n = Math.floor(partitionIds.length / 2);
       partitionOwnershipMap.get(processorByName[`processor-0`].id)!.length.should.oneOf([n, n + 1]);
       partitionOwnershipMap.get(processorByName[`processor-1`].id)!.length.should.oneOf([n, n + 1]);
@@ -1490,7 +1491,7 @@ describe("Event Processor", function(): void {
         async processEvents(_events: ReceivedEventData[], context: PartitionContext) {
           partitionOwnershipArr.add(context.partitionId);
         }
-        async processError() {}
+        async processError() { /* no-op */ }
       }
 
       // create messages
@@ -1582,8 +1583,8 @@ describe("Event Processor", function(): void {
           claimedPartitions.add(partitionId);
           claimedPartitionsMap[eventProcessorId] = claimedPartitions;
         },
-        async processEvents() {},
-        async processError() {},
+        async processEvents() { /* no-op */ },
+        async processError() { /* no-op */ },
         async processClose(reason, context) {
           const eventProcessorId: string = (context as any).eventProcessorId;
           const partitionId = context.partitionId;
@@ -1672,7 +1673,7 @@ describe("Event Processor", function(): void {
             }
 
             // All partitions must be claimed.
-            const allPartitionsClaimed =
+            allPartitionsClaimed =
               aProcessorPartitions.size + bProcessorPartitions.size === partitionIds.length;
 
             if (!allPartitionsClaimed) {
@@ -1695,7 +1696,6 @@ describe("Event Processor", function(): void {
       }
 
       loggerForTest(`All partitions have been claimed.`);
-      allPartitionsClaimed = true;
 
       try {
         // loop for some time to see if thrashing occurs
@@ -1745,8 +1745,8 @@ describe("Event Processor", function(): void {
           claimedPartitions.add(partitionId);
           claimedPartitionsMap[eventProcessorId] = claimedPartitions;
         },
-        async processEvents() {},
-        async processError() {},
+        async processEvents() { /* no-op */ },
+        async processError() { /* no-op */ },
         async processClose(reason, context) {
           const eventProcessorId: string = (context as any).eventProcessorId;
           const partitionId = context.partitionId;
@@ -1835,7 +1835,7 @@ describe("Event Processor", function(): void {
             }
 
             // All partitions must be claimed.
-            const allPartitionsClaimed =
+            allPartitionsClaimed =
               aProcessorPartitions.size + bProcessorPartitions.size === partitionIds.length;
 
             if (!allPartitionsClaimed) {
@@ -1858,7 +1858,6 @@ describe("Event Processor", function(): void {
       }
 
       loggerForTest(`All partitions have been claimed.`);
-      allPartitionsClaimed = true;
 
       try {
         // loop for some time to see if thrashing occurs
@@ -1911,9 +1910,9 @@ function triggerAbortedSignalAfterNumCalls(maxCalls: number): AbortSignal {
 
       return false;
     },
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    onabort: () => {},
+    addEventListener: () => { /* no-op */ },
+    removeEventListener: () => { /* no-op */ },
+    onabort: () => { /* no-op */ },
     dispatchEvent: () => true
   };
 

--- a/sdk/eventhub/event-hubs/test/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventdata.spec.ts
@@ -35,12 +35,12 @@ const testSourceEventData: EventData = {
   properties: properties
 };
 
-const testEventData = fromRheaMessage(testMessage);
 const messageFromED = toRheaMessage(testSourceEventData);
 
 describe("EventData", function(): void {
   describe("fromRheaMessage", function(): void {
     it("populates body with the message body", function(): void {
+      const testEventData = fromRheaMessage(testMessage);
       testEventData.body.should.equal(testBody);
     });
 

--- a/sdk/eventhub/event-hubs/test/loadBalancingStrategy.spec.ts
+++ b/sdk/eventhub/event-hubs/test/loadBalancingStrategy.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import chai from 'chai';
+import chai from "chai";
 const should = chai.should();
 import { PartitionOwnership } from "../src/eventProcessor";
 import { BalancedLoadBalancingStrategy } from "../src/loadBalancerStrategies/balancedStrategy";

--- a/sdk/eventhub/event-hubs/test/loadBalancingStrategy.spec.ts
+++ b/sdk/eventhub/event-hubs/test/loadBalancingStrategy.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import chai from 'chai';
+const should = chai.should();
 import { PartitionOwnership } from "../src/eventProcessor";
 import { BalancedLoadBalancingStrategy } from "../src/loadBalancerStrategies/balancedStrategy";
 import { GreedyLoadBalancingStrategy } from "../src/loadBalancerStrategies/greedyStrategy";
@@ -33,7 +35,7 @@ describe("LoadBalancingStrategy", () => {
       const lb = new UnbalancedLoadBalancingStrategy();
 
       lb.getPartitionsToCliam("ownerId", m, ["1", "2", "3"]).should.deep.eq(["1", "2", "3"]);
-      m.should.be.empty;
+      should.equal(m.size, 0);
     });
 
     it("claim partitions we already own", () => {
@@ -201,7 +203,7 @@ describe("LoadBalancingStrategy", () => {
       // meet the minimum.
       const partitions = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
-      const lb = new BalancedLoadBalancingStrategy(1000 * 60);
+      const lbs = new BalancedLoadBalancingStrategy(1000 * 60);
 
       // we'll do 4 consumers
       const initialOwnershipMap = createOwnershipMap({
@@ -220,7 +222,7 @@ describe("LoadBalancingStrategy", () => {
         "9": "d"
       });
 
-      const requestedPartitions = lb.getPartitionsToCliam("c", initialOwnershipMap, partitions);
+      const requestedPartitions = lbs.getPartitionsToCliam("c", initialOwnershipMap, partitions);
       requestedPartitions.sort();
 
       requestedPartitions.should.deep.equal(
@@ -297,7 +299,7 @@ describe("LoadBalancingStrategy", () => {
 
     it("honors the partitionOwnershipExpirationIntervalInMs", () => {
       const intervalInMs = 1000;
-      const lb = new BalancedLoadBalancingStrategy(intervalInMs);
+      const lbs = new BalancedLoadBalancingStrategy(intervalInMs);
       const allPartitions = ["0", "1"];
       const ownershipMap = createOwnershipMap({
         "0": "b",
@@ -305,14 +307,14 @@ describe("LoadBalancingStrategy", () => {
       });
 
       // At this point, 'a' has its fair share of partitions, and none should be returned.
-      let partitionsToOwn = lb.getPartitionsToCliam("a", ownershipMap, allPartitions);
+      let partitionsToOwn = lbs.getPartitionsToCliam("a", ownershipMap, allPartitions);
       partitionsToOwn.length.should.equal(0, "Expected to not claim any new partitions.");
 
       // Change the ownership of partition "0" so it is older than the interval.
       const ownership = ownershipMap.get("0")!;
       ownership.lastModifiedTimeInMs = Date.now() - (intervalInMs + 1); // Add 1 to the interval to ensure it has just expired.
 
-      partitionsToOwn = lb.getPartitionsToCliam("a", ownershipMap, allPartitions);
+      partitionsToOwn = lbs.getPartitionsToCliam("a", ownershipMap, allPartitions);
       partitionsToOwn.should.deep.equal(["0"]);
     });
   });
@@ -441,7 +443,7 @@ describe("LoadBalancingStrategy", () => {
         allPartitions.push(`${i}`);
       }
 
-      let partitionsToOwn = lb.getPartitionsToCliam(
+      const partitionsToOwn = lb.getPartitionsToCliam(
         "a",
         createOwnershipMap({
           "0": "",
@@ -481,7 +483,7 @@ describe("LoadBalancingStrategy", () => {
       // meet the minimum.
       const partitions = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
-      const lb = new BalancedLoadBalancingStrategy(1000 * 60);
+      const lbs = new BalancedLoadBalancingStrategy(1000 * 60);
 
       // we'll do 4 consumers
       const initialOwnershipMap = createOwnershipMap({
@@ -500,7 +502,7 @@ describe("LoadBalancingStrategy", () => {
         "9": "d"
       });
 
-      const requestedPartitions = lb.getPartitionsToCliam("c", initialOwnershipMap, partitions);
+      const requestedPartitions = lbs.getPartitionsToCliam("c", initialOwnershipMap, partitions);
       requestedPartitions.sort();
 
       requestedPartitions.should.deep.equal(
@@ -577,7 +579,7 @@ describe("LoadBalancingStrategy", () => {
 
     it("honors the partitionOwnershipExpirationIntervalInMs", () => {
       const intervalInMs = 1000;
-      const lb = new GreedyLoadBalancingStrategy(intervalInMs);
+      const lbs = new GreedyLoadBalancingStrategy(intervalInMs);
       const allPartitions = ["0", "1", "2", "3"];
       const ownershipMap = createOwnershipMap({
         "0": "b",
@@ -585,7 +587,7 @@ describe("LoadBalancingStrategy", () => {
       });
 
       // At this point, "a" should only grab 1 partition since both "a" and "b" should end up with 2 partitions each.
-      let partitionsToOwn = lb.getPartitionsToCliam("a", ownershipMap, allPartitions);
+      let partitionsToOwn = lbs.getPartitionsToCliam("a", ownershipMap, allPartitions);
       partitionsToOwn.length.should.equal(1, "Expected to claim 1 new partitions.");
 
       // Change the ownership of partition "0" so it is older than the interval.
@@ -595,7 +597,7 @@ describe("LoadBalancingStrategy", () => {
       // At this point, "a" should grab partitions 0, 2, and 3.
       // This is because "b" only owned 1 partition and that claim is expired,
       // so "a" as treated as if it is the only owner.
-      partitionsToOwn = lb.getPartitionsToCliam("a", ownershipMap, allPartitions);
+      partitionsToOwn = lbs.getPartitionsToCliam("a", ownershipMap, allPartitions);
       partitionsToOwn.sort();
       partitionsToOwn.should.deep.equal(["0", "2", "3"]);
     });

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -335,12 +335,6 @@ describe("Misc tests", function(): void {
   it("should consistently send messages with partitionkey to a partitionId", async function(): Promise<
     void
   > {
-    const consumerClient = new EventHubConsumerClient(
-      EventHubConsumerClient.defaultConsumerGroupName,
-      service.connectionString!,
-      service.path
-    );
-
     const {
       subscriptionEventHandler,
       startPosition
@@ -398,7 +392,6 @@ describe("Misc tests", function(): void {
       if (subscription) {
         await subscription.close();
       }
-      await consumerClient.close();
     }
   });
 }).timeout(60000);

--- a/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
@@ -22,10 +22,6 @@ describe("PartitionPump", () => {
       public spanOptions: SpanOptions | undefined;
       public spanName: string | undefined;
 
-      constructor() {
-        super();
-      }
-
       startSpan(nameArg: string, optionsArg?: SpanOptions): TestSpan {
         this.spanName = nameArg;
         this.spanOptions = optionsArg;
@@ -105,10 +101,10 @@ describe("PartitionPump", () => {
       const tracer = new TestTracer();
       const span = tracer.startSpan("whatever");
 
-      await trace(async () => {}, span);
+      await trace(async () => { /* no-op */ }, span);
 
       span.status!.code.should.equal(CanonicalCode.OK);
-      span.endCalled.should.be.ok;
+      should.equal(span.endCalled, true);
     });
 
     it("trace - throws", async () => {
@@ -121,7 +117,7 @@ describe("PartitionPump", () => {
 
       span.status!.code.should.equal(CanonicalCode.UNKNOWN);
       span.status!.message!.should.equal("error thrown from fn");
-      span.endCalled.should.be.ok;
+      should.equal(span.endCalled, true);
     });
   });
 });

--- a/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
@@ -101,7 +101,9 @@ describe("PartitionPump", () => {
       const tracer = new TestTracer();
       const span = tracer.startSpan("whatever");
 
-      await trace(async () => { /* no-op */ }, span);
+      await trace(async () => {
+        /* no-op */
+      }, span);
 
       span.status!.code.should.equal(CanonicalCode.OK);
       should.equal(span.endCalled, true);

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -63,7 +63,7 @@ describe("EventHubConsumerClient", function(): void {
       let subscription: Subscription | undefined;
       await new Promise<void>((resolve, reject) => {
         subscription = consumerClient.subscribe(
-          // @ts-expect-error
+          // @ts-expect-error Testing that partitionId can be passed as a number for JS users.
           0,
           {
             processEvents: async () => {
@@ -704,7 +704,7 @@ describe("EventHubConsumerClient", function(): void {
       let subscription: Subscription | undefined;
       const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
         subscription = badConsumerClient.subscribe({
-          processEvents: async () => {},
+          processEvents: async () => { /* no-op */ },
           processError: async (err) => {
             resolve(err);
           }
@@ -723,7 +723,7 @@ describe("EventHubConsumerClient", function(): void {
       let subscription: Subscription | undefined;
       const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
         subscription = consumerClient.subscribe("boo", {
-          processEvents: async () => {},
+          processEvents: async () => { /* no-op */ },
           processError: async (err) => {
             resolve(err);
           }

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -704,7 +704,9 @@ describe("EventHubConsumerClient", function(): void {
       let subscription: Subscription | undefined;
       const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
         subscription = badConsumerClient.subscribe({
-          processEvents: async () => { /* no-op */ },
+          processEvents: async () => {
+            /* no-op */
+          },
           processError: async (err) => {
             resolve(err);
           }
@@ -723,7 +725,9 @@ describe("EventHubConsumerClient", function(): void {
       let subscription: Subscription | undefined;
       const caughtErr = await new Promise<Error | MessagingError>((resolve) => {
         subscription = consumerClient.subscribe("boo", {
-          processEvents: async () => { /* no-op */ },
+          processEvents: async () => {
+            /* no-op */
+          },
           processError: async (err) => {
             resolve(err);
           }

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -133,8 +133,9 @@ describe("EventHub Sender", function(): void {
       should.equal(batch.tryAdd({ body: list[1] }), false); // The Mike message will be rejected - it's over the limit.
       should.equal(batch.tryAdd({ body: list[2] }), true); // Marie should get added";
 
-
-      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(
+        producerClient
+      );
 
       const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
@@ -172,7 +173,9 @@ describe("EventHub Sender", function(): void {
       should.equal(batch.tryAdd({ body: list[0] }), true);
       should.equal(batch.tryAdd({ body: list[1] }), true);
 
-      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(
+        producerClient
+      );
 
       const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
@@ -208,7 +211,9 @@ describe("EventHub Sender", function(): void {
       should.equal(batch.tryAdd({ body: list[0] }), true);
       should.equal(batch.tryAdd({ body: list[1] }), true);
 
-      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(
+        producerClient
+      );
 
       const subscriber = consumerClient.subscribe(subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
@@ -247,7 +252,9 @@ describe("EventHub Sender", function(): void {
 
       const receivedEvents: ReceivedEventData[] = [];
       let waitUntilEventsReceivedResolver: (value?: any) => void;
-      const waitUntilEventsReceived = new Promise((resolve) => (waitUntilEventsReceivedResolver = resolve));
+      const waitUntilEventsReceived = new Promise(
+        (resolve) => (waitUntilEventsReceivedResolver = resolve)
+      );
 
       const sequenceNumber = (await consumerClient.getPartitionProperties("0"))
         .lastEnqueuedSequenceNumber;
@@ -255,7 +262,9 @@ describe("EventHub Sender", function(): void {
       const subscriber = consumerClient.subscribe(
         "0",
         {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(events) {
             receivedEvents.push(...events);
             if (receivedEvents.length >= 3) {
@@ -493,7 +502,9 @@ describe("EventHub Sender", function(): void {
 
   describe("Multiple sendBatch calls", function(): void {
     it("should be sent successfully in parallel", async function(): Promise<void> {
-      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(consumerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(
+        consumerClient
+      );
 
       const promises = [];
       for (let i = 0; i < 5; i++) {
@@ -501,7 +512,9 @@ describe("EventHub Sender", function(): void {
       }
       await Promise.all(promises);
 
-      const subscription = await consumerClient.subscribe(subscriptionEventHandler, { startPosition });
+      const subscription = await consumerClient.subscribe(subscriptionEventHandler, {
+        startPosition
+      });
 
       try {
         const events = await subscriptionEventHandler.waitForEvents(
@@ -726,7 +739,9 @@ describe("EventHub Sender", function(): void {
       const receivingPromise = new Promise((resolve) => (receivingResolver = resolve));
       const subscription = consumerClient.subscribe(
         {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();
@@ -754,7 +769,9 @@ describe("EventHub Sender", function(): void {
       const receivingPromise = new Promise((resolve) => (receivingResolver = resolve));
       const subscription = consumerClient.subscribe(
         {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();
@@ -787,7 +804,9 @@ describe("EventHub Sender", function(): void {
       const subscription = consumerClient.subscribe(
         partitionId,
         {
-          async processError() { /* no-op */ },
+          async processError() {
+            /* no-op */
+          },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -92,7 +92,7 @@ describe("EventHub Sender", function(): void {
 
     it("partitionId is set as expected when it is 0 i.e. falsy", async () => {
       const batch = await producerClient.createBatch({
-        //@ts-expect-error
+        // @ts-expect-error Ensure numbers can be passed as partitionKey for JS users.
         partitionId: 0
       });
       should.equal(batch.partitionId, "0");
@@ -107,7 +107,7 @@ describe("EventHub Sender", function(): void {
 
     it("partitionKey is set as expected when it is 0 i.e. falsy", async () => {
       const batch = await producerClient.createBatch({
-        //@ts-expect-error
+        // @ts-expect-error Ensure numbers can be passed as partitionKey for JS users.
         partitionKey: 0
       });
       should.equal(batch.partitionKey, "0");
@@ -129,18 +129,14 @@ describe("EventHub Sender", function(): void {
       should.not.exist(batch.partitionKey);
       batch.maxSizeInBytes.should.be.gt(0);
 
-      batch.tryAdd({ body: list[0] }).should.be.ok;
-      batch.tryAdd({ body: list[1] }).should.not.be.ok; // The Mike message will be rejected - it's over the limit.
-      batch.tryAdd({ body: list[2] }).should.be.ok; // Marie should get added";
+      should.equal(batch.tryAdd({ body: list[0] }), true);
+      should.equal(batch.tryAdd({ body: list[1] }), false); // The Mike message will be rejected - it's over the limit.
+      should.equal(batch.tryAdd({ body: list[2] }), true); // Marie should get added";
 
-      const {
-        subscriptionEventHandler,
-        startPosition
-      } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
 
-      const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, {
-        startPosition
-      });
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+
+      const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
 
       let receivedEvents;
@@ -165,7 +161,7 @@ describe("EventHub Sender", function(): void {
       const list = ["Albert", "Marie"];
 
       const batch = await producerClient.createBatch({
-        //@ts-expect-error
+        // @ts-expect-error Ensure numbers can be passed as partitionKey for JS users.
         partitionId: 0
       });
 
@@ -173,17 +169,12 @@ describe("EventHub Sender", function(): void {
       should.not.exist(batch.partitionKey);
       batch.maxSizeInBytes.should.be.gt(0);
 
-      batch.tryAdd({ body: list[0] }).should.be.ok;
-      batch.tryAdd({ body: list[1] }).should.be.ok;
+      should.equal(batch.tryAdd({ body: list[0] }), true);
+      should.equal(batch.tryAdd({ body: list[1] }), true);
 
-      const {
-        subscriptionEventHandler,
-        startPosition
-      } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
 
-      const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, {
-        startPosition
-      });
+      const subscriber = consumerClient.subscribe("0", subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
 
       let receivedEvents;
@@ -206,7 +197,7 @@ describe("EventHub Sender", function(): void {
       const list = ["Albert", "Marie"];
 
       const batch = await producerClient.createBatch({
-        //@ts-expect-error
+        // @ts-expect-error Ensure numbers can be passed as partitionKey for JS users.
         partitionKey: 0
       });
 
@@ -214,17 +205,12 @@ describe("EventHub Sender", function(): void {
       should.not.exist(batch.partitionId);
       batch.maxSizeInBytes.should.be.gt(0);
 
-      batch.tryAdd({ body: list[0] }).should.be.ok;
-      batch.tryAdd({ body: list[1] }).should.be.ok;
+      should.equal(batch.tryAdd({ body: list[0] }), true);
+      should.equal(batch.tryAdd({ body: list[1] }), true);
 
-      const {
-        subscriptionEventHandler,
-        startPosition
-      } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
 
-      const subscriber = consumerClient.subscribe(subscriptionEventHandler, {
-        startPosition
-      });
+      const subscriber = consumerClient.subscribe(subscriptionEventHandler, { startPosition });
       await producerClient.sendBatch(batch);
 
       let receivedEvents;
@@ -255,13 +241,13 @@ describe("EventHub Sender", function(): void {
 
       batch.maxSizeInBytes.should.be.gt(0);
 
-      batch.tryAdd(list[0]).should.be.ok;
-      batch.tryAdd(list[1]).should.be.ok;
-      batch.tryAdd(list[2]).should.be.ok;
+      should.equal(batch.tryAdd(list[0]), true);
+      should.equal(batch.tryAdd(list[1]), true);
+      should.equal(batch.tryAdd(list[2]), true);
 
       const receivedEvents: ReceivedEventData[] = [];
-      let waitUntilEventsReceivedResolver: Function;
-      const waitUntilEventsReceived = new Promise((r) => (waitUntilEventsReceivedResolver = r));
+      let waitUntilEventsReceivedResolver: (value?: any) => void;
+      const waitUntilEventsReceived = new Promise((resolve) => (waitUntilEventsReceivedResolver = resolve));
 
       const sequenceNumber = (await consumerClient.getPartitionProperties("0"))
         .lastEnqueuedSequenceNumber;
@@ -269,7 +255,7 @@ describe("EventHub Sender", function(): void {
       const subscriber = consumerClient.subscribe(
         "0",
         {
-          async processError() {},
+          async processError() { /* no-op */ },
           async processEvents(events) {
             receivedEvents.push(...events);
             if (receivedEvents.length >= 3) {
@@ -507,10 +493,7 @@ describe("EventHub Sender", function(): void {
 
   describe("Multiple sendBatch calls", function(): void {
     it("should be sent successfully in parallel", async function(): Promise<void> {
-      const {
-        subscriptionEventHandler,
-        startPosition
-      } = await SubscriptionHandlerForTests.startingFromHere(consumerClient);
+      const { subscriptionEventHandler } = await SubscriptionHandlerForTests.startingFromHere(consumerClient);
 
       const promises = [];
       for (let i = 0; i < 5; i++) {
@@ -518,9 +501,7 @@ describe("EventHub Sender", function(): void {
       }
       await Promise.all(promises);
 
-      const subscription = await consumerClient.subscribe(subscriptionEventHandler, {
-        startPosition
-      });
+      const subscription = await consumerClient.subscribe(subscriptionEventHandler, { startPosition });
 
       try {
         const events = await subscriptionEventHandler.waitForEvents(
@@ -740,12 +721,12 @@ describe("EventHub Sender", function(): void {
     it("should be sent successfully", async () => {
       const data: EventData[] = [{ body: "Hello World 1" }, { body: "Hello World 2" }];
       const receivedEvents: ReceivedEventData[] = [];
-      let receivingResolver: Function;
+      let receivingResolver: (value?: unknown) => void;
 
-      const receivingPromise = new Promise((r) => (receivingResolver = r));
+      const receivingPromise = new Promise((resolve) => (receivingResolver = resolve));
       const subscription = consumerClient.subscribe(
         {
-          async processError() {},
+          async processError() { /* no-op */ },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();
@@ -769,11 +750,11 @@ describe("EventHub Sender", function(): void {
     it("should be sent successfully with partitionKey", async () => {
       const data: EventData[] = [{ body: "Hello World 1" }, { body: "Hello World 2" }];
       const receivedEvents: ReceivedEventData[] = [];
-      let receivingResolver: Function;
-      const receivingPromise = new Promise((r) => (receivingResolver = r));
+      let receivingResolver: (value?: unknown) => void;
+      const receivingPromise = new Promise((resolve) => (receivingResolver = resolve));
       const subscription = consumerClient.subscribe(
         {
-          async processError() {},
+          async processError() { /* no-op */ },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();
@@ -801,12 +782,12 @@ describe("EventHub Sender", function(): void {
       const partitionId = "0";
       const data: EventData[] = [{ body: "Hello World 1" }, { body: "Hello World 2" }];
       const receivedEvents: ReceivedEventData[] = [];
-      let receivingResolver: Function;
-      const receivingPromise = new Promise((r) => (receivingResolver = r));
+      let receivingResolver: (value?: unknown) => void;
+      const receivingPromise = new Promise((resolve) => (receivingResolver = resolve));
       const subscription = consumerClient.subscribe(
         partitionId,
         {
-          async processError() {},
+          async processError() { /* no-op */ },
           async processEvents(events) {
             receivedEvents.push(...events);
             receivingResolver();
@@ -1033,7 +1014,7 @@ describe("EventHub Sender", function(): void {
       it("throws an error if partitionId and partitionKey are set and partitionId is 0 i.e. falsy", async () => {
         try {
           await producerClient.createBatch({
-            //@ts-expect-error
+            // @ts-expect-error Testing bad options.
             partitionId: 0,
             partitionKey: "boo"
           });
@@ -1049,7 +1030,7 @@ describe("EventHub Sender", function(): void {
         try {
           await producerClient.createBatch({
             partitionId: "1",
-            //@ts-expect-error
+            // @ts-expect-error Testing bad options.
             partitionKey: 0
           });
           throw new Error("Test failure");
@@ -1202,7 +1183,7 @@ describe("EventHub Sender", function(): void {
       it("throws an error if partitionId and partitionKey are set with partitionId set to 0 i.e. falsy", async () => {
         const badOptions: SendBatchOptions = {
           partitionKey: "foo",
-          //@ts-expect-error
+          // @ts-expect-error Testing bad options.
           partitionId: 0
         };
         const batch = [{ body: "Hello 1" }, { body: "Hello 2" }];
@@ -1217,7 +1198,7 @@ describe("EventHub Sender", function(): void {
       });
       it("throws an error if partitionId and partitionKey are set with partitionKey set to 0 i.e. falsy", async () => {
         const badOptions: SendBatchOptions = {
-          //@ts-expect-error
+          // @ts-expect-error Testing bad options.
           partitionKey: 0,
           partitionId: "0"
         };

--- a/sdk/eventhub/event-hubs/test/utils/fakeSubscriptionEventHandlers.ts
+++ b/sdk/eventhub/event-hubs/test/utils/fakeSubscriptionEventHandlers.ts
@@ -7,7 +7,7 @@ export class FakeSubscriptionEventHandlers implements SubscriptionEventHandlers 
   public events: Map<string, ReceivedEventData[]> = new Map();
   public errors: Error[] = [];
 
-  async processEvents(events: ReceivedEventData[], context: PartitionContext) {
+  async processEvents(events: ReceivedEventData[], context: PartitionContext): Promise<void> {
     for (const event of events) {
       let receivedEvents = this.events.get(context.partitionId);
 
@@ -20,7 +20,7 @@ export class FakeSubscriptionEventHandlers implements SubscriptionEventHandlers 
     }
   }
 
-  async processError(err: Error) {
+  async processError(err: Error): Promise<void> {
     this.errors.push(err);
   }
 }

--- a/sdk/eventhub/event-hubs/test/utils/logHelpers.ts
+++ b/sdk/eventhub/event-hubs/test/utils/logHelpers.ts
@@ -24,7 +24,7 @@ export class LogTester {
     debugModule.enable(loggers.map((logger) => logger.namespace).join(","));
   }
 
-  assert() {
+  assert(): void {
     this.close();
 
     if (this._expectedMessages.length > 0) {
@@ -32,7 +32,7 @@ export class LogTester {
     }
   }
 
-  private check(message: string) {
+  private check(message: string): void {
     for (let i = 0; i < this._expectedMessages.length; ++i) {
       const expectedMessage = this._expectedMessages[i];
       if (typeof expectedMessage === "string") {
@@ -49,7 +49,7 @@ export class LogTester {
     }
   }
 
-  private close() {
+  private close(): void {
     for (const logger of this._attachedLoggers) {
       logger.logger.enabled = logger.wasEnabled;
       logger.logger.log = logger.previousLogFunction;
@@ -59,7 +59,7 @@ export class LogTester {
     debugModule.disable();
   }
 
-  private attach(logger: debugModule.Debugger) {
+  private attach(logger: debugModule.Debugger): void {
     this._attachedLoggers.push({
       logger,
       wasEnabled: logger.enabled,

--- a/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
@@ -85,7 +85,7 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
       // So it's okay that initialize is called more than once per partition
       // in that case since the consumers, for a short time, can overlap as
       // load balancing occurs.
-      this.data.has(context.partitionId).should.not.be.ok;
+      should.equal(this.data.has(context.partitionId), false);
     }
 
     this.data.set(context.partitionId, {
@@ -138,7 +138,7 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
     console.log("All messages received");
   }
 
-  private async produceMessages(client: EventHubProducerClient) {
+  private async produceMessages(client: EventHubProducerClient): Promise<number> {
     const expectedMessagePrefix = `EventHubConsumerClient test - ${Date.now().toString()}`;
     const messagesToSend = [];
 
@@ -162,15 +162,15 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
   }
 
   private get(partitionId: string): ReceivedMessages {
-    this.data.has(partitionId).should.be.ok;
+    should.equal(this.data.has(partitionId), true);
     const receivedData = this.data.get(partitionId)!;
     return receivedData;
   }
 
   private contextIsOk(context: PartitionContext | PartitionContext): void {
-    context.consumerGroup.should.be.ok;
-    context.eventHubName.should.be.ok;
-    context.fullyQualifiedNamespace.should.be.ok;
+    should.exist(context.consumerGroup);
+    should.exist(context.eventHubName);
+    should.exist(context.fullyQualifiedNamespace);
 
     // if we start getting messages for other partitions
     // we should immediately error out)

--- a/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
@@ -110,7 +110,8 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
 
     countOfExpectedEvents = countOfExpectedEvents || partitionIds.length;
 
-    while (true) { // eslint-disable-line no-constant-condition
+    while (true) {
+      // eslint-disable-line no-constant-condition
       loggerForTest(`Received ${this.events.length} messages (need ${countOfExpectedEvents})`);
 
       if (this.events.length !== countOfExpectedEvents && !this.hasErrors(partitionIds)) {

--- a/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
@@ -56,15 +56,15 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
 
   public events: { partitionId: string; event: ReceivedEventData }[] = [];
 
-  async processInitialize(context: PartitionContext) {
+  async processInitialize(context: PartitionContext): Promise<void> {
     this.data.set(context.partitionId, {});
   }
 
-  async processClose(reason: CloseReason, context: PartitionContext) {
+  async processClose(reason: CloseReason, context: PartitionContext): Promise<void> {
     this.data.get(context.partitionId)!.closeReason = reason;
   }
 
-  async processEvents(events: ReceivedEventData[], context: PartitionContext) {
+  async processEvents(events: ReceivedEventData[], context: PartitionContext): Promise<void> {
     // by default we don't fill out the lastEnqueuedEventInfo field (they have to enable it
     // explicitly in the options for the processor).
     should.not.exist(context.lastEnqueuedEventProperties);
@@ -79,7 +79,7 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
     );
   }
 
-  async processError(err: Error, context: PartitionContext) {
+  async processError(err: Error, context: PartitionContext): Promise<void> {
     loggerForTest(`Error in partition ${context.partitionId}: ${err}`);
     should.exist(
       context.partitionId,
@@ -110,7 +110,7 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
 
     countOfExpectedEvents = countOfExpectedEvents || partitionIds.length;
 
-    while (true) {
+    while (true) { // eslint-disable-line no-constant-condition
       loggerForTest(`Received ${this.events.length} messages (need ${countOfExpectedEvents})`);
 
       if (this.events.length !== countOfExpectedEvents && !this.hasErrors(partitionIds)) {
@@ -147,7 +147,7 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
     });
   }
 
-  clear() {
+  clear(): void {
     this.data = new Map();
     this.events = [];
   }

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -11,6 +11,8 @@ import { NoOpTracer, TestTracer, setTracer } from "@azure/core-tracing";
 
 dotenv.config();
 
+declare const window: any;
+
 export const isNode =
   !!process && !!process.version && !!process.versions && !!process.versions.node;
 
@@ -26,7 +28,6 @@ function getEnvVarValue(name: string): string | undefined {
   if (isNode) {
     return process.env[name];
   } else {
-    // @ts-ignore
     return window.__env__[name];
   }
 }


### PR DESCRIPTION
Round 1 addressing #10777 
These changes addresses ~300 of the eslint errors and some warnings found by running eslint with the TSDoc rules disabled.

This leaves 13 errors and 51 warnings left after this PR is merged.

- 5 'options parameter type is not prefixed with the class|method name' errors. Fixing this changes the public API so holding off on this.
- 4 'Promise executor functions should not be async' errors. Fixing this will take a lot of care and I would want these to be reviewed on their own so they don't get lost in the noise.
- 2 'X was used before it was defined' errors. These are somewhat misleading because they are used within methods and defined before those methods can be invoked. We might be able to fix these if we refactor the async promise executor functions.
- 1 'Argument X should be types with a non-any type'. This isn't an external API so this should be fine. Need to think about best way to disable this (maybe just eslint-disable-line).
- 1 'N is already defined'. This is due to a constant matching an interface name.

