### PR TITLE
Update axios dependency

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -85,7 +85,7 @@
     "@azure/logger": "^1.0.0",
     "@azure/msal-node": "1.0.0-beta.1",
     "@opentelemetry/api": "^0.10.2",
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "events": "^3.0.0",
     "jws": "^4.0.0",
     "msal": "^1.0.2",


### PR DESCRIPTION
yarn audit show an error with version 0.20.0 because of https://www.npmjs.com/advisories/1594

As far as I understand SSRF this would not be a problem for azure identity, but I would like my yarn audit to be clean.