### PR TITLE
Update CHANGELOG for digital-twins-core

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2021-01-14)
 
 - Bug Fix: include the types definition file in the shipped package
 

--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.2 (Unreleased)
 
+- Bug Fix: include the types definition file in the shipped package
 
 ## 1.0.1 (2021-01-12)
 

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -56,7 +56,7 @@ import { createSpan } from "./tracing";
 import { CanonicalCode } from "@opentelemetry/api";
 import { logger } from "./logger";
 
-export const SDK_VERSION: string = "1.0.0-preview.1";
+export const SDK_VERSION: string = "1.0.2";
 
 export interface DigitalTwinsClientOptions extends PipelineOptions {
   /**

--- a/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPIContext.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPIContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AzureDigitalTwinsAPIOptionalParams } from "./models";
 
 const packageName = "@azure/digital-twins-core";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.2";
 
 export class AzureDigitalTwinsAPIContext extends coreHttp.ServiceClient {
   $host: string;


### PR DESCRIPTION
Add an entry listing a recent bug fix where we did not
ship the renamed type definition file.