### PR TITLE
Getting the smoke testing pipeline green again

### DIFF
--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -122,5 +122,10 @@
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
     "typedoc": "0.15.0"
+  },
+  "//smokeTestConfiguration": {
+    "skip": [
+      "releasePhoneNumbers.js"
+    ]
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -137,7 +137,8 @@
       "trainUnlabeledModel.js",
       "copyModel.js",
       "authenticationMethods.js",
-      "recognizeContent.js"
+      "recognizeContent.js",
+      "deleteAllModels.js"
     ]
   }
 }


### PR DESCRIPTION
* Ignore a sample that's clearly intended to only be run with caution and manually in form-recognizer
* Create the first ignore for communication-administration package, just to be helpful (hopefully)