### PR TITLE
[core-auth] remove core-tracing dependency

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.4 (Unreleased)
 
-- Updated to use OpenTelemetry 0.10.2 via `@azure/core-tracing`
+- Removed direct dependency on `@opentelemetry/api` and `@azure/core-tracing`.
 
 ## 1.1.3 (2020-06-30)
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -67,8 +67,6 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.9",
-    "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AbortSignalLike } from '@azure/abort-controller';
-import { SpanOptions } from '@azure/core-tracing';
 
 // @public
 export interface AccessToken {
@@ -37,6 +36,21 @@ export function isTokenCredential(credential: unknown): credential is TokenCrede
 // @public
 export interface KeyCredential {
     readonly key: string;
+}
+
+// @public
+export interface SpanContext {
+    spanId: string;
+    traceFlags: number;
+    traceId: string;
+}
+
+// @public
+export interface SpanOptions {
+    attributes?: {
+        [key: string]: unknown;
+    };
+    parent?: SpanContext | null;
 }
 
 // @public

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -9,3 +9,5 @@ export {
   AccessToken,
   isTokenCredential
 } from "./tokenCredential";
+
+export { SpanContext, SpanOptions } from "./tracing";

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AbortSignalLike } from "@azure/abort-controller";
-import { SpanOptions } from "@azure/core-tracing";
+import { SpanOptions } from "./tracing";
 
 /**
  * Represents a credential capable of providing an authentication token.

--- a/sdk/core/core-auth/src/tracing.ts
+++ b/sdk/core/core-auth/src/tracing.ts
@@ -1,0 +1,35 @@
+/**
+ * An interface that enables manual propagation of Spans.
+ */
+export interface SpanOptions {
+    /**
+     * The SpanContext that refers to a parent span, if any.
+     * A null value indicates that this should be a new root span,
+     * rather than potentially detecting a span via a context manager.
+     */
+    parent?: SpanContext | null;
+    /**
+     * Attributes to set on the Span
+     */
+    attributes?: {
+        [key: string]: unknown;
+    };
+}
+
+/**
+ * A light interface that tries to be structurally compatible with OpenTelemetry.
+ */
+export declare interface SpanContext {
+    /**
+     * UUID of a trace.
+     */
+    traceId: string;
+    /**
+     * UUID of a Span.
+     */
+    spanId: string;
+    /**
+     * https://www.w3.org/TR/trace-context/#trace-flags
+     */
+    traceFlags: number;
+}

--- a/sdk/core/core-auth/src/tracing.ts
+++ b/sdk/core/core-auth/src/tracing.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// The interfaces in this file should be kept in sync with those
+// found in the `@azure/core-tracing` package.
+
 /**
  * An interface that enables manual propagation of Spans.
  */

--- a/sdk/core/core-auth/src/tracing.ts
+++ b/sdk/core/core-auth/src/tracing.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * An interface that enables manual propagation of Spans.
  */


### PR DESCRIPTION
Fixes #12612.

This PR removes the `@azure/core-tracing` and `@opentelemetry/api` dependencies from `@azure/core-auth`. Instead, `SpanOptions` and `SpanContext` are duplicated and exported from `@azure/core-auth`.

This will allow our older code generation to use `@azure/core-auth` without requiring the `@azure/core-tracing` dependency.