### PR TITLE
[Text Analytics] Address feedback from the arch board meeting 11/1

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 5.1.0 (unreleased)
 
-- The poller for the `beginAnalyze` long-running operation gained the ability to return certain metadata information about the currently running job (e.g., when the job was created, will be expired, and last time it was updated, and also how many tasks completed and failed so far). Also, the poller for `beginAnalyzeHealthcare` gained a similar ability.
-- The healthcare entities returned by `beginAnalyzeHealthcare` are now organized as a directed graph where the edges represent a certain type of healthcare relationship between the source and target nodes.
-- A new option to control how the offset is calculated by the service, `stringIndexType`, is added to `analyzeSentiment`, `recognizeEntities`, `recognizePiiEntities`, and `beginAnalyzeHealthcare`. Furthermore, `StringUnitOfLength` is added to task types `EntitiesTask` and `PiiTask`, which are the types of input tasks to the `beginAnalyze` method. For more information, see [the Text Analytics documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/text-offsets#offsets-in-api-version-31-preview).
+- A new option to control how the offset is calculated by the service, `stringIndexType`, is added to `analyzeSentiment`, `recognizeEntities`, `recognizePiiEntities`, and `beginAnalyzeHealthcareEntities`. Furthermore, `stringIndexType` is added to task types `EntitiesTask` and `PiiTask`, which are the types of input tasks to the `beginAnalyze` method. For more information, see [the Text Analytics documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/text-offsets#offsets-in-api-version-31-preview).
+- [Breaking] `beginAnalyzeHealthcare` is renamed to `beginAnalyzeHealthcareEntities`.
+- [Breaking] The healthcare entities returned by `beginAnalyzeHealthcare` are now organized as a directed graph where the edges represent a certain type of healthcare relationship between the source and target entities. Edges are stored in the `relatedEntities` property.
+- [Breaking] The `links` property of `HealthcareEntity` is renamed to `dataSources`, a list of objects representing medical databases, where each object has `name` and `id` properties.
+- The poller for the `beginAnalyze` long-running operation gained the ability to return certain metadata information about the currently running job (e.g., when the job was created, will be expired, and last time it was updated, and also how many tasks completed and failed so far). Also, the poller for `beginAnalyzeHealthcareEntities` gained a similar ability.
 
 ## 5.1.0-beta.3 (2020-11-23)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -18,6 +18,13 @@ export interface AnalysisPollOperationState<TResult> extends PollOperationState<
 }
 
 // @public
+export interface AnalyzeBatchTasksResult {
+    entitiesRecognitionResults: RecognizeCategorizedEntitiesResultArray[];
+    keyPhrasesExtractionResults: ExtractKeyPhrasesResultArray[];
+    piiEntitiesRecognitionResults: RecognizePiiEntitiesResultArray[];
+}
+
+// @public
 export interface AnalyzeJobMetadata extends JobMetadata {
     displayName?: string;
     failedTasksCount?: number;
@@ -27,13 +34,6 @@ export interface AnalyzeJobMetadata extends JobMetadata {
 
 // @public
 export type AnalyzePollerLike = PollerLike<BeginAnalyzeOperationState, PagedAnalyzeResults>;
-
-// @public
-export interface AnalyzeResult {
-    entitiesRecognitionResults: RecognizeCategorizedEntitiesResultArray[];
-    keyPhrasesExtractionResults: ExtractKeyPhrasesResultArray[];
-    piiEntitiesRecognitionResults: RecognizePiiEntitiesResultArray[];
-}
 
 // @public
 export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult;
@@ -193,15 +193,15 @@ export interface HealthcareEntitiesArray extends Array<HealthcareResult> {
 
 // @public
 export interface HealthcareEntity extends Entity {
-    dataSource?: HealthcareEntityDataSource[];
+    dataSources: HealthcareEntityDataSource[];
     isNegated: boolean;
-    relatedHealthcareEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
+    relatedEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
 }
 
 // @public
 export interface HealthcareEntityDataSource {
-    dataSource: string;
-    dataSourceId: string;
+    id: string;
+    name: string;
 }
 
 // @public
@@ -280,7 +280,7 @@ export interface PagedAnalyzeResults extends PagedAsyncIterableAnalyzeResults {
 }
 
 // @public
-export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<AnalyzeResult, AnalyzeResult>;
+export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<AnalyzeBatchTasksResult, AnalyzeBatchTasksResult>;
 
 // @public
 export type PagedAsyncIterableHealthcareEntities = PagedAsyncIterableIterator<HealthcareResult, HealthcareEntitiesArray>;
@@ -424,8 +424,8 @@ export class TextAnalyticsClient {
     analyzeSentiment(documents: TextDocumentInput[], options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultArray>;
     beginAnalyzeBatchTasks(documents: string[], tasks: JobManifestTasks, language?: string, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
     beginAnalyzeBatchTasks(documents: TextDocumentInput[], tasks: JobManifestTasks, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
-    beginAnalyzeHealthcare(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
-    beginAnalyzeHealthcare(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
+    beginAnalyzeHealthcareEntities(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
+    beginAnalyzeHealthcareEntities(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
     defaultCountryHint: string;
     defaultLanguage: string;
     detectLanguage(documents: string[], countryHint?: string, options?: DetectLanguageOptions): Promise<DetectLanguageResultArray>;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -88,14 +88,14 @@ export interface BeginAnalyzeBatchTasksOptions extends OperationOptions {
 }
 
 // @public
-export interface BeginAnalyzeHealthcareOperationState extends AnalysisPollOperationState<PagedHealthcareEntities> {
-}
-
-// @public
-export interface BeginAnalyzeHealthcareOptions extends TextAnalyticsOperationOptions {
+export interface BeginAnalyzeHealthcareEntitiesOptions extends TextAnalyticsOperationOptions {
     resumeFrom?: string;
     stringIndexType?: StringIndexType;
     updateIntervalInMs?: number;
+}
+
+// @public
+export interface BeginAnalyzeHealthcareOperationState extends AnalysisPollOperationState<PagedHealthcareEntities> {
 }
 
 // @public
@@ -424,8 +424,8 @@ export class TextAnalyticsClient {
     analyzeSentiment(documents: TextDocumentInput[], options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultArray>;
     beginAnalyzeBatchTasks(documents: string[], tasks: JobManifestTasks, language?: string, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
     beginAnalyzeBatchTasks(documents: TextDocumentInput[], tasks: JobManifestTasks, options?: BeginAnalyzeBatchTasksOptions): Promise<AnalyzePollerLike>;
-    beginAnalyzeHealthcareEntities(documents: string[], language?: string, options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
-    beginAnalyzeHealthcareEntities(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareOptions): Promise<HealthcarePollerLike>;
+    beginAnalyzeHealthcareEntities(documents: string[], language?: string, options?: BeginAnalyzeHealthcareEntitiesOptions): Promise<HealthcarePollerLike>;
+    beginAnalyzeHealthcareEntities(documents: TextDocumentInput[], options?: BeginAnalyzeHealthcareEntitiesOptions): Promise<HealthcarePollerLike>;
     defaultCountryHint: string;
     defaultLanguage: string;
     detectLanguage(documents: string[], countryHint?: string, options?: DetectLanguageOptions): Promise<DetectLanguageResultArray>;

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcare.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcare.ts
@@ -26,7 +26,7 @@ export async function main() {
 
   const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
 
-  const poller = await client.beginAnalyzeHealthcare(documents, "en", {
+  const poller = await client.beginAnalyzeHealthcareEntities(documents, "en", {
     includeStatistics: true
   });
   const results = await poller.pollUntilDone();
@@ -42,18 +42,16 @@ export async function main() {
       for (const entity of result.entities) {
         console.log(
           `\t- Entity ${entity.text} of type ${entity.category} ${
-            entity.relatedHealthcareEntities.size > 0
-              ? "and it is related to the following entitites"
-              : ""
+            entity.relatedEntities.size > 0 ? "and it is related to the following entities" : ""
           }`
         );
-        for (const edge of entity.relatedHealthcareEntities) {
+        for (const edge of entity.relatedEntities) {
           console.log(`\t\t- ${edge[0].text} with the relationship being ${edge[1]}`);
         }
-        if (entity.dataSource && entity.dataSource.length > 0) {
+        if (entity.dataSources.length > 0) {
           console.log("\t and it can be referenced in the following data sources:");
-          for (const ds of entity.dataSource!) {
-            console.log(`\t\t- ${ds.dataSource} with ID: ${ds.dataSourceId}`);
+          for (const ds of entity.dataSources) {
+            console.log(`\t\t- ${ds.name} with ID: ${ds.id}`);
           }
         }
       }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeResult.ts
@@ -10,7 +10,7 @@ import { RecognizePiiEntitiesResultArray } from "./recognizePiiEntitiesResultArr
 /**
  * The results of a successful analyze job.
  */
-export interface AnalyzeResult {
+export interface AnalyzeBatchTasksResult {
   /**
    * Array of the results for each categorized entities recognition task.
    */
@@ -30,8 +30,8 @@ export interface AnalyzeResult {
  * iterates over the results of the requested tasks.
  */
 export type PagedAsyncIterableAnalyzeResults = PagedAsyncIterableIterator<
-  AnalyzeResult,
-  AnalyzeResult
+  AnalyzeBatchTasksResult,
+  AnalyzeBatchTasksResult
 >;
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/healthResult.ts
@@ -82,11 +82,11 @@ export interface HealthcareEntityDataSource {
   /**
    * Entity Catalog. Examples include: UMLS, CHV, MSH, etc.
    */
-  dataSource: string;
+  name: string;
   /**
    * Entity id in the given source catalog.
    */
-  dataSourceId: string;
+  id: string;
 }
 
 /**
@@ -101,13 +101,13 @@ export interface HealthcareEntity extends Entity {
   /**
    * Entity references in known data sources.
    */
-  dataSource?: HealthcareEntityDataSource[];
+  dataSources: HealthcareEntityDataSource[];
   /**
    * Other healthcare entities related to the current one. It is a directed
    * relationship where the current entity is the source and the entities in
    * the map are the target.
    */
-  relatedHealthcareEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
+  relatedEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
 }
 
 /**
@@ -182,11 +182,11 @@ function makeHealthcareEntitiesWithoutNeighbors(
     length,
     text,
     subCategory,
-    dataSource: links?.map(
-      ({ dataSource, id }): HealthcareEntityDataSource => ({ dataSource, dataSourceId: id })
-    ),
+    dataSources:
+      links?.map(({ dataSource, id }): HealthcareEntityDataSource => ({ name: dataSource, id })) ??
+      [],
     // initialize the neighbors map to be filled later.
-    relatedHealthcareEntities: new Map()
+    relatedEntities: new Map()
   };
 }
 
@@ -210,9 +210,9 @@ function makeHealthcareEntitiesGraph(
     const sourceEntity = entities[sourceIndex];
     const targetEntity = entities[targetIndex];
     if (isHealthcareEntityRelationType(relationType)) {
-      sourceEntity.relatedHealthcareEntities.set(targetEntity, relationType);
+      sourceEntity.relatedEntities.set(targetEntity, relationType);
       if (relation.bidirectional) {
-        targetEntity.relatedHealthcareEntities.set(sourceEntity, relationType);
+        targetEntity.relatedEntities.set(sourceEntity, relationType);
       }
     } else {
       throw new Error(`Unrecognized healthcare entity relation type: ${relationType}`);

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -23,7 +23,7 @@ export {
   KeyPhrasesExtractionTask,
   BeginAnalyzeBatchTasksOptions,
   AnalyzePollerLike,
-  BeginAnalyzeHealthcareOptions,
+  BeginAnalyzeHealthcareEntitiesOptions,
   HealthcarePollerLike,
   BeginAnalyzeOperationState,
   BeginAnalyzeHealthcareOperationState,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -89,7 +89,7 @@ export {
 export {
   PagedAnalyzeResults,
   PagedAsyncIterableAnalyzeResults,
-  AnalyzeResult
+  AnalyzeBatchTasksResult
 } from "./analyzeResult";
 export {
   TextAnalyticsResult,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -16,7 +16,7 @@ import {
   TextDocumentInput
 } from "../../generated/models";
 import {
-  AnalyzeResult,
+  AnalyzeBatchTasksResult,
   PagedAsyncIterableAnalyzeResults,
   PagedAnalyzeResults
 } from "../../analyzeResult";
@@ -46,7 +46,7 @@ import { logger } from "../../logger";
 export { State };
 
 interface AnalyzeResultsWithPagination {
-  result: AnalyzeResult;
+  result: AnalyzeBatchTasksResult;
   top?: number;
   skip?: number;
 }
@@ -166,7 +166,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
   private async *_listAnalyzeResultsPaged(
     jobId: string,
     options?: AnalyzeJobStatusOptions
-  ): AsyncIterableIterator<AnalyzeResult> {
+  ): AsyncIterableIterator<AnalyzeBatchTasksResult> {
     let response = await this._listAnalyzeResultsSinglePage(jobId, options);
     yield response.result;
     while (response.skip) {
@@ -196,7 +196,7 @@ export class BeginAnalyzePollerOperation extends AnalysisPollOperation<
         jobId,
         operationOptionsToRequestOptionsBase(finalOptions)
       );
-      const result: AnalyzeResult = {
+      const result: AnalyzeBatchTasksResult = {
         entitiesRecognitionResults:
           response.tasks.entityRecognitionTasks?.map(
             ({ results }): RecognizeCategorizedEntitiesResultArray =>

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -78,7 +78,7 @@ interface BeginAnalyzeHealthcareInternalOptions extends OperationOptions {
 /**
  * Options for the begin analyze healthcare operation.
  */
-export interface BeginAnalyzeHealthcareOptions extends TextAnalyticsOperationOptions {
+export interface BeginAnalyzeHealthcareEntitiesOptions extends TextAnalyticsOperationOptions {
   /**
    * Delay to wait until next poll, in milliseconds.
    */
@@ -111,7 +111,7 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
     // eslint-disable-next-line @azure/azure-sdk/ts-use-interface-parameters
     private client: Client,
     private documents: TextDocumentInput[],
-    private options: BeginAnalyzeHealthcareOptions = {}
+    private options: BeginAnalyzeHealthcareEntitiesOptions = {}
   ) {
     super(state);
   }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -56,7 +56,7 @@ import {
 } from "./util";
 import { BeginAnalyzeHealthcarePoller, HealthcarePollerLike } from "./lro/health/poller";
 import {
-  BeginAnalyzeHealthcareOptions,
+  BeginAnalyzeHealthcareEntitiesOptions,
   BeginAnalyzeHealthcareOperationState
 } from "./lro/health/operation";
 import { TextAnalyticsOperationOptions } from "./textAnalyticsOperationOptions";
@@ -72,7 +72,7 @@ export {
   BeginAnalyzeBatchTasksOptions,
   AnalyzePollerLike,
   BeginAnalyzeOperationState,
-  BeginAnalyzeHealthcareOptions,
+  BeginAnalyzeHealthcareEntitiesOptions,
   HealthcarePollerLike,
   BeginAnalyzeHealthcareOperationState,
   AnalysisPollOperationState,
@@ -857,7 +857,7 @@ export class TextAnalyticsClient {
   async beginAnalyzeHealthcareEntities(
     documents: string[],
     language?: string,
-    options?: BeginAnalyzeHealthcareOptions
+    options?: BeginAnalyzeHealthcareEntitiesOptions
   ): Promise<HealthcarePollerLike>;
   /**
    * Start a healthcare analysis job to recognize healthcare related entities (drugs, conditions,
@@ -867,15 +867,15 @@ export class TextAnalyticsClient {
    */
   async beginAnalyzeHealthcareEntities(
     documents: TextDocumentInput[],
-    options?: BeginAnalyzeHealthcareOptions
+    options?: BeginAnalyzeHealthcareEntitiesOptions
   ): Promise<HealthcarePollerLike>;
 
   async beginAnalyzeHealthcareEntities(
     documents: string[] | TextDocumentInput[],
-    languageOrOptions?: string | BeginAnalyzeHealthcareOptions,
-    options?: BeginAnalyzeHealthcareOptions
+    languageOrOptions?: string | BeginAnalyzeHealthcareEntitiesOptions,
+    options?: BeginAnalyzeHealthcareEntitiesOptions
   ): Promise<HealthcarePollerLike> {
-    let realOptions: BeginAnalyzeHealthcareOptions;
+    let realOptions: BeginAnalyzeHealthcareEntitiesOptions;
     let realInputs: TextDocumentInput[];
     if (isStringArray(documents)) {
       const language = (languageOrOptions as string) || this.defaultLanguage;
@@ -883,7 +883,7 @@ export class TextAnalyticsClient {
       realOptions = options || {};
     } else {
       realInputs = documents;
-      realOptions = (languageOrOptions as BeginAnalyzeHealthcareOptions) || {};
+      realOptions = (languageOrOptions as BeginAnalyzeHealthcareEntitiesOptions) || {};
     }
 
     const poller = new BeginAnalyzeHealthcarePoller({

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -854,7 +854,7 @@ export class TextAnalyticsClient {
         where the language is explicitly set to "None".
    * @param options - Options for the operation.
    */
-  async beginAnalyzeHealthcare(
+  async beginAnalyzeHealthcareEntities(
     documents: string[],
     language?: string,
     options?: BeginAnalyzeHealthcareOptions
@@ -865,12 +865,12 @@ export class TextAnalyticsClient {
    * @param documents - Collection of documents to analyze.
    * @param options - Options for the operation.
    */
-  async beginAnalyzeHealthcare(
+  async beginAnalyzeHealthcareEntities(
     documents: TextDocumentInput[],
     options?: BeginAnalyzeHealthcareOptions
   ): Promise<HealthcarePollerLike>;
 
-  async beginAnalyzeHealthcare(
+  async beginAnalyzeHealthcareEntities(
     documents: string[] | TextDocumentInput[],
     languageOrOptions?: string | BeginAnalyzeHealthcareOptions,
     options?: BeginAnalyzeHealthcareOptions

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -95,7 +95,7 @@ describe("[API Key] TextAnalyticsClient", function() {
 
     describe("#health", function() {
       it("input strings", async function() {
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [
             "Patient does not suffer from high blood pressure.",
             "Prescribed 100mg ibuprofen, taken twice daily."
@@ -112,8 +112,8 @@ describe("[API Key] TextAnalyticsClient", function() {
           assert.ok(doc1.entities);
           const doc1Entity1 = doc1.entities[0];
           assert.equal(doc1Entity1.text, "high");
-          const doc1Entity1Target1 = doc1Entity1.relatedHealthcareEntities.keys().next().value;
-          const doc1Entity1Edge1Label = doc1Entity1.relatedHealthcareEntities.values().next().value;
+          const doc1Entity1Target1 = doc1Entity1.relatedEntities.keys().next().value;
+          const doc1Entity1Edge1Label = doc1Entity1.relatedEntities.values().next().value;
           assert.equal(doc1Entity1Target1.text, "blood pressure");
           assert.equal(doc1Entity1Edge1Label, "ValueOfExamination");
 
@@ -127,8 +127,8 @@ describe("[API Key] TextAnalyticsClient", function() {
           assert.ok(doc2.entities);
           const doc2Entity1 = doc2.entities[0];
           assert.equal(doc2Entity1.text, "100mg");
-          const doc2Entity1Target1 = doc2Entity1.relatedHealthcareEntities.keys().next().value;
-          const doc2Entity1Edge1Label = doc2Entity1.relatedHealthcareEntities.values().next().value;
+          const doc2Entity1Target1 = doc2Entity1.relatedEntities.keys().next().value;
+          const doc2Entity1Edge1Label = doc2Entity1.relatedEntities.values().next().value;
           assert.equal(doc2Entity1Target1.text, "ibuprofen");
           assert.equal(doc2Entity1Edge1Label, "DosageOfMedication");
 
@@ -137,15 +137,15 @@ describe("[API Key] TextAnalyticsClient", function() {
 
           const doc2Entity3 = doc2.entities[2];
           assert.equal(doc2Entity3.text, "twice daily");
-          const doc2Entity3Target1 = doc2Entity3.relatedHealthcareEntities.keys().next().value;
-          const doc2Entity3Edge1Label = doc2Entity3.relatedHealthcareEntities.values().next().value;
+          const doc2Entity3Target1 = doc2Entity3.relatedEntities.keys().next().value;
+          const doc2Entity3Edge1Label = doc2Entity3.relatedEntities.values().next().value;
           assert.equal(doc2Entity3Target1.text, "ibuprofen");
           assert.equal(doc2Entity3Edge1Label, "FrequencyOfMedication");
         }
       });
 
       it("input documents", async function() {
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [
             { id: "1", text: "Patient does not suffer from high blood pressure.", language: "en" },
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
@@ -174,7 +174,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "3", language: "en", text: "Prescribed 100mg ibuprofen, taken twice daily." }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -200,7 +200,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "3", language: "en", text: "" }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -215,7 +215,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it("too many documents", async function() {
         const docs = Array(11).fill("random text");
         try {
-          const response = await client.beginAnalyzeHealthcare(docs, "en", {
+          const response = await client.beginAnalyzeHealthcareEntities(docs, "en", {
             updateIntervalInMs: pollingInterval
           });
           console.log(response);
@@ -247,7 +247,7 @@ describe("[API Key] TextAnalyticsClient", function() {
               for revascularization with open heart surgery.";
         const docs = Array(500).fill(large_doc);
         try {
-          await client.beginAnalyzeHealthcare(docs, "en", {
+          await client.beginAnalyzeHealthcareEntities(docs, "en", {
             updateIntervalInMs: pollingInterval
           });
           assert.fail("Oops, an exception didn't happen.");
@@ -263,7 +263,7 @@ describe("[API Key] TextAnalyticsClient", function() {
 
       it("document warnings", async function() {
         const docs = [{ id: "1", text: "This won't actually create a warning :'(" }];
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -282,7 +282,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "4", text: "four" },
           { id: "5", text: "five" }
         ];
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -300,7 +300,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "19", text: ":P" },
           { id: "1", text: ":D" }
         ];
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -319,7 +319,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "19", text: ":P" },
           { id: "1", text: ":D" }
         ];
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           modelVersion: "latest",
           includeStatistics: true,
           updateIntervalInMs: pollingInterval
@@ -340,7 +340,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           "The restaurant was not as good as I hoped."
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, "en", {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, "en", {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -356,7 +356,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           "The restaurant was not as good as I hoped."
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, "", {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, "", {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -372,7 +372,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "3", text: "The restaurant had really good food." }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -388,7 +388,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "3", text: "猫は幸せ" }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -400,7 +400,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it("invalid language hint", async function() {
         const docs = ["This should fail because we're passing in an invalid language hint"];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, "notalanguage", {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, "notalanguage", {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -417,7 +417,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -438,7 +438,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         try {
-          await client.beginAnalyzeHealthcare(docs, {
+          await client.beginAnalyzeHealthcareEntities(docs, {
             modelVersion: "bad",
             updateIntervalInMs: pollingInterval
           });
@@ -459,7 +459,7 @@ describe("[API Key] TextAnalyticsClient", function() {
           { id: "3", text: text }
         ];
 
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const doc_errors = await poller.pollUntilDone();
@@ -475,7 +475,7 @@ describe("[API Key] TextAnalyticsClient", function() {
         ];
 
         try {
-          await client.beginAnalyzeHealthcare(docs, {
+          await client.beginAnalyzeHealthcareEntities(docs, {
             updateIntervalInMs: pollingInterval
           });
           assert.fail("Oops, an exception didn't happen.");
@@ -495,7 +495,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it.skip("paged results one loop", async function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -517,7 +517,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it.skip("paged results nested loop", async function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -544,7 +544,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       it.skip("paged results with custom page size", async function() {
         const docs = Array(40).fill("random text");
         docs.push("Prescribed 100mg ibuprofen, taken twice daily.");
-        const poller = await client.beginAnalyzeHealthcare(docs, {
+        const poller = await client.beginAnalyzeHealthcareEntities(docs, {
           updateIntervalInMs: pollingInterval
         });
         const result = await poller.pollUntilDone();
@@ -570,7 +570,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       });
 
       it("cancelled", async function() {
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [
             { id: "1", text: "Patient does not suffer from high blood pressure.", language: "en" },
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
@@ -584,7 +584,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       });
 
       it("job metadata", async function() {
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [
             { id: "1", text: "Patient does not suffer from high blood pressure.", language: "en" },
             { id: "2", text: "Prescribed 100mg ibuprofen, taken twice daily.", language: "en" }
@@ -605,7 +605,7 @@ describe("[API Key] TextAnalyticsClient", function() {
 
       it("family emoji wit skin tone modifier with Utf16CodeUnit", async function() {
         const doc = "👩🏻‍👩🏽‍👧🏾‍👦🏿 ibuprofen";
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [{ id: "0", text: doc, language: "en" }],
           {
             updateIntervalInMs: pollingInterval
@@ -624,7 +624,7 @@ describe("[API Key] TextAnalyticsClient", function() {
       });
 
       it("family emoji wit skin tone modifier with UnicodeCodePoint", async function() {
-        const poller = await client.beginAnalyzeHealthcare(
+        const poller = await client.beginAnalyzeHealthcareEntities(
           [{ id: "0", text: "👩🏻‍👩🏽‍👧🏾‍👦🏿 ibuprofen", language: "en" }],
           {
             updateIntervalInMs: pollingInterval,


### PR DESCRIPTION
We received great feedback from the arch board meeting and this PR addresses the following issues discussed during the meeting:
- renames `dataSource` to `dataSources` and makes it required. If the list is not returned by the service, we return an empty list instead to conform to how we treat output lists in other parts of the SDK.
- renames `beginAnalyzeHealthcare` to `beginAnalyzeHealthcareEntities`.
- renames `AnalyzeResult` to `AnalyzeBatchTasksResult `.
- renames `relatedHealthcareEntities` to `relatedEntities`.
- simplifies the properties names of `HealthcareEntityDataSource` to just `name` and `id` instead of `dataSource` and `dataSourceId` respectively.
- massages the `CHANGELOG.md`.