### PR TITLE
[Digital Twins] Include the correct type declaration file

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.4 (unreleased)
+
+## 1.0.3 (2021-01-15)
+
+- Bug Fix: include the types definition file in the shipped package
+
 ## 1.0.2 (2021-01-14)
 
 - Bug Fix: include the types definition file in the shipped package

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -45,7 +45,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/digital-twins-client.d.ts",
+    "types/digital-twins-core.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
v1.0.2 did not fix the issue of not including the type declaration file because I just renamed the file name from camel case to use dashes instead (https://github.com/Azure/azure-sdk-for-js/pull/13222) but it turns out the file name changed to `digital-twins-core.d.ts` instead. This PR fixes this issue and makes sure the file name generated by the api extractor tool matches that of the shipped one.
```
dealmaha@dev:~/repo/sdk/digitaltwins/digital-twins-core$ git grep "digital-twins-core.d.ts" .
api-extractor.json:    "publicTrimmedFilePath": "./types/digital-twins-core.d.ts"
package.json:  "types": "types/digital-twins-core.d.ts",
package.json:    "types/digital-twins-core.d.ts",
```

This PR also prepares for release for v1.0.3.

The release fixes the failure the docs team see here: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=187936&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=ce91d5d6-0c55-50f5-8ab9-6695c03ab102