### PR TITLE
[Text Analytics] Diagnose issue with test resources

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -599,7 +599,9 @@ describe("[API Key] TextAnalyticsClient", function() {
             }
           }
         );
-        await poller.cancelOperation();
+        if (!poller.isDone()) {
+          await poller.cancelOperation();
+        }
         assert.ok(poller.getOperationState().isCancelled);
       });
     });

--- a/sdk/textanalytics/test-resources.json
+++ b/sdk/textanalytics/test-resources.json
@@ -17,7 +17,7 @@
     },
     "cognitiveServicesEndpointSuffix": {
       "type": "string",
-      "defaultValue": "cognitiveservices.azure.com"
+      "defaultValue": ".cognitiveservices.azure.com"
     }
   },
   "variables": {
@@ -61,7 +61,7 @@
     },
     "ENDPOINT": {
       "type": "string",
-      "value": "[concat('https://', variables('accountName'), '.', parameters('cognitiveServicesEndpointSuffix'), '/')]"
+      "value": "[concat('https://', variables('accountName'), parameters('cognitiveServicesEndpointSuffix'), '/')]"
     }
   }
 }


### PR DESCRIPTION
Diagnosing why the endpoint has double dots (`https://textanalytics-tebb4f92e457542af..cognitiveservices.azure.com/`) in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=664806&view=logs&j=34d05327-3286-5fd0-44d3-76aebff5d924&t=69f66ec9-cb96-5533-f751-56577de2d134.

EDIT:
According to @danieljurek, we're overriding that default value with a "subscription configuration" secret that's handed to the ARM template. The "subscription configuration" is written as: `"cognitiveServicesEndpointSuffix": ".cognitiveservices.azure.com"`. So with the current way the ARM template is generating URLs you'll get your 2 dots in the URL and that's an error.