### PR TITLE
[communication] skip purchase phone number sample when smoke testing

### DIFF
--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -126,5 +126,10 @@
     "sinon": "^9.0.2",
     "typescript": "4.1.2",
     "typedoc": "0.15.0"
+  },
+  "//smokeTestConfiguration": {
+    "skip": [
+      "purchasePhoneNumber.js"
+    ]
   }
 }

--- a/sdk/communication/communication-administration/samples/javascript/purchasePhoneNumber.js
+++ b/sdk/communication/communication-administration/samples/javascript/purchasePhoneNumber.js
@@ -40,10 +40,10 @@ async function main() {
   // poll until phone number reservation is made
   const reservation = await reservationPoller.pollUntilDone();
 
-  console.log("Phone number reserved for purchase.");
-  console.log(`Reservation: ${JSON.stringify(reservation)}`);
-
   if (reservation.reservationId && reservation.phoneNumbers && reservation.phoneNumbers.length) {
+    console.log("Phone number reserved for purchase.");
+    console.log(`Reservation: ${JSON.stringify(reservation)}`);
+
     const phoneNumber = reservation.phoneNumbers[0];
 
     // create purchase poller
@@ -58,7 +58,7 @@ async function main() {
 
     console.log(`Phone number, ${phoneNumber}, purchased successfully.`);
   } else {
-    throw new Error("No phone numbers found.");
+    console.log("No phone number found matching request.");
   }
 }
 

--- a/sdk/communication/communication-administration/samples/typescript/src/purchasePhoneNumber.ts
+++ b/sdk/communication/communication-administration/samples/typescript/src/purchasePhoneNumber.ts
@@ -44,10 +44,10 @@ export const main = async () => {
   // poll until phone number reservation is made
   const reservation = await reservationPoller.pollUntilDone();
 
-  console.log("Phone number reserved for purchase.");
-  console.log(`Reservation: ${JSON.stringify(reservation)}`);
-
   if (reservation.reservationId && reservation.phoneNumbers && reservation.phoneNumbers.length) {
+    console.log("Phone number reserved for purchase.");
+    console.log(`Reservation: ${JSON.stringify(reservation)}`);
+
     const phoneNumber = reservation.phoneNumbers[0];
 
     // create purchase poller
@@ -62,7 +62,7 @@ export const main = async () => {
 
     console.log(`Phone number, ${phoneNumber}, purchased successfully.`);
   } else {
-    throw new Error("No phone numbers found.");
+    console.log("No phone number found matching request.");
   }
 };
 


### PR DESCRIPTION
This PR adds the `purchasePhoneNumber.js` sample to the list of skipped samples when smoke testing. The sample is purchasing a real phone number on smoke test runs; we do not want this.