### PR TITLE
[core-client] Switch _response property for callback.

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -202,6 +202,7 @@ export interface OperationArguments {
 // @public
 export interface OperationOptions {
     abortSignal?: AbortSignalLike;
+    rawResponseCallback?: RawResponseCallback;
     requestOptions?: OperationRequestOptions;
     serializerOptions?: SerializerOptions;
     tracingOptions?: OperationTracingOptions;
@@ -239,13 +240,6 @@ export interface OperationRequestOptions {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     shouldDeserialize?: boolean | ((response: PipelineResponse) => boolean);
     timeout?: number;
-}
-
-// @public
-export interface OperationResponse {
-    // (undocumented)
-    [key: string]: any;
-    _response: FullOperationResponse;
 }
 
 // @public
@@ -297,6 +291,9 @@ export interface PolymorphicDiscriminator {
 // @public
 export type QueryCollectionFormat = "CSV" | "SSV" | "TSV" | "Pipes" | "Multi";
 
+// @public
+export type RawResponseCallback = (rawResponse: FullOperationResponse, flatResponse: unknown) => void;
+
 // @public (undocumented)
 export interface SequenceMapper extends BaseMapper {
     // (undocumented)
@@ -347,7 +344,7 @@ export interface SerializerOptions {
 // @public
 export class ServiceClient {
     constructor(options?: ServiceClientOptions);
-    sendOperationRequest(operationArguments: OperationArguments, operationSpec: OperationSpec): Promise<OperationResponse>;
+    sendOperationRequest<T>(operationArguments: OperationArguments, operationSpec: OperationSpec): Promise<T>;
     sendRequest(request: PipelineRequest): Promise<PipelineResponse>;
 }
 

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -202,7 +202,7 @@ export interface OperationArguments {
 // @public
 export interface OperationOptions {
     abortSignal?: AbortSignalLike;
-    rawResponseCallback?: RawResponseCallback;
+    onResponse?: RawResponseCallback;
     requestOptions?: OperationRequestOptions;
     serializerOptions?: SerializerOptions;
     tracingOptions?: OperationTracingOptions;

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -36,14 +36,14 @@ export {
   OperationRequestInfo,
   QueryCollectionFormat,
   ParameterPath,
-  OperationResponse,
   FullOperationResponse,
   PolymorphicDiscriminator,
   SpanConfig,
   XML_ATTRKEY,
   XML_CHARKEY,
   XmlOptions,
-  SerializerOptions
+  SerializerOptions,
+  RawResponseCallback
 } from "./interfaces";
 export {
   deserializationPolicy,

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -105,6 +105,13 @@ export interface OperationOptions {
    * Options to override serialization/de-serialization behavior.
    */
   serializerOptions?: SerializerOptions;
+
+  /**
+   * A function to be called each time a response is received from the server
+   * while performing the requested operation.
+   * May be called multiple times.
+   */
+  rawResponseCallback?: RawResponseCallback;
 }
 
 /**
@@ -333,17 +340,14 @@ export interface FullOperationResponse extends PipelineResponse {
 }
 
 /**
- * The processed and flattened response to an operation call.
- * Contains merged properties of the parsed body and headers.
+ * A function to be called each time a response is received from the server
+ * while performing the requested operation.
+ * May be called multiple times.
  */
-export interface OperationResponse {
-  /**
-   * The underlying HTTP response containing both raw and deserialized response data.
-   */
-  _response: FullOperationResponse;
-
-  [key: string]: any;
-}
+export type RawResponseCallback = (
+  rawResponse: FullOperationResponse,
+  flatResponse: unknown
+) => void;
 
 /**
  * Used to map raw response objects to final shapes.

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -111,7 +111,7 @@ export interface OperationOptions {
    * while performing the requested operation.
    * May be called multiple times.
    */
-  rawResponseCallback?: RawResponseCallback;
+  onResponse?: RawResponseCallback;
 }
 
 /**

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -203,8 +203,8 @@ export class ServiceClient {
         rawResponse,
         operationSpec.responses[rawResponse.status]
       ) as T;
-      if (options?.rawResponseCallback) {
-        options.rawResponseCallback(rawResponse, flatResponse);
+      if (options?.onResponse) {
+        options.onResponse(rawResponse, flatResponse);
       }
       return flatResponse;
     } catch (error) {

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -124,6 +124,7 @@ export class ServiceClient {
 
   /**
    * Send an HTTP request that is populated using the provided OperationSpec.
+   * @typeParam T The typed result of the request, based on the OperationSpec.
    * @param {OperationArguments} operationArguments The arguments that the HTTP request's templated values will be populated from.
    * @param {OperationSpec} operationSpec The OperationSpec to use to populate the httpRequest.
    */

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -269,7 +269,7 @@ describe("ServiceClient", function() {
     let rawResponse: FullOperationResponse | undefined;
 
     const response = await client.sendOperationRequest(
-      { options: { rawResponseCallback: (response) => (rawResponse = response) } },
+      { options: { onResponse: (response) => (rawResponse = response) } },
       {
         httpMethod: "GET",
         baseUrl: "https://example.com",
@@ -349,7 +349,7 @@ describe("ServiceClient", function() {
     const res = await client1.sendOperationRequest<Array<number>>(
       {
         options: {
-          rawResponseCallback: (response) => {
+          onResponse: (response) => {
             rawResponse = response;
           }
         }

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -14,7 +14,8 @@ import {
   Mapper,
   CompositeMapper,
   OperationSpec,
-  serializationPolicy
+  serializationPolicy,
+  FullOperationResponse
 } from "../src";
 import {
   createHttpHeaders,
@@ -249,20 +250,26 @@ describe("ServiceClient", function() {
     assert.deepEqual(request!.headers.toJSON(), expected);
   });
 
-  it("responses should not show the _response property when serializing", async function() {
+  it("should call rawResponseCallback with the full response", async function() {
     let request: OperationRequest;
     const client = new ServiceClient({
       httpsClient: {
         sendRequest: (req) => {
           request = req;
-          return Promise.resolve({ request, status: 200, headers: createHttpHeaders() });
+          return Promise.resolve({
+            request,
+            status: 200,
+            headers: createHttpHeaders({ "X-Extra-Info": "foo" })
+          });
         }
       },
       pipeline: createEmptyPipeline()
     });
 
+    let rawResponse: FullOperationResponse | undefined;
+
     const response = await client.sendOperationRequest(
-      {},
+      { options: { rawResponseCallback: (response) => (rawResponse = response) } },
       {
         httpMethod: "GET",
         baseUrl: "https://example.com",
@@ -275,8 +282,10 @@ describe("ServiceClient", function() {
     );
 
     assert(request!);
-    // _response should be not enumerable
     assert.strictEqual(JSON.stringify(response), "{}");
+    assert.strictEqual(rawResponse?.status, 200);
+    assert.strictEqual(rawResponse?.request, request!);
+    assert.strictEqual(rawResponse?.headers.get("X-Extra-Info"), "foo");
   });
 
   it("should serialize collection:csv query parameters", async function() {
@@ -336,8 +345,15 @@ describe("ServiceClient", function() {
       pipeline
     });
 
-    const res = await client1.sendOperationRequest(
-      {},
+    let rawResponse: FullOperationResponse | undefined;
+    const res = await client1.sendOperationRequest<Array<number>>(
+      {
+        options: {
+          rawResponseCallback: (response) => {
+            rawResponse = response;
+          }
+        }
+      },
       {
         serializer: createSerializer(),
         httpMethod: "GET",
@@ -359,7 +375,7 @@ describe("ServiceClient", function() {
       }
     );
 
-    assert.strictEqual(res._response.status, 200);
+    assert.strictEqual(rawResponse?.status, 200);
     assert.deepStrictEqual(res.slice(), [1, 2, 3]);
   });
 


### PR DESCRIPTION
This PR introduces a new `OperationOptions` member called `onResponse` that is called with the full HTTP response of each operation. This option replaces the previous behavior of attaching the `FullOperationResponse` as a special non-enumerable `_response` property on the flattened response object.

This PR also makes `sendOperationRequest` generic instead of returning an indexer type that is effectively `any`. This should make it even easier for generated code to properly express the correct return type without extra casting.

This PR is based on #12944, but does not change the header mapping behavior of `sendOperationRequest`.