### PR TITLE
[Tables] Support Emulator and Azurite

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-beta.4 (2021-01-12)
 
+- Fix issue that prevented support for Azure Storage Emulator and Azurite [#13165](https://github.com/Azure/azure-sdk-for-js/pull/13165)
+
 ### Breaking Changes
 
 - Don't deserialize DateTime into a JavaScript Date to avoid losing precision [#12650](https://github.com/Azure/azure-sdk-for-js/pull/12650)

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -132,6 +132,7 @@ export class TableClient {
         ? credentialOrOptions
         : options) || {};
 
+    clientOptions.endpoint = clientOptions.endpoint || url;
     if (!clientOptions.userAgentOptions) {
       clientOptions.userAgentOptions = {};
     }
@@ -151,15 +152,15 @@ export class TableClient {
     } else {
       // The client is meant to be a regular service client, so we need to create the regular set of pipelines
       const internalPipelineOptions: InternalPipelineOptions = {
-        ...clientOptions,
-        ...{
-          loggingOptions: {
-            logger: logger.info,
-            allowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
-          }
+        loggingOptions: {
+          logger: logger.info,
+          allowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
         }
       };
-      pipeline = createPipelineFromOptions(internalPipelineOptions, credential);
+      pipeline = {
+        ...clientOptions,
+        ...createPipelineFromOptions(internalPipelineOptions, credential)
+      };
     }
 
     this.tableName = tableName;

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -103,6 +103,8 @@ export class TableServiceClient {
         ? credentialOrOptions
         : options) || {};
 
+    clientOptions.endpoint = clientOptions.endpoint || url;
+
     if (!clientOptions.userAgentOptions) {
       clientOptions.userAgentOptions = {};
     }
@@ -114,16 +116,16 @@ export class TableServiceClient {
     }
 
     const internalPipelineOptions: InternalPipelineOptions = {
-      ...clientOptions,
-      ...{
-        loggingOptions: {
-          logger: logger.info,
-          allowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
-        }
+      loggingOptions: {
+        logger: logger.info,
+        allowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
       }
     };
 
-    const pipeline = createPipelineFromOptions(internalPipelineOptions, credential);
+    const pipeline = {
+      ...clientOptions,
+      ...createPipelineFromOptions(internalPipelineOptions, credential)
+    };
     const client = new GeneratedClient(url, pipeline);
     this.table = client.table;
     this.service = client.service;

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -23,7 +23,7 @@ export function getClientParamsFromConnectionString(
   connectionString: string,
   options?: TableServiceClientOptions
 ): ClientParamsFromConnectionString {
-  if (connectionString.indexOf("UseDevelopmentStorage=true") !== -1) {
+  if (connectionString.toLocaleLowerCase().indexOf("usedevelopmentstorage=true") !== -1) {
     connectionString = DevelopmentConnectionString;
   }
   const extractedCreds = extractConnectionStringParts(connectionString);

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -6,6 +6,9 @@ import { fromAccountConnectionString, getAccountConnectionString } from "./accou
 import { ClientParamsFromConnectionString, ConnectionString } from "./internalModels";
 import { URL } from "./url";
 
+const DevelopmentConnectionString =
+  "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1";
+
 /**
  * This function parses a connection string into a set of
  * parameters to pass to be passed to TableClientService,
@@ -20,6 +23,9 @@ export function getClientParamsFromConnectionString(
   connectionString: string,
   options?: TableServiceClientOptions
 ): ClientParamsFromConnectionString {
+  if (connectionString.indexOf("UseDevelopmentStorage=true") !== -1) {
+    connectionString = DevelopmentConnectionString;
+  }
   const extractedCreds = extractConnectionStringParts(connectionString);
   if (extractedCreds.kind === "AccountConnString") {
     return fromAccountConnectionString(extractedCreds, options);

--- a/sdk/tables/data-tables/src/utils/connectionString.ts
+++ b/sdk/tables/data-tables/src/utils/connectionString.ts
@@ -23,7 +23,7 @@ export function getClientParamsFromConnectionString(
   connectionString: string,
   options?: TableServiceClientOptions
 ): ClientParamsFromConnectionString {
-  if (connectionString.toLocaleLowerCase().indexOf("usedevelopmentstorage=true") !== -1) {
+  if (connectionString.toLowerCase().indexOf("usedevelopmentstorage=true") !== -1) {
     connectionString = DevelopmentConnectionString;
   }
   const extractedCreds = extractConnectionStringParts(connectionString);


### PR DESCRIPTION
Fixes issues #13100, #13118 and ##12753

This PR fixes the issues above enabling support for Azure Storage Emulator and Azurite. The underlying issue is described in #13159 in which core-http's URLBuilder doesn't play nicely with parametrized enpoint + parametrized paths. i.e replacing `{url}/{param1}` drops `param1` if `{url}` value contains any path elements.

However, in the Tables clients, we can explicitly set the `options.endpoint`, doing this the URL is no longer parametrized and the path parameters are not dropped. 

This is why, from the generated client:
![image](https://user-images.githubusercontent.com/21109913/104358755-810f5e00-54d4-11eb-8354-1f0da41ad027.png)


Running tests against the emulator and Azurite is tracked by #13164 