### PR TITLE
[Perf Tests] streamToBuffer helper method

### DIFF
--- a/sdk/test-utils/perfstress/src/index.ts
+++ b/sdk/test-utils/perfstress/src/index.ts
@@ -6,4 +6,4 @@ export * from "./options";
 export * from "./policy";
 export * from "./parallel";
 export * from "./program";
-export { getEnvVar, streamToBuffer } from "./utils";
+export { getEnvVar, readStream } from "./utils";

--- a/sdk/test-utils/perfstress/src/index.ts
+++ b/sdk/test-utils/perfstress/src/index.ts
@@ -6,4 +6,4 @@ export * from "./options";
 export * from "./policy";
 export * from "./parallel";
 export * from "./program";
-export { getEnvVar, readStream } from "./utils";
+export { getEnvVar, drainStream } from "./utils";

--- a/sdk/test-utils/perfstress/src/index.ts
+++ b/sdk/test-utils/perfstress/src/index.ts
@@ -6,4 +6,4 @@ export * from "./options";
 export * from "./policy";
 export * from "./parallel";
 export * from "./program";
-export { getEnvVar } from "./utils";
+export { getEnvVar, streamToBuffer } from "./utils";

--- a/sdk/test-utils/perfstress/src/utils.ts
+++ b/sdk/test-utils/perfstress/src/utils.ts
@@ -14,3 +14,17 @@ export function getEnvVar(name: string) {
   }
   return val;
 }
+
+/**
+ * Reads a readable stream. Doesn't save to a buffer.
+ *
+ * @export
+ * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
+ */
+export async function streamToBuffer(readableStream: NodeJS.ReadableStream) {
+  return new Promise((resolve, reject) => {
+    readableStream.on("data", () => {});
+    readableStream.on("end", resolve);
+    readableStream.on("error", reject);
+  });
+}

--- a/sdk/test-utils/perfstress/src/utils.ts
+++ b/sdk/test-utils/perfstress/src/utils.ts
@@ -21,7 +21,7 @@ export function getEnvVar(name: string) {
  * @export
  * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
  */
-export async function readStream(stream: NodeJS.ReadableStream) {
+export async function drainStream(stream: NodeJS.ReadableStream) {
   return new Promise((resolve, reject) => {
     stream.on("data", () => {});
     stream.on("end", resolve);

--- a/sdk/test-utils/perfstress/src/utils.ts
+++ b/sdk/test-utils/perfstress/src/utils.ts
@@ -21,10 +21,10 @@ export function getEnvVar(name: string) {
  * @export
  * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
  */
-export async function streamToBuffer(readableStream: NodeJS.ReadableStream) {
+export async function readStream(stream: NodeJS.ReadableStream) {
   return new Promise((resolve, reject) => {
-    readableStream.on("data", () => {});
-    readableStream.on("end", resolve);
-    readableStream.on("error", reject);
+    stream.on("data", () => {});
+    stream.on("end", resolve);
+    stream.on("error", reject);
   });
 }


### PR DESCRIPTION
This address the comment at https://github.com/Azure/azure-sdk-for-js/pull/12746#discussion_r546922303 by adding a new `readStream` method in perf framework so that it could be reused.

Inspired from https://github.com/Azure/azure-sdk-for-js/blob/ee733377bd63a7aba6e80b5cc0d895a251cb70e1/sdk/storage/storage-blob/src/utils/utils.node.ts#L118

This new method is meant to be used by the perf tests in various storage packages(in various different versions).
https://github.com/Azure/azure-sdk-for-js/pull/12737 https://github.com/Azure/azure-sdk-for-js/pull/12746 https://github.com/Azure/azure-sdk-for-js/pull/12806