### PR TITLE
[eph] Skip EPH samples from smoke-test runs

### DIFF
--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -66,6 +66,15 @@
       }
     ]
   },
+  "//smokeTestConfiguration": {
+    "skip": [
+      "iothubEph.js",
+      "multiEph.js",
+      "sendBatch.js",
+      "singleEph.js",
+      "websockets.js"
+    ]
+  },
   "dependencies": {
     "@azure/event-hubs": "^2.1.4",
     "@azure/ms-rest-nodeauth": "^0.9.2",


### PR DESCRIPTION
/cc @richardpark-msft 

Disables EPH samples from running as part of the automated smoke test runs. EPH functionality has been replaced by the `@azure/event-hubs` v5 package.