### PR TITLE
[core] prepare for January 2021 release

### DIFF
--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.2 (2020-01-07)
+
+Updates the `tslib` dependency to version 2.x.
+
 ## 1.0.1 (2019-12-04)
 
 Fixes the [bug 6271](https://github.com/Azure/azure-sdk-for-js/issues/6271) that can occur with angular prod builds due to triple-slash directives.

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/abort-controller",
   "sdk-type": "client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microsoft Azure SDK for JavaScript - Aborter",
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.4 (Unreleased)
+## 1.1.4 (2021-01-07)
 
 - Removed direct dependency on `@opentelemetry/api` and `@azure/core-tracing`.
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.2 (Unreleased)
+## 1.2.2 (2021-01-07)
 
 - Cache the default `HttpClient` used when one isn't passed in to `ServiceClient`. This means that for most packages we will only create a single `HttpClient`, which will improve platform resource usage by reducing overhead. [PR 12966](https://github.com/Azure/azure-sdk-for-js/pull/12966)
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Release History
 
-## 1.0.3 (Unreleased)
+## 1.0.3 (2021-01-07)
 
+- Updates the `tslib` dependency to version 2.x.
 
 ## 1.0.2 (2020-04-28)
+
 - Moved `@opentelemetry/types` to the `devDependencies`.
 
 ## 1.0.1 (2020-02-28)

--- a/sdk/core/logger/CHANGELOG.md
+++ b/sdk/core/logger/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2021-01-07)
+
+- Updates the `tslib` dependency to version 2.x.
 
 ## 1.0.0 (2019-10-29)
 


### PR DESCRIPTION
Same as #12797 except in January!

Note that all of the core packages are just being released so that the published version pulls in tslib 2.x instead of tslib 1.x. This fixes #12631, where it was discovered that using a bundler (e.g. webpack) to generate an application bundle that includes our SDK also pulled in multiple copies of tslib 1.x.

Multiple copies of tslib were pulled in because due to the way node_modules were being resolved, tslib 2.x would be at the root of a package's node_modules directory, and every package that used tslib 1.x had its own copy of tslib that would then be included in the bundle.