### PR TITLE
[communication-common] Add serializer for communication identifiers

### DIFF
--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -63,6 +63,9 @@ export const createCommunicationAccessKeyCredentialPolicy: (credential: KeyCrede
 // @public
 export const createCommunicationAuthPolicy: (credential: KeyCredential | TokenCredential) => RequestPolicyFactory;
 
+// @internal
+export const _deserializeCommunicationIdentifier: (serializedIdentifier: _SerializedCommunicationIdentifier) => CommunicationIdentifierKind;
+
 // @public
 export const getIdentifierKind: (identifier: CommunicationIdentifier) => CommunicationIdentifierKind;
 
@@ -107,6 +110,21 @@ export interface PhoneNumberIdentifier {
 export interface PhoneNumberKind extends PhoneNumberIdentifier {
     kind: "PhoneNumber";
 }
+
+// @internal
+export const _serializeCommunicationIdentifier: (identifier: CommunicationIdentifier) => _SerializedCommunicationIdentifier;
+
+// @internal
+export interface _SerializedCommunicationIdentifier {
+    id?: string;
+    isAnonymous?: boolean;
+    kind: _SerializedCommunicationIdentifierKind;
+    microsoftTeamsUserId?: string;
+    phoneNumber?: string;
+}
+
+// @internal
+export type _SerializedCommunicationIdentifierKind = "unknown" | "communicationUser" | "phoneNumber" | "callingApplication" | "microsoftTeamsUser";
 
 // @public
 export interface UnknownIdentifier {

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -71,6 +71,8 @@ export const _serializeCommunicationIdentifier = (
       };
     case "Unknown":
       return { kind: "unknown", id: identifierKind.id };
+    default:
+      throw new Error(`Can't serialize an identifier with kind ${(identifierKind as any).kind}`);
   }
 };
 
@@ -110,7 +112,7 @@ export const _deserializeCommunicationIdentifier = (
     case "unknown":
       return { kind: "Unknown", id: assertNotNullOrUndefined(serializedIdentifier, "id") };
     default:
-      throw new Error(`Unsupported identifier kind ${serializedIdentifier.kind}.`);
+      return { kind: "Unknown", id: assertNotNullOrUndefined(serializedIdentifier, "id") };
   }
 };
 

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  CommunicationIdentifier,
+  CommunicationIdentifierKind,
+  getIdentifierKind
+} from "./identifierModels";
+
+/**
+ * @internal
+ * Identifies a participant in Azure Communication services. A participant is, for example, a phone number or an Azure communication user.
+ * This interface is the serialized format of a CommunicationIdentifier used in web requests and responses.
+ */
+export interface _SerializedCommunicationIdentifier {
+  /**
+   * Kind of the communication identifier.
+   */
+  kind: _SerializedCommunicationIdentifierKind;
+  /**
+   * Full Id of the identifier.
+   */
+  id?: string;
+  /**
+   * The phone number in E.164 format.
+   */
+  phoneNumber?: string;
+  /**
+   * The AAD object Id of the Microsoft Teams user.
+   */
+  microsoftTeamsUserId?: string;
+  /**
+   * True if the identifier is anonymous.
+   */
+  isAnonymous?: boolean;
+}
+
+/**
+ * @internal
+ * Defines values for CommunicationIdentifierKind.
+ * This type is the serialized format of a CommunicationIdentifier kind used in web requests and responses.
+ */
+export type _SerializedCommunicationIdentifierKind =
+  | "unknown"
+  | "communicationUser"
+  | "phoneNumber"
+  | "callingApplication"
+  | "microsoftTeamsUser";
+
+/**
+ * @internal
+ * Translates a CommunicationIdentifier to its serialized format for sending a request.
+ * @param identifier The CommunicationIdentifier to be serialized.
+ */
+export const _serializeCommunicationIdentifier = (
+  identifier: CommunicationIdentifier
+): _SerializedCommunicationIdentifier => {
+  const identifierKind = getIdentifierKind(identifier);
+  switch (identifierKind.kind) {
+    case "CommunicationUser":
+      return { kind: "communicationUser", id: identifierKind.communicationUserId };
+    case "CallingApplication":
+      return { kind: "callingApplication", id: identifierKind.callingApplicationId };
+    case "PhoneNumber":
+      return { kind: "phoneNumber", phoneNumber: identifierKind.phoneNumber };
+    case "MicrosoftTeamsUser":
+      return {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: identifierKind.microsoftTeamsUserId,
+        isAnonymous: identifierKind.isAnonymous
+      };
+    case "Unknown":
+      return { kind: "unknown", id: identifierKind.id };
+  }
+};
+
+/**
+ * @internal
+ * Translates the serialized format of a communication identifier to CommunicationIdentifier.
+ * @param serializedIdentifier The SerializedCommunicationIdentifier to be deserialized.
+ */
+export const _deserializeCommunicationIdentifier = (
+  serializedIdentifier: _SerializedCommunicationIdentifier
+): CommunicationIdentifierKind => {
+  switch (serializedIdentifier.kind) {
+    case "communicationUser":
+      return {
+        kind: "CommunicationUser",
+        communicationUserId: assertNotNullOrUndefined(serializedIdentifier, "id")
+      };
+    case "callingApplication":
+      return {
+        kind: "CallingApplication",
+        callingApplicationId: assertNotNullOrUndefined(serializedIdentifier, "id")
+      };
+    case "phoneNumber":
+      return {
+        kind: "PhoneNumber",
+        phoneNumber: assertNotNullOrUndefined(serializedIdentifier, "phoneNumber")
+      };
+    case "microsoftTeamsUser":
+      return {
+        kind: "MicrosoftTeamsUser",
+        microsoftTeamsUserId: assertNotNullOrUndefined(
+          serializedIdentifier,
+          "microsoftTeamsUserId"
+        ),
+        isAnonymous: assertNotNullOrUndefined(serializedIdentifier, "isAnonymous")
+      };
+    case "unknown":
+      return { kind: "Unknown", id: assertNotNullOrUndefined(serializedIdentifier, "id") };
+    default:
+      throw new Error(`Unsupported identifier kind ${serializedIdentifier.kind}.`);
+  }
+};
+
+const assertNotNullOrUndefined = <T extends _SerializedCommunicationIdentifier, P extends keyof T>(
+  obj: T,
+  prop: P
+): Required<T>[P] => {
+  if (prop in obj) {
+    return obj[prop];
+  }
+  throw new Error(`Property ${prop} is required for identifier of kind ${obj.kind}.`);
+};

--- a/sdk/communication/communication-common/src/index.ts
+++ b/sdk/communication/communication-common/src/index.ts
@@ -8,3 +8,4 @@ export {
 export { CommunicationTokenRefreshOptions } from "./autoRefreshTokenCredential";
 export * from "./credential";
 export * from "./identifierModels";
+export * from "./identifierModelSerializer";

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import {
+  _serializeCommunicationIdentifier,
+  _deserializeCommunicationIdentifier,
+  CommunicationIdentifier,
+  _SerializedCommunicationIdentifier,
+  CommunicationIdentifierKind
+} from "../src";
+
+const assertSerialize = (
+  identifier: CommunicationIdentifier,
+  expected: _SerializedCommunicationIdentifier
+): void => {
+  assert.deepEqual(_serializeCommunicationIdentifier(identifier), expected);
+};
+
+const assertDeserialize = (
+  serializedIdentifier: _SerializedCommunicationIdentifier,
+  expected: CommunicationIdentifierKind
+): void => {
+  assert.deepEqual(_deserializeCommunicationIdentifier(serializedIdentifier), expected);
+};
+
+const assertThrowsMissingProperty = <P extends keyof _SerializedCommunicationIdentifier>(
+  serializedIdentifier: _SerializedCommunicationIdentifier,
+  missingPropertyName: P
+) => {
+  assert.throws(() => {
+    _deserializeCommunicationIdentifier(serializedIdentifier);
+  }, `Property ${missingPropertyName} is required for identifier of kind ${serializedIdentifier.kind}.`);
+};
+
+describe("Identifier model serializer", () => {
+  it("can serialize", () => {
+    assertSerialize(
+      {
+        communicationUserId:
+          "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+      },
+      {
+        kind: "communicationUser",
+        id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+      }
+    );
+    assertSerialize(
+      { callingApplicationId: "28:37691ec4-57fb-4c0f-ae31-32791610cb14" },
+      { kind: "callingApplication", id: "28:37691ec4-57fb-4c0f-ae31-32791610cb14" }
+    );
+    assertSerialize(
+      { phoneNumber: "+1234555000" },
+      { kind: "phoneNumber", phoneNumber: "+1234555000" }
+    );
+    assertSerialize(
+      { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14", isAnonymous: false },
+      {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: false
+      }
+    );
+    assertSerialize(
+      { microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14", isAnonymous: true },
+      {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: true
+      }
+    );
+    assertSerialize(
+      { id: "48:37691ec4-57fb-4c0f-ae31-32791610cb14" },
+      { kind: "unknown", id: "48:37691ec4-57fb-4c0f-ae31-32791610cb14" }
+    );
+  });
+
+  it("can deserialize", () => {
+    assertDeserialize(
+      {
+        kind: "communicationUser",
+        id: "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+      },
+      {
+        kind: "CommunicationUser",
+        communicationUserId:
+          "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+      }
+    );
+    assertDeserialize(
+      { kind: "callingApplication", id: "28:37691ec4-57fb-4c0f-ae31-32791610cb14" },
+      {
+        kind: "CallingApplication",
+        callingApplicationId: "28:37691ec4-57fb-4c0f-ae31-32791610cb14"
+      }
+    );
+    assertDeserialize(
+      { kind: "phoneNumber", phoneNumber: "+1234555000" },
+      { kind: "PhoneNumber", phoneNumber: "+1234555000" }
+    );
+    assertDeserialize(
+      {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: false
+      },
+      {
+        kind: "MicrosoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: false
+      }
+    );
+    assertDeserialize(
+      {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: true
+      },
+      {
+        kind: "MicrosoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: true
+      }
+    );
+    assertDeserialize(
+      { kind: "unknown", id: "48:37691ec4-57fb-4c0f-ae31-32791610cb14" },
+      { kind: "Unknown", id: "48:37691ec4-57fb-4c0f-ae31-32791610cb14" }
+    );
+  });
+
+  it("throws if kind not understood", () => {
+    assert.throws(() => {
+      _deserializeCommunicationIdentifier({
+        kind: "foobar",
+        id: "42"
+      } as any);
+    }, `Unsupported identifier kind foobar.`);
+  });
+
+  it("throws if property is missing", () => {
+    assertThrowsMissingProperty(
+      {
+        kind: "communicationUser"
+      },
+      "id"
+    );
+    assertThrowsMissingProperty(
+      {
+        kind: "callingApplication"
+      },
+      "id"
+    );
+    assertThrowsMissingProperty(
+      {
+        kind: "phoneNumber"
+      },
+      "phoneNumber"
+    );
+    assertThrowsMissingProperty(
+      {
+        kind: "microsoftTeamsUser",
+        isAnonymous: false
+      },
+      "microsoftTeamsUserId"
+    );
+    assertThrowsMissingProperty(
+      {
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14"
+      },
+      "isAnonymous"
+    );
+    assertThrowsMissingProperty(
+      {
+        kind: "unknown"
+      },
+      "id"
+    );
+  });
+
+  it("ignores additional properties", () => {
+    assert.doesNotThrow(() => {
+      _deserializeCommunicationIdentifier({
+        kind: "microsoftTeamsUser",
+        microsoftTeamsUserId: "37691ec4-57fb-4c0f-ae31-32791610cb14",
+        isAnonymous: true,
+        id: "8:teamsvisitor:37691ec4-57fb-4c0f-ae31-32791610cb14"
+      });
+    });
+  });
+});

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -75,6 +75,13 @@ describe("Identifier model serializer", () => {
     );
   });
 
+  it("serializes as unknown identifier if kind not understood", () => {
+    assertSerialize({ kind: "foobar", id: "42", someOtherProp: true } as any, {
+      kind: "unknown",
+      id: "42"
+    });
+  });
+
   it("can deserialize", () => {
     assertDeserialize(
       {
@@ -128,13 +135,21 @@ describe("Identifier model serializer", () => {
     );
   });
 
-  it("throws if kind not understood", () => {
-    assert.throws(() => {
-      _deserializeCommunicationIdentifier({
+  it("deserializes as unknown identifier if kind not understood", () => {
+    assertDeserialize({ kind: "foobar", id: "42", someOtherProp: true } as any, {
+      kind: "Unknown",
+      id: "42"
+    });
+  });
+
+  it("throws if kind not understood and id property is missing", () => {
+    assertThrowsMissingProperty(
+      {
         kind: "foobar",
-        id: "42"
-      } as any);
-    }, `Unsupported identifier kind foobar.`);
+        someOtherProp: true
+      } as any,
+      "id"
+    );
   });
 
   it("throws if property is missing", () => {


### PR DESCRIPTION
This is part of our work to replace MRI-formatted ids in our services with an understandable communication identifier object format. Communication services should use this serializer to translate between wire format and SDK model format.