### PR TITLE
[Identity] Bump Axios version to 0.21.1

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1595,12 +1595,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  /axios/0.20.0:
+  /axios/0.21.1:
     dependencies:
       follow-redirects: 1.13.1
     dev: false
     resolution:
-      integrity: sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+      integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /azure-storage/2.10.3:
     dependencies:
       browserify-mime: 1.2.9
@@ -9041,6 +9041,7 @@ packages:
       karma-remap-istanbul: 0.6.0_karma@5.2.3
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
+      nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -9056,7 +9057,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-q7N2kw0AD/INh87gkzzATH88kOQ6/qO78ipb8D0vRin+En7CUV1/fo7jZzl1dM5lGTWeneGYQ7aWOcXrw6pInA==
+      integrity: sha512-4Rw9bJONHF4b63GMcRXMMedfBfpmEfz/sXPYQrXZJuXm48X+kZp5TVYLxmgjAOUBozyCv7U9cGK2DWPBpesPyA==
       tarball: 'file:projects/data-tables.tgz'
     version: 0.0.0
   'file:projects/dev-tool.tgz':
@@ -9441,7 +9442,7 @@ packages:
       '@types/sinon': 9.0.9
       '@types/uuid': 8.3.0
       assert: 1.5.0
-      axios: 0.20.0
+      axios: 0.21.1
       cross-env: 7.0.3
       eslint: 7.15.0
       events: 3.2.0
@@ -9480,7 +9481,7 @@ packages:
     optionalDependencies:
       keytar: 5.6.0
     resolution:
-      integrity: sha512-gDqAgKO9IiU3fs1ndBcG862UQXuswjFTKIotljAb1lgW/GAEQvtw0FcqZOvIVhWeYGznlCeD0lYclCUxpXNHsA==
+      integrity: sha512-du1ENhjYGMpczYJQxuydC8TJb4Ub9V9pbghrQGJ7ogu77xVjUtL8AWYMZW6djp2Gh5Fv+kBiMmIy0nTGzfcb3Q==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-admin.tgz':

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -85,7 +85,7 @@
     "@azure/logger": "^1.0.0",
     "@azure/msal-node": "1.0.0-beta.1",
     "@opentelemetry/api": "^0.10.2",
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "events": "^3.0.0",
     "jws": "^4.0.0",
     "msal": "^1.0.2",


### PR DESCRIPTION
CVE-2020-28168:
> Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.

This PR is a simple version bump from Axios 0.20.0 to 0.21.1. No breaking changes.