### PR TITLE
[core-http][core-client] Eliminate default content-type on empty requests

### DIFF
--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -153,7 +153,7 @@ export class ServiceClient {
     request.additionalInfo.operationArguments = operationArguments;
 
     const contentType = operationSpec.contentType || this._requestContentType;
-    if (contentType) {
+    if (contentType && operationSpec.requestBody) {
       request.headers.set("Content-Type", contentType);
     }
 

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -431,7 +431,7 @@ export class ServiceClient {
       httpRequest.url = requestUrl.toString();
 
       const contentType = operationSpec.contentType || this.requestContentType;
-      if (contentType) {
+      if (contentType && operationSpec.requestBody) {
         httpRequest.headers.set("Content-Type", contentType);
       }
 


### PR DESCRIPTION
Our friends on the ACS team noticed that we are always setting an "application/json" content type on requests, even when the body is empty. This appears to be some strange codegen where we always set the default type on the client object, which then gets assigned to every request.

As a short-term solution, this PR changes the behavior of when to set the default content-type to only do so if there is a `requestBody` key on the `OperationSpec`.  This should avoid the trouble that ACS ran into as requests without a body will no longer have an incorrect default header applied to them.

In the future we should change codgen to use the "consumes" property on the swagger to set the content type in the OperationSpec instead of relying on a client-wide default.