### PR TITLE
[Cosmos] Update README to use non deprecated method

### DIFF
--- a/sdk/cosmosdb/cosmos/README.md
+++ b/sdk/cosmosdb/cosmos/README.md
@@ -44,7 +44,7 @@ You will need your Cosmos DB **Account Endpoint** and **Key**. You can find thes
 
 ```Bash
 az cosmosdb show --resource-group <your-resource-group> --name <your-account-name> --query documentEndpoint --output tsv
-az cosmosdb list-keys --resource-group <your-resource-group> --name <your-account-name> --query documentEndpoint --output tsv
+az cosmosdb keys list --resource-group <your-resource-group> --name <your-account-name> --query documentEndpoint --output tsv
 ```
 
 ### Create an instance of `CosmosClient`


### PR DESCRIPTION
This commit makes a minor update to the Cosmos README to use
`keys list` instead of `list-keys` since the latter is deprecated and 
shows a warning on the CLI when ran.

I ran into this in passing when using Cosmos DB.