### PR TITLE
[Perf framework] No-op methods for setup and cleanup and the global ones

### DIFF
--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -288,19 +288,14 @@ export class PerfStressProgram {
     console.log("=== Parsed options ===");
     console.table(options);
 
-    if (this.tests[0].globalSetup) {
-      console.log(
-        `=== Calling globalSetup() once for (all) the instance(s) of ${this.testName} ===`
-      );
-      await this.tests[0].globalSetup();
-    }
-    if (this.tests[0].setup) {
-      console.log(
-        `=== Calling setup() for the ${this.parallelNumber} instantiated ${this.testName} tests ===`
-      );
-      for (const test of this.tests) {
-        await test.setup!();
-      }
+    console.log(`=== Calling globalSetup() once for (all) the instance(s) of ${this.testName} ===`);
+    await this.tests[0].globalSetup();
+
+    console.log(
+      `=== Calling setup() for the ${this.parallelNumber} instantiated ${this.testName} tests ===`
+    );
+    for (const test of this.tests) {
+      await test.setup();
     }
 
     if (Number(options.warmup.value) > 0) {
@@ -312,22 +307,20 @@ export class PerfStressProgram {
       await this.runTest(i, Number(options.duration.value), "test");
     }
 
-    if (!options["no-cleanup"].value && this.tests[0].cleanup) {
+    if (!options["no-cleanup"].value) {
       console.log(
         `=== Calling cleanup() for the ${this.parallelNumber} instantiated ${this.testName} tests ===`
       );
       for (const test of this.tests) {
-        await test.cleanup!();
+        await test.cleanup();
       }
     }
 
     if (!options["no-cleanup"].value) {
-      if (this.tests[0].globalCleanup) {
-        console.log(
-          `=== Calling globalCleanup() once for (all) the instance(s) of ${this.testName} ===`
-        );
-        await this.tests[0].globalCleanup();
-      }
+      console.log(
+        `=== Calling globalCleanup() once for (all) the instance(s) of ${this.testName} ===`
+      );
+      await this.tests[0].globalCleanup();
     }
   }
 }

--- a/sdk/test-utils/perfstress/src/tests.ts
+++ b/sdk/test-utils/perfstress/src/tests.ts
@@ -47,8 +47,8 @@ export abstract class PerfStressTest<TOptions = {}> {
   public setup(): void | Promise<void> {}
   public cleanup(): void | Promise<void> {}
 
-  public run?(abortSignal?: AbortSignalLike): void;
-  public async runAsync?(abortSignal?: AbortSignalLike): Promise<void>;
+  public abstract run(abortSignal?: AbortSignalLike): void;
+  public abstract runAsync(abortSignal?: AbortSignalLike): Promise<void>;
 }
 
 /**

--- a/sdk/test-utils/perfstress/src/tests.ts
+++ b/sdk/test-utils/perfstress/src/tests.ts
@@ -41,11 +41,11 @@ export abstract class PerfStressTest<TOptions = {}> {
   }
 
   // Before and after running a bunch of the same test.
-  public globalSetup?(): void | Promise<void>;
-  public globalCleanup?(): void | Promise<void>;
+  public globalSetup(): void | Promise<void> {}
+  public globalCleanup(): void | Promise<void> {}
 
-  public setup?(): void | Promise<void>;
-  public cleanup?(): void | Promise<void>;
+  public setup(): void | Promise<void> {}
+  public cleanup(): void | Promise<void> {}
 
   public run?(abortSignal?: AbortSignalLike): void;
   public async runAsync?(abortSignal?: AbortSignalLike): Promise<void>;

--- a/sdk/test-utils/perfstress/test/delay.spec.ts
+++ b/sdk/test-utils/perfstress/test/delay.spec.ts
@@ -44,4 +44,6 @@ export class Delay500ms extends PerfStressTest {
   async runAsync(): Promise<void> {
     await delay(500);
   }
+
+  run() {}
 }

--- a/sdk/test-utils/perfstress/test/delay.spec.ts
+++ b/sdk/test-utils/perfstress/test/delay.spec.ts
@@ -45,5 +45,7 @@ export class Delay500ms extends PerfStressTest {
     await delay(500);
   }
 
-  run() {}
+  run() {
+    throw new Error("Method is not implemented");
+  }
 }

--- a/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
+++ b/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
@@ -36,4 +36,6 @@ export class NodeFetchTest extends PerfStressTest<NodeFetchOptions> {
     const response = await fetch(this.url, NodeFetchTest.fetchOptions);
     await response.text();
   }
+
+  run() {}
 }

--- a/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
+++ b/sdk/test-utils/perfstress/test/nodeFetch.spec.ts
@@ -37,5 +37,7 @@ export class NodeFetchTest extends PerfStressTest<NodeFetchOptions> {
     await response.text();
   }
 
-  run() {}
+  run() {
+    throw new Error("Method is not implemented");
+  }
 }

--- a/sdk/test-utils/perfstress/test/options.spec.ts
+++ b/sdk/test-utils/perfstress/test/options.spec.ts
@@ -76,4 +76,6 @@ export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
       this.compare(key as keyof OptionsTestOptions);
     }
   }
+
+  async runAsync() {}
 }

--- a/sdk/test-utils/perfstress/test/options.spec.ts
+++ b/sdk/test-utils/perfstress/test/options.spec.ts
@@ -77,5 +77,7 @@ export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
     }
   }
 
-  async runAsync() {}
+  async runAsync() {
+    throw new Error("Method is not implemented");
+  }
 }

--- a/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
+++ b/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
@@ -66,4 +66,6 @@ export class PerfStressPolicyTest extends PerfStressTest<PerfStressPolicyOptions
     );
     await policy.sendRequest(request);
   }
+
+  run() {}
 }

--- a/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
+++ b/sdk/test-utils/perfstress/test/perfStressPolicy.spec.ts
@@ -67,5 +67,7 @@ export class PerfStressPolicyTest extends PerfStressTest<PerfStressPolicyOptions
     await policy.sendRequest(request);
   }
 
-  run() {}
+  run() {
+    throw new Error("Method is not implemented");
+  }
 }

--- a/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
+++ b/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
@@ -48,4 +48,5 @@ export class SetupCleanupTest extends PerfStressTest {
   }
 
   run(): void {}
+  async runAsync() {}
 }

--- a/sdk/test-utils/perfstress/test/sleep.spec.ts
+++ b/sdk/test-utils/perfstress/test/sleep.spec.ts
@@ -24,4 +24,6 @@ export class SleepTest extends PerfStressTest {
   async runAsync(): Promise<void> {
     await delay(this.secondsPerOperation * 1000);
   }
+
+  run() {}
 }

--- a/sdk/test-utils/perfstress/test/sleep.spec.ts
+++ b/sdk/test-utils/perfstress/test/sleep.spec.ts
@@ -25,5 +25,7 @@ export class SleepTest extends PerfStressTest {
     await delay(this.secondsPerOperation * 1000);
   }
 
-  run() {}
+  run() {
+    throw new Error("Method is not implemented");
+  }
 }


### PR DESCRIPTION
- Defines `globalSetup`, `globalCleanup`, `setup` and `cleanup`
- I don't see a reason for them to be optional, so changing that.
- Making run and runAsync abstract
 
To address @mikeharder's comment at https://github.com/Azure/azure-sdk-for-js/pull/12737#discussion_r554141769