### PR TITLE
[Keys] Revert change that introduced enum for API version that had only the latest API version value

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -13,9 +13,6 @@ import { PollOperationState } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-http';
 
 // @public
-export type ApiVersion = string;
-
-// @public
 export interface BackupKeyOptions extends coreHttp.OperationOptions {
 }
 
@@ -178,7 +175,7 @@ export class KeyClient {
 
 // @public
 export interface KeyClientOptions extends coreHttp.PipelineOptions {
-    serviceVersion?: ApiVersion;
+    serviceVersion?: "7.0" | "7.1" | "7.2-preview";
 }
 
 // @public
@@ -241,11 +238,6 @@ export interface KeyVaultKeyId {
 
 // @public
 export type KeyWrapAlgorithm = "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_5";
-
-// @public
-export const enum KnownApiVersions {
-    Seven2Preview = "7.2-preview"
-}
 
 // @public
 export const enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -30,8 +30,7 @@ import {
   KeyVaultClientGetKeysOptionalParams,
   KeyVaultClientRestoreKeyResponse,
   KeyVaultClientUpdateKeyResponse,
-  KnownApiVersion72Preview as KnownApiVersions,
-  ApiVersion72Preview as ApiVersion
+  KnownApiVersion72Preview as KnownApiVersions
 } from "./generated/models";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import { SDK_VERSION } from "./constants";
@@ -165,9 +164,7 @@ export {
   VerifyResult,
   WrapKeyOptions,
   WrapResult,
-  logger,
-  KnownApiVersions,
-  ApiVersion
+  logger
 };
 
 /**

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -29,8 +29,7 @@ import {
   KeyItem,
   KeyVaultClientGetKeysOptionalParams,
   KeyVaultClientRestoreKeyResponse,
-  KeyVaultClientUpdateKeyResponse,
-  KnownApiVersion72Preview as KnownApiVersions
+  KeyVaultClientUpdateKeyResponse
 } from "./generated/models";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import { SDK_VERSION } from "./constants";
@@ -70,7 +69,8 @@ import {
   RestoreKeyBackupOptions,
   UpdateKeyPropertiesOptions,
   KeyClientOptions,
-  CryptographyClientOptions
+  CryptographyClientOptions,
+  LATEST_API_VERSION
 } from "./keysModels";
 
 import { CryptographyClient } from "./cryptographyClient";
@@ -239,7 +239,7 @@ export class KeyClient {
     };
 
     this.client = new KeyVaultClient(
-      pipelineOptions.serviceVersion || KnownApiVersions.Seven2Preview,
+      pipelineOptions.serviceVersion || LATEST_API_VERSION,
       createPipelineFromOptions(internalPipelineOptions, authPolicy)
     );
   }

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -3,7 +3,6 @@
 
 import * as coreHttp from "@azure/core-http";
 import {
-  ApiVersion72Preview as ApiVersion,
   DeletionRecoveryLevel,
   JsonWebKeyType as KeyType,
   KnownJsonWebKeyType as KnownKeyTypes,
@@ -15,13 +14,18 @@ import { KeyCurveName } from "./cryptographyClientModels";
 export { KeyType, KnownKeyTypes, KeyOperation, KnownKeyOperations };
 
 /**
+ * The latest supported Key Vault service API version
+ */
+export const LATEST_API_VERSION = "7.2-preview";
+
+/**
  * The optional parameters accepted by the KeyVault's KeyClient
  */
 export interface KeyClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: ApiVersion;
+  serviceVersion?: "7.0" | "7.1" | "7.2-preview";
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { createSandbox, SinonSandbox, SinonSpy } from "sinon";
 import { KeyClient } from "../../src";
-import { KnownApiVersions } from "../../src/";
+import { LATEST_API_VERSION } from "../../src/keysModels";
 import { HttpClient, HttpOperationResponse, WebResourceLike, HttpHeaders } from "@azure/core-http";
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
@@ -54,7 +54,7 @@ describe("The Keys client should set the serviceVersion", () => {
     const calls = spy.getCalls();
     assert.equal(
       calls[0].args[0].url,
-      `https://keyVaultName.vault.azure.net/keys/keyName/create?api-version=${KnownApiVersions.Seven2Preview}`
+      `https://keyVaultName.vault.azure.net/keys/keyName/create?api-version=${LATEST_API_VERSION}`
     );
   });
 


### PR DESCRIPTION
The PR https://github.com/Azure/azure-sdk-for-js/pull/13092 was merged on January 7, 2021. That PR was to migrate Keyvault Keys Package from Old SDK generator to New V6 Code Generator.

As a part of this task, I have exposed KnownApiVersions and ApiVersion properties. Per the SDK, if you look at the definition the KnownApiVersions has only one value (7.2-preview). Though you can pass any value (because it is a string property), it is confusing to the user. Also, we want to restrict the usage so there is no adverse impact. 

So, in this PR I have reverted that change. 

@sadasant Please review and approve.

@ramya-rao-a FYI......