### PR TITLE
[Text Analytics] Organize healthcare entities as nodes in a graph

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 5.1.0 (unreleased)
+
+- The poller for the `beginAnalyze` long-running operation gained the ability to return certain metadata information about the currently running job (e.g., when the job was created, will be expired, and last time it was updated, and also how many tasks completed and failed so far). Also, the poller for `beginAnalyzeHealthcare` gained a similar ability.
+- The healthcare entities returned by `beginAnalyzeHealthcare` are now organized as a directed graph where the edges represent a certain type of healthcare relationship between the source and target nodes.
+
 ## 5.1.0-beta.3 (2020-11-23)
 
 - We are now targeting the service's v3.1-preview.3 API as the default instead of v3.1-preview.2.

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -186,17 +186,21 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
 export interface HealthcareEntitiesArray extends Array<HealthcareResult> {
 }
 
-// @public (undocumented)
+// @public
 export type HealthcareEntity = Entity & {
     isNegated: boolean;
-    links?: HealthcareEntityLink[];
+    dataSource?: HealthcareEntityDataSource[];
+    relatedHealthcareEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
 };
 
-// @public (undocumented)
-export interface HealthcareEntityLink {
+// @public
+export interface HealthcareEntityDataSource {
     dataSource: string;
-    id: string;
+    dataSourceId: string;
 }
+
+// @public
+export type HealthcareEntityRelationType = "DirectionOfBodyStructure" | "DirectionOfExamination" | "RelationOfExamination" | "TimeOfExamination" | "UnitOfExamination" | "ValueOfExamination" | "DirectionOfCondition" | "QualifierOfCondition" | "TimeOfCondition" | "UnitOfCondition" | "ValueOfCondition" | "DosageOfMedication" | "FormOfMedication" | "FrequencyOfMedication" | "RouteOfMedication" | "TimeOfMedication" | "DirectionOfTreatment" | "TimeOfTreatment" | "FrequencyOfTreatment";
 
 // @public
 export type HealthcareErrorResult = TextAnalyticsErrorResult;
@@ -204,21 +208,12 @@ export type HealthcareErrorResult = TextAnalyticsErrorResult;
 // @public
 export type HealthcarePollerLike = PollerLike<BeginAnalyzeHealthcareOperationState, PagedHealthcareEntities>;
 
-// @public (undocumented)
-export interface HealthcareRelation {
-    bidirectional: boolean;
-    relationType: string;
-    source: string;
-    target: string;
-}
-
 // @public
 export type HealthcareResult = HealthcareSuccessResult | HealthcareErrorResult;
 
 // @public
 export interface HealthcareSuccessResult extends TextAnalyticsSuccessResult {
     entities: HealthcareEntity[];
-    relations: HealthcareRelation[];
 }
 
 // @public
@@ -304,6 +299,9 @@ export interface PiiEntity extends Entity {
 export enum PiiEntityDomainType {
     PROTECTED_HEALTH_INFORMATION = "PHI"
 }
+
+// @public
+export type PiiTaskParametersDomain = "phi" | "none" | string;
 
 // @public
 export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -187,11 +187,11 @@ export interface HealthcareEntitiesArray extends Array<HealthcareResult> {
 }
 
 // @public
-export type HealthcareEntity = Entity & {
-    isNegated: boolean;
+export interface HealthcareEntity extends Entity {
     dataSource?: HealthcareEntityDataSource[];
+    isNegated: boolean;
     relatedHealthcareEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
-};
+}
 
 // @public
 export interface HealthcareEntityDataSource {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -20,7 +20,7 @@ import {
   TokenSentimentValue as SentenceAspectSentiment,
   AspectConfidenceScoreLabel
 } from "./generated/models";
-import { findOpinionIndex, OpinionIndex } from "./util";
+import { OpinionIndex, parseOpinionIndex } from "./util";
 
 /**
  * The result of the analyze sentiment operation on a single document.
@@ -207,7 +207,7 @@ function convertAspectRelationToOpinionSentiment(
   document: DocumentSentiment
 ): OpinionSentiment {
   const opinionPtr = aspectRelation.ref;
-  const opinionIndex: OpinionIndex = findOpinionIndex(opinionPtr);
+  const opinionIndex: OpinionIndex = parseOpinionIndex(opinionPtr);
   const opinion: SentenceOpinion | undefined =
     document.sentenceSentiments?.[opinionIndex.sentence].opinions?.[opinionIndex.opinion];
   if (opinion !== undefined) {

--- a/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
@@ -93,7 +93,7 @@ export interface HealthcareEntityDataSource {
  * A healthcare entity represented as a node in a directed graph where the edges are
  * a particular type of relationship between the source and target nodes.
  */
-export type HealthcareEntity = Entity & {
+export interface HealthcareEntity extends Entity {
   /**
    * Whether the entity is negated.
    */
@@ -108,7 +108,7 @@ export type HealthcareEntity = Entity & {
    * the map are the target.
    */
   relatedHealthcareEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
-};
+}
 
 /**
  * The results of a successful healthcare job for a single document.
@@ -201,7 +201,7 @@ function makeHealthcareEntitiesWithoutNeighbors(
 function makeHealthcareEntitiesGraph(
   entities: HealthcareEntity[],
   relations: HealthcareRelation[]
-): HealthcareEntity[] {
+): void {
   for (const relation of relations) {
     const relationType = relation.relationType;
     const sourceIndex = parseHealthcareEntityIndex(relation.source);
@@ -217,7 +217,6 @@ function makeHealthcareEntitiesGraph(
       throw new Error(`Unrecognized healthcare entity relation type: ${relationType}`);
     }
   }
-  return entities;
 }
 
 /**
@@ -230,8 +229,8 @@ export function makeHealthcareEntitiesResult(
   document: DocumentHealthcareEntities
 ): HealthcareSuccessResult {
   const { id, entities, relations, warnings, statistics } = document;
-  const newEntitiesWithoutNeighbors = entities.map(makeHealthcareEntitiesWithoutNeighbors);
-  const newEntities = makeHealthcareEntitiesGraph(newEntitiesWithoutNeighbors, relations);
+  const newEntities = entities.map(makeHealthcareEntitiesWithoutNeighbors);
+  makeHealthcareEntitiesGraph(newEntities, relations);
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     entities: newEntities

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -80,7 +80,10 @@ export {
   HealthcareEntitiesArray,
   HealthcareResult,
   HealthcareSuccessResult,
-  HealthcareErrorResult
+  HealthcareErrorResult,
+  HealthcareEntity,
+  HealthcareEntityDataSource,
+  HealthcareEntityRelationType
 } from "./healthResult";
 export {
   PagedAnalyzeResults,
@@ -115,8 +118,6 @@ export {
   AspectConfidenceScoreLabel,
   TokenSentimentValue,
   TextAnalyticsWarning,
-  HealthcareEntity,
-  HealthcareRelation,
-  HealthcareEntityLink,
+  PiiTaskParametersDomain,
   State
 } from "./generated/models";

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -18,7 +18,8 @@ import {
   HealthcareResult,
   HealthcareEntitiesArray,
   PagedAsyncIterableHealthcareEntities,
-  PagedHealthcareEntities
+  PagedHealthcareEntities,
+  makeHealthcareEntitiesResult
 } from "../../healthResult";
 import { PageSettings } from "@azure/core-paging";
 import {
@@ -29,7 +30,7 @@ import {
 } from "../../util";
 import { AnalysisPollOperation, AnalysisPollOperationState, JobMetadata } from "../poller";
 import { GeneratedClient as Client } from "../../generated";
-import { combineSuccessfulAndErroneousDocuments } from "../../textAnalyticsResult";
+import { processAndCombineSuccessfulAndErroneousDocuments } from "../../textAnalyticsResult";
 import { CanonicalCode } from "@opentelemetry/api";
 import { createSpan } from "../../tracing";
 import { TextAnalyticsOperationOptions } from "../../textAnalyticsOperationOptions";
@@ -177,7 +178,11 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
         operationOptionsToRequestOptionsBase(finalOptions)
       );
       if (response.results) {
-        const result = combineSuccessfulAndErroneousDocuments(this.documents, response.results);
+        const result = processAndCombineSuccessfulAndErroneousDocuments(
+          this.documents,
+          response.results,
+          makeHealthcareEntitiesResult
+        );
         return response.nextLink
           ? { result, ...nextLinkToTopAndSkip(response.nextLink) }
           : { result };

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -51,7 +51,7 @@ export interface OpinionIndex {
   opinion: number;
 }
 
-export function findOpinionIndex(pointer: string): OpinionIndex {
+export function parseOpinionIndex(pointer: string): OpinionIndex {
   const regex = new RegExp(/#\/documents\/(\d+)\/sentences\/(\d+)\/opinions\/(\d+)/);
   const res = regex.exec(pointer);
   if (res !== null) {
@@ -63,6 +63,22 @@ export function findOpinionIndex(pointer: string): OpinionIndex {
     return opinionIndex;
   } else {
     throw new Error(`Pointer "${pointer}" is not a valid opinion pointer`);
+  }
+}
+
+/**
+ * Parses the index of the healthcare entity from a JSON pointer.
+ * @param pointer - a JSON pointer representing an entity
+ * @internal
+ * @hidden
+ */
+export function parseHealthcareEntityIndex(pointer: string): number {
+  const regex = new RegExp(/#\/results\/documents\/(\d+)\/entities\/(\d+)/);
+  const res = regex.exec(pointer);
+  if (res !== null) {
+    return parseInt(res[2]);
+  } else {
+    throw new Error(`Pointer "${pointer}" is not a valid healthcare entity pointer`);
   }
 }
 

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -105,12 +105,41 @@ describe("[API Key] TextAnalyticsClient", function() {
           }
         );
         const result = await poller.pollUntilDone();
-        for await (const doc of result) {
-          if (!doc.error) {
-            assert.ok(doc.id);
-            assert.ok(doc.entities);
-            assert.ok(doc.relations);
-          }
+        const doc1 = (await result.next()).value;
+        if (!doc1.error) {
+          assert.ok(doc1.id);
+          assert.ok(doc1.entities);
+          const doc1Entity1 = doc1.entities[0];
+          assert.equal(doc1Entity1.text, "high");
+          const doc1Entity1Target1 = doc1Entity1.relatedHealthcareEntities.keys().next().value;
+          const doc1Entity1Edge1Label = doc1Entity1.relatedHealthcareEntities.values().next().value;
+          assert.equal(doc1Entity1Target1.text, "blood pressure");
+          assert.equal(doc1Entity1Edge1Label, "ValueOfExamination");
+
+          const doc1Entity2 = doc1.entities[1];
+          assert.equal(doc1Entity2.text, "blood pressure");
+        }
+
+        const doc2 = (await result.next()).value;
+        if (!doc2.error) {
+          assert.ok(doc2.id);
+          assert.ok(doc2.entities);
+          const doc2Entity1 = doc2.entities[0];
+          assert.equal(doc2Entity1.text, "100mg");
+          const doc2Entity1Target1 = doc2Entity1.relatedHealthcareEntities.keys().next().value;
+          const doc2Entity1Edge1Label = doc2Entity1.relatedHealthcareEntities.values().next().value;
+          assert.equal(doc2Entity1Target1.text, "ibuprofen");
+          assert.equal(doc2Entity1Edge1Label, "DosageOfMedication");
+
+          const doc2Entity2 = doc2.entities[1];
+          assert.equal(doc2Entity2.text, "ibuprofen");
+
+          const doc2Entity3 = doc2.entities[2];
+          assert.equal(doc2Entity3.text, "twice daily");
+          const doc2Entity3Target1 = doc2Entity3.relatedHealthcareEntities.keys().next().value;
+          const doc2Entity3Edge1Label = doc2Entity3.relatedHealthcareEntities.values().next().value;
+          assert.equal(doc2Entity3Target1.text, "ibuprofen");
+          assert.equal(doc2Entity3Edge1Label, "FrequencyOfMedication");
         }
       });
 
@@ -129,7 +158,6 @@ describe("[API Key] TextAnalyticsClient", function() {
           if (!doc.error) {
             assert.ok(doc.id);
             assert.ok(doc.entities);
-            assert.ok(doc.relations);
           }
         }
       });
@@ -155,7 +183,6 @@ describe("[API Key] TextAnalyticsClient", function() {
         if (!result3.error) {
           assert.ok(result3.id);
           assert.ok(result3.entities);
-          assert.ok(result3.relations);
         }
         assert.ok(result1.error);
         assert.ok(result2.error);


### PR DESCRIPTION
The service returns a list of relationships between pairs of healthcare entities represented as JSON pointers. This PR creates a directed graph out of these relationships. This is an initial design and it is basically the simplest until we hear from the service about concrete user cases and how they consume these relationships information. You can find this design in action in the updated unit test in `apiKey.spec.ts`. This current design is set to be discussed in the arch board meeting scheduled on Jan 7th. This PR is based on https://github.com/Azure/azure-sdk-for-js/pull/13031, so please review that one first before reviewing this.

js api review: https://apiview.dev/Assemblies/Review/8754191c44914b7e88232f8aba5073de?diffRevisionId=2c0a26254a524f45bf18cdfb36479cf8&doc=False
java api review (leading design): https://apiview.dev/Assemblies/Review/329cfc783b474d97891a5349e705feb4?diffRevisionId=2d29649d53c4457c97f7e4e5870d04fc&doc=False#com.azure.ai.textanalytics.models.HealthcareEntity

We are waiting on customers scenarios from the service team so we can write proper samples.