### PR TITLE
[ESLint plugin] Upgrade node to v10

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -59,9 +59,9 @@
     "@opentelemetry/api": ["^0.17.0"],
     // Monitor: Allow node 10 types until Timeout / Timer conflict is resolved in OpenTelemetry repo
     // TODO: remove when released https://github.com/open-telemetry/opentelemetry-js/pull/1352
-    "@types/node": ["^10.0.0"],
     // @azure/test-utils-perfstress should depend on lowest version of @azure/core-http for maximum compatibility, allowing test
     // projects to choose a higher version if desired.
-    "@azure/core-http": ["^1.0.0"]
+    "@azure/core-http": ["^1.0.0"],
+    "@types/node": ["^10.0.0", "^10.12.0"]
   }
 }

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -60,9 +60,9 @@
     // Monitor: Allow node 10 types until Timeout / Timer conflict is resolved in OpenTelemetry repo
     // TODO: remove when released https://github.com/open-telemetry/opentelemetry-js/pull/1352
     // eslint v7.15 needs node v10.12
-    "@types/node": ["^10.0.0", "^10.12.0"]
+    "@types/node": ["^10.0.0", "^10.12.0"],
     // @azure/test-utils-perfstress should depend on lowest version of @azure/core-http for maximum compatibility, allowing test
     // projects to choose a higher version if desired.
-    "@azure/core-http": ["^1.0.0"],
+    "@azure/core-http": ["^1.0.0"]
   }
 }

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -59,9 +59,10 @@
     "@opentelemetry/api": ["^0.17.0"],
     // Monitor: Allow node 10 types until Timeout / Timer conflict is resolved in OpenTelemetry repo
     // TODO: remove when released https://github.com/open-telemetry/opentelemetry-js/pull/1352
+    // eslint v7.15 needs node v10.12
+    "@types/node": ["^10.0.0", "^10.12.0"]
     // @azure/test-utils-perfstress should depend on lowest version of @azure/core-http for maximum compatibility, allowing test
     // projects to choose a higher version if desired.
     "@azure/core-http": ["^1.0.0"],
-    "@types/node": ["^10.0.0", "^10.12.0"]
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9123,7 +9123,7 @@ packages:
       '@types/glob': 7.1.3
       '@types/json-schema': 7.0.7
       '@types/mocha': 7.0.2
-      '@types/node': 8.10.66
+      '@types/node': 10.17.55
       '@typescript-eslint/eslint-plugin': 4.13.0_01b3bfb19f42ed087655aa69bb24f4f9
       '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.21.0+typescript@4.1.2
       '@typescript-eslint/parser': 4.13.0_eslint@7.21.0+typescript@4.1.2
@@ -9148,7 +9148,7 @@ packages:
     dev: false
     name: '@rush-temp/eslint-plugin-azure-sdk'
     resolution:
-      integrity: sha512-JNWQRRsexu1eih1J4kcqkFiMNA9PrhDapMiKfw3oCS4VMKIbI0YMFaftO+mQ7KyD5umGMRLI2H39oryCgbtdpQ==
+      integrity: sha512-+mmkqBqcZQYcRW6KtAufghyDYXK6DCyV0Ajn5ibQI+FewbbEWTf1plrWXThmhCvNUfeWN1uwkAd1WSh4cROAoA==
       tarball: file:projects/eslint-plugin-azure-sdk.tgz
     version: 0.0.0
   file:projects/event-hubs.tgz:

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -55,7 +55,7 @@
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": "^10.12.0 || >=12.0.0"
   },
   "prettier": "./prettier.json",
   "peerDependencies": {
@@ -82,7 +82,7 @@
     "@types/glob": "^7.1.1",
     "@types/json-schema": "^7.0.6",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^8.0.0",
+    "@types/node": "^10.12.0",
     "@typescript-eslint/eslint-plugin": "4.13.0",
     "@typescript-eslint/experimental-utils": "4.13.0",
     "@typescript-eslint/parser": "4.13.0",


### PR DESCRIPTION
The linter test suite fails using node8 in this PR: https://github.com/Azure/azure-sdk-for-js/pull/13162. ESLint v7.15 supports node10.12.0 and up only.