### PR TITLE
[ESLint Plugin] ts-doc-internal checks for hidden instead of ignore

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md
@@ -4,6 +4,16 @@ Requires any TSDoc comments on internal objects to include either an `@internal`
 
 Internal objects are defined as classes, interfaces, or standalone functions that are not exported from the main entrypoint to the package and are not members of any exports from the main entrypoint (defined recursively). **Files that are specified as excluded in a `typedoc.json` file are ignored by this rule.**
 
+## Background
+
+We used to use either `@hidden` or `@ignore` to hide definitions from showing up in our docs but none of them is supported by TSDoc. However, we opted to whitelist `@hidden` with TSDoc ESLint plugin and replaced all uses of `@ignore` with `@hidden` so we can stick with just one of them.
+
+## When to use either tags
+
+TSDoc supports `@internal` and it is confusing to decide whether to use that or `@hidden`. `@internal`, unlike `@hidden`, has compilation implications. In particular, using the former can instruct the compiler to not emit declarations for the annotated definitions (see [here](https://www.typescriptlang.org/zh/tsconfig#stripInternal)). So it is advised to use `@internal` if you want this specific behavior along with the compiler flag. However, unfortunately, you still need to also insert `@hidden` because our docs generator tool (TypeDoc) does not understand the stripInternal flag. This is why you can find many definitions in our code base annotated with both. If the definition is supposed to be exported but you do not want to have it in the docs, then use `@hidden` only.
+
+## Configuration
+
 By default, the main entrypoint is assumed to be `src/index.ts`. However, if your package's main entrypoint is elsewhere, you'll need to specify so in your `.eslintrc` configuration file as follows (for example, if the entrypoint is `index.ts`):
 
 ```json

--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md
@@ -1,6 +1,6 @@
 # ts-doc-internal
 
-Requires any TSDoc comments on internal objects to include either an `@internal` or an `@ignore` tag.
+Requires any TSDoc comments on internal objects to include either an `@internal` or an `@hidden` tag.
 
 Internal objects are defined as classes, interfaces, or standalone functions that are not exported from the main entrypoint to the package and are not members of any exports from the main entrypoint (defined recursively). **Files that are specified as excluded in a `typedoc.json` file are ignored by this rule.**
 
@@ -33,7 +33,7 @@ class ExampleClass {}
 ```ts
 /**
  * Other documentation
- * @ignore
+ * @hidden
  */
 interface ExampleInterface {}
 ```
@@ -65,6 +65,7 @@ interface ExampleInterface {}
 ```ts
 /**
  * Other documentation
+ * @ignore
  */
 function exampleFunction(): void {}
 ```

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -39,7 +39,7 @@ const reportInternal = (
 
   // if type is internal and has a TSDoc
   if (!context.settings.exported.includes(symbol) && tsNode.jsDoc !== undefined) {
-    // fetc all tags
+    // fetch all tags
     let TSDocTags: string[] = [];
     tsNode.jsDoc.forEach((TSDocComment: any): void => {
       TSDocTags = TSDocTags.concat(
@@ -50,7 +50,7 @@ const reportInternal = (
     });
 
     // see if any match hidden or internal
-    if (TSDocTags.every((TSDocTag: string): boolean => !/|(internal)|(hidden)/.test(TSDocTag))) {
+    if (!TSDocTags.some((TSDocTag: string): boolean => /(internal)|(hidden)/.test(TSDocTag))) {
       context.report({
         node: node,
         message: "internal items with TSDoc comments should include an @internal or @hidden tag"

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 /**
- * @file Rule to require TSDoc comments to include internal or ignore tags if the object is internal.
+ * @file Rule to require TSDoc comments to include internal or hidden tags if the object is internal.
  * @author Arpan Laha
  */
 
@@ -26,7 +26,7 @@ import { getLocalExports, getRuleMetaData } from "../utils";
  * @param context the ESLint runtime context
  * @param converter a converter from TSESTree Nodes to TSNodes
  * @param typeChecker the TypeScript TypeChecker
- * @throws if the Node passes throught the initial checks and does not have an internal or ignore tag
+ * @throws if the Node passes throught the initial checks and does not have an internal or hidden tag
  */
 const reportInternal = (
   node: Node,
@@ -49,11 +49,11 @@ const reportInternal = (
       );
     });
 
-    // see if any match ignore or internal
-    if (TSDocTags.every((TSDocTag: string): boolean => !/(ignore)|(internal)/.test(TSDocTag))) {
+    // see if any match hidden or internal
+    if (TSDocTags.every((TSDocTag: string): boolean => !/|(internal)|(hidden)/.test(TSDocTag))) {
       context.report({
         node: node,
-        message: "internal items with TSDoc comments should include an @internal or @ignore tag"
+        message: "internal items with TSDoc comments should include an @internal or @hidden tag"
       });
     }
   }
@@ -95,7 +95,7 @@ try {
 export = {
   meta: getRuleMetaData(
     "ts-doc-internal",
-    "require TSDoc comments to include an '@internal' or '@ignore' tag if the object is not public-facing"
+    "require TSDoc comments to include an '@internal' or '@hidden' tag if the object is not public-facing"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const fileName = context.getFilename();

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
@@ -40,7 +40,7 @@ ruleTester.run("ts-doc-internal", rule, {
       code: `
             /**
              * Other documentation
-             * @ignore
+             * @hidden
              */
             class ExampleClass {}`,
       filename: "src/test.ts"
@@ -59,7 +59,7 @@ ruleTester.run("ts-doc-internal", rule, {
       code: `
             /**
              * Other documentation
-             * @ignore
+             * @hidden
              */
             interface ExampleInterface {}`,
       filename: "src/test.ts"
@@ -78,7 +78,7 @@ ruleTester.run("ts-doc-internal", rule, {
       code: `
             /**
              * Other documentation
-             * @ignore
+             * @hidden
              */
             function ExampleFunction() {}`,
       filename: "src/test.ts"
@@ -95,7 +95,7 @@ ruleTester.run("ts-doc-internal", rule, {
       filename: "src/test.ts",
       errors: [
         {
-          message: "internal items with TSDoc comments should include an @internal or @ignore tag"
+          message: "internal items with TSDoc comments should include an @internal or @hidden tag"
         }
       ]
     },
@@ -109,7 +109,7 @@ ruleTester.run("ts-doc-internal", rule, {
       filename: "src/test.ts",
       errors: [
         {
-          message: "internal items with TSDoc comments should include an @internal or @ignore tag"
+          message: "internal items with TSDoc comments should include an @internal or @hidden tag"
         }
       ]
     },
@@ -118,12 +118,13 @@ ruleTester.run("ts-doc-internal", rule, {
       code: `
             /**
              * Other documentation
+             * @ignore
              */
             function ExampleFunction() {}`,
       filename: "src/test.ts",
       errors: [
         {
-          message: "internal items with TSDoc comments should include an @internal or @ignore tag"
+          message: "internal items with TSDoc comments should include an @internal or @hidden tag"
         }
       ]
     }


### PR DESCRIPTION
We are no longer using JSDoc's `@ignore` here https://github.com/Azure/azure-sdk-for-js/pull/12963.