### PR TITLE
[Digital Twins] bump version

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/digital-twins-core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An isomorphic client library for Azure Digital Twins",
   "sdk-type": "client",
   "author": "Microsoft Corporation",

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -56,7 +56,7 @@ import { createSpan } from "./tracing";
 import { CanonicalCode } from "@opentelemetry/api";
 import { logger } from "./logger";
 
-export const SDK_VERSION: string = "1.0.2";
+export const SDK_VERSION: string = "1.0.3";
 
 export interface DigitalTwinsClientOptions extends PipelineOptions {
   /**

--- a/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPIContext.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPIContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AzureDigitalTwinsAPIOptionalParams } from "./models";
 
 const packageName = "@azure/digital-twins-core";
-const packageVersion = "1.0.2";
+const packageVersion = "1.0.3";
 
 export class AzureDigitalTwinsAPIContext extends coreHttp.ServiceClient {
   $host: string;


### PR DESCRIPTION
to v1.0.3 in `package.json` and in `src`. This is the version of the release prepared here: https://github.com/Azure/azure-sdk-for-js/pull/13249.