### PR TITLE
[app-configuration] Fixing some lint issues

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
@@ -6,6 +6,7 @@ import { sha256Digest, sha256Hmac } from "./internal/cryptoHelpers";
 
 /**
  * @internal
+ * @hidden
  */
 export class AppConfigCredential implements ServiceClientCredentials {
   private credential: string;

--- a/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
@@ -6,7 +6,6 @@ import { sha256Digest, sha256Hmac } from "./internal/cryptoHelpers";
 
 /**
  * @internal
- * @ignore
  */
 export class AppConfigCredential implements ServiceClientCredentials {
   private credential: string;

--- a/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
@@ -19,8 +19,8 @@ export class AppConfigCredential implements ServiceClientCredentials {
   /**
    * Signs a request with the values provided in the credential and secret parameter.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
-   * @returns {Promise<WebResource>} The signed request object.
+   * @param webResource - The WebResource to be signed.
+   * @returns The signed request object.
    */
   async signRequest(webResource: WebResource): Promise<WebResource> {
     const verb = webResource.method.toUpperCase();

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -119,16 +119,16 @@ export class AppConfigurationClient {
 
   /**
    * Initializes a new instance of the AppConfigurationClient class.
-   * @param connectionString Connection string needed for a client to connect to Azure.
-   * @param options Options for the AppConfigurationClient.
+   * @param connectionString - Connection string needed for a client to connect to Azure.
+   * @param options - Options for the AppConfigurationClient.
    */
   constructor(connectionString: string, options?: AppConfigurationClientOptions);
   /**
    * Initializes a new instance of the AppConfigurationClient class using
    * a TokenCredential.
-   * @param endpoint The endpoint of the App Configuration service (ex: https://sample.azconfig.io).
-   * @param tokenCredential An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the @azure/identity package to create a credential that suits your needs.
-   * @param options Options for the AppConfigurationClient.
+   * @param endpoint - The endpoint of the App Configuration service (ex: https://sample.azconfig.io).
+   * @param tokenCredential - An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the \@azure/identity package to create a credential that suits your needs.
+   * @param options - Options for the AppConfigurationClient.
    */
   constructor(
     endpoint: string,
@@ -182,8 +182,8 @@ export class AppConfigurationClient {
    * ```ts
    * const result = await client.addConfigurationSetting({ key: "MyKey", label: "MyLabel", value: "MyValue" });
    * ```
-   * @param configurationSetting A configuration setting.
-   * @param options Optional parameters for the request.
+   * @param configurationSetting - A configuration setting.
+   * @param options - Optional parameters for the request.
    */
   addConfigurationSetting(
     configurationSetting: AddConfigurationSettingParam,
@@ -209,8 +209,8 @@ export class AppConfigurationClient {
    * ```ts
    * const deletedSetting = await client.deleteConfigurationSetting({ key: "MyKey", label: "MyLabel" });
    * ```
-   * @param id The id of the configuration setting to delete.
-   * @param options Optional parameters for the request (ex: etag, label)
+   * @param id - The id of the configuration setting to delete.
+   * @param options - Optional parameters for the request (ex: etag, label)
    */
   deleteConfigurationSetting(
     id: ConfigurationSettingId,
@@ -235,8 +235,8 @@ export class AppConfigurationClient {
    * ```ts
    * const setting = await client.getConfigurationSetting({ key: "MyKey", label: "MyLabel" });
    * ```
-   * @param id The id of the configuration setting to get.
-   * @param options Optional parameters for the request.
+   * @param id - The id of the configuration setting to get.
+   * @param options - Optional parameters for the request.
    */
   async getConfigurationSetting(
     id: ConfigurationSettingId,
@@ -279,7 +279,7 @@ export class AppConfigurationClient {
    * ```ts
    * const allSettingsWithLabel = client.listConfigurationSettings({ labels: [ "MyLabel" ] });
    * ```
-   * @param options Optional parameters for the request.
+   * @param options - Optional parameters for the request.
    */
   listConfigurationSettings(
     options: ListConfigurationSettingsOptions = {}
@@ -370,7 +370,7 @@ export class AppConfigurationClient {
    * ```ts
    * const revisionsIterator = client.listRevisions({ keys: ["MyKey"] });
    * ```
-   * @param options Optional parameters for the request.
+   * @param options - Optional parameters for the request.
    */
   listRevisions(
     options?: ListRevisionsOptions
@@ -444,9 +444,9 @@ export class AppConfigurationClient {
 
   /**
    * Sets the value of a key in the Azure App Configuration service, allowing for an optional etag.
-   * @param key The name of the key.
-   * @param configurationSetting A configuration value.
-   * @param options Optional parameters for the request.
+   * @param key - The name of the key.
+   * @param configurationSetting - A configuration value.
+   * @param options - Optional parameters for the request.
    *
    * Example code:
    * ```ts
@@ -473,7 +473,7 @@ export class AppConfigurationClient {
 
   /**
    * Sets or clears a key's read-only status.
-   * @param id The id of the configuration setting to modify.
+   * @param id - The id of the configuration setting to modify.
    */
   async setReadOnly(
     id: ConfigurationSettingId,

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -66,7 +66,6 @@ const packageName = "azsdk-js-app-configuration";
  * This constant should always be the same as the package.json's version - we use it when forming the
  * User - Agent header. There's a unit test that makes sure it always stays in sync.
  * @internal
- * @ignore
  */
 export const packageVersion = "1.1.1";
 const apiVersion = "1.0";
@@ -102,7 +101,6 @@ export interface AppConfigurationClientOptions {
 /**
  * Provides internal configuration options for AppConfigurationClient.
  * @internal
- * @ignore
  */
 export interface InternalAppConfigurationClientOptions extends AppConfigurationClientOptions {
   /**
@@ -509,7 +507,6 @@ export class AppConfigurationClient {
 /**
  * Gets the options for the generated AppConfigurationClient
  * @internal
- * @ignore
  */
 export function getGeneratedClientOptions(
   baseUri: string,
@@ -545,7 +542,6 @@ export function getGeneratedClientOptions(
 
 /**
  * @internal
- * @ignore
  */
 export function getUserAgentPrefix(userSuppliedUserAgent: string | undefined): string {
   const appConfigDefaultUserAgent = `${packageName}/${packageVersion} ${getCoreHttpDefaultUserAgentValue()}`;

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -66,6 +66,7 @@ const packageName = "azsdk-js-app-configuration";
  * This constant should always be the same as the package.json's version - we use it when forming the
  * User - Agent header. There's a unit test that makes sure it always stays in sync.
  * @internal
+ * @hidden
  */
 export const packageVersion = "1.1.1";
 const apiVersion = "1.0";
@@ -101,6 +102,7 @@ export interface AppConfigurationClientOptions {
 /**
  * Provides internal configuration options for AppConfigurationClient.
  * @internal
+ * @hidden
  */
 export interface InternalAppConfigurationClientOptions extends AppConfigurationClientOptions {
   /**
@@ -507,6 +509,7 @@ export class AppConfigurationClient {
 /**
  * Gets the options for the generated AppConfigurationClient
  * @internal
+ * @hidden
  */
 export function getGeneratedClientOptions(
   baseUri: string,
@@ -542,6 +545,7 @@ export function getGeneratedClientOptions(
 
 /**
  * @internal
+ * @hidden
  */
 export function getUserAgentPrefix(userSuppliedUserAgent: string | undefined): string {
   const appConfigDefaultUserAgent = `${packageName}/${packageVersion} ${getCoreHttpDefaultUserAgentValue()}`;

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
@@ -5,7 +5,6 @@
 
 /**
  * @internal
- * @ignore
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   const digest = await self.crypto.subtle.digest("SHA-256", new TextEncoder().encode(body || ""));
@@ -17,7 +16,6 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
- * @ignore
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const key = await self.crypto.subtle.importKey(

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
@@ -5,6 +5,7 @@
 
 /**
  * @internal
+ * @hidden
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   const digest = await self.crypto.subtle.digest("SHA-256", new TextEncoder().encode(body || ""));
@@ -16,6 +17,7 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
+ * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const key = await self.crypto.subtle.importKey(

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
@@ -5,7 +5,6 @@ import { createHash, createHmac } from "crypto";
 
 /**
  * @internal
- * @ignore
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   return createHash("sha256")
@@ -15,7 +14,6 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
- * @ignore
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const decodedSecret = Buffer.from(secret, "base64");

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
@@ -5,6 +5,7 @@ import { createHash, createHmac } from "crypto";
 
 /**
  * @internal
+ * @hidden
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   return createHash("sha256")
@@ -14,6 +15,7 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
+ * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const decodedSecret = Buffer.from(secret, "base64");

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -120,8 +120,8 @@ export function formatAcceptDateTime(newOptions: {
  * @internal
  */
 export function extractAfterTokenFromNextLink(nextLink: string) {
-  let parsedLink = URLBuilder.parse(nextLink);
-  let afterToken = parsedLink.getQueryParameterValue("after");
+  const parsedLink = URLBuilder.parse(nextLink);
+  const afterToken = parsedLink.getQueryParameterValue("after");
 
   if (afterToken == null || Array.isArray(afterToken)) {
     throw new Error("Invalid nextLink - invalid after token");

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -38,7 +38,7 @@ export function quoteETag(etag: string | undefined): string | undefined {
 /**
  * Checks the onlyIfChanged/onlyIfUnchanged properties to make sure we haven't specified both
  * and throws an Error. Otherwise, returns the properties properly quoted.
- * @param options An options object with onlyIfChanged/onlyIfUnchanged fields
+ * @param options - An options object with onlyIfChanged/onlyIfUnchanged fields
  * @internal
  */
 export function checkAndFormatIfAndIfNoneMatch(
@@ -103,7 +103,7 @@ export function formatWildcards(
 
 /**
  * Handles translating a Date acceptDateTime into a string as needed by the API
- * @param newOptions A newer style options with acceptDateTime as a date (and with proper casing!)
+ * @param newOptions - A newer style options with acceptDateTime as a date (and with proper casing!)
  * @internal
  */
 export function formatAcceptDateTime(newOptions: {
@@ -135,7 +135,7 @@ export function extractAfterTokenFromNextLink(nextLink: string) {
  * to prevent possible errors by the user in accessing a model that is uninitialized. This can happen
  * in cases like HTTP status code 204 or 304, which return an empty response body.
  *
- * @param configurationSetting The configuration setting to alter
+ * @param configurationSetting - The configuration setting to alter
  */
 export function makeConfigurationSettingEmpty(
   configurationSetting: Partial<Record<Exclude<keyof ConfigurationSetting, "key">, any>>

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -17,6 +17,7 @@ import { AppConfigurationGetKeyValuesOptionalParams, KeyValue } from "../generat
 /**
  * Formats the etag so it can be used with a If-Match/If-None-Match header
  * @internal
+ * @hidden
  */
 export function quoteETag(etag: string | undefined): string | undefined {
   // https://tools.ietf.org/html/rfc7232#section-3.1
@@ -40,6 +41,7 @@ export function quoteETag(etag: string | undefined): string | undefined {
  * and throws an Error. Otherwise, returns the properties properly quoted.
  * @param options - An options object with onlyIfChanged/onlyIfUnchanged fields
  * @internal
+ * @hidden
  */
 export function checkAndFormatIfAndIfNoneMatch(
   configurationSetting: ConfigurationSettingId,
@@ -71,6 +73,7 @@ export function checkAndFormatIfAndIfNoneMatch(
  * into the format the REST call will need.
  *
  * @internal
+ * @hidden
  */
 export function formatWildcards(
   listConfigOptions: ListConfigurationSettingsOptions | ListRevisionsOptions
@@ -105,6 +108,7 @@ export function formatWildcards(
  * Handles translating a Date acceptDateTime into a string as needed by the API
  * @param newOptions - A newer style options with acceptDateTime as a date (and with proper casing!)
  * @internal
+ * @hidden
  */
 export function formatAcceptDateTime(newOptions: {
   acceptDateTime?: Date;
@@ -118,6 +122,7 @@ export function formatAcceptDateTime(newOptions: {
  * Take the URL that gets returned from next link and extract the 'after' token needed
  * to get the next page of results.
  * @internal
+ * @hidden
  */
 export function extractAfterTokenFromNextLink(nextLink: string) {
   const parsedLink = URLBuilder.parse(nextLink);
@@ -157,6 +162,7 @@ export function makeConfigurationSettingEmpty(
 
 /**
  * @internal
+ * @hidden
  */
 export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
   const obj: ConfigurationSetting & KeyValue = {
@@ -170,6 +176,7 @@ export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
 
 /**
  * @internal
+ * @hidden
  */
 export function transformKeyValueResponseWithStatusCode<
   T extends KeyValue & HttpResponseField<any>
@@ -184,6 +191,7 @@ export function transformKeyValueResponseWithStatusCode<
 
 /**
  * @internal
+ * @hidden
  */
 export function transformKeyValueResponse<
   T extends KeyValue & { eTag?: string } & HttpResponseField<any>

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -17,7 +17,6 @@ import { AppConfigurationGetKeyValuesOptionalParams, KeyValue } from "../generat
 /**
  * Formats the etag so it can be used with a If-Match/If-None-Match header
  * @internal
- * @ignore
  */
 export function quoteETag(etag: string | undefined): string | undefined {
   // https://tools.ietf.org/html/rfc7232#section-3.1
@@ -41,7 +40,6 @@ export function quoteETag(etag: string | undefined): string | undefined {
  * and throws an Error. Otherwise, returns the properties properly quoted.
  * @param options An options object with onlyIfChanged/onlyIfUnchanged fields
  * @internal
- * @ignore
  */
 export function checkAndFormatIfAndIfNoneMatch(
   configurationSetting: ConfigurationSettingId,
@@ -73,7 +71,6 @@ export function checkAndFormatIfAndIfNoneMatch(
  * into the format the REST call will need.
  *
  * @internal
- * @ignore
  */
 export function formatWildcards(
   listConfigOptions: ListConfigurationSettingsOptions | ListRevisionsOptions
@@ -108,7 +105,6 @@ export function formatWildcards(
  * Handles translating a Date acceptDateTime into a string as needed by the API
  * @param newOptions A newer style options with acceptDateTime as a date (and with proper casing!)
  * @internal
- * @ignore
  */
 export function formatAcceptDateTime(newOptions: {
   acceptDateTime?: Date;
@@ -122,7 +118,6 @@ export function formatAcceptDateTime(newOptions: {
  * Take the URL that gets returned from next link and extract the 'after' token needed
  * to get the next page of results.
  * @internal
- * @ignore
  */
 export function extractAfterTokenFromNextLink(nextLink: string) {
   let parsedLink = URLBuilder.parse(nextLink);
@@ -161,7 +156,6 @@ export function makeConfigurationSettingEmpty(
 }
 
 /**
- * @ignore
  * @internal
  */
 export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
@@ -175,7 +169,6 @@ export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
 }
 
 /**
- * @ignore
  * @internal
  */
 export function transformKeyValueResponseWithStatusCode<
@@ -190,7 +183,6 @@ export function transformKeyValueResponseWithStatusCode<
 }
 
 /**
- * @ignore
  * @internal
  */
 export function transformKeyValueResponse<

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -14,6 +14,7 @@ import {
  * The sync token header, as described here:
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  * @internal
+ * @hidden
  */
 export const SyncTokenHeaderName = "sync-token";
 
@@ -21,6 +22,7 @@ export const SyncTokenHeaderName = "sync-token";
  * A policy factory for injecting sync tokens properly into outgoing requests.
  * @param syncTokens - the sync tokens store to be used across requests.
  * @internal
+ * @hidden
  */
 export function syncTokenPolicy(syncTokens: SyncTokens): RequestPolicyFactory {
   return {
@@ -60,6 +62,7 @@ class SyncTokenPolicy extends BaseRequestPolicy {
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  *
  * @internal
+ * @hidden
  */
 export class SyncTokens {
   private _currentSyncTokens = new Map<string, SyncToken>();
@@ -137,6 +140,7 @@ interface SyncToken {
  * @param syncToken - A single sync token.
  *
  * @internal
+ * @hidden
  */
 export function parseSyncToken(syncToken: string): SyncToken {
   const matches = syncToken.match(syncTokenRegex);

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -14,7 +14,6 @@ import {
  * The sync token header, as described here:
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  * @internal
- * @ignore
  */
 export const SyncTokenHeaderName = "sync-token";
 
@@ -22,7 +21,6 @@ export const SyncTokenHeaderName = "sync-token";
  * A policy factory for injecting sync tokens properly into outgoing requests.
  * @param syncTokens
  * @internal
- * @ignore
  */
 export function syncTokenPolicy(syncTokens: SyncTokens): RequestPolicyFactory {
   return {
@@ -62,7 +60,6 @@ class SyncTokenPolicy extends BaseRequestPolicy {
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  *
  * @internal
- * @ignore
  */
 export class SyncTokens {
   private _currentSyncTokens = new Map<string, SyncToken>();
@@ -140,7 +137,6 @@ interface SyncToken {
  * @param syncToken A single sync token.
  *
  * @internal
- * @ignore
  */
 export function parseSyncToken(syncToken: string): SyncToken {
   const matches = syncToken.match(syncTokenRegex);

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   RequestPolicy,

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -19,7 +19,7 @@ export const SyncTokenHeaderName = "sync-token";
 
 /**
  * A policy factory for injecting sync tokens properly into outgoing requests.
- * @param syncTokens
+ * @param syncTokens - the sync tokens store to be used across requests.
  * @internal
  */
 export function syncTokenPolicy(syncTokens: SyncTokens): RequestPolicyFactory {
@@ -73,7 +73,7 @@ export class SyncTokens {
    * If given an empty value (or undefined) it clears the current list of sync tokens.
    * (indicates the service has properly absorbed values into the cluster).
    *
-   * @param syncTokenHeaderValue The full value of the sync token header.
+   * @param syncTokenHeaderValue - The full value of the sync token header.
    */
   addSyncTokenFromHeaderValue(syncTokenHeaderValue: string | undefined) {
     if (syncTokenHeaderValue == null || syncTokenHeaderValue === "") {
@@ -134,7 +134,7 @@ interface SyncToken {
 /**
  * Parses a single sync token into it's constituent parts.
  *
- * @param syncToken A single sync token.
+ * @param syncToken - A single sync token.
  *
  * @internal
  */

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { getTracer } from "@azure/core-tracing";
 import { Span, SpanKind, CanonicalCode } from "@opentelemetry/api";

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -9,7 +9,6 @@ import { RestError } from "@azure/core-http";
 
 /**
  * @internal
- * @ignore
  */
 export interface Spannable {
   spanOptions?: SpanOptions;
@@ -17,7 +16,6 @@ export interface Spannable {
 
 /**
  * @internal
- * @ignore
  */
 export class Spanner<TClient> {
   constructor(private baseOperationName: string) {}

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -23,10 +23,10 @@ export class Spanner<TClient> {
   /**
    * Traces an operation and properly handles reporting start, end and errors for a given span
    *
-   * @param operationName Name of a method in the TClient type
-   * @param options An options class, typically derived from @azure/core-http/RequestOptionsBase
-   * @param fn The function to call with an options class that properly propagates the span context
-   * @param translateToCanonicalCodeFn An optional function to translate thrown errors into a CanonicalCode for the span
+   * @param operationName - Name of a method in the TClient type
+   * @param options - An options class, typically derived from \@azure/core-http/RequestOptionsBase
+   * @param fn - The function to call with an options class that properly propagates the span context
+   * @param translateToCanonicalCodeFn - An optional function to translate thrown errors into a CanonicalCode for the span
    */
   async trace<OptionsT extends Spannable, ReturnT>(
     operationName: keyof TClient,

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -9,6 +9,7 @@ import { RestError } from "@azure/core-http";
 
 /**
  * @internal
+ * @hidden
  */
 export interface Spannable {
   spanOptions?: SpanOptions;
@@ -16,6 +17,7 @@ export interface Spannable {
 
 /**
  * @internal
+ * @hidden
  */
 export class Spanner<TClient> {
   constructor(private baseOperationName: string) {}

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -244,7 +244,7 @@ export interface ListSettingsOptions extends OptionalFields {
    *    | abc*         | Matches key names that start with abc |
    *
    * These characters are reserved and must be prefixed with backslash in order
-   * to be specified: * or \ or ,
+   * to be specified: * or \\ or ,
    */
   keyFilter?: string;
 
@@ -262,7 +262,7 @@ export interface ListSettingsOptions extends OptionalFields {
    *    | prod*        | Matches key with label names that start with prod |
    *
    * These characters are reserved and must be prefixed with backslash in order
-   * to be specified: * or \ or ,
+   * to be specified: * or \\ or ,
    */
   labelFilter?: string;
 }

--- a/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   BaseRequestPolicy,

--- a/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
@@ -15,6 +15,7 @@ import {
 
 /**
  * @internal
+ * @hidden
  */
 export function throttlingRetryPolicy(): RequestPolicyFactory {
   return {
@@ -30,6 +31,7 @@ export function throttlingRetryPolicy(): RequestPolicyFactory {
  * responding to 429 responses (which is to throw a RestError).
  *
  * @internal
+ * @hidden
  */
 export class ThrottlingRetryPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -84,6 +86,7 @@ const RetryAfterMillisecondsHeaders: string[] = ["retry-after-ms", "x-ms-retry-a
  * Extracts the retry response header, checking against several
  * header names.
  * @internal
+ * @hidden
  */
 export function getDelayInMs(responseHeaders: {
   get: (headerName: string) => string | undefined;

--- a/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
@@ -15,7 +15,6 @@ import {
 
 /**
  * @internal
- * @ignore
  */
 export function throttlingRetryPolicy(): RequestPolicyFactory {
   return {
@@ -31,7 +30,6 @@ export function throttlingRetryPolicy(): RequestPolicyFactory {
  * responding to 429 responses (which is to throw a RestError).
  *
  * @internal
- * @ignore
  */
 export class ThrottlingRetryPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -86,7 +84,6 @@ const RetryAfterMillisecondsHeaders: string[] = ["retry-after-ms", "x-ms-retry-a
  * Extracts the retry response header, checking against several
  * header names.
  * @internal
- * @ignore
  */
 export function getDelayInMs(responseHeaders: {
   get: (headerName: string) => string | undefined;

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -124,7 +124,7 @@ describe("helper methods", () => {
 
   describe("extractAfterTokenFromNextLink", () => {
     it("token is extracted and properly unescaped", () => {
-      let token = extractAfterTokenFromNextLink("/kv?key=someKey&api-version=1.0&after=bGlah%3D");
+      const token = extractAfterTokenFromNextLink("/kv?key=someKey&api-version=1.0&after=bGlah%3D");
       assert.equal("bGlah=", token);
     });
   });

--- a/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
@@ -1,4 +1,7 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 import { parseSyncToken, SyncTokens } from "../../src/internal/synctokenpolicy";
@@ -31,11 +34,12 @@ describe("http request related tests", function() {
       });
 
       it("throws on invalid sync tokens", () => {
-        for (const invalidToken of ["invalid token", "missing=sequencenumber", "key=value;"])
+        for (const invalidToken of ["invalid token", "missing=sequencenumber", "key=value;"]) {
           assert.throws(
             () => parseSyncToken(invalidToken),
             new RegExp(`Failed to parse sync token '${invalidToken}' with regex .+$`)
           );
+        }
       });
     });
 

--- a/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/package.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { join } from "path";
 import * as assert from "assert";
 import { isNode } from "@azure/core-http";

--- a/sdk/appconfiguration/app-configuration/test/internal/throttlingRetryPolicyTests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/throttlingRetryPolicyTests.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import chai from "chai";
 import sinon from "sinon";

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { Spanner } from "../../src/internal/tracingHelpers";
 import { RestError } from "@azure/core-http";

--- a/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import {
   createAppConfigurationClientForTests,
   assertThrowsRestError,

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import * as assert from "assert";
 import {
@@ -438,7 +438,7 @@ describe("AppConfigurationClient", () => {
     let listConfigSettingA: ConfigurationSetting;
     let count = 0;
 
-    let productionASettingId: {
+    const productionASettingId: {
       key: string;
       label: string;
       value: string;
@@ -448,7 +448,7 @@ describe("AppConfigurationClient", () => {
       value: "[A] production value"
     };
 
-    let keys: {
+    const keys: {
       listConfigSettingA: string;
       listConfigSettingB: string;
     } = {
@@ -497,7 +497,7 @@ describe("AppConfigurationClient", () => {
 
     it("exact match on label", async () => {
       // query with a direct label match
-      let byLabelIterator = client.listConfigurationSettings({ labelFilter: uniqueLabel });
+      const byLabelIterator = client.listConfigurationSettings({ labelFilter: uniqueLabel });
       const byLabelSettings = await toSortedArray(byLabelIterator);
 
       assertEqualSettings(
@@ -521,7 +521,7 @@ describe("AppConfigurationClient", () => {
 
     it("label wildcards", async () => {
       // query with a direct label match
-      let byLabelIterator = client.listConfigurationSettings({
+      const byLabelIterator = client.listConfigurationSettings({
         labelFilter: uniqueLabel.substring(0, uniqueLabel.length - 1) + "*"
       });
       const byLabelSettings = await toSortedArray(byLabelIterator);
@@ -546,7 +546,7 @@ describe("AppConfigurationClient", () => {
     });
 
     it("exact match on key", async () => {
-      let byKeyIterator = client.listConfigurationSettings({
+      const byKeyIterator = client.listConfigurationSettings({
         keyFilter: keys.listConfigSettingA
       });
       const byKeySettings = await toSortedArray(byKeyIterator);
@@ -573,7 +573,7 @@ describe("AppConfigurationClient", () => {
     it("key wildcards", async () => {
       // query with a key wildcard
       const keyFilter = keys.listConfigSettingA;
-      let byKeyIterator = client.listConfigurationSettings({
+      const byKeyIterator = client.listConfigurationSettings({
         keyFilter: keyFilter.substring(0, keyFilter.length - 1) + "*"
       });
       const byKeySettings = await toSortedArray(byKeyIterator);
@@ -632,12 +632,12 @@ describe("AppConfigurationClient", () => {
     });
 
     it("by date", async () => {
-      let byKeyIterator = client.listConfigurationSettings({
+      const byKeyIterator = client.listConfigurationSettings({
         keyFilter: "listConfigSetting*",
         acceptDateTime: listConfigSettingA.lastModified
       });
 
-      let settings = await toSortedArray(byKeyIterator);
+      const settings = await toSortedArray(byKeyIterator);
       let foundMyExactSettingToo = false;
 
       // all settings returned should be the same date or as old as my setting
@@ -678,7 +678,7 @@ describe("AppConfigurationClient", () => {
 
       await Promise.all(addSettingPromises);
 
-      let listResult = client.listConfigurationSettings({
+      const listResult = client.listConfigurationSettings({
         keyFilter: key
       });
 
@@ -800,12 +800,12 @@ describe("AppConfigurationClient", () => {
     });
 
     it("by date", async () => {
-      let byKeyIterator = client.listRevisions({
+      const byKeyIterator = client.listRevisions({
         keyFilter: key,
         acceptDateTime: originalSetting.lastModified
       });
 
-      let settings = await toSortedArray(byKeyIterator);
+      const settings = await toSortedArray(byKeyIterator);
 
       assert.deepEqual(
         {

--- a/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { AppConfigurationClient, ConfigurationSetting } from "../../src";
 import {
   createAppConfigurationClientForTests,

--- a/sdk/appconfiguration/app-configuration/tsdoc.json
+++ b/sdk/appconfiguration/app-configuration/tsdoc.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    "extends": [
+        "../../../tsdoc.json"
+    ]
+}


### PR DESCRIPTION
- Make eslint run clean for typedoc (still has other warnings/errors that I need to get back to)
- Ran eslint auto fix, which got some simple stuff like being able to use 'const' and the copyright header.

Fixes #12948