### PR TITLE
[Service Bus] Remove message count check - flaky rule filter test

### DIFF
--- a/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomRuleFilters.spec.ts
@@ -57,18 +57,6 @@ describe("Filter messages with the rules set by the ATOM API", () => {
 
     await serviceBusClient.createSender(topicName).sendMessages(messagesToSend);
 
-    // Making sure the subscription has the expected number of messages
-    should.equal(
-      (
-        await serviceBusAtomManagementClient.getSubscriptionRuntimeProperties(
-          topicName,
-          subscriptionName
-        )
-      ).totalMessageCount,
-      numberOfMessagesToBeFiltered,
-      "Unexpected number of messages filtered"
-    );
-
     const receivedMessages = await serviceBusClient
       .createReceiver(topicName, subscriptionName)
       .receiveMessages(5);


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/13105 investigates the flakyness.

The reason why the message count in the test can sometimes(5/1000 times) be zero is that the sent messages might not have been filtered into the subscription by the time we call the runtime properties method.

If we call the receiveMessages directly, the inherent delay would help in receiving the messages and should be enough for the test.