### PR TITLE
Removed step to build samples temporarily

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,10 +48,6 @@ steps:
       node eng/tools/rush-runner.js pack "${{parameters.ServiceDirectory}}" --verbose
     displayName: "Pack libraries"
 
-  - script: |
-      node eng/tools/rush-runner.js build:samples "${{parameters.ServiceDirectory}}" --verbose
-    displayName: "Build samples"
-
   # Unlink node_modules folders to significantly improve performance of subsequent tasks
   # which need to walk the directory tree (and are hardcoded to follow symlinks).
   - script: |


### PR DESCRIPTION
Disabling step to build sample to avoid npm clean which removes artifacts built in previous step. This is to unblock release.