### PR TITLE
[Tables] Increase timeout for list all test

### DIFF
--- a/sdk/tables/data-tables/test/integration/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/integration/tableclient.spec.ts
@@ -87,7 +87,7 @@ describe("TableClient", () => {
       }
 
       assert.lengthOf(all, totalItems);
-    });
+    }).timeout(10000);
 
     it("should list by page", async function() {
       const totalItems = 21;


### PR DESCRIPTION
We are getting some random timeouts in live tests when listing all entities. Increasing the timeout for the specific test to make sure it has enough time to list all entities.