### PR TITLE
OpenTelemetry exporter use correct error code when there is a network issue

### DIFF
--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
@@ -68,9 +68,9 @@ export class AzureMonitorTraceExporter implements SpanExporter {
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
-          code: ExportResultCode.FAILED,
-          error: new Error("Failed to persist envelope in disk.")
-        };
+            code: ExportResultCode.FAILED,
+            error: new Error("Failed to persist envelope in disk.")
+          };
     } catch (ex) {
       return { code: ExportResultCode.FAILED, error: ex };
     }
@@ -158,11 +158,7 @@ export class AzureMonitorTraceExporter implements SpanExporter {
 
   private _isNetworkError(error: Error): boolean {
     if (error instanceof RestError) {
-      if (
-        error &&
-        error.code &&
-        (error.code === "REQUEST_SEND_ERROR")
-      ) {
+      if (error && error.code && error.code === "REQUEST_SEND_ERROR") {
         return true;
       }
     }

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/export/trace.ts
@@ -68,9 +68,9 @@ export class AzureMonitorTraceExporter implements SpanExporter {
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
-            code: ExportResultCode.FAILED,
-            error: new Error("Failed to persist envelope in disk.")
-          };
+          code: ExportResultCode.FAILED,
+          error: new Error("Failed to persist envelope in disk.")
+        };
     } catch (ex) {
       return { code: ExportResultCode.FAILED, error: ex };
     }
@@ -161,11 +161,7 @@ export class AzureMonitorTraceExporter implements SpanExporter {
       if (
         error &&
         error.code &&
-        (error.code === "ETIMEDOUT" ||
-          error.code === "ESOCKETTIMEDOUT" ||
-          error.code === "ECONNREFUSED" ||
-          error.code === "ECONNRESET" ||
-          error.code === "ENOENT")
+        (error.code === "REQUEST_SEND_ERROR")
       ) {
         return true;
       }


### PR DESCRIPTION
core-http return REQUEST_SEND_ERROR as error code when there is a network issue


https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-http/src/fetchHttpClient.ts#L191
https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-http/src/xhrHttpClient.ts#L163