### PR TITLE
[Service Bus] Bug Fix: Correlation Rule Filter with the "label" doesn't filter the messages

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Updates documentation for `ServiceBusMessage` to call out that the `body` field
   must be converted to a byte array or `Buffer` when cross-language
   compatibility while receiving events is required.
+- [Bug Fix] Correlation Rule Filter with the "label" set using the `createRule()` method doesn't filter the messages to the subscription.
+  The bug has been fixed in [PR 13069](https://github.com/Azure/azure-sdk-for-js/pull/13069), also fixes the related issues where the messages are not filtered when a subset of properties are set in the correlation filter.
 
 ## 7.0.0 (2020-11-23)
 

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -94,9 +94,12 @@ export async function executeAtomXmlOperation(
 /**
  * @internal
  * @hidden
- * The key value pairs having undefined/null as the values are removed recursively from the object in order to address the following issues
- * - ATOM based management operations throw a "Bad Request" error if empty tags are included in the xml request body at top level.
- * - At the inner levels, Service assigns the empty strings as values to the empty tags instead of throwing.
+ * The key-value pairs having undefined/null as the values would lead to the empty tags in the serialized XML request.
+ * Empty tags in the request body is problematic because of the following reasons.
+ * - ATOM based management operations throw a "Bad Request" error if empty tags are included in the XML request body at top level.
+ * - At the inner levels, Service assigns the empty strings as values to the empty tags instead of throwing an error.
+ *
+ * This method recursively removes the key-value pairs with undefined/null as the values from the request object that is to be serialized.
  *
  * @param {{ [key: string]: any }} resource
  */

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -19,6 +19,7 @@ import { administrationLogger as logger } from "../log";
 import { Buffer } from "buffer";
 
 import { parseURL } from "./parseUrl";
+import { isJSONLikeObject } from "./utils";
 
 /**
  * @internal
@@ -92,25 +93,6 @@ export async function executeAtomXmlOperation(
 }
 
 /**
- * This helper method returns true if an object is JSON, returns false otherwise.
- */
-export function isJSONObject(value: any): boolean {
-  // `value.constructor === {}.constructor` differentiates among the "object"s,
-  //    would filter the JSON objects and won't match any array or other kinds of objects
-
-  // -------------------------------------------------------------------------------
-  // Few examples       | typeof obj ==="object" |  obj.constructor==={}.constructor
-  // -------------------------------------------------------------------------------
-  // {abc:1}            | true                   | true
-  // ["a","b"]          | true                   | false
-  // [{"a":1},{"b":2}]  | true                   | false
-  // new Date()         | true                   | false
-  // 123                | false                  | false
-  // -------------------------------------------------------------------------------
-  return typeof value === "object" && value.constructor === {}.constructor;
-}
-
-/**
  * @internal
  * @hidden
  * The key-value pairs having undefined/null as the values would lead to the empty tags in the serialized XML request.
@@ -126,7 +108,7 @@ export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
     if (resource[property] == undefined) {
       delete resource[property];
-    } else if (isJSONObject(resource[property])) {
+    } else if (isJSONLikeObject(resource[property])) {
       sanitizeSerializableObject(resource[property]);
     }
   });

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -92,6 +92,26 @@ export async function executeAtomXmlOperation(
 }
 
 /**
+ * The key value pairs having undefined/null as the values are removed recursively from the object in order to address the following issues
+ * - ATOM based management operations throw a "Bad Request" error if empty tags are included in the xml request body at top level.
+ * - At the inner levels, Service assigns the empty strings as values to the empty tags instead of throwing.
+ *
+ * @param {{ [key: string]: any }} resource
+ */
+function sanitizeSerializableObject(resource: { [key: string]: any }) {
+  Object.keys(resource).forEach(function(property) {
+    if (resource[property] == undefined) {
+      delete resource[property];
+    } else if (
+      typeof resource[property] === "object" &&
+      resource[property].constructor === {}.constructor
+    ) {
+      sanitizeSerializableObject(resource[property]);
+    }
+  });
+}
+
+/**
  * @internal
  * @hidden
  * Serializes input information to construct the Atom XML request
@@ -103,15 +123,8 @@ export async function executeAtomXmlOperation(
 export function serializeToAtomXmlRequest(resourceName: string, resource: any): object {
   const content: any = {};
 
-  // The top level key value pairs having undefined/null as the value are removed in order to address issue where the Service Bus'
-  // ATOM based management operations throw a "Bad Request" error if empty tags are included in the xml request body at top level.
-  const processedResource = Object.assign({}, resource);
-  Object.keys(processedResource).forEach(function(property) {
-    if (processedResource[property] == undefined) {
-      delete processedResource[property];
-    }
-  });
-  content[resourceName] = processedResource;
+  content[resourceName] = Object.assign({}, resource);
+  sanitizeSerializableObject(content[resourceName]);
 
   content[resourceName][Constants.XML_METADATA_MARKER] = {
     xmlns: "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -92,6 +92,25 @@ export async function executeAtomXmlOperation(
 }
 
 /**
+ * This helper method returns true if an object is JSON, returns false otherwise.
+ */
+export function isJSONObject(value: any): boolean {
+  // `value.constructor === {}.constructor` differentiates among the "object"s,
+  //    would filter the JSON objects and won't match any array or other kinds of objects
+
+  // -------------------------------------------------------------------------------
+  // Few examples       | typeof obj ==="object" |  obj.constructor==={}.constructor
+  // -------------------------------------------------------------------------------
+  // {abc:1}            | true                   | true
+  // ["a","b"]          | true                   | false
+  // [{"a":1},{"b":2}]  | true                   | false
+  // new Date()         | true                   | false
+  // 123                | false                  | false
+  // -------------------------------------------------------------------------------
+  return typeof value === "object" && value.constructor === {}.constructor;
+}
+
+/**
  * @internal
  * @hidden
  * The key-value pairs having undefined/null as the values would lead to the empty tags in the serialized XML request.
@@ -107,10 +126,7 @@ export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
     if (resource[property] == undefined) {
       delete resource[property];
-    } else if (
-      typeof resource[property] === "object" &&
-      resource[property].constructor === {}.constructor
-    ) {
+    } else if (isJSONObject(resource[property])) {
       sanitizeSerializableObject(resource[property]);
     }
   });

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -92,13 +92,15 @@ export async function executeAtomXmlOperation(
 }
 
 /**
+ * @internal
+ * @hidden
  * The key value pairs having undefined/null as the values are removed recursively from the object in order to address the following issues
  * - ATOM based management operations throw a "Bad Request" error if empty tags are included in the xml request body at top level.
  * - At the inner levels, Service assigns the empty strings as values to the empty tags instead of throwing.
  *
  * @param {{ [key: string]: any }} resource
  */
-function sanitizeSerializableObject(resource: { [key: string]: any }) {
+export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
     if (resource[property] == undefined) {
       delete resource[property];

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -285,11 +285,30 @@ export function getBooleanOrUndefined(value: any): boolean | undefined {
 /**
  * @internal
  * @hidden
+ * Helps in differentiating JSON like objects from other kinds of objects.
+ */
+const EMPTY_JSON_OBJECT_CONSTRUCTOR = {}.constructor;
+
+/**
+ * @internal
+ * @hidden
  * Returns `true` if given input is a JSON like object.
  * @param value
  */
 export function isJSONLikeObject(value: any): boolean {
-  return typeof value === "object" && !(value instanceof Number) && !(value instanceof String);
+  // `value.constructor === {}.constructor` differentiates among the "object"s,
+  //    would filter the JSON objects and won't match any array or other kinds of objects
+
+  // -------------------------------------------------------------------------------
+  // Few examples       | typeof obj ==="object" |  obj.constructor==={}.constructor
+  // -------------------------------------------------------------------------------
+  // {abc:1}            | true                   | true
+  // ["a","b"]          | true                   | false
+  // [{"a":1},{"b":2}]  | true                   | false
+  // new Date()         | true                   | false
+  // 123                | false                  | false
+  // -------------------------------------------------------------------------------
+  return typeof value === "object" && value.constructor === EMPTY_JSON_OBJECT_CONSTRUCTOR;
 }
 
 /**

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -2300,74 +2300,68 @@ describe(`createRule() using different variations to the input parameter "ruleOp
 });
 
 // Rule tests
-[
-  {
-    testCaseTitle: "Sql Filter rule options",
-    input: {
-      filter: {
-        sqlExpression: "stringValue = @stringParam",
-        sqlParameters: { "@stringParam": "b" }
+describe(`updateRule() using different variations to the input parameter "ruleOptions"`, function(): void {
+  beforeEach(async () => {
+    await recreateTopic(managementTopic1);
+    await recreateSubscription(managementTopic1, managementSubscription1);
+    await createEntity(EntityType.RULE, managementRule1, managementTopic1, managementSubscription1);
+  });
+
+  afterEach(async () => {
+    await deleteEntity(EntityType.TOPIC, managementTopic1);
+  });
+  [
+    {
+      testCaseTitle: "Sql Filter rule options",
+      input: {
+        filter: {
+          sqlExpression: "stringValue = @stringParam",
+          sqlParameters: { "@stringParam": "b" }
+        },
+        action: { sqlExpression: "SET a='c'" }
       },
-      action: { sqlExpression: "SET a='c'" }
+      output: {
+        filter: {
+          sqlExpression: "stringValue = @stringParam",
+          sqlParameters: { "@stringParam": "b" }
+        },
+        action: {
+          sqlExpression: "SET a='c'",
+          sqlParameters: undefined
+        },
+
+        name: managementRule1
+      }
     },
-    output: {
-      filter: {
-        sqlExpression: "stringValue = @stringParam",
-        sqlParameters: { "@stringParam": "b" }
+    {
+      testCaseTitle: "Correlation Filter rule options",
+      input: {
+        filter: {
+          correlationId: "defg"
+        },
+        action: { sqlExpression: "SET sys.label='RED'" }
       },
-      action: {
-        sqlExpression: "SET a='c'",
-        sqlParameters: undefined
-      },
+      output: {
+        filter: {
+          correlationId: "defg",
+          contentType: undefined,
+          subject: undefined,
+          messageId: undefined,
+          replyTo: undefined,
+          replyToSessionId: undefined,
+          sessionId: undefined,
+          to: undefined,
+          applicationProperties: undefined
+        },
+        action: {
+          sqlExpression: "SET sys.label='RED'",
+          sqlParameters: undefined
+        },
 
-      name: managementRule1
+        name: managementRule1
+      }
     }
-  },
-  {
-    testCaseTitle: "Correlation Filter rule options",
-    input: {
-      filter: {
-        correlationId: "defg"
-      },
-      action: { sqlExpression: "SET sys.label='RED'" }
-    },
-    output: {
-      filter: {
-        correlationId: "defg",
-        contentType: "",
-        subject: "",
-        messageId: "",
-        replyTo: "",
-        replyToSessionId: "",
-        sessionId: "",
-        to: "",
-        applicationProperties: undefined
-      },
-      action: {
-        sqlExpression: "SET sys.label='RED'",
-        sqlParameters: undefined
-      },
-
-      name: managementRule1
-    }
-  }
-].forEach((testCase) => {
-  describe(`updateRule() using different variations to the input parameter "ruleOptions"`, function(): void {
-    beforeEach(async () => {
-      await recreateTopic(managementTopic1);
-      await recreateSubscription(managementTopic1, managementSubscription1);
-      await createEntity(
-        EntityType.RULE,
-        managementRule1,
-        managementTopic1,
-        managementSubscription1
-      );
-    });
-
-    afterEach(async () => {
-      await deleteEntity(EntityType.TOPIC, managementTopic1);
-    });
-
+  ].forEach((testCase) => {
     it(`${testCase.testCaseTitle}`, async () => {
       try {
         const response = await updateEntity(

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1712,135 +1712,135 @@ describe(`createSubscription() using different variations to the input parameter
   });
 });
 
-// Rule tests
-const createRuleTests: {
-  testCaseTitle: string;
-  input: Omit<CreateRuleOptions, "name"> | undefined;
-  output: RuleProperties;
-}[] = [
-  {
-    testCaseTitle: "Undefined rule options",
-    input: undefined,
-    output: {
-      filter: {
-        sqlExpression: "1=1",
-        sqlParameters: undefined
-      },
-      action: {
-        sqlExpression: undefined,
-        sqlParameters: undefined
-      },
-      name: managementRule1
-    }
-  },
-  {
-    testCaseTitle: "Sql Filter rule options",
-    input: {
-      filter: {
-        sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
-        sqlParameters: { "@intParam": 1, "@stringParam": "b" }
-      },
-      action: { sqlExpression: "SET a='b'" }
-    },
-    output: {
-      filter: {
-        sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
-        sqlParameters: { "@intParam": 1, "@stringParam": "b" }
-      },
-      action: {
-        sqlExpression: "SET a='b'",
-        sqlParameters: undefined
-      },
-      name: managementRule1
-    }
-  },
-  {
-    testCaseTitle: "Correlation Filter rule options with a single property",
-    input: {
-      filter: {
-        correlationId: "abcd",
-        applicationProperties: {
-          randomState: "WA"
-        }
-      },
-      action: { sqlExpression: "SET sys.label='GREEN'" }
-    },
-    output: {
-      filter: {
-        correlationId: "abcd",
-        contentType: "",
-        subject: "",
-        messageId: "",
-        replyTo: "",
-        replyToSessionId: "",
-        sessionId: "",
-        to: "",
-        applicationProperties: {
-          randomState: "WA"
-        }
-      },
-      action: {
-        sqlExpression: "SET sys.label='GREEN'",
-        sqlParameters: undefined
-      },
-      name: managementRule1
-    }
-  },
-  {
-    testCaseTitle: "Correlation Filter rule options with multiple properties",
-    input: {
-      filter: {
-        correlationId: "abcd",
-        applicationProperties: {
-          randomState: "WA",
-          randomCountry: "US",
-          randomInt: 25,
-          randomIntDisguisedAsDouble: 3.0,
-          randomDouble: 12.4,
-          randomBool: true,
-          randomDate: randomDate
-        }
-      },
-      action: { sqlExpression: "SET sys.label='GREEN'" }
-    },
-    output: {
-      filter: {
-        correlationId: "abcd",
-        contentType: "",
-        subject: "",
-        messageId: "",
-        replyTo: "",
-        replyToSessionId: "",
-        sessionId: "",
-        to: "",
-        applicationProperties: {
-          randomState: "WA",
-          randomCountry: "US",
-          randomInt: 25,
-          randomIntDisguisedAsDouble: 3.0,
-          randomDouble: 12.4,
-          randomBool: true,
-          randomDate: randomDate
-        }
-      },
-      action: {
-        sqlExpression: "SET sys.label='GREEN'",
-        sqlParameters: undefined
-      },
-      name: managementRule1
-    }
-  }
-];
-createRuleTests.forEach((testCase) => {
-  describe(`createRule() using different variations to the input parameter "ruleOptions"`, function(): void {
-    beforeEach(async () => {
-      await recreateTopic(managementTopic1);
-      await recreateSubscription(managementTopic1, managementSubscription1);
-    });
-    afterEach(async () => {
-      await deleteEntity(EntityType.TOPIC, managementTopic1);
-    });
+describe(`createRule() using different variations to the input parameter "ruleOptions"`, function(): void {
+  beforeEach(async () => {
+    await recreateTopic(managementTopic1);
+    await recreateSubscription(managementTopic1, managementSubscription1);
+  });
+  afterEach(async () => {
+    await deleteEntity(EntityType.TOPIC, managementTopic1);
+  });
 
+  // Rule tests
+  const createRuleTests: {
+    testCaseTitle: string;
+    input: Omit<CreateRuleOptions, "name"> | undefined;
+    output: RuleProperties;
+  }[] = [
+    {
+      testCaseTitle: "Undefined rule options",
+      input: undefined,
+      output: {
+        filter: {
+          sqlExpression: "1=1",
+          sqlParameters: undefined
+        },
+        action: {
+          sqlExpression: undefined,
+          sqlParameters: undefined
+        },
+        name: managementRule1
+      }
+    },
+    {
+      testCaseTitle: "Sql Filter rule options",
+      input: {
+        filter: {
+          sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
+          sqlParameters: { "@intParam": 1, "@stringParam": "b" }
+        },
+        action: { sqlExpression: "SET a='b'" }
+      },
+      output: {
+        filter: {
+          sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
+          sqlParameters: { "@intParam": 1, "@stringParam": "b" }
+        },
+        action: {
+          sqlExpression: "SET a='b'",
+          sqlParameters: undefined
+        },
+        name: managementRule1
+      }
+    },
+    {
+      testCaseTitle: "Correlation Filter rule options with a single property",
+      input: {
+        filter: {
+          correlationId: "abcd",
+          applicationProperties: {
+            randomState: "WA"
+          }
+        },
+        action: { sqlExpression: "SET sys.label='GREEN'" }
+      },
+      output: {
+        filter: {
+          correlationId: "abcd",
+          contentType: undefined,
+          subject: undefined,
+          messageId: undefined,
+          replyTo: undefined,
+          replyToSessionId: undefined,
+          sessionId: undefined,
+          to: undefined,
+          applicationProperties: {
+            randomState: "WA"
+          }
+        },
+        action: {
+          sqlExpression: "SET sys.label='GREEN'",
+          sqlParameters: undefined
+        },
+        name: managementRule1
+      }
+    },
+    {
+      testCaseTitle: "Correlation Filter rule options with multiple properties",
+      input: {
+        filter: {
+          correlationId: "abcd",
+          applicationProperties: {
+            randomState: "WA",
+            randomCountry: "US",
+            randomInt: 25,
+            randomIntDisguisedAsDouble: 3.0,
+            randomDouble: 12.4,
+            randomBool: true,
+            randomDate: randomDate
+          }
+        },
+        action: { sqlExpression: "SET sys.label='GREEN'" }
+      },
+      output: {
+        filter: {
+          correlationId: "abcd",
+          contentType: undefined,
+          subject: undefined,
+          messageId: undefined,
+          replyTo: undefined,
+          replyToSessionId: undefined,
+          sessionId: undefined,
+          to: undefined,
+          applicationProperties: {
+            randomState: "WA",
+            randomCountry: "US",
+            randomInt: 25,
+            randomIntDisguisedAsDouble: 3.0,
+            randomDouble: 12.4,
+            randomBool: true,
+            randomDate: randomDate
+          }
+        },
+        action: {
+          sqlExpression: "SET sys.label='GREEN'",
+          sqlParameters: undefined
+        },
+        name: managementRule1
+      }
+    }
+  ];
+  createRuleTests.forEach((testCase) => {
     it(`${testCase.testCaseTitle}`, async () => {
       const response = await createEntity(
         EntityType.RULE,

--- a/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
@@ -53,11 +53,9 @@ describe("Filter messages with the rules set by the ATOM API", () => {
       "rule-name",
       filter
     );
-    try {
-      await serviceBusClient.createSender(topicName).sendMessages(messageToSend);
-    } catch (error) {
-      console.log(error);
-    }
+
+    await serviceBusClient.createSender(topicName).sendMessages(messageToSend);
+
     const receivedMessages = await serviceBusClient
       .createReceiver(topicName, subscriptionName)
       .receiveMessages(1);

--- a/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
@@ -72,4 +72,6 @@ describe("Filter messages with the rules set by the ATOM API", () => {
       chai.assert.deepEqual(msg.subject, subject, "Unexpected subject on the message");
     });
   });
+
+  // TODO: New tests for rule filters to match the sent messages can be added
 });

--- a/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import chaiExclude from "chai-exclude";
+import * as dotenv from "dotenv";
+import {
+  CorrelationRuleFilter,
+  ServiceBusReceivedMessage,
+  ServiceBusClient,
+  ServiceBusMessage,
+  SqlRuleFilter
+} from "../src";
+import { ServiceBusAdministrationClient } from "../src/serviceBusAtomManagementClient";
+import { DEFAULT_RULE_NAME } from "../src/util/constants";
+import { recreateSubscription, recreateTopic } from "./utils/managementUtils";
+import { getConnectionString } from "./utils/testutils2";
+
+chai.use(chaiAsPromised);
+chai.use(chaiExclude);
+const should = chai.should();
+
+dotenv.config();
+
+const serviceBusAtomManagementClient: ServiceBusAdministrationClient = new ServiceBusAdministrationClient(
+  getConnectionString()
+);
+
+describe("Filter messages with the rules set by the ATOM API", () => {
+  const topicName = "new-topic";
+  const subscriptionName = "new-subscription";
+  const serviceBusClient = new ServiceBusClient(getConnectionString());
+
+  beforeEach(async () => {
+    await recreateTopic(topicName);
+    await recreateSubscription(topicName, subscriptionName);
+    await serviceBusAtomManagementClient.deleteRule(topicName, subscriptionName, DEFAULT_RULE_NAME);
+  });
+
+  after(async () => {
+    await serviceBusClient.close();
+  });
+
+  async function verifyRuleFilter(
+    messageToSend: ServiceBusMessage,
+    filter: SqlRuleFilter | CorrelationRuleFilter,
+    toCheck: (msg: ServiceBusReceivedMessage) => void
+  ) {
+    await serviceBusAtomManagementClient.createRule(
+      topicName,
+      subscriptionName,
+      "rule-name",
+      filter
+    );
+    try {
+      await serviceBusClient.createSender(topicName).sendMessages(messageToSend);
+    } catch (error) {
+      console.log(error);
+    }
+    const receivedMessages = await serviceBusClient
+      .createReceiver(topicName, subscriptionName)
+      .receiveMessages(1);
+    should.equal(receivedMessages.length, 1, "Unexpected number of messages received");
+
+    toCheck(receivedMessages[0]);
+  }
+
+  it("subject", async () => {
+    const subject = "new-subject";
+    await verifyRuleFilter({ body: "random-body", subject }, { subject }, (msg) => {
+      chai.assert.deepEqual(msg.subject, subject, "Unexpected subject on the message");
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -10,7 +10,6 @@ import {
   AtomXmlSerializer,
   deserializeAtomXmlResponse,
   executeAtomXmlOperation,
-  isJSONObject,
   sanitizeSerializableObject
 } from "../../src/util/atomXmlHelper";
 import * as Constants from "../../src/util/constants";
@@ -20,6 +19,7 @@ import { HttpHeaders, HttpOperationResponse, WebResource } from "@azure/core-htt
 import { TopicResourceSerializer } from "../../src/serializers/topicResourceSerializer";
 import { SubscriptionResourceSerializer } from "../../src/serializers/subscriptionResourceSerializer";
 import { RuleResourceSerializer } from "../../src/serializers/ruleResourceSerializer";
+import { isJSONLikeObject } from "../../src/util/utils";
 
 const queueProperties = [
   Constants.LOCK_DURATION,
@@ -1196,9 +1196,11 @@ describe("ATOM Serializers", () => {
     });
   });
 
-  describe("isJSONObject helper method", () => {
+  describe.only("isJSONLikeObject helper method", () => {
     [
-      { input: { abc: 1 }, output: true },
+      { input: {}, output: true },
+      { input: { abc: 1, d: undefined }, output: true },
+      { input: { a: "2", b: { c: 3, d: "x" } }, output: true },
       { input: ["a", "b"], output: false },
       { input: [{ a: 1 }, { b: { c: 3, d: "x" } }], output: false },
       { input: new Date(), output: false },
@@ -1206,7 +1208,7 @@ describe("ATOM Serializers", () => {
       { input: "abc", output: false }
     ].forEach((testCase) => {
       it(`${JSON.stringify(testCase.input)}`, () => {
-        chai.assert.equal(isJSONObject(testCase.input), testCase.output);
+        chai.assert.equal(isJSONLikeObject(testCase.input), testCase.output);
       });
     });
   });

--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -10,6 +10,7 @@ import {
   AtomXmlSerializer,
   deserializeAtomXmlResponse,
   executeAtomXmlOperation,
+  isJSONObject,
   sanitizeSerializableObject
 } from "../../src/util/atomXmlHelper";
 import * as Constants from "../../src/util/constants";
@@ -1191,6 +1192,21 @@ describe("ATOM Serializers", () => {
       it(testCase.title, () => {
         sanitizeSerializableObject(testCase.input);
         chai.assert.deepEqual(testCase.input, testCase.output as any);
+      });
+    });
+  });
+
+  describe("isJSONObject helper method", () => {
+    [
+      { input: { abc: 1 }, output: true },
+      { input: ["a", "b"], output: false },
+      { input: [{ a: 1 }, { b: { c: 3, d: "x" } }], output: false },
+      { input: new Date(), output: false },
+      { input: 123, output: false },
+      { input: "abc", output: false }
+    ].forEach((testCase) => {
+      it(`${JSON.stringify(testCase.input)}`, () => {
+        chai.assert.equal(isJSONObject(testCase.input), testCase.output);
       });
     });
   });

--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -9,7 +9,8 @@ const assert = chai.assert;
 import {
   AtomXmlSerializer,
   deserializeAtomXmlResponse,
-  executeAtomXmlOperation
+  executeAtomXmlOperation,
+  sanitizeSerializableObject
 } from "../../src/util/atomXmlHelper";
 import * as Constants from "../../src/util/constants";
 import { ServiceBusAdministrationClient } from "../../src/serviceBusAtomManagementClient";
@@ -1119,6 +1120,78 @@ describe("ATOM Serializers", () => {
         "testSubscription"
       );
       assertEmptyArray(result);
+    });
+  });
+
+  describe("key-value pairs having undefined/null as the values to be sanitized with sanitizeSerializableObject", function() {
+    [
+      {
+        title: "queue options with undefined fields",
+        input: {
+          DefaultMessageTimeToLive: undefined,
+          MaxSizeInMegabytes: undefined,
+          RequiresDuplicateDetection: undefined,
+          DuplicateDetectionHistoryTimeWindow: undefined,
+          EnableBatchedOperations: undefined,
+          AuthorizationRules: undefined,
+          Status: undefined,
+          UserMetadata: undefined,
+          SupportOrdering: undefined,
+          AutoDeleteOnIdle: undefined,
+          EnablePartitioning: undefined,
+          EntityAvailabilityStatus: undefined,
+          EnableExpress: undefined
+        },
+        output: {}
+      },
+      {
+        title: "correlation filter with some fields undefined ",
+        input: {
+          Filter: {
+            CorrelationId: undefined,
+            Label: "new-subject",
+            To: undefined,
+            ReplyTo: undefined,
+            ReplyToSessionId: undefined,
+            ContentType: undefined,
+            SessionId: undefined,
+            MessageId: undefined,
+            Properties: undefined,
+            $: {
+              "p4:type": "CorrelationFilter",
+              "xmlns:p4": "http://www.w3.org/2001/XMLSchema-instance"
+            }
+          },
+          Action: {
+            $: {
+              "p4:type": "EmptyRuleAction",
+              "xmlns:p4": "http://www.w3.org/2001/XMLSchema-instance"
+            }
+          },
+          Name: "rule-name"
+        },
+        output: {
+          Filter: {
+            Label: "new-subject",
+            $: {
+              "p4:type": "CorrelationFilter",
+              "xmlns:p4": "http://www.w3.org/2001/XMLSchema-instance"
+            }
+          },
+          Action: {
+            $: {
+              "p4:type": "EmptyRuleAction",
+              "xmlns:p4": "http://www.w3.org/2001/XMLSchema-instance"
+            }
+          },
+          Name: "rule-name"
+        }
+      }
+    ].forEach((testCase) => {
+      it(testCase.title, () => {
+        sanitizeSerializableObject(testCase.input);
+        chai.assert.deepEqual(testCase.input, testCase.output as any);
+      });
     });
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/atomXml.spec.ts
@@ -1196,7 +1196,7 @@ describe("ATOM Serializers", () => {
     });
   });
 
-  describe.only("isJSONLikeObject helper method", () => {
+  describe("isJSONLikeObject helper method", () => {
     [
       { input: {}, output: true },
       { input: { abc: 1, d: undefined }, output: true },

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -494,7 +494,7 @@ export function createServiceBusClientForTests(
   options?: ServiceBusClientOptions
 ): ServiceBusClientForTests {
   const serviceBusClient = new ServiceBusClient(
-    connectionString(),
+    getConnectionString(),
     options
   ) as ServiceBusClientForTests;
 
@@ -516,7 +516,7 @@ export async function drainReceiveAndDeleteReceiver(receiver: ServiceBusReceiver
   }
 }
 
-function connectionString() {
+export function getConnectionString() {
   if (env[EnvVarNames.SERVICEBUS_CONNECTION_STRING] == null) {
     throw new Error(
       `No service bus connection string defined in ${EnvVarNames.SERVICEBUS_CONNECTION_STRING}. If you're in a unit test you should not be depending on the deployed environment!`


### PR DESCRIPTION
### BUG
https://github.com/Azure/azure-sdk-for-js/issues/13063
The correlation filter with the "subject" set using the `createRule` method doesn't filter the messages to the subscription. However, when we create the rule with the same correlation filter from the service bus explorer, messages get filtered as expected.

### CAUSE
The key-value pairs having undefined/null as the values can be present in the request object at any level. They get serialized as empty tags in the XML request for the ATOM management operations.

If such empty tags are present at the top level, the service throws a "Bad Request" error. This was handled by the SDK to make sure that the top-level of the request body doesn't have any empty tags.

If such empty tags are present at the inner levels, the service assigns the empty strings as values to the empty tags instead of throwing an error. This wasn't handled and the empty tags at the rule filter created an unexpected filter for the subscription. This PR attempts to fix this issue.

### FIX
The key-value pairs having undefined/null as the values are removed recursively from the object that is being serialized.