### PR TITLE
[core-auth] Add AzureSasCredential

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.5 (Unreleased)
 
+- Add `AzureSASCredential` and `SASCredential` for use by service clients which allow authenticiation using a shared access signature.
 
 ## 1.1.4 (2021-01-07)
 

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -20,6 +20,13 @@ export class AzureKeyCredential implements KeyCredential {
 }
 
 // @public
+export class AzureSASCredential implements SASCredential {
+    constructor(signature: string);
+    get signature(): string;
+    update(newSignature: string): void;
+}
+
+// @public
 export interface GetTokenOptions {
     abortSignal?: AbortSignalLike;
     requestOptions?: {
@@ -36,6 +43,11 @@ export function isTokenCredential(credential: unknown): credential is TokenCrede
 // @public
 export interface KeyCredential {
     readonly key: string;
+}
+
+// @public
+export interface SASCredential {
+    readonly signature: string;
 }
 
 // @public

--- a/sdk/core/core-auth/src/azureSASCredential.ts
+++ b/sdk/core/core-auth/src/azureSASCredential.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Represents a credential defined by a static shared access signature.
+ */
+export interface SASCredential {
+  /**
+   * The value of the shared access signature represented as a string
+   */
+  readonly signature: string;
+}
+
+/**
+ * A static-signature-based credential that supports updating
+ * the underlying signature value.
+ */
+export class AzureSASCredential implements SASCredential {
+  private _signature: string;
+
+  /**
+   * The value of the shared access signature to be used in authentication
+   */
+  public get signature(): string {
+    return this._signature;
+  }
+
+  /**
+   * Create an instance of an AzureSASCredential for use
+   * with a service client.
+   *
+   * @param signature - The initial value of the shared access signature to use in authentication
+   */
+  constructor(signature: string) {
+    if (!signature) {
+      throw new Error("shared access signature must be a non-empty string");
+    }
+
+    this._signature = signature;
+  }
+
+  /**
+   * Change the value of the signature.
+   *
+   * Updates will take effect upon the next request after
+   * updating the signature value.
+   *
+   * @param newSignature - The new shared access signature value to be used
+   */
+  public update(newSignature: string): void {
+    if (!newSignature) {
+      throw new Error("shared access signature must be a non-empty string");
+    }
+
+    this._signature = newSignature;
+  }
+}

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export { AzureKeyCredential, KeyCredential } from "./azureKeyCredential";
+export { AzureSASCredential, SASCredential } from "./azureSASCredential";
 
 export {
   TokenCredential,

--- a/sdk/core/core-auth/test/index.spec.ts
+++ b/sdk/core/core-auth/test/index.spec.ts
@@ -4,6 +4,7 @@
 import assert from "assert";
 
 import { AzureKeyCredential } from "../src/azureKeyCredential";
+import { AzureSASCredential } from "../src/azureSASCredential";
 import { isTokenCredential } from "../src/tokenCredential";
 
 describe("AzureKeyCredential", () => {
@@ -24,6 +25,41 @@ describe("AzureKeyCredential", () => {
     assert.equal(credential.key, "credential1");
     credential.update("credential2");
     assert.equal(credential.key, "credential2");
+  });
+});
+
+describe("AzureSASCredential", () => {
+  it("credential constructor throws on invalid signature", () => {
+    assert.throws(() => {
+      void new AzureSASCredential("");
+    }, /shared access signature must be a non-empty string/);
+    assert.throws(() => {
+      void new AzureSASCredential((null as unknown) as string);
+    }, /shared access signature must be a non-empty string/);
+    assert.throws(() => {
+      void new AzureSASCredential((undefined as unknown) as string);
+    }, /shared access signature must be a non-empty string/);
+  });
+
+  it("credential correctly updates", () => {
+    const credential = new AzureSASCredential("credential1");
+    assert.equal(credential.signature, "credential1");
+    credential.update("credential2");
+    assert.equal(credential.signature, "credential2");
+  });
+
+  it("throws when upadting with an invalid signature", () => {
+    const credential = new AzureSASCredential("credential1");
+
+    assert.throws(() => {
+      credential.update("");
+    }, /shared access signature must be a non-empty string/);
+    assert.throws(() => {
+      credential.update((null as unknown) as string);
+    }, /shared access signature must be a non-empty string/);
+    assert.throws(() => {
+      credential.update((undefined as unknown) as string);
+    }, /shared access signature must be a non-empty string/);
   });
 });
 


### PR DESCRIPTION
This change adds an interfance and supporting class for use by services
which support authentication used a shared acccess signature.

Fixes #13053