### PR TITLE
[Text Analytics] Cancel a healthcare job only if not completed

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -331,7 +331,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
 
   async cancel(): Promise<BeginAnalyzeHealthcarePollerOperation> {
     const state = this.state;
-    if (state.jobId) {
+    if (state.jobId && !state.isCompleted) {
       await this.client.cancelHealthJob(state.jobId, this.options.health);
     }
     state.isCancelled = true;


### PR DESCRIPTION
If we attempt to cancel an already completed job, we will get a service error saying the job has already been completed. I think it would be better to not send the cancellation request if the job has already been completed so the user does not get this error error. It would be nice to have a way to tell the service to cleanup the job results in this case, perhaps using the same cancellation API. What does the crew think?