### PR TITLE
[eventhub] Remove old uglify dependency

### DIFF
--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -118,7 +118,6 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
     "ts-node": "^8.3.0",
     "typescript": "4.1.2",
     "ws": "^7.1.1",

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -13,7 +13,6 @@ import path from "path";
 const pkg = require("./package.json");
 const depNames = Object.keys(pkg.dependencies);
 const input = "dist-esm/src/index.js";
-const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
   const externalNodeBuiltins = ["events", "util"];

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -6,7 +6,6 @@ import multiEntry from "@rollup/plugin-multi-entry";
 import cjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
 import sourcemaps from "rollup-plugin-sourcemaps";
 
 import path from "path";
@@ -66,8 +65,6 @@ export function nodeConfig(test = false) {
     // the "sideEffects" field in package.json.  Since our package.json sets "sideEffects=false", this also
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
-  } else if (production) {
-    baseConfig.plugins.push(uglify());
   }
 
   return baseConfig;
@@ -117,8 +114,6 @@ export function browserConfig(test = false) {
     // the "sideEffects" field in package.json.  Since our package.json sets "sideEffects=false", this also
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
-  } else if (production) {
-    baseConfig.plugins.push(uglify());
   }
 
   return baseConfig;


### PR DESCRIPTION
Uglify was used to ship minified browser builds, but we don't actually ship browser bundles.