### PR TITLE
[Attestation] Adds missing npm scripts and adds tsdoc.json

### DIFF
--- a/sdk/attestation/attestation/CHANGELOG.md
+++ b/sdk/attestation/attestation/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Release History
+
+## 1.0.0-beta.1 (unreleased)
+
+Initial early preview release for MAA Data Plane SDK Demonstrates use of the machine generated MAA APIs.
+
+- Initial Release

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -37,7 +37,6 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^8.2.0",
-    "eslint": "^7.15.0",
     "jsrsasign": "^10.1.4",
     "karma": "^5.1.0",
     "karma-chrome-launcher": "^3.0.0",
@@ -61,7 +60,8 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "safe-buffer": "^5.2.1",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "4.1.2",
+    "typedoc": "0.15.0"
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/attestation/attestation/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
@@ -99,7 +99,6 @@
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
-  "autoPublish": true,
   "browser": {
     "./dist-esm/test/utils/base64url.js": "./dist-esm/test/utils/base64url.browser.js",
     "./dist-esm/test/utils/Buffer.js": "./dist-esm/test/utils/Buffer.browser.js",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -13,7 +13,8 @@
     "azure",
     "typescript",
     "browser",
-    "isomorphic"
+    "isomorphic",
+    "cloud"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@opentelemetry/api": "^0.10.2",
@@ -36,6 +38,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^8.2.0",
+    "eslint": "^7.15.0",
     "jsrsasign": "^10.1.4",
     "karma": "^5.1.0",
     "karma-chrome-launcher": "^3.0.0",
@@ -61,11 +64,8 @@
     "ts-node": "^8.3.0",
     "typescript": "4.1.2"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-for-js.git"
-  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/attestation/attestation/README.md",
+  "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
@@ -77,17 +77,27 @@
     "LICENSE"
   ],
   "scripts": {
+    "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
     "build:samples": "echo skipped",
     "build:test": "tsc -p . && rollup -c 2>&1",
+    "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test temp types *.tgz *.log",
+    "execute:samples": "echo skipped",
     "extract-api": "api-extractor run --local",
-    "lint": "echo skipped",
-    "prepack": "npm install && npm run build",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "integration-test:browser": "karma start --single-run",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace \"dist-esm/test/{,!(browser)/**/}*.spec.js\"",
+    "integration-test": "npm run integration-test:node && npm run integration-test:browser",
+    "lint:fix": "eslint package.json api-extractor.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json api-extractor.json test --ext .ts",
+    "pack": "npm pack 2>&1",
+    "prebuild": "npm run clean",
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "mocha -r esm --require ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace \"test/{,!(browser)/**/}*.spec.ts\"",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --mode file --out ./dist/docs ./src"
   },
   "sideEffects": false,
   "autoPublish": true,

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -24,7 +24,6 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "@azure/dev-tool": "^1.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -24,6 +24,7 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
+    "@azure/dev-tool": "^1.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@opentelemetry/api": "^0.10.2",
@@ -89,8 +88,8 @@
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 5000000 --full-trace \"dist-esm/test/{,!(browser)/**/}*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json api-extractor.json test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json test --ext .ts",
+    "lint:fix": "echo skipped",
+    "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test": "npm run clean && npm run build:test && npm run unit-test",

--- a/sdk/attestation/attestation/test/public/attestationTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTests.spec.ts
@@ -8,7 +8,6 @@ chaiUse(chaiPromises);
 import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 
 import { createRecordedClient, createRecorder } from "../utils/recordedClient";
-import { AttestationClient } from "../../src";
 import * as base64url from "../utils/base64url";
 import { verifyAttestationToken } from "../utils/helpers";
 
@@ -119,8 +118,7 @@ describe("[AAD] Attestation Client", function() {
     "PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCgA";
 
   it("#AttestSgxShared", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Shared");
+    const client = createRecordedClient("Shared");
     const binaryRuntimeData = base64url.decodeString(_runtimeData);
     const attestationResult = await client.attestation.attestSgxEnclave({
       quote: base64url.decodeString(_sgxQuote),
@@ -137,8 +135,7 @@ describe("[AAD] Attestation Client", function() {
     }
   });
   it("#AttestSgxAad", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("AAD");
+    const client = createRecordedClient("AAD");
     const binaryRuntimeData = base64url.decodeString(_runtimeData);
     const attestationResult = await client.attestation.attestSgxEnclave({
       quote: base64url.decodeString(_sgxQuote),
@@ -156,8 +153,7 @@ describe("[AAD] Attestation Client", function() {
   });
 
   it("#AttestSgxIsolated", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("AAD");
+    const client = createRecordedClient("AAD");
     const binaryRuntimeData = base64url.decodeString(_runtimeData);
     const attestationResult = await client.attestation.attestSgxEnclave({
       quote: base64url.decodeString(_sgxQuote),

--- a/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
@@ -8,7 +8,7 @@ chaiUse(chaiPromises);
 import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 
 import { createRecordedClient, createRecorder } from "../utils/recordedClient";
-import { AttestationClient, KnownAttestationType } from "../../src";
+import { KnownAttestationType } from "../../src";
 import { verifyAttestationToken } from "../utils/helpers";
 
 describe("PolicyGetSetTests ", function() {
@@ -24,8 +24,7 @@ describe("PolicyGetSetTests ", function() {
   });
 
   it("#GetPolicyAad", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("AAD");
+    const client = createRecordedClient("AAD");
     const policyResult = await client.policy.get(KnownAttestationType.SgxEnclave);
     const result = policyResult.token;
     assert(result, "Expected a token from the service but did not receive one");
@@ -35,8 +34,7 @@ describe("PolicyGetSetTests ", function() {
   });
 
   it("#GetPolicyIsolated", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Isolated");
+    const client = createRecordedClient("Isolated");
     const policyResult = await client.policy.get(KnownAttestationType.SgxEnclave);
     const result = policyResult.token;
     assert(result, "Expected a token from the service but did not receive one");
@@ -46,8 +44,7 @@ describe("PolicyGetSetTests ", function() {
   });
 
   it("#GetPolicyShared", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Shared");
+    const client = createRecordedClient("Shared");
     const policyResult = await client.policy.get(KnownAttestationType.SgxEnclave);
     const result = policyResult.token;
     assert(result, "Expected a token from the service but did not receive one");

--- a/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
@@ -8,7 +8,6 @@ chaiUse(chaiPromises);
 import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 
 import { createRecordedClient, createRecorder } from "../utils/recordedClient";
-import { AttestationClient } from "../../src";
 import { verifyAttestationToken } from "../utils/helpers";
 
 describe("PolicyManagementTests ", function() {
@@ -24,8 +23,7 @@ describe("PolicyManagementTests ", function() {
   });
 
   it("#GetPolicyManagementCertificatesAad", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("AAD");
+    const client = createRecordedClient("AAD");
 
     const policyResult = await client.policyCertificates.get();
     const result = policyResult.token;
@@ -41,8 +39,7 @@ describe("PolicyManagementTests ", function() {
   });
 
   it("#GetPolicyShared", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Shared");
+    const client = createRecordedClient("Shared");
     const policyResult = await client.policyCertificates.get();
 
     const result = policyResult.token;
@@ -58,8 +55,7 @@ describe("PolicyManagementTests ", function() {
   });
 
   it("#GetPolicyIsolated", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Isolated");
+    const client = createRecordedClient("Isolated");
     const policyResult = await client.policyCertificates.get();
 
     const result = policyResult.token;

--- a/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
@@ -8,7 +8,6 @@ chaiUse(chaiPromises);
 import { Recorder } from "@azure/test-utils-recorder";
 
 import { createRecordedClient, createRecorder } from "../utils/recordedClient";
-import { AttestationClient } from "../../src";
 import { Buffer } from "../utils/Buffer";
 
 describe("TokenCertTests", function() {
@@ -24,8 +23,7 @@ describe("TokenCertTests", function() {
   });
 
   it("#GetCertificatesAAD", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("AAD");
+    const client = createRecordedClient("AAD");
     const signingCertificates = await client.signingCertificates.get();
     const certs = signingCertificates.keys!;
     assert(certs.length > 0);
@@ -38,8 +36,7 @@ describe("TokenCertTests", function() {
     }
   });
   it("#GetCertificatesIsolated", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Isolated");
+    const client = createRecordedClient("Isolated");
     const signingCertificates = await client.signingCertificates.get();
     const certs = signingCertificates.keys!;
     assert(certs.length > 0);
@@ -53,8 +50,7 @@ describe("TokenCertTests", function() {
   });
 
   it("#GetCertificatesShared", async () => {
-    let client: AttestationClient;
-    client = createRecordedClient("Shared");
+    const client = createRecordedClient("Shared");
     const signingCertificates = await client.signingCertificates.get();
     const certs = signingCertificates.keys!;
     assert(certs.length > 0);

--- a/sdk/attestation/attestation/test/utils/base64url.browser.ts
+++ b/sdk/attestation/attestation/test/utils/base64url.browser.ts
@@ -5,7 +5,7 @@
 
 /**
  * Encodes a string in base64 format.
- * @param value the string to encode
+ * @param value - the string to encode
  */
 export function encodeString(value: string): string {
   return btoa(value);
@@ -13,7 +13,7 @@ export function encodeString(value: string): string {
 
 /**
  * Encodes a byte array in base64 format.
- * @param value the Uint8Array to encode
+ * @param value - the Uint8Array to encode
  */
 export function encodeByteArray(value: Uint8Array): string {
   let str = "";
@@ -25,7 +25,7 @@ export function encodeByteArray(value: Uint8Array): string {
 
 /**
  * Decodes a base64 string into a byte array.
- * @param value the base64 string to decode
+ * @param value - the base64 string to decode
  */
 function decodeStringFromBase64(value: string): Uint8Array {
   const byteString = atob(value);
@@ -38,8 +38,8 @@ function decodeStringFromBase64(value: string): Uint8Array {
 
 /**
  * Adds missing padding to a Base64 encoded string
- * @param unpadded The unpadded input string
- * @return The padded string
+ * @param unpadded - The unpadded input string
+ * @returns The padded string
  */
 function fixPadding(unpadded: string): string {
   const count = 3 - ((unpadded.length + 3) % 4);
@@ -48,7 +48,7 @@ function fixPadding(unpadded: string): string {
 
 /**
  * Decodes a base64url string into a byte array.
- * @param value the base64url string to decode
+ * @param value - the base64url string to decode
  */
 export function decodeString(value: string): Uint8Array {
   const encoded = value.replace(/-/g, "+").replace(/_/g, "/");

--- a/sdk/attestation/attestation/test/utils/base64url.ts
+++ b/sdk/attestation/attestation/test/utils/base64url.ts
@@ -3,7 +3,7 @@
 
 /**
  * Encodes a string in base64 format.
- * @param value the string to encode
+ * @param value - the string to encode
  */
 export function encodeString(value: string): string {
   return Buffer.from(value).toString("base64");
@@ -11,7 +11,7 @@ export function encodeString(value: string): string {
 
 /**
  * Encodes a byte array in base64 format.
- * @param value the Uint8Array to encode
+ * @param value - the Uint8Array to encode
  */
 export function encodeByteArray(value: Uint8Array): string {
   // Buffer.from accepts <ArrayBuffer> | <SharedArrayBuffer>-- the TypeScript definition is off here
@@ -22,7 +22,7 @@ export function encodeByteArray(value: Uint8Array): string {
 
 /**
  * Decodes a base64 string into a byte array.
- * @param value the base64 string to decode
+ * @param value - the base64 string to decode
  */
 function decodeStringFromBase64(value: string): Uint8Array {
   return Buffer.from(value, "base64");
@@ -30,8 +30,8 @@ function decodeStringFromBase64(value: string): Uint8Array {
 
 /**
  * Adds missing padding to a Base64 encoded string
- * @param unpadded The unpadded input string
- * @return The padded string
+ * @param unpadded - The unpadded input string
+ * @returns The padded string
  */
 function fixPadding(unpadded: string): string {
   const count = 3 - ((unpadded.length + 3) % 4);
@@ -40,7 +40,7 @@ function fixPadding(unpadded: string): string {
 
 /**
  * Decodes a base64url string into a byte array.
- * @param value the base64url string to decode
+ * @param value - the base64url string to decode
  */
 export function decodeString(value: string): Uint8Array {
   const encoded = value.replace(/-/g, "+").replace(/_/g, "/");

--- a/sdk/attestation/attestation/test/utils/decodeJWT.ts
+++ b/sdk/attestation/attestation/test/utils/decodeJWT.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 // typed implementation of jwsDecode, copied from here: https://github.com/auth0/node-jws/blob/master/lib/verify-stream.js
+/* eslint-disable */
 
 import { Buffer } from "./Buffer";
 

--- a/sdk/attestation/attestation/tsdoc.json
+++ b/sdk/attestation/attestation/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../../tsdoc.json"]
+}


### PR DESCRIPTION
The attestation pipeline failed for various errors (listed below), mainly because some crucial `npm` scripts were missing. This PR adds the standard ones and fixes linting issues in all but `src`.

## Failures 
Link: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=682555&view=logs&j=23e2e6de-b7c3-5918-7121-f16b46172e49&t=7bd26578-88b4-5baa-f548-7813777930ca

- `ERROR: The project [@azure/dev-tool] does not define a 'unit-test:node' command`
- `ERROR: The project [@azure/attestation] does not define a 'pack' command`
- failures in the eslint plugin, opened https://github.com/Azure/azure-sdk-for-js/pull/13189 to fix them and rebased
- failures in dev-tool because of an outdated unit test. After fixing this issue , now I get this https://github.com/Azure/azure-sdk-for-js/issues/13202 instead:
```
  1 failing
npm ERR! code ELIFECYCLE

npm ERR! errno 1
  1) Project Resolution
npm ERR! @azure/dev-tool@1.0.0 unit-test: `mocha --require ts-node/register test/**/*.spec.ts`
       resolution finds dev-tool package:
npm ERR! Exit status 1
     AssertionError: expected 'D:\\vss-agent-2.179.0\\_work\\1\\s\\common\\tools\\dev-tool' to match /.*\common\tools\dev-tool/
npm ERR! 
      at D:\vss-agent-2.179.0\_work\1\s\common\tools\dev-tool\test\resolveProject.spec.ts:25:12
npm ERR! Failed at the @azure/dev-tool@1.0.0 unit-test script.
      at Generator.next (<anonymous>)
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
      at fulfilled (test\resolveProject.spec.ts:7:58)
```
EDIT: I moved `dev-tool` changes to https://github.com/Azure/azure-sdk-for-js/pull/13204.