### PR TITLE
Enable 1ES pools in JS repository

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,28 +1,41 @@
 parameters:
-  Artifacts: []
-  TestPipeline: false
-  ServiceDirectory: not-specified
-  Matrix:
-    Linux_Node8:
-      OSVmImage: "ubuntu-18.04"
-      NodeTestVersion: "8.x"
-      TestType: "node"
-    Windows_Node10:
-      OSVmImage: "windows-2019"
-      NodeTestVersion: "10.x"
-      TestType: "node"
-    macOS_Node12:
-      OSVmImage: "macOS-10.15"
-      NodeTestVersion: "12.x"
-      TestType: "node"
-    Browser_Linux_Node12:
-      OSVmImage: "ubuntu-18.04"
-      NodeTestVersion: "$(NodeVersion)"
-      TestType: "browser"
-    Linux_Node14:
-      OSVmImage: "ubuntu-18.04"
-      NodeTestVersion: "14.x"
-      TestType: "node"
+  - name: Artifacts
+    type: object
+    default: []
+  - name: TestPipeline
+    type: boolean
+    default: false
+  - name: ServiceDirectory
+    type: string
+    default: not-specified
+  - name: Matrix
+    type: object
+    default:
+      Linux_Node8:
+        Pool: $(LinuxPool)
+        OSVmImage:
+        NodeTestVersion: "8.x"
+        TestType: "node"
+      Windows_Node10:
+        Pool: $(WindowsPool)
+        OSVmImage:
+        NodeTestVersion: "10.x"
+        TestType: "node"
+      macOS_Node12:
+        Pool:
+        OSVmImage: "macOS-10.15"
+        NodeTestVersion: "12.x"
+        TestType: "node"
+      Browser_Linux_Node12:
+        Pool: $(LinuxPool)
+        OSVmImage: "ubuntu-18.04"
+        NodeTestVersion: "$(NodeVersion)"
+        TestType: "browser"
+      Linux_Node14:
+        Pool: $(LinuxPool)
+        OSVmImage: "ubuntu-18.04"
+        NodeTestVersion: "14.x"
+        TestType: "node"
 
 jobs:
   - job: "Build"
@@ -30,7 +43,7 @@ jobs:
       - template: ../variables/globals.yml
 
     pool:
-      vmImage: "$(OSVmImage)"
+      name: ${{ parameters.LinuxPool }}
 
     steps:
       - script: |
@@ -57,7 +70,7 @@ jobs:
       - template: ../variables/globals.yml
 
     pool:
-      vmImage: "$(OSVmImage)"
+      name: ${{ parameters.LinuxPool }}
 
     steps:
       - template: ../steps/common.yml
@@ -69,21 +82,26 @@ jobs:
 
   # Only run tests if the matrix has entries
   - ${{ if ne(parameters.RunUnitTests, false) }}:
-    - job: "UnitTest"
+      - job: "UnitTest"
 
-      strategy:
-        matrix: ${{parameters.Matrix}}
+        strategy:
+          matrix: ${{parameters.Matrix}}
 
-      pool:
-        vmImage: "$(OSVmImage)"
+        pool:
+          name: $[coalesce(variables['Pool'], '')]
+          vmImage: $[coalesce(variables['OSVmImage'], '')]
 
-      variables:
-        - template: ../variables/globals.yml
+        variables:
+          - template: ../variables/globals.yml
+          - name: WindowsPool
+            value: ${{ parameters.WindowsPool }}
+          - name: LinuxPool
+            value: ${{ parameters.LinuxPool }}
 
-      steps:
-        - template: ../steps/common.yml
+        steps:
+          - template: ../steps/common.yml
 
-        - template: ../steps/test.yml
-          parameters:
-            Artifacts: ${{parameters.Artifacts}}
-            ServiceDirectory: ${{parameters.ServiceDirectory}}
+          - template: ../steps/test.yml
+            parameters:
+              Artifacts: ${{parameters.Artifacts}}
+              ServiceDirectory: ${{parameters.ServiceDirectory}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -1,44 +1,52 @@
 parameters:
-- name: Artifacts
-  type: object
-  default: []
-- name: TestPipeline
-  type: boolean
-  default: false
-- name: ServiceDirectory
-  type: string
-  default: not-specified
-- name: IncludeRelease
-  type: boolean
-  default: true
-- name: TargetDocRepoOwner
-  type: string
-  default: MicrosoftDocs
-- name: TargetDocRepoName
-  type: string
-  default: azure-docs-sdk-node
-- name: RunUnitTests
-  type: boolean
-  default: true
+  - name: Artifacts
+    type: object
+    default: []
+  - name: TestPipeline
+    type: boolean
+    default: false
+  - name: ServiceDirectory
+    type: string
+    default: not-specified
+  - name: IncludeRelease
+    type: boolean
+    default: true
+  - name: TargetDocRepoOwner
+    type: string
+    default: MicrosoftDocs
+  - name: TargetDocRepoName
+    type: string
+    default: azure-docs-sdk-node
+  - name: RunUnitTests
+    type: boolean
+    default: true
+  - name: WindowsPool
+    type: string
+    default: azsdk-pool-mms-win-2019-general
+  - name: LinuxPool
+    type: string
+    default: azsdk-pool-mms-ubuntu-1804-general
 
 stages:
-- stage: Build
-  jobs:
-  - template: ../jobs/archetype-sdk-client.yml
-    parameters:
-      ServiceDirectory: ${{ parameters.ServiceDirectory }}
-      Artifacts: ${{ parameters.Artifacts }}
-      TestPipeline: ${{ parameters.TestPipeline }}
-      RunUnitTests: ${{ parameters.RunUnitTests }}
+  - stage: Build
+    jobs:
+      - template: ../jobs/archetype-sdk-client.yml
+        parameters:
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          Artifacts: ${{ parameters.Artifacts }}
+          TestPipeline: ${{ parameters.TestPipeline }}
+          RunUnitTests: ${{ parameters.RunUnitTests }}
+          WindowsPool: ${{ parameters.WindowsPool }}
+          LinuxPool: ${{ parameters.LinuxPool }}
 
-# The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-- ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq(parameters.IncludeRelease,true))}}:
-  - template: archetype-js-release.yml
-    parameters:
-      DependsOn: Build
-      ServiceDirectory: ${{ parameters.ServiceDirectory }}
-      Artifacts: ${{ parameters.Artifacts }}
-      TestPipeline: ${{ parameters.TestPipeline }}
-      ArtifactName: packages
-      TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-      TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
+  # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq(parameters.IncludeRelease,true))}}:
+    - template: archetype-js-release.yml
+        parameters:
+          DependsOn: Build
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          Artifacts: ${{ parameters.Artifacts }}
+          TestPipeline: ${{ parameters.TestPipeline }}
+          ArtifactName: packages
+          TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
+          TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -6,6 +6,4 @@ steps:
     inputs:
       versionSpec: "3.6"
 
-  - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-
   - template: use-node-version.yml


### PR DESCRIPTION
This PR contains the necessary changes to cut over to the 1ES hosted pools for the JS pipelines. The top level changes are:

Swap to long form parameter declarations (- name:, type: etc)
Introduction of LinuxPool and WindowsPool parameters to stage and job template.
Changes to job template to use these values.