### PR TITLE
Enable 1ES pools for live tests.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -54,19 +54,23 @@ parameters:
   type: object
   default:
     Windows Node 8:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-win-2019-general
+      OSVmImage: MMS2019
       TestType: "node"
       NodeTestVersion: "8.x"
       PublishCodeCoverage: true
     Linux Node 10:
-      OSVmImage: "ubuntu-18.04"
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       TestType: "node"
       NodeTestVersion: "10.x"
     Linux Node 12:
-      OSVmImage: "ubuntu-18.04"
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       TestType: "node"
       NodeTestVersion: "12.x"
     MacOS Node 14:
+      Pool: Azure Pipelines
       OSVmImage: "macOS-10.15"
       TestType: "node"
       NodeTestVersion: "14.x"
@@ -103,7 +107,8 @@ jobs:
         # Add matrix entry for browser testing
         ${{ if eq(parameters.TestBrowser, 'true') }}:
           Windows Browser:
-            OSVmImage: "windows-2019"
+            Pool: azsdk-pool-mms-win-2019-general
+            OSVmImage: MMS2019
             TestType: "browser"
             NodeTestVersion: "$(NodeVersion)"
             TestResultsFiles: "**/test-results.browser.xml"
@@ -111,20 +116,23 @@ jobs:
         # Add matrix entry for sample testing
         ${{ if eq(parameters.TestSamples, 'true') }}:
           Samples Linux Node 10:
-            OSVmImage: "ubuntu-18.04"
+            Pool: azsdk-pool-mms-ubuntu-1804-general
+            OSVmImage: MMSUbuntu18.04
             TestType: "sample"
             NodeTestVersion: "10.x"            
         
         # Add matrix entry for min-max testing
         ${{ if eq(parameters.TestMinMax, 'true') }}:
           MaxVersion_Node:
-            OSVmImage: "ubuntu-18.04"
+            Pool: azsdk-pool-mms-ubuntu-1804-general
+            OSVmImage: MMSUbuntu18.04
             TestType: "node"
             DependencyVersion: max
             NodeTestVersion: "$(NodeVersion)"
             TestResultsFiles: "**/test-results.xml"            
           MinVersion_Node:
-            OSVmImage: "ubuntu-18.04"
+            Pool: azsdk-pool-mms-ubuntu-1804-general
+            OSVmImage: MMSUbuntu18.04
             TestType: "node"
             DependencyVersion: min
             NodeTestVersion: "$(NodeVersion)"
@@ -133,7 +141,8 @@ jobs:
         # Add matrix entry for same dep testing
         ${{ if eq(parameters.TestSame, 'true') }}:
           SameVersion_Node:
-            OSVmImage: "ubuntu-18.04"
+            Pool: azsdk-pool-mms-ubuntu-1804-general
+            OSVmImage: MMSUbuntu18.04
             TestType: "node"
             DependencyVersion: same
             NodeTestVersion: "$(NodeVersion)"
@@ -142,14 +151,17 @@ jobs:
         # Add matrix entry for canary testing
         ${{ if eq(parameters.TestCanary, 'true') }}:
           CanaryTest_Node:
-            OSVmImage: "ubuntu-18.04"
+            Pool: azsdk-pool-mms-ubuntu-1804-general
+            OSVmImage: MMSUbuntu18.04
             TestType: "node"
             NodeTestVersion: "$(NodeVersion)"
             TestResultsFiles: "**/test-results.xml"
             SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
             ResourceGroupLocation: ${{ parameters.ResourceGroupLocationCanary }}
+
     pool:
-      vmImage: "$(OSVmImage)"
+      name: $(Pool)
+      vmImage: $(OSVmImage)
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 


### PR DESCRIPTION
This PR enables the 1ES pools for live testing for Windows and Linux jobs. It adds a ```Pool``` parameter to the matrix entries and adjusts the image names accordingly.