### PR TITLE
[event-hubs] Update browser sample with AAD troubleshooting tip

### DIFF
--- a/sdk/eventhub/event-hubs/samples/browserSample/README.md
+++ b/sdk/eventhub/event-hubs/samples/browserSample/README.md
@@ -37,6 +37,8 @@ Register a new application in AAD and assign the "Azure Event Hubs Data Owner" r
 
 Ensure your app registration has been configured properly to allow the [implicit grant flow][implicitgrantflow]
 and allow both `Access tokens` and `ID tokens` to be issued by the authorization endpoint.
+Also add a `redirect URI` that points to where you'll be hosting your application.
+For running the sample locally, you can set this to `http://localhost:8080`.
 In your app registration, you will also need to add a permission for the `Microsoft.EventHubs` app.
 When adding permission for `Microsoft.EventHubs`, the type should be `delegated permissions` and the permission should be `user_impersonation`.
 
@@ -68,7 +70,8 @@ npm start
 
 ### Authentication error: AADSTS50011
 
-If you receive error `AADSTS50011` with the message `The reply URL specified in the request does not match the reply URLs configured for the application`, make sure that you're accessing the sample using `localhost` and not an IP address (e.g. 127.0.0.1).
+If you receive error `AADSTS50011` with the message `The reply URL specified in the request does not match the reply URLs configured for the application`, make sure that you're accessing the sample using the same URI
+as the redirect URI you added to your app registration. If you're following along with the sample, this should be `http://localhost:8080`.
 
 ## Next Steps
 

--- a/sdk/eventhub/event-hubs/samples/browserSample/README.md
+++ b/sdk/eventhub/event-hubs/samples/browserSample/README.md
@@ -64,6 +64,12 @@ npm start
 
 4. Navigate to the web page by visiting http://localhost:8080 in a browser.
 
+## Troubleshooting
+
+### Authentication error: AADSTS50011
+
+If you receive error `AADSTS50011` with the message `The reply URL specified in the request does not match the reply URLs configured for the application`, make sure that you're accessing the sample using `localhost` and not an IP address (e.g. 127.0.0.1).
+
 ## Next Steps
 
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.


### PR DESCRIPTION
Fixes #12917

The browser sample was failing in #12917 because the user was accessing the sample using the ip address for local host (127.0.0.1) instead of from `http://localhost`. This causes problems because the address needs to match the reply url used when setting up the app registration, which in our sample uses `http://localhost`.

I added a troubleshooting section that calls out what to do if the user encounters a specific AAD error caused by navigating to the sample via an address other than localhost.