### PR TITLE
[Text Analytics] [3.1-preview.3 design] Exposing job's metadata as part of the poller state for LROs

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_job_metadata.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_job_metadata.json
@@ -1,0 +1,1295 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:15 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11328.13 - WUS2 ProdSlices",
+    "x-ms-request-id": "e31ef6c4-bd27-49d2-a98a-ed3d7e0c0402"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze",
+   "query": {},
+   "requestBody": "{\"displayName\":\"testJob\",\"tasks\":{\"entityRecognitionPiiTasks\":[{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}}]},\"analysisInput\":{\"documents\":[{\"id\":\"1\",\"text\":\"I will go to the park.\"},{\"id\":\"2\",\"text\":\"Este es un document escrito en Español.\"},{\"id\":\"3\",\"text\":\"猫は幸せ\"}]}}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "apim-request-id": "d905cac3-0baf-45cc-9d7b-8cc2aa7d176f",
+    "date": "Tue, 29 Dec 2020 01:37:16 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "455"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:16Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:16Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "responseHeaders": {
+    "apim-request-id": "8f0b26a5-9199-48df-b47d-92c15c16bfba",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:16 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "16"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:16Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:16Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "responseHeaders": {
+    "apim-request-id": "3a9061ef-3483-449b-ae98-2457693772f6",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:16 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "22"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "5e30a9e5-0b59-4f12-a3d2-71e8fd5f9396",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "104"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "4cdd9309-14f1-4aff-98f2-4708b46106c9",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:21 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "51"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "dfc8c3ff-424d-47cd-923e-532be1adece2",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "77"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "14a175d6-0581-4ca9-bad3-e34c08170135",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:25 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "34"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "1d3e2a4c-d9a5-4ea3-871f-a3bd49ac4c27",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:27 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "6ead2818-6369-4042-a5f1-63e0a8078c61",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:30 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "102"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "729abc93-9c70-46a1-94f8-f5c3f9c70546",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:32 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "70"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "1c08e68c-52e9-4e6f-a2ad-5c271b9df160",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:34 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "75"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "f8dbefbc-05fd-4795-ab12-18de55d27c36",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:36 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "dae40e23-123b-4c7e-8f95-2c5e8bbc09f8",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:38 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "38"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "b546ec16-1ac9-41b9-ba55-17096f332867",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:40 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "67"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "fab8130e-cb4e-4795-a848-8ef2a39c086f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "119"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "93adb31a-af54-4e36-a345-7dc64eee6d46",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "45"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "b3214066-578a-4323-90e1-6903e83aa62c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:46 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "75"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:46 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11328.13 - WUS2 ProdSlices",
+    "x-ms-request-id": "695fdd98-cea7-4f02-861a-22448dae5302"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "cd9e917b-b6ff-48a1-bd82-b67bf66df90c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:48 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "67"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "6345036a-ffde-4d3c-aadf-8557ddf163ad",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:50 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "35"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a8b8b9ca-ff47-4354-ae8d-1ea998bff7ed",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:53 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "66"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "8cca72bd-a647-47ab-a78a-35a2edf98e5d",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:55 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "45"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "907ae0bf-8e90-4c9d-ad33-f4def228f35f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:57 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "95b5c400-f9fa-4c2b-a82d-4801f23d07a5",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:37:59 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "52d46614-5156-46b7-9569-b26bc64f5a8c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:01 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "78"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "265112e7-70fc-4519-83c9-a1dafff0d732",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:04 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "1102"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "3f6d5790-6fa3-46df-b9fd-847e5fccd227",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:06 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "40"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "be109dec-ccfe-40c7-a2f4-86e489789b13",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:08 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "41"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "d3c7da0f-ff97-47d3-bb8e-c7879689c74c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:10 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "34"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "037f26f9-ca78-4d4f-b964-071bc24e8392",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:12 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "43"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "e54ff9f3-3946-4679-9932-1795f35703ff",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:14 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:17 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11328.13 - WUS2 ProdSlices",
+    "x-ms-request-id": "695fdd98-cea7-4f02-861a-22442bb55302"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "9d1f7e6c-b4d7-4762-a251-bd54a7638674",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:16 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "c63bb934-5961-45ea-aded-038662743ae0",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "71"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "9389f096-c9d6-49d3-9b5a-87800cd4855f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:21 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "73"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "fd87289f-d71f-49ac-8be1-37f3c2c64eec",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "40"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "f42cb855-4234-4fa5-8250-341a77c1f566",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:27 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "2096"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "83a96748-67f7-47bf-9db4-ce1387ea491f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:30 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "40"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "0640cfad-be54-41cd-9e25-3ac6fbf3f029",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:32 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "43"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "870af33a-82e0-4c99-9051-38d0e3d134c6",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:34 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "40"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "0c7fe4de-a1ed-4057-9316-323ed2e7732a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:36 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "41"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "2dcf15dd-a144-4cce-b47c-cb5d9df84865",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:38 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "35"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "377cf21e-f817-44fe-962c-1445bfc4ed34",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:40 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "76"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "d50723ee-d297-44bc-b0d3-3c4c586f11a9",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a16ecef9-3b06-4f73-bdcd-26c90383e46f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "66"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "9eccd4d8-88e0-4812-93c5-721e215d4405",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:46 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "45"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "8d82b6e2-9c0d-4b4a-bc5b-976d6f6a4a60",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:48 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "38"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:48 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11328.13 - EUS ProdSlices",
+    "x-ms-request-id": "e7724430-617f-4448-930a-b72ed2663202"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "5499733f-4603-4a87-8824-2745915b64da",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:50 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "40"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "9fd55db7-cf0c-4cb6-bcc3-a16a4908f05d",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:53 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "112"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "b753b7c1-d87a-40fb-878d-ab7f07fb5d41",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:55 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "34"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "7cfa3030-51a3-4027-b884-57a06346f82a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:57 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "35"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "ceb11313-88e8-48c9-a9df-89a8d1168106",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:38:59 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "77"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "dbbdd3d0-a9ec-4122-a791-bec3475c32c4",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:01 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "71"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "f71740ad-6bb1-4a99-91a7-50766d453f22",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:03 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "87"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a7a23dbb-f234-4cb9-a01d-d1b66cc02b09",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:05 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "74"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a67430f4-c175-4ff5-bbe4-f3cfcd64b6a3",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:07 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "42"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "7f784b03-9c07-4222-a052-c64ca81b7349",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:09 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "46"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "1685dbfa-bca9-447b-94f3-152f422cb884",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:11 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "49"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "8abd6615-dd84-4a9d-a275-626c02cba53b",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:13 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "49"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "6a721ab2-cb1f-4853-a12b-6db94f644f6d",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:15 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "44"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "0e24d608-4c9d-4f62-915b-813c12b6d6fd",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:17 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "65"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:19 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11328.13 - NCUS ProdSlices",
+    "x-ms-request-id": "80083987-8d47-4292-8498-980ddc134102"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "727d5b99-c022-40ff-ade6-575655434f93",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "95"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "bc1139af-a081-4e0c-bebf-44c2145383d4",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:22 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "32"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"8bb8f3eb-c660-45e1-88e3-e720390a1237_637447968000000000\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\",\"createdDateTime\":\"2020-12-29T01:37:16Z\",\"expirationDateTime\":\"2020-12-30T01:37:16Z\",\"status\":\"succeeded\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18Z\"},\"completed\":1,\"failed\":0,\"inProgress\":0,\"total\":1,\"entityRecognitionPiiTasks\":[{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2020-12-29T01:37:18.0497207Z\",\"results\":{\"inTerminalState\":true,\"documents\":[{\"redactedText\":\"I will go to the park.\",\"id\":\"1\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"Este es un document escrito en Español.\",\"id\":\"2\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"猫は幸せ\",\"id\":\"3\",\"entities\":[],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "0bec56e0-b534-4fad-b86b-f0fbb0a9b5ec",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 29 Dec 2020 01:39:24 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "73"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "76b407d217e3e4578342f673654cb5fb"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/api_key_textanalyticsclient_lros_health/recording_job_metadata.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/api_key_textanalyticsclient_lros_health/recording_job_metadata.json
@@ -10,32 +10,89 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "apim-request-id": "74999ccb-b70b-44d6-9af6-6aea269885f5",
-    "date": "Mon, 28 Dec 2020 20:13:00 GMT",
-    "operation-location": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/19b51ca8-2bf7-480d-9076-ec81582b5fbf",
+    "apim-request-id": "c27d439a-baba-40fe-ad17-40f4cbbdfee1",
+    "date": "Mon, 28 Dec 2020 20:42:52 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/e39d6a62-5a41-46e8-83ef-295d695d0d9c",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "355"
+    "x-envoy-upstream-service-time": "86"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/19b51ca8-2bf7-480d-9076-ec81582b5fbf",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/e39d6a62-5a41-46e8-83ef-295d695d0d9c",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"19b51ca8-2bf7-480d-9076-ec81582b5fbf\",\"lastUpdateDateTime\":\"2020-12-28T20:13:01Z\",\"createdDateTime\":\"2020-12-28T20:13:00Z\",\"expirationDateTime\":\"2020-12-29T20:13:00Z\",\"status\":\"notStarted\",\"errors\":[]}",
+   "response": "{\"jobId\":\"e39d6a62-5a41-46e8-83ef-295d695d0d9c\",\"lastUpdateDateTime\":\"2020-12-28T20:42:53Z\",\"createdDateTime\":\"2020-12-28T20:42:53Z\",\"expirationDateTime\":\"2020-12-29T20:42:53Z\",\"status\":\"notStarted\",\"errors\":[]}",
    "responseHeaders": {
-    "apim-request-id": "82ecd03e-8f7c-4350-b329-e8ea445940a7",
+    "apim-request-id": "1b27c96d-28b9-4eae-a085-1e50542d1456",
     "content-type": "application/json; charset=utf-8",
-    "date": "Mon, 28 Dec 2020 20:13:00 GMT",
+    "date": "Mon, 28 Dec 2020 20:42:52 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "6"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/e39d6a62-5a41-46e8-83ef-295d695d0d9c",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"e39d6a62-5a41-46e8-83ef-295d695d0d9c\",\"lastUpdateDateTime\":\"2020-12-28T20:42:53Z\",\"createdDateTime\":\"2020-12-28T20:42:53Z\",\"expirationDateTime\":\"2020-12-29T20:42:53Z\",\"status\":\"notStarted\",\"errors\":[]}",
+   "responseHeaders": {
+    "apim-request-id": "a7d1364a-d051-4acd-83df-894003320408",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 28 Dec 2020 20:42:52 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "14"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/e39d6a62-5a41-46e8-83ef-295d695d0d9c",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"e39d6a62-5a41-46e8-83ef-295d695d0d9c\",\"lastUpdateDateTime\":\"2020-12-28T20:42:53Z\",\"createdDateTime\":\"2020-12-28T20:42:53Z\",\"expirationDateTime\":\"2020-12-29T20:42:53Z\",\"status\":\"notStarted\",\"errors\":[]}",
+   "responseHeaders": {
+    "apim-request-id": "7f796bb0-32ee-4099-bf05-2c705d97ce35",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 28 Dec 2020 20:42:54 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
     "x-envoy-upstream-service-time": "7"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/e39d6a62-5a41-46e8-83ef-295d695d0d9c",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"e39d6a62-5a41-46e8-83ef-295d695d0d9c\",\"lastUpdateDateTime\":\"2020-12-28T20:42:56Z\",\"createdDateTime\":\"2020-12-28T20:42:53Z\",\"expirationDateTime\":\"2020-12-29T20:42:53Z\",\"status\":\"succeeded\",\"errors\":[],\"results\":{\"documents\":[{\"id\":\"1\",\"entities\":[{\"offset\":29,\"length\":4,\"text\":\"high\",\"category\":\"MeasurementValue\",\"confidenceScore\":0.93,\"isNegated\":false},{\"offset\":34,\"length\":14,\"text\":\"blood pressure\",\"category\":\"ExaminationName\",\"confidenceScore\":0.91,\"isNegated\":true,\"links\":[{\"dataSource\":\"UMLS\",\"id\":\"C0005824\"},{\"dataSource\":\"AOD\",\"id\":\"0000007392\"},{\"dataSource\":\"CCC\",\"id\":\"K33.1\"},{\"dataSource\":\"CHV\",\"id\":\"0000002009\"},{\"dataSource\":\"ICNP\",\"id\":\"10031996\"},{\"dataSource\":\"LCH_NW\",\"id\":\"sh85015011\"},{\"dataSource\":\"MDR\",\"id\":\"10076581\"},{\"dataSource\":\"MEDCIN\",\"id\":\"6045\"},{\"dataSource\":\"MSH\",\"id\":\"D001795\"},{\"dataSource\":\"SNM\",\"id\":\"P-Y107\"},{\"dataSource\":\"SNMI\",\"id\":\"PA-00540\"},{\"dataSource\":\"SNOMEDCT_US\",\"id\":\"46973005\"}]}],\"relations\":[{\"relationType\":\"ValueOfExamination\",\"bidirectional\":false,\"source\":\"#/results/documents/0/entities/0\",\"target\":\"#/results/documents/0/entities/1\"}],\"warnings\":[]},{\"id\":\"2\",\"entities\":[{\"offset\":11,\"length\":5,\"text\":\"100mg\",\"category\":\"Dosage\",\"confidenceScore\":1.0,\"isNegated\":false},{\"offset\":17,\"length\":9,\"text\":\"ibuprofen\",\"category\":\"MedicationName\",\"confidenceScore\":1.0,\"isNegated\":false,\"links\":[{\"dataSource\":\"UMLS\",\"id\":\"C0020740\"},{\"dataSource\":\"AOD\",\"id\":\"0000019879\"},{\"dataSource\":\"ATC\",\"id\":\"M01AE01\"},{\"dataSource\":\"CCPSS\",\"id\":\"0046165\"},{\"dataSource\":\"CHV\",\"id\":\"0000006519\"},{\"dataSource\":\"CSP\",\"id\":\"2270-2077\"},{\"dataSource\":\"DRUGBANK\",\"id\":\"DB01050\"},{\"dataSource\":\"GS\",\"id\":\"1611\"},{\"dataSource\":\"LCH_NW\",\"id\":\"sh97005926\"},{\"dataSource\":\"LNC\",\"id\":\"LP16165-0\"},{\"dataSource\":\"MEDCIN\",\"id\":\"40458\"},{\"dataSource\":\"MMSL\",\"id\":\"d00015\"},{\"dataSource\":\"MSH\",\"id\":\"D007052\"},{\"dataSource\":\"MTHSPL\",\"id\":\"WK2XYI10QM\"},{\"dataSource\":\"NCI\",\"id\":\"C561\"},{\"dataSource\":\"NCI_CTRP\",\"id\":\"C561\"},{\"dataSource\":\"NCI_DCP\",\"id\":\"00803\"},{\"dataSource\":\"NCI_DTP\",\"id\":\"NSC0256857\"},{\"dataSource\":\"NCI_FDA\",\"id\":\"WK2XYI10QM\"},{\"dataSource\":\"NCI_NCI-GLOSS\",\"id\":\"CDR0000613511\"},{\"dataSource\":\"NDDF\",\"id\":\"002377\"},{\"dataSource\":\"PDQ\",\"id\":\"CDR0000040475\"},{\"dataSource\":\"RCD\",\"id\":\"x02MO\"},{\"dataSource\":\"RXNORM\",\"id\":\"5640\"},{\"dataSource\":\"SNM\",\"id\":\"E-7772\"},{\"dataSource\":\"SNMI\",\"id\":\"C-603C0\"},{\"dataSource\":\"SNOMEDCT_US\",\"id\":\"387207008\"},{\"dataSource\":\"USP\",\"id\":\"m39860\"},{\"dataSource\":\"USPMG\",\"id\":\"MTHU000060\"},{\"dataSource\":\"VANDF\",\"id\":\"4017840\"}]},{\"offset\":34,\"length\":11,\"text\":\"twice daily\",\"category\":\"Frequency\",\"confidenceScore\":1.0,\"isNegated\":false}],\"relations\":[{\"relationType\":\"DosageOfMedication\",\"bidirectional\":false,\"source\":\"#/results/documents/1/entities/0\",\"target\":\"#/results/documents/1/entities/1\"},{\"relationType\":\"FrequencyOfMedication\",\"bidirectional\":false,\"source\":\"#/results/documents/1/entities/2\",\"target\":\"#/results/documents/1/entities/1\"}],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2020-09-03\"}}",
+   "responseHeaders": {
+    "apim-request-id": "3b51d4ac-3deb-48ec-8c8b-d4032d9d27e0",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 28 Dec 2020 20:42:56 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "100"
    }
   }
  ],
@@ -43,5 +100,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "454ad0de963e97c8bd01d24b121e2865"
+ "hash": "ce4e194b8b610696870903ac2dfeec4f"
 }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/api_key_textanalyticsclient_lros_health/recording_job_metadata.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/api_key_textanalyticsclient_lros_health/recording_job_metadata.json
@@ -1,0 +1,47 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs",
+   "query": {
+    "stringIndexType": "Utf16CodeUnit"
+   },
+   "requestBody": "{\"documents\":[{\"id\":\"1\",\"text\":\"Patient does not suffer from high blood pressure.\",\"language\":\"en\"},{\"id\":\"2\",\"text\":\"Prescribed 100mg ibuprofen, taken twice daily.\",\"language\":\"en\"}]}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "apim-request-id": "74999ccb-b70b-44d6-9af6-6aea269885f5",
+    "date": "Mon, 28 Dec 2020 20:13:00 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/19b51ca8-2bf7-480d-9076-ec81582b5fbf",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "355"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/19b51ca8-2bf7-480d-9076-ec81582b5fbf",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"19b51ca8-2bf7-480d-9076-ec81582b5fbf\",\"lastUpdateDateTime\":\"2020-12-28T20:13:01Z\",\"createdDateTime\":\"2020-12-28T20:13:00Z\",\"expirationDateTime\":\"2020-12-29T20:13:00Z\",\"status\":\"notStarted\",\"errors\":[]}",
+   "responseHeaders": {
+    "apim-request-id": "82ecd03e-8f7c-4350-b329-e8ea445940a7",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 28 Dec 2020 20:13:00 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "7"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "454ad0de963e97c8bd01d24b121e2865"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_job_metadata.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_job_metadata.js
@@ -1,0 +1,1429 @@
+let nock = require('nock');
+
+module.exports.hash = "f7498d74f6f9a29ceccde964fe73a18a";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2509c19b-ead4-4eca-af85-e08a15d6db01',
+  'x-ms-ests-server',
+  '2.1.11328.13 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag7Gql5Twf5MhtL48gR0olpz_bg1AQAAALh-fNcOAAAA; expires=Thu, 28-Jan-2021 01:34:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 29 Dec 2020 01:34:48 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.1-preview.3/analyze', {"displayName":"testJob","tasks":{"entityRecognitionPiiTasks":[{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}}]},"analysisInput":{"documents":[{"id":"1","text":"I will go to the park."},{"id":"2","text":"Este es un document escrito en Español."},{"id":"3","text":"猫は幸せ"}]}})
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'operation-location',
+  'https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000',
+  'x-envoy-upstream-service-time',
+  '503',
+  'apim-request-id',
+  '9b129b3d-51cd-4586-8f3e-edcef42b90ed',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:34:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:54Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"notStarted","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:54Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '279',
+  'apim-request-id',
+  'fb6ba3b8-5392-4e46-b252-3fc63b134041',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:34:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:54Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"notStarted","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:54Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '105',
+  'apim-request-id',
+  '8f6e32a4-0161-433f-bb96-feb8165380ef',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:34:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '366',
+  'apim-request-id',
+  'e0e76d8a-adcb-46e8-8fe4-d51419074529',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:34:58 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '69',
+  'apim-request-id',
+  'd2d1adae-2630-48ef-a19a-cf0ae18bcb2a',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:00 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '133',
+  'apim-request-id',
+  'efe0b37f-ef68-4e18-8a76-3709565f17d6',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:02 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '140',
+  'apim-request-id',
+  '1bf021a4-260f-44bf-b2c6-388f84f227e1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:04 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '102',
+  'apim-request-id',
+  '439b6545-39a6-4d18-8a98-da22327d5075',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:06 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '33',
+  'apim-request-id',
+  '75dbfd07-15ca-4fab-8e4c-7ce16ce95d3f',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:08 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '46',
+  'apim-request-id',
+  'a85e55d1-f37a-4fac-9574-0b7ce67d8f88',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:10 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '39',
+  'apim-request-id',
+  '74542fe7-35e1-4eef-9a16-8bf8740510d7',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:12 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '40',
+  'apim-request-id',
+  'd4559c83-4705-499e-aac4-0f8a503182bb',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:14 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '76',
+  'apim-request-id',
+  '54212ba1-b9f3-4847-9e3b-782d803fa564',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:17 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  '91c67423-13f8-47e4-b6b5-c726df176d67',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:19 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'b727b4af-214d-414e-b73c-606342422e02',
+  'x-ms-ests-server',
+  '2.1.11328.13 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag7Gql5Twf5MhtL48gR0olpz_bg1AgAAALh-fNcOAAAA; expires=Thu, 28-Jan-2021 01:35:19 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:19 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '110',
+  'apim-request-id',
+  '81676ccf-eafc-4180-b7da-9739c88f53a0',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:21 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '46',
+  'apim-request-id',
+  '5993643e-cc19-4f73-8d5b-2df2f421c145',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:23 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '69',
+  'apim-request-id',
+  '0c7deec9-b223-4c5c-8ce6-32c85f8b2566',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:25 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '45',
+  'apim-request-id',
+  'c52bd59f-28cf-4105-b712-483b4e8736c6',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:27 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '44',
+  'apim-request-id',
+  '9a50a541-99f5-48d0-a4f6-b88ad83cc3aa',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:29 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '74',
+  'apim-request-id',
+  'a6953a5b-a017-455a-995f-647cd6d3c287',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:31 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '79',
+  'apim-request-id',
+  '2405df46-ad1d-4ee5-8403-f8690077a40e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:33 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '77',
+  'apim-request-id',
+  '1ca56571-aa11-47c4-9c50-73bf9a4ff558',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:36 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '36',
+  'apim-request-id',
+  '2541dbce-2cac-42ce-a3f1-2befe3dce3eb',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:38 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  'b33ccd86-7daf-4ef8-bf15-f8291380d820',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:40 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  '8da4dd0b-c7b2-4966-bfc9-98c7b76a0648',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:43 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '70',
+  'apim-request-id',
+  'fe624f52-7618-4ac5-b83e-3df188609863',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:45 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '78',
+  'apim-request-id',
+  '66234481-8d97-4638-a3cc-1b477c7786ae',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:47 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '69',
+  'apim-request-id',
+  'e0cba622-7519-44af-85de-928401b20955',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:49 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  '1260793d-5386-49dd-8617-76e4c89d777e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:51 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '27f2771d-174d-433f-bbb7-1a9f572c4102',
+  'x-ms-ests-server',
+  '2.1.11328.13 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag7Gql5Twf5MhtL48gR0olpz_bg1AwAAALh-fNcOAAAA; expires=Thu, 28-Jan-2021 01:35:51 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:51 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '75',
+  'apim-request-id',
+  '862285a5-d528-4856-b5f1-ad5475f04723',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:53 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  '9c3ea4d6-80f7-4c97-a0ce-ef959f0c899d',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '63',
+  'apim-request-id',
+  '233808de-0ce6-4a20-b631-70e067048f1b',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:57 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '67',
+  'apim-request-id',
+  '9594304c-863e-4a5e-980a-300d50f22ae2',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:35:59 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '78',
+  'apim-request-id',
+  'b5dc4e64-bafb-4903-bff2-cfccf4b328fc',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:01 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  '4058e485-042e-406b-9d16-0ec64a9bccfc',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:03 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '75',
+  'apim-request-id',
+  'd6745f9b-b73c-4fab-966a-78d37d58274b',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:05 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '49',
+  'apim-request-id',
+  'b380f852-78f3-4e91-9310-35931e7f57b9',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:08 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '49',
+  'apim-request-id',
+  '6b29d2ff-0c1d-47f8-9c0a-afd93dc6589d',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:10 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '43',
+  'apim-request-id',
+  '1c5f2b38-0ff4-46c1-9f42-2f34480a61ae',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:12 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '35',
+  'apim-request-id',
+  'fc00daec-c6a1-482e-bc53-97107ee47fc2',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:14 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  'b22d2daf-0ff3-4cc0-b650-45c50de3a6ba',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:16 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '41',
+  'apim-request-id',
+  'e25e7176-e7d2-458f-b7a4-fdeacff36b8f',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:18 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '101',
+  'apim-request-id',
+  '5b3a5093-e912-4150-b679-6b1814b7612c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:20 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  'f70db183-68f2-4ce9-9d1b-51a9e8425612',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:22 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'e10b13d8-b73a-4ab1-9656-3429cfa44502',
+  'x-ms-ests-server',
+  '2.1.11328.13 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag7Gql5Twf5MhtL48gR0olpz_bg1BAAAALh-fNcOAAAA; expires=Thu, 28-Jan-2021 01:36:23 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:22 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '77',
+  'apim-request-id',
+  '0aca1527-8d90-493a-9a4a-645263163647',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:24 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '70',
+  'apim-request-id',
+  '241eb10e-164a-41b1-b1f2-edfacc502891',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:27 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '110',
+  'apim-request-id',
+  'a6630ed3-6608-4481-96b8-311682c20623',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:29 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '75',
+  'apim-request-id',
+  'f189411d-1a59-44a5-b971-85f5c2c33679',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:31 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '41',
+  'apim-request-id',
+  '669e6c2b-fbd0-4b57-b119-a7de68adcd31',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:33 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '60',
+  'apim-request-id',
+  '1bb68462-db3d-437e-8a33-c28f8132cff3',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:35 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '72',
+  'apim-request-id',
+  '29664d49-76e6-4131-a482-c2fbda231e73',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:37 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '70',
+  'apim-request-id',
+  'b0dd2757-a4ac-48f3-b9a0-a066604eb893',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:39 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '40',
+  'apim-request-id',
+  '7e76c261-33b7-483a-9a73-b34c6b85c810',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:42 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '39',
+  'apim-request-id',
+  'ee4784c7-1cad-47ee-860f-1d7d80b55b13',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:44 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '65',
+  'apim-request-id',
+  'eee1d096-b507-4207-899d-062f1ca618dd',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:46 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '71',
+  'apim-request-id',
+  '03e2fe79-007f-4a19-9f01-9215ab03f753',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:48 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '44',
+  'apim-request-id',
+  '923b8247-4229-4e9b-83fa-e63e8f89fc91',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:50 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '46',
+  'apim-request-id',
+  '7238df7a-03bc-421e-a8f8-01aa00bcdf55',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:52 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '36',
+  'apim-request-id',
+  'e7cb36a9-916b-4624-8aab-7e451fcdc54b',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:54 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '5c1c0802-892b-457f-8118-5ad79d544402',
+  'x-ms-ests-server',
+  '2.1.11328.13 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag7Gql5Twf5MhtL48gR0olpz_bg1BQAAALh-fNcOAAAA; expires=Thu, 28-Jan-2021 01:36:55 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:54 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '67',
+  'apim-request-id',
+  'c687f2a9-0c78-467c-b17b-9f798271502a',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:56 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '67',
+  'apim-request-id',
+  '22dfb2a6-1588-4958-9048-91beebc917f4',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:36:58 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '47',
+  'apim-request-id',
+  '4053f3e3-4953-4c5f-a0ad-3adea7c901e4',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:37:01 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"70ac7205-b654-4567-89b0-ad2fe001db4c_637447968000000000","lastUpdateDateTime":"2020-12-29T01:34:56Z","createdDateTime":"2020-12-29T01:34:54Z","expirationDateTime":"2020-12-30T01:34:54Z","status":"succeeded","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56Z"},"completed":1,"failed":0,"inProgress":0,"total":1,"entityRecognitionPiiTasks":[{"name":"testJob","lastUpdateDateTime":"2020-12-29T01:34:56.0303439Z","results":{"inTerminalState":true,"documents":[{"redactedText":"I will go to the park.","id":"1","entities":[],"warnings":[]},{"redactedText":"Este es un document escrito en Español.","id":"2","entities":[],"warnings":[]},{"redactedText":"猫は幸せ","id":"3","entities":[],"warnings":[]}],"errors":[],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '346',
+  'apim-request-id',
+  'ba07261a-9790-4325-9a0d-ae73757079ab',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Tue, 29 Dec 2020 01:37:03 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_job_metadata.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_job_metadata.js
@@ -11,95 +11,135 @@ nock('https://endpoint', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'operation-location',
-  'https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472',
+  'https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05',
   'x-envoy-upstream-service-time',
-  '565',
+  '321',
   'apim-request-id',
-  'a414688a-fe85-4af8-b99b-927c5dfae2c9',
+  '88372926-fdfd-4856-aa0c-9355cbcbe889',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 28 Dec 2020 20:12:51 GMT'
+  'Mon, 28 Dec 2020 20:42:37 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
   .query(true)
-  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:38Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"notStarted","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '9',
+  '249',
   'apim-request-id',
-  '2041e529-43f4-45a9-9985-94ab6996bf6b',
+  'bafa2bd2-5ae7-4278-bc63-219c2f534c8d',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 28 Dec 2020 20:12:51 GMT'
+  'Mon, 28 Dec 2020 20:42:38 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
   .query(true)
-  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:38Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"notStarted","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '10',
+  '186',
   'apim-request-id',
-  '9723da1e-03d2-49a3-85cc-656195fc06a0',
+  '241ce560-c875-4c96-9bc5-9135a075205e',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 28 Dec 2020 20:12:51 GMT'
+  'Mon, 28 Dec 2020 20:42:38 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
   .query(true)
-  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:38Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"notStarted","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '12',
+  '269',
   'apim-request-id',
-  'ee32c91f-320e-4b00-a73e-a4f95a8e5440',
+  'b4c81c04-2e9f-4588-93a6-ce2a5ae037a4',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 28 Dec 2020 20:12:53 GMT'
+  'Mon, 28 Dec 2020 20:42:40 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
   .query(true)
-  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:55Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"1","entities":[{"offset":29,"length":4,"text":"high","category":"MeasurementValue","confidenceScore":0.93,"isNegated":false},{"offset":34,"length":14,"text":"blood pressure","category":"ExaminationName","confidenceScore":0.91,"isNegated":true,"links":[{"dataSource":"UMLS","id":"C0005824"},{"dataSource":"AOD","id":"0000007392"},{"dataSource":"CCC","id":"K33.1"},{"dataSource":"CHV","id":"0000002009"},{"dataSource":"ICNP","id":"10031996"},{"dataSource":"LCH_NW","id":"sh85015011"},{"dataSource":"MDR","id":"10076581"},{"dataSource":"MEDCIN","id":"6045"},{"dataSource":"MSH","id":"D001795"},{"dataSource":"SNM","id":"P-Y107"},{"dataSource":"SNMI","id":"PA-00540"},{"dataSource":"SNOMEDCT_US","id":"46973005"}]}],"relations":[{"relationType":"ValueOfExamination","bidirectional":false,"source":"#/results/documents/0/entities/0","target":"#/results/documents/0/entities/1"}],"warnings":[]},{"id":"2","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":1,"isNegated":false},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"isNegated":false,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1,"isNegated":false}],"relations":[{"relationType":"DosageOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/0","target":"#/results/documents/1/entities/1"},{"relationType":"FrequencyOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/2","target":"#/results/documents/1/entities/1"}],"warnings":[]}],"errors":[],"modelVersion":"2020-09-03"}}, [
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:38Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"notStarted","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '48',
+  '153',
   'apim-request-id',
-  '3ff1e112-b64a-4b39-b842-ee501e93a82c',
+  '1c2b04d4-8c4e-4f2e-8337-355a3b055f87',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Mon, 28 Dec 2020 20:12:55 GMT'
+  'Mon, 28 Dec 2020 20:42:42 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
+  .query(true)
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:38Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"notStarted","errors":[]}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '181',
+  'apim-request-id',
+  'ddef53b5-5000-40c7-a5b1-1f188f4ce88a',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:42:44 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/edfd406c-7cd3-4de0-b76c-6d340f3ddf05')
+  .query(true)
+  .reply(200, {"jobId":"edfd406c-7cd3-4de0-b76c-6d340f3ddf05","lastUpdateDateTime":"2020-12-28T20:42:47Z","createdDateTime":"2020-12-28T20:42:38Z","expirationDateTime":"2020-12-29T20:42:38Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"1","entities":[{"offset":29,"length":4,"text":"high","category":"MeasurementValue","confidenceScore":0.93,"isNegated":false},{"offset":34,"length":14,"text":"blood pressure","category":"ExaminationName","confidenceScore":0.91,"isNegated":true,"links":[{"dataSource":"UMLS","id":"C0005824"},{"dataSource":"AOD","id":"0000007392"},{"dataSource":"CCC","id":"K33.1"},{"dataSource":"CHV","id":"0000002009"},{"dataSource":"ICNP","id":"10031996"},{"dataSource":"LCH_NW","id":"sh85015011"},{"dataSource":"MDR","id":"10076581"},{"dataSource":"MEDCIN","id":"6045"},{"dataSource":"MSH","id":"D001795"},{"dataSource":"SNM","id":"P-Y107"},{"dataSource":"SNMI","id":"PA-00540"},{"dataSource":"SNOMEDCT_US","id":"46973005"}]}],"relations":[{"relationType":"ValueOfExamination","bidirectional":false,"source":"#/results/documents/0/entities/0","target":"#/results/documents/0/entities/1"}],"warnings":[]},{"id":"2","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":1,"isNegated":false},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"isNegated":false,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1,"isNegated":false}],"relations":[{"relationType":"DosageOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/0","target":"#/results/documents/1/entities/1"},{"relationType":"FrequencyOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/2","target":"#/results/documents/1/entities/1"}],"warnings":[]}],"errors":[],"modelVersion":"2020-09-03"}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '472',
+  'apim-request-id',
+  'e712c5dd-0f06-4f39-b94f-86466de9a6c6',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:42:47 GMT'
 ]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_job_metadata.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_job_metadata.js
@@ -1,0 +1,105 @@
+let nock = require('nock');
+
+module.exports.hash = "4b79eadddaad1235c0d80281d06ab707";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.1-preview.3/entities/health/jobs', {"documents":[{"id":"1","text":"Patient does not suffer from high blood pressure.","language":"en"},{"id":"2","text":"Prescribed 100mg ibuprofen, taken twice daily.","language":"en"}]})
+  .query(true)
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'operation-location',
+  'https://endpoint/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472',
+  'x-envoy-upstream-service-time',
+  '565',
+  'apim-request-id',
+  'a414688a-fe85-4af8-b99b-927c5dfae2c9',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:12:51 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .query(true)
+  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '9',
+  'apim-request-id',
+  '2041e529-43f4-45a9-9985-94ab6996bf6b',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:12:51 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .query(true)
+  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '10',
+  'apim-request-id',
+  '9723da1e-03d2-49a3-85cc-656195fc06a0',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:12:51 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .query(true)
+  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:51Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"notStarted","errors":[]}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '12',
+  'apim-request-id',
+  'ee32c91f-320e-4b00-a73e-a4f95a8e5440',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:12:53 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/entities/health/jobs/a308d10c-2551-4aaf-b4ba-84c3c3f9e472')
+  .query(true)
+  .reply(200, {"jobId":"a308d10c-2551-4aaf-b4ba-84c3c3f9e472","lastUpdateDateTime":"2020-12-28T20:12:55Z","createdDateTime":"2020-12-28T20:12:51Z","expirationDateTime":"2020-12-29T20:12:51Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"1","entities":[{"offset":29,"length":4,"text":"high","category":"MeasurementValue","confidenceScore":0.93,"isNegated":false},{"offset":34,"length":14,"text":"blood pressure","category":"ExaminationName","confidenceScore":0.91,"isNegated":true,"links":[{"dataSource":"UMLS","id":"C0005824"},{"dataSource":"AOD","id":"0000007392"},{"dataSource":"CCC","id":"K33.1"},{"dataSource":"CHV","id":"0000002009"},{"dataSource":"ICNP","id":"10031996"},{"dataSource":"LCH_NW","id":"sh85015011"},{"dataSource":"MDR","id":"10076581"},{"dataSource":"MEDCIN","id":"6045"},{"dataSource":"MSH","id":"D001795"},{"dataSource":"SNM","id":"P-Y107"},{"dataSource":"SNMI","id":"PA-00540"},{"dataSource":"SNOMEDCT_US","id":"46973005"}]}],"relations":[{"relationType":"ValueOfExamination","bidirectional":false,"source":"#/results/documents/0/entities/0","target":"#/results/documents/0/entities/1"}],"warnings":[]},{"id":"2","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":1,"isNegated":false},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"isNegated":false,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1,"isNegated":false}],"relations":[{"relationType":"DosageOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/0","target":"#/results/documents/1/entities/1"},{"relationType":"FrequencyOfMedication","bidirectional":false,"source":"#/results/documents/1/entities/2","target":"#/results/documents/1/entities/1"}],"warnings":[]}],"errors":[],"modelVersion":"2020-09-03"}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '48',
+  'apim-request-id',
+  '3ff1e112-b64a-4b39-b842-ee501e93a82c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 28 Dec 2020 20:12:55 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -14,6 +14,10 @@ import { PollOperationState } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
+export interface AnalysisPollOperationState<TResult> extends PollOperationState<TResult>, JobMetadata {
+}
+
+// @public
 export interface AnalyzeJobOptions extends OperationOptions {
     includeStatistics?: boolean;
 }
@@ -71,12 +75,13 @@ export interface AspectSentiment {
 export { AzureKeyCredential }
 
 // @public
-export type BeginAnalyzeHealthcareOperationState = PollOperationState<PaginatedHealthcareEntities>;
-
-// @public
 export interface BeginAnalyzeHealthcareOptions {
     health?: HealthcareJobOptions;
     polling?: PollingOptions;
+}
+
+// @public
+export interface BeginAnalyzeHealthcarePollState extends AnalysisPollOperationState<PaginatedHealthcareEntities> {
 }
 
 // @public
@@ -212,7 +217,7 @@ export interface HealthcareSuccessResult extends TextAnalyticsSuccessResult {
 }
 
 // @public
-export type HealthPollerLike = PollerLike<BeginAnalyzeHealthcareOperationState, PaginatedHealthcareEntities>;
+export type HealthPollerLike = PollerLike<BeginAnalyzeHealthcarePollState, PaginatedHealthcareEntities>;
 
 // @public
 export type InnerErrorCodeValue = "InvalidParameterValue" | "InvalidRequestBodyFormat" | "EmptyRequest" | "MissingInputRecords" | "InvalidDocument" | "ModelVersionIncorrect" | "InvalidDocumentBatch" | "UnsupportedLanguageCode" | "InvalidCountryHint" | string;
@@ -222,6 +227,15 @@ export interface JobManifestTasks {
     entityRecognitionPiiTasks?: PiiTask[];
     entityRecognitionTasks?: EntitiesTask[];
     keyPhraseExtractionTasks?: KeyPhrasesTask[];
+}
+
+// @public
+export interface JobMetadata {
+    createdAt?: Date;
+    expiredAt?: Date;
+    jobId?: string;
+    status?: State;
+    updatedAt?: Date;
 }
 
 // @public
@@ -391,6 +405,9 @@ export interface SentimentConfidenceScores {
     // (undocumented)
     positive: number;
 }
+
+// @public
+export type State = "notStarted" | "running" | "succeeded" | "failed" | "rejected" | "cancelled" | "cancelling" | "partiallyCompleted" | "partiallySucceeded";
 
 // @public
 export class TextAnalyticsClient {

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -17,13 +17,22 @@ import { TokenCredential } from '@azure/core-auth';
 export interface AnalysisPollOperationState<TResult> extends PollOperationState<TResult>, JobMetadata {
 }
 
+// @public (undocumented)
+export interface AnalyzeJobMetadata extends JobMetadata {
+    displayName?: string;
+    failedTasksCount?: number;
+    inProgressTasksCount?: number;
+    successfullyCompletedTasksCount?: number;
+}
+
 // @public
 export interface AnalyzeJobOptions extends OperationOptions {
+    displayName?: string;
     includeStatistics?: boolean;
 }
 
 // @public
-export type AnalyzePollerLike = PollerLike<BeginAnalyzeOperationState, PaginatedAnalyzeResults>;
+export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PaginatedAnalyzeResults>;
 
 // @public
 export interface AnalyzeResult {
@@ -85,12 +94,13 @@ export interface BeginAnalyzeHealthcarePollState extends AnalysisPollOperationSt
 }
 
 // @public
-export type BeginAnalyzeOperationState = PollOperationState<PaginatedAnalyzeResults>;
-
-// @public
 export interface BeginAnalyzeOptions {
     analyze?: AnalyzeJobOptions;
     polling?: PollingOptions;
+}
+
+// @public
+export interface BeginAnalyzePollState extends AnalysisPollOperationState<PaginatedAnalyzeResults>, AnalyzeJobMetadata {
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -32,7 +32,7 @@ export interface AnalyzeJobOptions extends OperationOptions {
 }
 
 // @public
-export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PaginatedAnalyzeResults>;
+export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PagedAnalyzeResults>;
 
 // @public
 export interface AnalyzeResult {
@@ -84,6 +84,12 @@ export interface AspectSentiment {
 export { AzureKeyCredential }
 
 // @public
+export interface BeginAnalyzeBatchTasksOptions {
+    analyze?: AnalyzeJobOptions;
+    polling?: PollingOptions;
+}
+
+// @public
 export interface BeginAnalyzeHealthcareOptions {
     healthcare?: HealthcareJobOptions;
     polling?: PollingOptions;
@@ -94,14 +100,13 @@ export interface BeginAnalyzeHealthcarePollState extends AnalysisPollOperationSt
 }
 
 // @public
-export interface BeginAnalyzeOptions {
-    analyze?: AnalyzeJobOptions;
-    polling?: PollingOptions;
+export interface BeginAnalyzePollState extends AnalysisPollOperationState<PagedAnalyzeResults>, AnalyzeJobMetadata {
 }
 
 // @public
-export interface BeginAnalyzePollState extends AnalysisPollOperationState<PaginatedAnalyzeResults>, AnalyzeJobMetadata {
-}
+export type CategorizedEntitiesRecognitionTask = {
+    modelVersion?: string;
+};
 
 // @public
 export interface CategorizedEntity extends Entity {
@@ -145,11 +150,6 @@ export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult 
 
 // @public
 export type DocumentSentimentLabel = "positive" | "neutral" | "negative" | "mixed";
-
-// @public
-export type EntitiesTask = {
-    modelVersion?: string;
-};
 
 // @public
 export interface Entity {
@@ -234,9 +234,9 @@ export type InnerErrorCodeValue = "InvalidParameterValue" | "InvalidRequestBodyF
 
 // @public
 export interface JobManifestTasks {
-    entityRecognitionPiiTasks?: PiiTask[];
-    entityRecognitionTasks?: EntitiesTask[];
-    keyPhraseExtractionTasks?: KeyPhrasesTask[];
+    entityRecognitionPiiTasks?: PiiEntitiesRecognitionTask[];
+    entityRecognitionTasks?: CategorizedEntitiesRecognitionTask[];
+    keyPhraseExtractionTasks?: KeyPhrasesExtractionTask[];
 }
 
 // @public
@@ -249,7 +249,7 @@ export interface JobMetadata {
 }
 
 // @public
-export interface KeyPhrasesTask {
+export interface KeyPhrasesExtractionTask {
     modelVersion?: string;
 }
 
@@ -282,21 +282,27 @@ export interface OpinionSentiment extends SentenceOpinion {
 }
 
 // @public
+export interface PagedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
+    statistics?: TextDocumentBatchStatistics;
+}
+
+// @public
 export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<AnalyzeResult, AnalyzeResult>;
 
 // @public
 export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<HealthcareResult, HealthcareEntitiesArray>;
 
 // @public
-export interface PaginatedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
-    statistics?: TextDocumentBatchStatistics;
-}
-
-// @public
 export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
     modelVersion: string;
     statistics?: TextDocumentBatchStatistics;
 }
+
+// @public
+export type PiiEntitiesRecognitionTask = {
+    domain?: PiiEntityDomainType;
+    modelVersion?: string;
+};
 
 // @public
 export interface PiiEntity extends Entity {
@@ -306,15 +312,6 @@ export interface PiiEntity extends Entity {
 export enum PiiEntityDomainType {
     PROTECTED_HEALTH_INFORMATION = "PHI"
 }
-
-// @public
-export type PiiTask = {
-    domain?: PiiTaskParametersDomain;
-    modelVersion?: string;
-};
-
-// @public
-export type PiiTaskParametersDomain = "phi" | "none" | string;
 
 // @public
 export interface PollingOptions {
@@ -424,8 +421,8 @@ export class TextAnalyticsClient {
     constructor(endpointUrl: string, credential: TokenCredential | KeyCredential, options?: TextAnalyticsClientOptions);
     analyzeSentiment(documents: string[], language?: string, options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultArray>;
     analyzeSentiment(documents: TextDocumentInput[], options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultArray>;
-    beginAnalyze(documents: string[], tasks: JobManifestTasks, language?: string, options?: BeginAnalyzeOptions): Promise<AnalyzePollerLike>;
-    beginAnalyze(documents: TextDocumentInput[], tasks: JobManifestTasks, options?: BeginAnalyzeOptions): Promise<AnalyzePollerLike>;
+    beginAnalyzeBatchTasks(documents: string[], tasks: JobManifestTasks, language?: string, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
+    beginAnalyzeBatchTasks(documents: TextDocumentInput[], tasks: JobManifestTasks, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
     beginAnalyzeHealthcare(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
     beginAnalyzeHealthcare(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
     defaultCountryHint: string;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -36,9 +36,9 @@ export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PagedAnalyzeRe
 
 // @public
 export interface AnalyzeResult {
-    entitiesRecognitionResults?: RecognizeCategorizedEntitiesResultArray[];
-    keyPhrasesExtractionResults?: ExtractKeyPhrasesResultArray[];
-    piiEntitiesRecognitionResults?: RecognizePiiEntitiesResultArray[];
+    entitiesRecognitionResults: RecognizeCategorizedEntitiesResultArray[];
+    keyPhrasesExtractionResults: ExtractKeyPhrasesResultArray[];
+    piiEntitiesRecognitionResults: RecognizePiiEntitiesResultArray[];
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -26,13 +26,7 @@ export interface AnalyzeJobMetadata extends JobMetadata {
 }
 
 // @public
-export interface AnalyzeJobOptions extends OperationOptions {
-    displayName?: string;
-    includeStatistics?: boolean;
-}
-
-// @public
-export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PagedAnalyzeResults>;
+export type AnalyzePollerLike = PollerLike<BeginAnalyzeOperationState, PagedAnalyzeResults>;
 
 // @public
 export interface AnalyzeResult {
@@ -84,23 +78,25 @@ export interface AspectSentiment {
 export { AzureKeyCredential }
 
 // @public
-export interface BeginAnalyzeBatchTasksOptions {
-    analyze?: AnalyzeJobOptions;
-    polling?: PollingOptions;
+export interface BeginAnalyzeBatchTasksOptions extends OperationOptions {
+    displayName?: string;
+    includeStatistics?: boolean;
+    resumeFrom?: string;
+    updateIntervalInMs?: number;
 }
 
 // @public
-export interface BeginAnalyzeHealthcareOptions {
-    healthcare?: HealthcareJobOptions;
-    polling?: PollingOptions;
+export interface BeginAnalyzeHealthcareOperationState extends AnalysisPollOperationState<PagedHealthcareEntities> {
 }
 
 // @public
-export interface BeginAnalyzeHealthcarePollState extends AnalysisPollOperationState<PaginatedHealthcareEntities> {
+export interface BeginAnalyzeHealthcareOptions extends TextAnalyticsOperationOptions {
+    resumeFrom?: string;
+    updateIntervalInMs?: number;
 }
 
 // @public
-export interface BeginAnalyzePollState extends AnalysisPollOperationState<PagedAnalyzeResults>, AnalyzeJobMetadata {
+export interface BeginAnalyzeOperationState extends AnalysisPollOperationState<PagedAnalyzeResults>, AnalyzeJobMetadata {
 }
 
 // @public
@@ -206,11 +202,7 @@ export interface HealthcareEntityLink {
 export type HealthcareErrorResult = TextAnalyticsErrorResult;
 
 // @public
-export interface HealthcareJobOptions extends TextAnalyticsOperationOptions {
-}
-
-// @public
-export type HealthcarePollerLike = PollerLike<BeginAnalyzeHealthcarePollState, PaginatedHealthcareEntities>;
+export type HealthcarePollerLike = PollerLike<BeginAnalyzeHealthcareOperationState, PagedHealthcareEntities>;
 
 // @public (undocumented)
 export interface HealthcareRelation {
@@ -241,11 +233,11 @@ export interface JobManifestTasks {
 
 // @public
 export interface JobMetadata {
-    createdAt?: Date;
-    expiresAt?: Date;
+    createdOn?: Date;
+    expiresOn?: Date;
     jobId?: string;
     status?: State;
-    updatedAt?: Date;
+    updatedOn?: Date;
 }
 
 // @public
@@ -293,7 +285,7 @@ export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<Analyz
 export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<HealthcareResult, HealthcareEntitiesArray>;
 
 // @public
-export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
+export interface PagedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
     modelVersion: string;
     statistics?: TextDocumentBatchStatistics;
 }
@@ -311,12 +303,6 @@ export interface PiiEntity extends Entity {
 // @public
 export enum PiiEntityDomainType {
     PROTECTED_HEALTH_INFORMATION = "PHI"
-}
-
-// @public
-export interface PollingOptions {
-    resumeFrom?: string;
-    updateIntervalInMs?: number;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -17,7 +17,7 @@ import { TokenCredential } from '@azure/core-auth';
 export interface AnalysisPollOperationState<TResult> extends PollOperationState<TResult>, JobMetadata {
 }
 
-// @public (undocumented)
+// @public
 export interface AnalyzeJobMetadata extends JobMetadata {
     displayName?: string;
     failedTasksCount?: number;
@@ -85,7 +85,7 @@ export { AzureKeyCredential }
 
 // @public
 export interface BeginAnalyzeHealthcareOptions {
-    health?: HealthcareJobOptions;
+    healthcare?: HealthcareJobOptions;
     polling?: PollingOptions;
 }
 
@@ -209,6 +209,9 @@ export type HealthcareErrorResult = TextAnalyticsErrorResult;
 export interface HealthcareJobOptions extends TextAnalyticsOperationOptions {
 }
 
+// @public
+export type HealthcarePollerLike = PollerLike<BeginAnalyzeHealthcarePollState, PaginatedHealthcareEntities>;
+
 // @public (undocumented)
 export interface HealthcareRelation {
     bidirectional: boolean;
@@ -227,9 +230,6 @@ export interface HealthcareSuccessResult extends TextAnalyticsSuccessResult {
 }
 
 // @public
-export type HealthPollerLike = PollerLike<BeginAnalyzeHealthcarePollState, PaginatedHealthcareEntities>;
-
-// @public
 export type InnerErrorCodeValue = "InvalidParameterValue" | "InvalidRequestBodyFormat" | "EmptyRequest" | "MissingInputRecords" | "InvalidDocument" | "ModelVersionIncorrect" | "InvalidDocumentBatch" | "UnsupportedLanguageCode" | "InvalidCountryHint" | string;
 
 // @public
@@ -242,7 +242,7 @@ export interface JobManifestTasks {
 // @public
 export interface JobMetadata {
     createdAt?: Date;
-    expiredAt?: Date;
+    expiresAt?: Date;
     jobId?: string;
     status?: State;
     updatedAt?: Date;
@@ -285,7 +285,7 @@ export interface OpinionSentiment extends SentenceOpinion {
 export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<AnalyzeResult, AnalyzeResult>;
 
 // @public
-export type PagedAsyncIterableHealthEntities = PagedAsyncIterableIterator<HealthcareResult, HealthcareEntitiesArray>;
+export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<HealthcareResult, HealthcareEntitiesArray>;
 
 // @public
 export interface PaginatedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
@@ -293,7 +293,7 @@ export interface PaginatedAnalyzeResults extends PagedAsyncIterableAnalyzeResult
 }
 
 // @public
-export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthEntities {
+export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
     modelVersion: string;
     statistics?: TextDocumentBatchStatistics;
 }
@@ -426,8 +426,8 @@ export class TextAnalyticsClient {
     analyzeSentiment(documents: TextDocumentInput[], options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultArray>;
     beginAnalyze(documents: string[], tasks: JobManifestTasks, language?: string, options?: BeginAnalyzeOptions): Promise<AnalyzePollerLike>;
     beginAnalyze(documents: TextDocumentInput[], tasks: JobManifestTasks, options?: BeginAnalyzeOptions): Promise<AnalyzePollerLike>;
-    beginAnalyzeHealthcare(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthPollerLike>;
-    beginAnalyzeHealthcare(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthPollerLike>;
+    beginAnalyzeHealthcare(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
+    beginAnalyzeHealthcare(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
     defaultCountryHint: string;
     defaultLanguage: string;
     detectLanguage(documents: string[], countryHint?: string, options?: DetectLanguageOptions): Promise<DetectLanguageResultArray>;

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyze.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyze.ts
@@ -33,7 +33,7 @@ export async function main() {
     entityRecognitionPiiTasks: [{ modelVersion: "latest" }],
     keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
   };
-  const poller = await client.beginAnalyze(documents, tasks);
+  const poller = await client.beginAnalyzeBatchTasks(documents, tasks);
   const resultPages = await poller.pollUntilDone();
 
   for await (const page of resultPages) {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
@@ -26,7 +26,7 @@ export interface AnalyzeResult {
 }
 
 /**
- * The results of an analyze job represented as a paginated iterator that
+ * The results of an analyze job represented as a paged iterator that
  * iterates over the results of the requested tasks.
  */
 export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<
@@ -35,7 +35,7 @@ export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<
 >;
 
 /**
- * The results of an analyze job represented as a paginated iterator that
+ * The results of an analyze job represented as a paged iterator that
  * iterates over the results of the requested tasks.
  */
 export interface PagedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
@@ -14,15 +14,15 @@ export interface AnalyzeResult {
   /**
    * Array of the results for each categorized entities recognition task.
    */
-  entitiesRecognitionResults?: RecognizeCategorizedEntitiesResultArray[];
+  entitiesRecognitionResults: RecognizeCategorizedEntitiesResultArray[];
   /**
    * Array of the results for each Pii entities recognition task.
    */
-  piiEntitiesRecognitionResults?: RecognizePiiEntitiesResultArray[];
+  piiEntitiesRecognitionResults: RecognizePiiEntitiesResultArray[];
   /**
    * Array of the results for each key phrases extraction task.
    */
-  keyPhrasesExtractionResults?: ExtractKeyPhrasesResultArray[];
+  keyPhrasesExtractionResults: ExtractKeyPhrasesResultArray[];
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
@@ -38,7 +38,7 @@ export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<
  * The results of an analyze job represented as a paginated iterator that
  * iterates over the results of the requested tasks.
  */
-export interface PaginatedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
+export interface PagedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true

--- a/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
@@ -43,7 +43,7 @@ export interface HealthcareEntitiesArray extends Array<HealthcareResult> {}
  * either iterate over the results on a document-by-document basis or, by
  * byPage(), can iterate over pages of documents.
  */
-export type PagedAsyncIterableHealthEntities = PagedAsyncIterableIterator<
+export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<
   HealthcareResult,
   HealthcareEntitiesArray
 >;
@@ -53,7 +53,7 @@ export type PagedAsyncIterableHealthEntities = PagedAsyncIterableIterator<
  * either iterate over the results on a document-by-document basis or, by
  * byPage(), can iterate over pages of documents.
  */
-export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthEntities {
+export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true

--- a/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
@@ -39,7 +39,7 @@ export type HealthcareResult = HealthcareSuccessResult | HealthcareErrorResult;
 export interface HealthcareEntitiesArray extends Array<HealthcareResult> {}
 
 /**
- * The results of a healthcare job represented as a paginated iterator that can
+ * The results of a healthcare job represented as a paged iterator that can
  * either iterate over the results on a document-by-document basis or, by
  * byPage(), can iterate over pages of documents.
  */
@@ -49,11 +49,11 @@ export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<
 >;
 
 /**
- * The results of a healthcare job represented as a paginated iterator that can
+ * The results of a healthcare job represented as a paged iterator that can
  * either iterate over the results on a document-by-document basis or, by
  * byPage(), can iterate over pages of documents.
  */
-export interface PaginatedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
+export interface PagedHealthcareEntities extends PagedAsyncIterableHealthcareEntities {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -24,7 +24,7 @@ export {
   BeginAnalyzeOptions,
   AnalyzePollerLike,
   BeginAnalyzeHealthcareOptions,
-  HealthPollerLike,
+  HealthcarePollerLike,
   BeginAnalyzePollState,
   HealthcareJobOptions,
   PollingOptions,
@@ -79,7 +79,7 @@ export {
 export { RecognizeLinkedEntitiesResultArray } from "./recognizeLinkedEntitiesResultArray";
 export {
   PaginatedHealthcareEntities,
-  PagedAsyncIterableHealthEntities,
+  PagedAsyncIterableHealthcareEntities,
   HealthcareEntitiesArray,
   HealthcareResult,
   HealthcareSuccessResult,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -29,7 +29,9 @@ export {
   HealthcareJobOptions,
   PollingOptions,
   AnalyzeJobOptions,
-  BeginAnalyzeHealthcareOperationState
+  BeginAnalyzeHealthcarePollState,
+  AnalysisPollOperationState,
+  JobMetadata
 } from "./textAnalyticsClient";
 export { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 export {
@@ -118,5 +120,6 @@ export {
   PiiTaskParametersDomain,
   HealthcareEntity,
   HealthcareRelation,
-  HealthcareEntityLink
+  HealthcareEntityLink,
+  State
 } from "./generated/models";

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -25,11 +25,8 @@ export {
   AnalyzePollerLike,
   BeginAnalyzeHealthcareOptions,
   HealthcarePollerLike,
-  BeginAnalyzePollState,
-  HealthcareJobOptions,
-  PollingOptions,
-  AnalyzeJobOptions,
-  BeginAnalyzeHealthcarePollState,
+  BeginAnalyzeOperationState,
+  BeginAnalyzeHealthcareOperationState,
   AnalysisPollOperationState,
   JobMetadata,
   AnalyzeJobMetadata
@@ -78,7 +75,7 @@ export {
 } from "./recognizeLinkedEntitiesResult";
 export { RecognizeLinkedEntitiesResultArray } from "./recognizeLinkedEntitiesResultArray";
 export {
-  PaginatedHealthcareEntities,
+  PagedHealthcareEntities,
   PagedAsyncIterableHealthcareEntities,
   HealthcareEntitiesArray,
   HealthcareResult,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -25,13 +25,14 @@ export {
   AnalyzePollerLike,
   BeginAnalyzeHealthcareOptions,
   HealthPollerLike,
-  BeginAnalyzeOperationState,
+  BeginAnalyzePollState,
   HealthcareJobOptions,
   PollingOptions,
   AnalyzeJobOptions,
   BeginAnalyzeHealthcarePollState,
   AnalysisPollOperationState,
-  JobMetadata
+  JobMetadata,
+  AnalyzeJobMetadata
 } from "./textAnalyticsClient";
 export { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 export {

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -18,10 +18,10 @@ export {
   RecognizeLinkedEntitiesOptions,
   PiiEntityDomainType,
   JobManifestTasks,
-  EntitiesTask,
-  PiiTask,
-  KeyPhrasesTask,
-  BeginAnalyzeOptions,
+  CategorizedEntitiesRecognitionTask,
+  PiiEntitiesRecognitionTask,
+  KeyPhrasesExtractionTask,
+  BeginAnalyzeBatchTasksOptions,
   AnalyzePollerLike,
   BeginAnalyzeHealthcareOptions,
   HealthcarePollerLike,
@@ -86,7 +86,7 @@ export {
   HealthcareErrorResult
 } from "./healthResult";
 export {
-  PaginatedAnalyzeResults,
+  PagedAnalyzeResults,
   PagedAsyncIterableAnalyzeResults,
   AnalyzeResult
 } from "./analyzeResult";
@@ -118,7 +118,6 @@ export {
   AspectConfidenceScoreLabel,
   TokenSentimentValue,
   TextAnalyticsWarning,
-  PiiTaskParametersDomain,
   HealthcareEntity,
   HealthcareRelation,
   HealthcareEntityLink,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -211,30 +211,33 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
         operationOptionsToRequestOptionsBase(finalOptions)
       );
       const result: AnalyzeResult = {
-        entitiesRecognitionResults: response.tasks.entityRecognitionTasks?.map(
-          ({ results }): RecognizeCategorizedEntitiesResultArray =>
-            makeRecognizeCategorizedEntitiesResultArray(
-              this.documents,
-              results?.documents,
-              results?.errors,
-              results?.modelVersion,
-              results?.statistics
-            )
-        ),
-        piiEntitiesRecognitionResults: response.tasks.entityRecognitionPiiTasks?.map(
-          ({ results }): RecognizePiiEntitiesResultArray =>
-            makeRecognizePiiEntitiesResultArray(this.documents, results)
-        ),
-        keyPhrasesExtractionResults: response.tasks.keyPhraseExtractionTasks?.map(
-          ({ results }): ExtractKeyPhrasesResultArray =>
-            makeExtractKeyPhrasesResultArray(
-              this.documents,
-              results?.documents,
-              results?.errors,
-              results?.modelVersion,
-              results?.statistics
-            )
-        )
+        entitiesRecognitionResults:
+          response.tasks.entityRecognitionTasks?.map(
+            ({ results }): RecognizeCategorizedEntitiesResultArray =>
+              makeRecognizeCategorizedEntitiesResultArray(
+                this.documents,
+                results?.documents,
+                results?.errors,
+                results?.modelVersion,
+                results?.statistics
+              )
+          ) ?? [],
+        piiEntitiesRecognitionResults:
+          response.tasks.entityRecognitionPiiTasks?.map(
+            ({ results }): RecognizePiiEntitiesResultArray =>
+              makeRecognizePiiEntitiesResultArray(this.documents, results)
+          ) ?? [],
+        keyPhrasesExtractionResults:
+          response.tasks.keyPhraseExtractionTasks?.map(
+            ({ results }): ExtractKeyPhrasesResultArray =>
+              makeExtractKeyPhrasesResultArray(
+                this.documents,
+                results?.documents,
+                results?.errors,
+                results?.modelVersion,
+                results?.statistics
+              )
+          ) ?? []
       };
       return response.nextLink
         ? { result, ...nextLinkToTopAndSkip(response.nextLink) }

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -18,7 +18,7 @@ import {
 import {
   AnalyzeResult,
   PagedAsyncIterableAnalyzeResults,
-  PaginatedAnalyzeResults
+  PagedAnalyzeResults
 } from "../../analyzeResult";
 import { PageSettings } from "@azure/core-paging";
 import {
@@ -112,7 +112,7 @@ export interface AnalyzeJobOptions extends OperationOptions {
 /**
  * Options for the begin analyze operation.
  */
-export interface BeginAnalyzeOptions {
+export interface BeginAnalyzeBatchTasksOptions {
   /**
    * Options related to polling from the service.
    */
@@ -127,7 +127,7 @@ export interface BeginAnalyzeOptions {
  * The state of the begin analyze polling operation.
  */
 export interface BeginAnalyzePollState
-  extends AnalysisPollOperationState<PaginatedAnalyzeResults>,
+  extends AnalysisPollOperationState<PagedAnalyzeResults>,
     AnalyzeJobMetadata {}
 
 /**
@@ -136,7 +136,7 @@ export interface BeginAnalyzePollState
  */
 export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
   BeginAnalyzePollState,
-  PaginatedAnalyzeResults
+  PagedAnalyzeResults
 > {
   constructor(
     public state: BeginAnalyzePollState,
@@ -144,7 +144,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
     private client: Client,
     private documents: TextDocumentInput[],
     private tasks: JobManifestTasks,
-    private options: BeginAnalyzeOptions = {},
+    private options: BeginAnalyzeBatchTasksOptions = {},
     private statusOptions: TextAnalyticsStatusOperationOptions = {}
   ) {
     super(state);
@@ -311,7 +311,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
     }
   }
 
-  private async beginAnalyze(
+  private async beginAnalyzeBatchTasks(
     documents: TextDocumentInput[],
     tasks: JobManifestTasks,
     options?: BeginAnalyzeInternalOptions
@@ -352,7 +352,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
     const updatedAbortSignal = options.abortSignal;
     if (!state.isStarted) {
       state.isStarted = true;
-      const response = await this.beginAnalyze(this.documents, this.tasks, {
+      const response = await this.beginAnalyzeBatchTasks(this.documents, this.tasks, {
         ...this.options.analyze,
         abortSignal: updatedAbortSignal ? updatedAbortSignal : this.options.analyze?.abortSignal
       });

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -58,6 +58,9 @@ interface AnalyzeResultsWithPagination {
   skip?: number;
 }
 
+/**
+ * The metadata for beginAnalyze jobs.
+ */
 export interface AnalyzeJobMetadata extends JobMetadata {
   /**
    * Number of successfully completed tasks.
@@ -273,7 +276,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
             jobMetdata: {
               createdAt: response.createdDateTime,
               updatedAt: response.lastUpdateDateTime,
-              expiredAt: response.expirationDateTime,
+              expiresAt: response.expirationDateTime,
               status: response.status,
               successfullyCompletedTasksCount: response.tasks.completed,
               failedTasksCount: response.tasks.failed,
@@ -367,7 +370,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
     });
 
     state.createdAt = jobStatus.jobMetdata?.createdAt;
-    state.expiredAt = jobStatus.jobMetdata?.expiredAt;
+    state.expiresAt = jobStatus.jobMetdata?.expiresAt;
     state.updatedAt = jobStatus.jobMetdata?.updatedAt;
     state.status = jobStatus.jobMetdata?.status;
     state.successfullyCompletedTasksCount = jobStatus.jobMetdata?.successfullyCompletedTasksCount;

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
@@ -3,7 +3,7 @@
 
 import { delay } from "@azure/core-http";
 import { PollerLike } from "@azure/core-lro";
-import { PaginatedAnalyzeResults } from "../../analyzeResult";
+import { PagedAnalyzeResults } from "../../analyzeResult";
 import { JobManifestTasks } from "../../generated/models";
 import { AnalyzeJobOptions } from "../../textAnalyticsClient";
 
@@ -18,15 +18,12 @@ export interface AnalyzePollerOptions extends AnalysisPollerOptions {
 /**
  * Result type of the Analyze Long-Running-Operation (LRO)
  */
-export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PaginatedAnalyzeResults>;
+export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PagedAnalyzeResults>;
 
 /**
  * Class that represents a poller that waits for the analyze results.
  */
-export class BeginAnalyzePoller extends AnalysisPoller<
-  BeginAnalyzePollState,
-  PaginatedAnalyzeResults
-> {
+export class BeginAnalyzePoller extends AnalysisPoller<BeginAnalyzePollState, PagedAnalyzeResults> {
   // eslint-disable-next-line @azure/azure-sdk/ts-use-interface-parameters
   constructor(pollerOptions: AnalyzePollerOptions) {
     const {

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
@@ -2,26 +2,23 @@
 // Licensed under the MIT license.
 
 import { delay } from "@azure/core-http";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
+import { PollerLike } from "@azure/core-lro";
 import { PaginatedAnalyzeResults } from "../../analyzeResult";
 import { JobManifestTasks } from "../../generated/models";
+import { AnalyzeJobOptions } from "../../textAnalyticsClient";
 
 import { AnalysisPoller, AnalysisPollerOptions } from "../poller";
 import { BeginAnalyzePollerOperation, BeginAnalyzePollState } from "./operation";
 
 export interface AnalyzePollerOptions extends AnalysisPollerOptions {
   tasks: JobManifestTasks;
+  readonly analysisOptions?: AnalyzeJobOptions;
 }
-
-/**
- * The status of an analyze operation
- */
-export type BeginAnalyzeOperationState = PollOperationState<PaginatedAnalyzeResults>;
 
 /**
  * Result type of the Analyze Long-Running-Operation (LRO)
  */
-export type AnalyzePollerLike = PollerLike<BeginAnalyzeOperationState, PaginatedAnalyzeResults>;
+export type AnalyzePollerLike = PollerLike<BeginAnalyzePollState, PaginatedAnalyzeResults>;
 
 /**
  * Class that represents a poller that waits for the analyze results.
@@ -46,20 +43,25 @@ export class BeginAnalyzePoller extends AnalysisPoller<
     if (resumeFrom) {
       state = JSON.parse(resumeFrom).state;
     }
-    const { requestOptions, tracingOptions } = analysisOptions || {};
+    const { requestOptions, tracingOptions, displayName, includeStatistics, abortSignal } =
+      analysisOptions || {};
     const operation = new BeginAnalyzePollerOperation(
       state || {},
       client,
       documents,
       tasks,
       {
-        analyze: { requestOptions, tracingOptions },
+        analyze: { requestOptions, tracingOptions, displayName },
         polling: {
           updateIntervalInMs,
           resumeFrom
         }
       },
-      analysisOptions
+      {
+        tracingOptions,
+        includeStatistics,
+        abortSignal
+      }
     );
 
     super(operation);

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -17,7 +17,7 @@ import {
 import {
   HealthcareResult,
   HealthcareEntitiesArray,
-  PagedAsyncIterableHealthEntities,
+  PagedAsyncIterableHealthcareEntities,
   PaginatedHealthcareEntities
 } from "../../healthResult";
 import { PageSettings } from "@azure/core-paging";
@@ -89,7 +89,7 @@ export interface BeginAnalyzeHealthcareOptions {
   /**
    * Options related to the healthcare job.
    */
-  health?: HealthcareJobOptions;
+  healthcare?: HealthcareJobOptions;
 }
 
 /**
@@ -124,7 +124,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
   private listHealthcareEntitiesByPage(
     jobId: string,
     options: HealthcareJobStatusOptions = {}
-  ): PagedAsyncIterableHealthEntities {
+  ): PagedAsyncIterableHealthcareEntities {
     const iter = this._listHealthcareEntities(jobId, options);
     return {
       next() {
@@ -234,7 +234,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
               jobMetdata: {
                 createdAt: response.createdDateTime,
                 updatedAt: response.lastUpdateDateTime,
-                expiredAt: response.expirationDateTime,
+                expiresAt: response.expirationDateTime,
                 status: response.status
               }
             };
@@ -305,7 +305,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
     if (!state.isStarted) {
       state.isStarted = true;
       const response = await this.beginAnalyzeHealthcare(this.documents, {
-        ...this.options.health,
+        ...this.options.healthcare,
         abortSignal: updatedAbortSignal ? updatedAbortSignal : options.abortSignal
       });
       if (!response.operationLocation) {
@@ -321,7 +321,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
     });
 
     state.createdAt = jobStatus.jobMetdata?.createdAt;
-    state.expiredAt = jobStatus.jobMetdata?.expiredAt;
+    state.expiresAt = jobStatus.jobMetdata?.expiresAt;
     state.updatedAt = jobStatus.jobMetdata?.updatedAt;
     state.status = jobStatus.jobMetdata?.status;
 
@@ -331,7 +331,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
       }
       const pagedIterator = this.listHealthcareEntitiesByPage(
         state.jobId!,
-        this.options.health || {}
+        this.options.healthcare || {}
       );
       state.result = Object.assign(pagedIterator, {
         statistics: jobStatus.statistics,
@@ -345,7 +345,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
   async cancel(): Promise<BeginAnalyzeHealthcarePollerOperation> {
     const state = this.state;
     if (state.jobId) {
-      await this.client.cancelHealthJob(state.jobId, this.options.health);
+      await this.client.cancelHealthJob(state.jobId, this.options.healthcare);
     }
     state.isCancelled = true;
     return this;

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
@@ -14,7 +14,7 @@ import {
 /**
  * Result type of the Health Long-Running-Operation (LRO)
  */
-export type HealthPollerLike = PollerLike<
+export type HealthcarePollerLike = PollerLike<
   BeginAnalyzeHealthcarePollState,
   PaginatedHealthcareEntities
 >;
@@ -47,7 +47,7 @@ export class BeginAnalyzeHealthcarePoller extends AnalysisPoller<
       client,
       documents,
       {
-        health: analysisOptions,
+        healthcare: analysisOptions,
         polling: {
           updateIntervalInMs,
           resumeFrom

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { delay } from "@azure/core-http";
-import { PollerLike, PollOperationState } from "@azure/core-lro";
+import { PollerLike } from "@azure/core-lro";
 import { PaginatedHealthcareEntities } from "../../healthResult";
 
 import { AnalysisPoller, AnalysisPollerOptions } from "../poller";
@@ -12,15 +12,10 @@ import {
 } from "./operation";
 
 /**
- * The status of a health operation
- */
-export type BeginAnalyzeHealthcareOperationState = PollOperationState<PaginatedHealthcareEntities>;
-
-/**
  * Result type of the Health Long-Running-Operation (LRO)
  */
 export type HealthPollerLike = PollerLike<
-  BeginAnalyzeHealthcareOperationState,
+  BeginAnalyzeHealthcarePollState,
   PaginatedHealthcareEntities
 >;
 

--- a/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
@@ -5,28 +5,6 @@ import { delay, OperationOptions } from "@azure/core-http";
 import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
 import { GeneratedClient } from "../generated/generatedClient";
 import { State, TextDocumentInput } from "../generated/models";
-import { TextAnalyticsOperationOptions } from "../textAnalyticsOperationOptions";
-
-/**
- * Options for configuring a polling operation.
- */
-export interface PollingOptions {
-  /**
-   * Delay to wait until next poll, in milliseconds.
-   */
-  updateIntervalInMs?: number;
-  /**
-   * A serialized poller which can be used to resume an existing paused Long-Running-Operation.
-   */
-  resumeFrom?: string;
-}
-
-export interface TextAnalyticsStatusOperationOptions extends OperationOptions {
-  /**
-   * If set to true, response will contain input and document level statistics.
-   */
-  includeStatistics?: boolean;
-}
 
 /**
  * Common parameters to a Poller.
@@ -34,7 +12,7 @@ export interface TextAnalyticsStatusOperationOptions extends OperationOptions {
 export interface AnalysisPollerOptions {
   readonly client: GeneratedClient;
   readonly documents: TextDocumentInput[];
-  readonly analysisOptions?: TextAnalyticsOperationOptions;
+  readonly analysisOptions?: OperationOptions;
   updateIntervalInMs?: number;
   resumeFrom?: string;
 }
@@ -46,11 +24,11 @@ export interface JobMetadata {
   /**
    * The date and time the job was created.
    */
-  createdAt?: Date;
+  createdOn?: Date;
   /**
    * The date and time when the job results will expire on the server.
    */
-  expiresAt?: Date;
+  expiresOn?: Date;
   /**
    * The job id.
    */
@@ -58,7 +36,7 @@ export interface JobMetadata {
   /**
    * The time the job status was last updated.
    */
-  updatedAt?: Date;
+  updatedOn?: Date;
   /**
    * The current status of the job.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
@@ -50,7 +50,7 @@ export interface JobMetadata {
   /**
    * The date and time when the job results will expire on the server.
    */
-  expiredAt?: Date;
+  expiresAt?: Date;
   /**
    * The job id.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
@@ -4,7 +4,7 @@
 import { delay, OperationOptions } from "@azure/core-http";
 import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
 import { GeneratedClient } from "../generated/generatedClient";
-import { TextDocumentInput } from "../generated/models";
+import { State, TextDocumentInput } from "../generated/models";
 import { TextAnalyticsOperationOptions } from "../textAnalyticsOperationOptions";
 
 /**
@@ -40,14 +40,37 @@ export interface AnalysisPollerOptions {
 }
 
 /**
- * An interface representing the state of an analysis poller operation.
+ * Metadata information for an analysis poller operation.
  */
-export interface AnalysisPollOperationState<TResult> extends PollOperationState<TResult> {
+export interface JobMetadata {
   /**
-   * The id of the analysis job.
+   * The date and time the job was created.
+   */
+  createdAt?: Date;
+  /**
+   * The date and time when the job results will expire on the server.
+   */
+  expiredAt?: Date;
+  /**
+   * The job id.
    */
   jobId?: string;
+  /**
+   * The time the job status was last updated.
+   */
+  updatedAt?: Date;
+  /**
+   * The current status of the job.
+   */
+  status?: State;
 }
+
+/**
+ * An interface representing the state of an analysis poller operation.
+ */
+export interface AnalysisPollOperationState<TResult>
+  extends PollOperationState<TResult>,
+    JobMetadata {}
 
 /**
  * Common properties and methods of analysis Pollers.

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -54,12 +54,12 @@ import {
   addStrEncodingParam,
   handleInvalidDocumentBatch
 } from "./util";
+import { BeginAnalyzeHealthcarePoller, HealthPollerLike } from "./lro/health/poller";
 import {
-  BeginAnalyzeHealthcareOperationState,
-  BeginAnalyzeHealthcarePoller,
-  HealthPollerLike
-} from "./lro/health/poller";
-import { BeginAnalyzeHealthcareOptions, HealthcareJobOptions } from "./lro/health/operation";
+  BeginAnalyzeHealthcareOptions,
+  BeginAnalyzeHealthcarePollState,
+  HealthcareJobOptions
+} from "./lro/health/operation";
 import { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 import {
   AnalyzePollerLike,
@@ -67,7 +67,7 @@ import {
   BeginAnalyzePoller
 } from "./lro/analyze/poller";
 import { AnalyzeJobOptions, BeginAnalyzeOptions } from "./lro/analyze/operation";
-import { PollingOptions } from "./lro/poller";
+import { AnalysisPollOperationState, JobMetadata, PollingOptions } from "./lro/poller";
 
 export {
   BeginAnalyzeOptions,
@@ -78,7 +78,9 @@ export {
   AnalyzeJobOptions,
   PollingOptions,
   HealthcareJobOptions,
-  BeginAnalyzeHealthcareOperationState
+  BeginAnalyzeHealthcarePollState,
+  AnalysisPollOperationState,
+  JobMetadata
 };
 
 const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default";

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -18,7 +18,6 @@ import {
   DetectLanguageInput,
   GeneratedClientEntitiesRecognitionPiiOptionalParams,
   GeneratedClientSentimentOptionalParams,
-  PiiTaskParametersDomain,
   TextDocumentInput
 } from "./generated/models";
 import {
@@ -65,13 +64,13 @@ import { AnalyzePollerLike, BeginAnalyzePoller } from "./lro/analyze/poller";
 import {
   AnalyzeJobMetadata,
   AnalyzeJobOptions,
-  BeginAnalyzeOptions,
+  BeginAnalyzeBatchTasksOptions,
   BeginAnalyzePollState
 } from "./lro/analyze/operation";
 import { AnalysisPollOperationState, JobMetadata, PollingOptions } from "./lro/poller";
 
 export {
-  BeginAnalyzeOptions,
+  BeginAnalyzeBatchTasksOptions,
   AnalyzePollerLike,
   BeginAnalyzePollState,
   BeginAnalyzeHealthcareOptions,
@@ -162,7 +161,7 @@ export type RecognizeLinkedEntitiesOptions = TextAnalyticsOperationOptions;
 /**
  * Options for an entities recognition task.
  */
-export type EntitiesTask = {
+export type CategorizedEntitiesRecognitionTask = {
   /**
    * The version of the text analytics model used by this operation on this
    * batch of input documents.
@@ -173,13 +172,13 @@ export type EntitiesTask = {
 /**
  * Options for a Pii entities recognition task.
  */
-export type PiiTask = {
+export type PiiEntitiesRecognitionTask = {
   /**
    * Filters entities to ones only included in the specified domain (e.g., if
    * set to 'PHI', entities in the Protected Healthcare Information domain will
    * only be returned). @see {@link https://aka.ms/tanerpii} for more information.
    */
-  domain?: PiiTaskParametersDomain;
+  domain?: PiiEntityDomainType;
   /**
    * The version of the text analytics model used by this operation on this
    * batch of input documents.
@@ -190,7 +189,7 @@ export type PiiTask = {
 /**
  * Options for a key phrases recognition task.
  */
-export interface KeyPhrasesTask {
+export interface KeyPhrasesExtractionTask {
   /**
    * The version of the text analytics model used by this operation on this
    * batch of input documents.
@@ -205,15 +204,15 @@ export interface JobManifestTasks {
   /**
    * A collection of descriptions of entities recognition tasks.
    */
-  entityRecognitionTasks?: EntitiesTask[];
+  entityRecognitionTasks?: CategorizedEntitiesRecognitionTask[];
   /**
    * A collection of descriptions of Pii entities recognition tasks.
    */
-  entityRecognitionPiiTasks?: PiiTask[];
+  entityRecognitionPiiTasks?: PiiEntitiesRecognitionTask[];
   /**
    * A collection of descriptions of key phrases recognition tasks.
    */
-  keyPhraseExtractionTasks?: KeyPhrasesTask[];
+  keyPhraseExtractionTasks?: KeyPhrasesExtractionTask[];
 }
 /**
  * Client class for interacting with Azure Text Analytics.
@@ -880,11 +879,11 @@ export class TextAnalyticsClient {
         where the language is explicitly set to "None".
    * @param options - Options for the operation.
    */
-  public async beginAnalyze(
+  public async beginAnalyzeBatchTasks(
     documents: string[],
     tasks: JobManifestTasks,
     language?: string,
-    options?: BeginAnalyzeOptions
+    options?: BeginAnalyzeBatchTasksOptions
   ): Promise<AnalyzePollerLike>;
   /**
    * Submit a collection of text documents for analysis. Specify one or more unique tasks to be executed.
@@ -892,18 +891,18 @@ export class TextAnalyticsClient {
    * @param tasks - Tasks to execute.
    * @param options - Options for the operation.
    */
-  public async beginAnalyze(
+  public async beginAnalyzeBatchTasks(
     documents: TextDocumentInput[],
     tasks: JobManifestTasks,
-    options?: BeginAnalyzeOptions
+    options?: BeginAnalyzeBatchTasksOptions
   ): Promise<AnalyzePollerLike>;
-  public async beginAnalyze(
+  public async beginAnalyzeBatchTasks(
     documents: string[] | TextDocumentInput[],
     tasks: JobManifestTasks,
-    languageOrOptions?: string | BeginAnalyzeOptions,
-    options?: BeginAnalyzeOptions
+    languageOrOptions?: string | BeginAnalyzeBatchTasksOptions,
+    options?: BeginAnalyzeBatchTasksOptions
   ): Promise<AnalyzePollerLike> {
-    let realOptions: BeginAnalyzeOptions;
+    let realOptions: BeginAnalyzeBatchTasksOptions;
     let realInputs: TextDocumentInput[];
 
     if (!Array.isArray(documents) || documents.length === 0) {
@@ -916,7 +915,7 @@ export class TextAnalyticsClient {
       realOptions = options || {};
     } else {
       realInputs = documents;
-      realOptions = (languageOrOptions as BeginAnalyzeOptions) || {};
+      realOptions = (languageOrOptions as BeginAnalyzeBatchTasksOptions) || {};
     }
     const compiledTasks = addEncodingParamToAnalyzeInput(tasks);
     const poller = new BeginAnalyzePoller({

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -56,29 +56,24 @@ import {
 import { BeginAnalyzeHealthcarePoller, HealthcarePollerLike } from "./lro/health/poller";
 import {
   BeginAnalyzeHealthcareOptions,
-  BeginAnalyzeHealthcarePollState,
-  HealthcareJobOptions
+  BeginAnalyzeHealthcareOperationState
 } from "./lro/health/operation";
 import { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
 import { AnalyzePollerLike, BeginAnalyzePoller } from "./lro/analyze/poller";
 import {
   AnalyzeJobMetadata,
-  AnalyzeJobOptions,
   BeginAnalyzeBatchTasksOptions,
-  BeginAnalyzePollState
+  BeginAnalyzeOperationState
 } from "./lro/analyze/operation";
-import { AnalysisPollOperationState, JobMetadata, PollingOptions } from "./lro/poller";
+import { AnalysisPollOperationState, JobMetadata } from "./lro/poller";
 
 export {
   BeginAnalyzeBatchTasksOptions,
   AnalyzePollerLike,
-  BeginAnalyzePollState,
+  BeginAnalyzeOperationState,
   BeginAnalyzeHealthcareOptions,
   HealthcarePollerLike,
-  AnalyzeJobOptions,
-  PollingOptions,
-  HealthcareJobOptions,
-  BeginAnalyzeHealthcarePollState,
+  BeginAnalyzeHealthcareOperationState,
   AnalysisPollOperationState,
   JobMetadata,
   AnalyzeJobMetadata
@@ -860,8 +855,15 @@ export class TextAnalyticsClient {
     const poller = new BeginAnalyzeHealthcarePoller({
       client: this.client,
       documents: realInputs,
-      analysisOptions: realOptions.healthcare,
-      ...realOptions.polling
+      analysisOptions: {
+        requestOptions: realOptions.requestOptions,
+        tracingOptions: realOptions.tracingOptions,
+        abortSignal: realOptions.abortSignal
+      },
+      updateIntervalInMs: realOptions.updateIntervalInMs,
+      resumeFrom: realOptions.resumeFrom,
+      includeStatistics: realOptions.includeStatistics,
+      modelVersion: realOptions.modelVersion
     });
 
     await poller.poll();
@@ -922,8 +924,15 @@ export class TextAnalyticsClient {
       client: this.client,
       documents: realInputs,
       tasks: compiledTasks,
-      analysisOptions: realOptions.analyze,
-      ...realOptions.polling
+      analysisOptions: {
+        requestOptions: realOptions.requestOptions,
+        tracingOptions: realOptions.tracingOptions,
+        abortSignal: realOptions.abortSignal
+      },
+      displayName: realOptions.displayName,
+      includeStatistics: realOptions.includeStatistics,
+      updateIntervalInMs: realOptions.updateIntervalInMs,
+      resumeFrom: realOptions.resumeFrom
     });
 
     await poller.poll();

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -61,18 +61,19 @@ import {
   HealthcareJobOptions
 } from "./lro/health/operation";
 import { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
+import { AnalyzePollerLike, BeginAnalyzePoller } from "./lro/analyze/poller";
 import {
-  AnalyzePollerLike,
-  BeginAnalyzeOperationState,
-  BeginAnalyzePoller
-} from "./lro/analyze/poller";
-import { AnalyzeJobOptions, BeginAnalyzeOptions } from "./lro/analyze/operation";
+  AnalyzeJobMetadata,
+  AnalyzeJobOptions,
+  BeginAnalyzeOptions,
+  BeginAnalyzePollState
+} from "./lro/analyze/operation";
 import { AnalysisPollOperationState, JobMetadata, PollingOptions } from "./lro/poller";
 
 export {
   BeginAnalyzeOptions,
   AnalyzePollerLike,
-  BeginAnalyzeOperationState,
+  BeginAnalyzePollState,
   BeginAnalyzeHealthcareOptions,
   HealthPollerLike,
   AnalyzeJobOptions,
@@ -80,7 +81,8 @@ export {
   HealthcareJobOptions,
   BeginAnalyzeHealthcarePollState,
   AnalysisPollOperationState,
-  JobMetadata
+  JobMetadata,
+  AnalyzeJobMetadata
 };
 
 const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default";

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -54,7 +54,7 @@ import {
   addStrEncodingParam,
   handleInvalidDocumentBatch
 } from "./util";
-import { BeginAnalyzeHealthcarePoller, HealthPollerLike } from "./lro/health/poller";
+import { BeginAnalyzeHealthcarePoller, HealthcarePollerLike } from "./lro/health/poller";
 import {
   BeginAnalyzeHealthcareOptions,
   BeginAnalyzeHealthcarePollState,
@@ -75,7 +75,7 @@ export {
   AnalyzePollerLike,
   BeginAnalyzePollState,
   BeginAnalyzeHealthcareOptions,
-  HealthPollerLike,
+  HealthcarePollerLike,
   AnalyzeJobOptions,
   PollingOptions,
   HealthcareJobOptions,
@@ -830,7 +830,7 @@ export class TextAnalyticsClient {
     documents: string[],
     language?: string,
     options?: BeginAnalyzeHealthcareOptions
-  ): Promise<HealthPollerLike>;
+  ): Promise<HealthcarePollerLike>;
   /**
    * Start a healthcare analysis job to recognize healthcare related entities (drugs, conditions,
    * symptoms, etc) and their relations.
@@ -840,13 +840,13 @@ export class TextAnalyticsClient {
   async beginAnalyzeHealthcare(
     documents: TextDocumentInput[],
     options?: BeginAnalyzeHealthcareOptions
-  ): Promise<HealthPollerLike>;
+  ): Promise<HealthcarePollerLike>;
 
   async beginAnalyzeHealthcare(
     documents: string[] | TextDocumentInput[],
     languageOrOptions?: string | BeginAnalyzeHealthcareOptions,
     options?: BeginAnalyzeHealthcareOptions
-  ): Promise<HealthPollerLike> {
+  ): Promise<HealthcarePollerLike> {
     let realOptions: BeginAnalyzeHealthcareOptions;
     let realInputs: TextDocumentInput[];
     if (isStringArray(documents)) {
@@ -861,7 +861,7 @@ export class TextAnalyticsClient {
     const poller = new BeginAnalyzeHealthcarePoller({
       client: this.client,
       documents: realInputs,
-      analysisOptions: realOptions.health,
+      analysisOptions: realOptions.healthcare,
       ...realOptions.polling
     });
 

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -101,9 +101,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           ],
           "en",
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -123,9 +121,7 @@ describe("[API Key] TextAnalyticsClient", function() {
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
           ],
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -150,9 +146,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         const result1 = (await result.next()).value;
@@ -179,9 +173,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         const result1 = (await result.next()).value;
@@ -196,9 +188,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = Array(11).fill("random text");
         try {
           const response = await client.beginAnalyzeHealthcare(docs, "en", {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           });
           console.log(response);
           assert.fail("Oops, an exception didn't happen.");
@@ -230,9 +220,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = Array(500).fill(large_doc);
         try {
           await client.beginAnalyzeHealthcare(docs, "en", {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           });
           assert.fail("Oops, an exception didn't happen.");
         } catch (e) {
@@ -248,9 +236,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it("document warnings", async function() {
         const docs = [{ id: "1", text: "This won't actually create a warning :'(" }];
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         for await (const doc of result) {
@@ -269,9 +255,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "5", text: "five" }
         ];
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         let i = 0;
@@ -289,9 +273,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "1", text: ":D" }
         ];
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         const in_order = [56, 0, 22, 19, 1];
@@ -310,13 +292,9 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "1", text: ":D" }
         ];
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          healthcare: {
-            modelVersion: "latest",
-            includeStatistics: true
-          },
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          modelVersion: "latest",
+          includeStatistics: true,
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         assert.ok(result);
@@ -335,9 +313,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, "en", {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         for await (const doc of result) {
@@ -353,9 +329,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, "", {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         for await (const doc of result) {
@@ -371,9 +345,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         for await (const doc of result) {
@@ -389,9 +361,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         for await (const doc of result) {
@@ -403,9 +373,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = ["This should fail because we're passing in an invalid language hint"];
 
         const poller = await client.beginAnalyzeHealthcare(docs, "notalanguage", {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
@@ -422,9 +390,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
@@ -445,10 +411,8 @@ describe("[API Key] TextAnalyticsClient", function() {
 
         try {
           await client.beginAnalyzeHealthcare(docs, {
-            healthcare: { modelVersion: "bad" },
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            modelVersion: "bad",
+            updateIntervalInMs: pollingInterval
           });
           assert.fail("Oops, an exception didn't happen.");
         } catch (e) {
@@ -468,9 +432,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const doc_errors = await poller.pollUntilDone();
         assert.equal((await doc_errors.next()).value.error?.code, "InvalidDocument");
@@ -486,9 +448,7 @@ describe("[API Key] TextAnalyticsClient", function() {
 
         try {
           await client.beginAnalyzeHealthcare(docs, {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           });
           assert.fail("Oops, an exception didn't happen.");
         } catch (e) {
@@ -508,9 +468,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         let count = 0;
@@ -532,9 +490,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         let docCount = 0,
@@ -561,9 +517,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          polling: {
-            updateIntervalInMs: pollingInterval
-          }
+          updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
         let docCount = 0;
@@ -594,9 +548,7 @@ describe("[API Key] TextAnalyticsClient", function() {
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
           ],
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         await poller.cancelOperation();
@@ -610,15 +562,13 @@ describe("[API Key] TextAnalyticsClient", function() {
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
           ],
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         poller.onProgress(() => {
-          assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
-          assert.ok(poller.getOperationState().expiresAt, "expiresAt is undefined!");
-          assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
+          assert.ok(poller.getOperationState().createdOn, "createdOn is undefined!");
+          assert.ok(poller.getOperationState().expiresOn, "expiresOn is undefined!");
+          assert.ok(poller.getOperationState().updatedOn, "updatedOn is undefined!");
           assert.ok(poller.getOperationState().status, "status is undefined!");
         });
         const result = await poller.pollUntilDone();

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -602,6 +602,28 @@ describe("[API Key] TextAnalyticsClient", function() {
         await poller.cancelOperation();
         assert.ok(poller.getOperationState().isCancelled);
       });
+
+      it.only("job metadata", async function() {
+        const poller = await client.beginAnalyzeHealthcare(
+          [
+            { id: "1", text: "Patient does not suffer from high blood pressure.", language: "en" },
+            { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
+          ],
+          {
+            polling: {
+              updateIntervalInMs: pollingInterval
+            }
+          }
+        );
+        poller.onProgress(() => {
+          assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
+          assert.ok(poller.getOperationState().expiredAt, "expiredAt is undefined!");
+          assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
+          assert.ok(poller.getOperationState().status, "status is undefined!");
+        });
+        const result = await poller.pollUntilDone();
+        assert.ok(result);
+      });
     });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -603,7 +603,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         assert.ok(poller.getOperationState().isCancelled);
       });
 
-      it.only("job metadata", async function() {
+      it("job metadata", async function() {
         const poller = await client.beginAnalyzeHealthcare(
           [
             { id: "1", text: "Patient does not suffer from high blood pressure.", language: "en" },

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -310,7 +310,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "1", text: ":D" }
         ];
         const poller = await client.beginAnalyzeHealthcare(docs, {
-          health: {
+          healthcare: {
             modelVersion: "latest",
             includeStatistics: true
           },
@@ -445,7 +445,7 @@ describe("[API Key] TextAnalyticsClient", function() {
 
         try {
           await client.beginAnalyzeHealthcare(docs, {
-            health: { modelVersion: "bad" },
+            healthcare: { modelVersion: "bad" },
             polling: {
               updateIntervalInMs: pollingInterval
             }
@@ -617,7 +617,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         );
         poller.onProgress(() => {
           assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
-          assert.ok(poller.getOperationState().expiredAt, "expiredAt is undefined!");
+          assert.ok(poller.getOperationState().expiresAt, "expiresAt is undefined!");
           assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
           assert.ok(poller.getOperationState().status, "status is undefined!");
         });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1560,6 +1560,47 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         }
       });
+
+      it("job metadata", async function() {
+        const docs = [
+          { id: "1", text: "I will go to the park." },
+          { id: "2", text: "Este es un document escrito en Español." },
+          { id: "3", text: "猫は幸せ" }
+        ];
+
+        const poller = await client.beginAnalyze(
+          docs,
+          {
+            entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
+          },
+          {
+            polling: {
+              updateIntervalInMs: pollingInterval
+            },
+            analyze: {
+              displayName: "testJob"
+            }
+          }
+        );
+        poller.onProgress(() => {
+          assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
+          assert.ok(poller.getOperationState().expiredAt, "expiredAt is undefined!");
+          assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
+          assert.ok(poller.getOperationState().status, "status is undefined!");
+          assert.ok(
+            poller.getOperationState().successfullyCompletedTasksCount,
+            "successfullyCompletedTasksCount is undefined!"
+          );
+          assert.equal(poller.getOperationState().failedTasksCount, 0);
+          assert.isDefined(
+            poller.getOperationState().inProgressTasksCount,
+            "inProgressTasksCount is undefined!"
+          );
+          assert.equal(poller.getOperationState().displayName, "testJob");
+        });
+        const result = await poller.pollUntilDone();
+        assert.ok(result);
+      });
     });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -802,7 +802,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const results = await poller.pollUntilDone();
         for await (const page of results) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const task = entitiesResult[0];
             for (const result of task) {
               if (!result.error) {
@@ -838,7 +838,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const results = await poller.pollUntilDone();
         for await (const page of results) {
           const keyPhrasesResult = page.keyPhrasesExtractionResults;
-          if (keyPhrasesResult && keyPhrasesResult.length === 1) {
+          if (keyPhrasesResult.length === 1) {
             const task = keyPhrasesResult[0];
             assert.equal(task.length, 2);
             for (const result of task) {
@@ -888,7 +888,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         for await (const page of result) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const task = entitiesResult[0];
             assert.equal(task.length, 3);
             for (const doc of task) {
@@ -933,7 +933,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         for await (const page of result) {
           const entitiesResult = page.piiEntitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const task = entitiesResult[0];
             assert.equal(task.length, 3);
             const doc1 = task[0];
@@ -1022,7 +1022,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         for await (const page of result) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
             assert.equal(entitiesDocs.length, 3);
             assert.isDefined(entitiesDocs[0].error);
@@ -1033,7 +1033,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const piiEntitiesResult = page.piiEntitiesRecognitionResults;
-          if (piiEntitiesResult && piiEntitiesResult.length === 1) {
+          if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
             assert.equal(piiEntitiesDocs.length, 3);
             assert.isDefined(piiEntitiesDocs[0].error);
@@ -1044,7 +1044,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const keyPhrasesResult = page.keyPhrasesExtractionResults;
-          if (keyPhrasesResult && keyPhrasesResult.length === 1) {
+          if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
             assert.equal(keyPhrasesDocs.length, 3);
             assert.isDefined(keyPhrasesDocs[0].error);
@@ -1090,7 +1090,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         for await (const page of result) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
             assert.equal(entitiesDocs.length, 3);
             assert.isDefined(entitiesDocs[0].error);
@@ -1101,7 +1101,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const piiEntitiesResult = page.piiEntitiesRecognitionResults;
-          if (piiEntitiesResult && piiEntitiesResult.length === 1) {
+          if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
             assert.equal(piiEntitiesDocs.length, 3);
             assert.isDefined(piiEntitiesDocs[0].error);
@@ -1149,7 +1149,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         for await (const page of result) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
             assert.equal(entitiesDocs.length, 5);
             let i = 1;
@@ -1161,7 +1161,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const piiEntitiesResult = page.piiEntitiesRecognitionResults;
-          if (piiEntitiesResult && piiEntitiesResult.length === 1) {
+          if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
             assert.equal(piiEntitiesDocs.length, 5);
             let i = 1;
@@ -1173,7 +1173,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const keyPhrasesResult = page.keyPhrasesExtractionResults;
-          if (keyPhrasesResult && keyPhrasesResult.length === 1) {
+          if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
             assert.equal(keyPhrasesDocs.length, 5);
             let i = 1;
@@ -1212,7 +1212,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const in_order = ["56", "0", "22", "19", "1"];
         for await (const page of result) {
           const entitiesResult = page.entitiesRecognitionResults;
-          if (entitiesResult && entitiesResult.length === 1) {
+          if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
             assert.equal(entitiesDocs.length, 5);
             let i = 0;
@@ -1224,7 +1224,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const piiEntitiesResult = page.piiEntitiesRecognitionResults;
-          if (piiEntitiesResult && piiEntitiesResult.length === 1) {
+          if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
             assert.equal(piiEntitiesDocs.length, 5);
             let i = 0;
@@ -1236,7 +1236,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
 
           const keyPhrasesResult = page.keyPhrasesExtractionResults;
-          if (keyPhrasesResult && keyPhrasesResult.length === 1) {
+          if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
             assert.equal(keyPhrasesDocs.length, 5);
             let i = 0;
@@ -1305,7 +1305,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         for await (const page of result) {
-          const entitiesResult = page.entitiesRecognitionResults!;
+          const entitiesResult = page.entitiesRecognitionResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
             assert.equal(entitiesDocs.length, 3);
@@ -1339,7 +1339,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         for await (const page of result) {
-          const entitiesResult = page.entitiesRecognitionResults!;
+          const entitiesResult = page.entitiesRecognitionResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
             assert.equal(entitiesDocs.length, 3);
@@ -1372,7 +1372,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         for await (const page of result) {
-          const entitiesResult = page.entitiesRecognitionResults!;
+          const entitiesResult = page.entitiesRecognitionResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
             assert.equal(entitiesDocs.length, 3);
@@ -1405,7 +1405,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         for await (const page of result) {
-          const entitiesResult = page.entitiesRecognitionResults!;
+          const entitiesResult = page.entitiesRecognitionResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
             assert.equal(entitiesDocs.length, 3);
@@ -1435,15 +1435,15 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
-        const entitiesTaskDocs = firstResult?.entitiesRecognitionResults![0];
+        const entitiesTaskDocs = firstResult?.entitiesRecognitionResults[0];
         for (const doc of entitiesTaskDocs) {
           assert.equal(doc.error?.code, "UnsupportedLanguageCode");
         }
-        const piiEntitiesTaskDocs = firstResult?.piiEntitiesRecognitionResults![0];
+        const piiEntitiesTaskDocs = firstResult?.piiEntitiesRecognitionResults[0];
         for (const doc of piiEntitiesTaskDocs) {
           assert.equal(doc.error?.code, "UnsupportedLanguageCode");
         }
-        const keyPhrasesTaskDocs = firstResult?.keyPhrasesExtractionResults![0];
+        const keyPhrasesTaskDocs = firstResult?.keyPhrasesExtractionResults[0];
         for (const doc of keyPhrasesTaskDocs) {
           assert.equal(doc.error?.code, "UnsupportedLanguageCode");
         }
@@ -1473,15 +1473,15 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
-        const entitiesTaskDocs = firstResult?.entitiesRecognitionResults![0];
+        const entitiesTaskDocs = firstResult?.entitiesRecognitionResults[0];
         for (const doc of entitiesTaskDocs) {
           assert.equal(doc.error?.code, "UnknownError");
         }
-        const piiEntitiesTaskDocs = firstResult?.piiEntitiesRecognitionResults![0];
+        const piiEntitiesTaskDocs = firstResult?.piiEntitiesRecognitionResults[0];
         for (const doc of piiEntitiesTaskDocs) {
           assert.equal(doc.error?.code, "UnknownError");
         }
-        const keyPhrasesTaskDocs = firstResult?.keyPhrasesExtractionResults![0];
+        const keyPhrasesTaskDocs = firstResult?.keyPhrasesExtractionResults[0];
         for (const doc of keyPhrasesTaskDocs) {
           assert.equal(doc.error?.code, "UnknownError");
         }
@@ -1509,7 +1509,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         let pageCount = 0;
         const pageSize = 10;
         for await (const page of result.byPage({ maxPageSize: pageSize })) {
-          const entitiesTaskDocs = page.entitiesRecognitionResults![0];
+          const entitiesTaskDocs = page.entitiesRecognitionResults[0];
           ++pageCount;
           for (const doc of entitiesTaskDocs) {
             assert.isUndefined(doc.error);
@@ -1547,7 +1547,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const result = await poller.pollUntilDone();
         for await (const page of result) {
-          const piiEntitiesResult = page.piiEntitiesRecognitionResults!;
+          const piiEntitiesResult = page.piiEntitiesRecognitionResults;
           assert.equal(piiEntitiesResult.length, 1);
           for (const piiEntitiesDocs of piiEntitiesResult) {
             assert.equal(piiEntitiesDocs.length, 3);

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -788,7 +788,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "2", language: "es", text: "Microsoft fue fundado por Bill Gates y Paul Allen" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }]
@@ -824,7 +824,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "2", language: "es", text: "Microsoft fue fundado por Bill Gates y Paul Allen" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
@@ -874,7 +874,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }]
@@ -919,7 +919,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "3", text: "Is 998.214.865-68 your Brazilian CPF number?" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
@@ -970,7 +970,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       it("bad request empty string", async function() {
         const docs = [""];
         try {
-          const poller = await client.beginAnalyze(
+          const poller = await client.beginAnalyzeBatchTasks(
             docs,
             {
               entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
@@ -1006,7 +1006,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1074,7 +1074,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1133,7 +1133,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "5", text: "five" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1195,7 +1195,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "1", text: ":D" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1261,7 +1261,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "1", text: ":D" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1289,7 +1289,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           "The restaurant was not as good as I hoped."
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1323,7 +1323,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           "The restaurant was not as good as I hoped."
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1357,7 +1357,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "3", text: "The restaurant had really good food." }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1390,7 +1390,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "3", text: "猫は幸せ" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1419,7 +1419,7 @@ describe("[AAD] TextAnalyticsClient", function() {
       it("invalid language hint", async function() {
         const docs = ["This should fail because we're passing in an invalid language hint"];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1458,7 +1458,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "bad" }],
@@ -1491,7 +1491,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         const totalDocs = 25;
         const docs = Array(totalDocs - 1).fill("random text");
         docs.push("Microsoft was founded by Bill Gates and Paul Allen");
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionTasks: [{ modelVersion: "latest" }],
@@ -1534,7 +1534,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "3", text: "猫は幸せ" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
@@ -1568,7 +1568,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           { id: "3", text: "猫は幸せ" }
         ];
 
-        const poller = await client.beginAnalyze(
+        const poller = await client.beginAnalyzeBatchTasks(
           docs,
           {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -794,9 +794,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             entityRecognitionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const results = await poller.pollUntilDone();
@@ -830,9 +828,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const results = await poller.pollUntilDone();
@@ -880,9 +876,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             entityRecognitionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -925,9 +919,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -977,9 +969,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             },
             "en",
             {
-              polling: {
-                updateIntervalInMs: pollingInterval
-              }
+              updateIntervalInMs: pollingInterval
             }
           );
           await poller.pollUntilDone();
@@ -1014,9 +1004,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1082,9 +1070,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1141,9 +1127,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1203,9 +1187,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1269,10 +1251,8 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            analyze: { includeStatistics: true },
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            includeStatistics: true,
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1298,9 +1278,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           },
           "en",
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1332,9 +1310,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           },
           "",
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1365,9 +1341,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1398,9 +1372,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1428,9 +1400,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           },
           "notalanguage",
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1466,9 +1436,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             keyPhraseExtractionTasks: [{ modelVersion: "bad" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1499,9 +1467,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           },
           "en",
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1540,9 +1506,7 @@ describe("[AAD] TextAnalyticsClient", function() {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            }
+            updateIntervalInMs: pollingInterval
           }
         );
         const result = await poller.pollUntilDone();
@@ -1574,18 +1538,14 @@ describe("[AAD] TextAnalyticsClient", function() {
             entityRecognitionPiiTasks: [{ modelVersion: "latest" }]
           },
           {
-            polling: {
-              updateIntervalInMs: pollingInterval
-            },
-            analyze: {
-              displayName: "testJob"
-            }
+            updateIntervalInMs: pollingInterval,
+            displayName: "testJob"
           }
         );
         poller.onProgress(() => {
-          assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
-          assert.ok(poller.getOperationState().expiresAt, "expiresAt is undefined!");
-          assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
+          assert.ok(poller.getOperationState().createdOn, "createdOn is undefined!");
+          assert.ok(poller.getOperationState().expiresOn, "expiresOn is undefined!");
+          assert.ok(poller.getOperationState().updatedOn, "updatedOn is undefined!");
           assert.ok(poller.getOperationState().status, "status is undefined!");
           assert.ok(
             poller.getOperationState().successfullyCompletedTasksCount,

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1584,7 +1584,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         poller.onProgress(() => {
           assert.ok(poller.getOperationState().createdAt, "createdAt is undefined!");
-          assert.ok(poller.getOperationState().expiredAt, "expiredAt is undefined!");
+          assert.ok(poller.getOperationState().expiresAt, "expiresAt is undefined!");
           assert.ok(poller.getOperationState().updatedAt, "updatedAt is undefined!");
           assert.ok(poller.getOperationState().status, "status is undefined!");
           assert.ok(


### PR DESCRIPTION
The first step to have a proper design for API v3.1-preview.3:

- replaces the redundant `BeginAnalyzeOperationState` with `BeginAnalyzePollState`
- replaces the redundant `BeginAnalyzeHealthcareOperationState` with `BeginAnalyzeHealthcarePollState`
- adds job's meta data to LRO's poller state
- adds an option to `beginAnalyze` for setting the job's display name
- adds a couple of unit tests for the additional stuff in the poller state