### PR TITLE
Removing npm clean step from build samples and run step before pack

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -12,6 +12,7 @@
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build": "tsc",
     "build:test": "echo Skipped.",
+    "clean": "rimraf dist dist-* *.tgz *.log",
     "extract-api": "echo skipped",
     "format": "prettier --write src/**/*.ts test/**/*.ts *.{js,json}",
     "integration-test:browser": "echo skipped",

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -12,7 +12,6 @@
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build": "tsc",
     "build:test": "echo Skipped.",
-    "clean": "rimraf dist dist-* *.tgz *.log",
     "extract-api": "echo skipped",
     "format": "prettier --write src/**/*.ts test/**/*.ts *.{js,json}",
     "integration-test:browser": "echo skipped",

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -39,6 +39,9 @@ steps:
   - script: |
       node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max --TransitiveDep
     displayName: "Build libraries"
+  - script: |
+      node eng/tools/rush-runner.js build:samples "${{parameters.ServiceDirectory}}" --verbose
+    displayName: "Build samples"
 
   - pwsh: |
       eng/tools/check-api-warning.ps1

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -27,7 +27,7 @@
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:samples": "npm run clean && cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
+    "build:samples": "cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
     "build:prep-samples": "dev-tool samples prep && cd dist-samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build:types": "downlevel-dts typings/latest typings/3.1",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -35,7 +35,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.4.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:samples": "npm run clean && cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
+    "build:samples": "cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
     "build:prep-samples": "dev-tool samples prep && cd dist-samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build:types": "downlevel-dts typings/latest typings/3.1",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -31,7 +31,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:samples": "npm run clean && cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
+    "build:samples": "cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
     "build:prep-samples": "dev-tool samples prep && cd dist-samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build:types": "downlevel-dts typings/latest typings/3.1",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -31,7 +31,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.4.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:samples": "npm run clean && cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
+    "build:samples": "cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
     "build:prep-samples": "dev-tool samples prep && cd dist-samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build:types": "downlevel-dts typings/latest typings/3.1",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -28,7 +28,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.3.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:samples": "npm run clean && cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
+    "build:samples": "cross-env ONLY_NODE=true npm run build && npm run build:prep-samples",
     "build:prep-samples": "dev-tool samples prep && cd dist-samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build:types": "downlevel-dts typings/latest typings/3.1",


### PR DESCRIPTION
- The "npm run clean" script from "build:samples" wipe out the storage artifacts generated by npm pack in the ci pipeline, hence this step needs to be removed
- Also moving the "Build:samples" step before npm pack in the CI pipeline so that the "npm run clean" from the prebuild steps of storage's package.json doesn't wipe out the generated artifacts