### PR TITLE
Regenerate and Release Attestation SDK

### DIFF
--- a/sdk/attestation/attestation/CHANGELOG.md
+++ b/sdk/attestation/attestation/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-01-19)
 
+Regenerated Attestation SDK. The properties alg, kid and use in JsonWebKey object have been marked as optional.
 
 ## 1.0.0-beta.1 (2021-01-15)
 

--- a/sdk/attestation/attestation/review/attestation.api.md
+++ b/sdk/attestation/attestation/review/attestation.api.md
@@ -160,20 +160,20 @@ export interface InitTimeData {
 
 // @public (undocumented)
 export interface JsonWebKey {
-    alg: string;
+    alg?: string;
     crv?: string;
     d?: string;
     dp?: string;
     dq?: string;
     e?: string;
     k?: string;
-    kid: string;
+    kid?: string;
     kty: string;
     n?: string;
     p?: string;
     q?: string;
     qi?: string;
-    use: string;
+    use?: string;
     x?: string;
     x5C?: string[];
     y?: string;

--- a/sdk/attestation/attestation/src/attestationClientContext.ts
+++ b/sdk/attestation/attestation/src/attestationClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AttestationClientOptionalParams } from "./models";
 
 const packageName = "@azure/attestation";
-const packageVersion = "1.0.0-beta.1";
+const packageVersion = "1.0.0-beta.2";
 
 export class AttestationClientContext extends coreHttp.ServiceClient {
   instanceUrl: string;

--- a/sdk/attestation/attestation/src/models/index.ts
+++ b/sdk/attestation/attestation/src/models/index.ts
@@ -183,7 +183,7 @@ export interface JsonWebKey {
    * established by [JWA] or be a value that contains a Collision-
    * Resistant Name.
    */
-  alg: string;
+  alg?: string;
   /**
    * The "crv" (curve) parameter identifies the curve type
    */
@@ -219,7 +219,7 @@ export interface JsonWebKey {
    * equivalent alternatives by the application using them.)  The "kid"
    * value is a case-sensitive string.
    */
-  kid: string;
+  kid?: string;
   /**
    * The "kty" (key type) parameter identifies the cryptographic algorithm
    * family used with the key, such as "RSA" or "EC". "kty" values should
@@ -250,7 +250,7 @@ export interface JsonWebKey {
    * a public key is used for encrypting data or verifying the signature
    * on data. Values are commonly "sig" (signature) or "enc" (encryption).
    */
-  use: string;
+  use?: string;
   /**
    * X coordinate for the Elliptic Curve point
    */

--- a/sdk/attestation/attestation/src/models/mappers.ts
+++ b/sdk/attestation/attestation/src/models/mappers.ts
@@ -287,7 +287,6 @@ export const JsonWebKey: coreHttp.CompositeMapper = {
     modelProperties: {
       alg: {
         serializedName: "alg",
-        required: true,
         type: {
           name: "String"
         }
@@ -330,7 +329,6 @@ export const JsonWebKey: coreHttp.CompositeMapper = {
       },
       kid: {
         serializedName: "kid",
-        required: true,
         type: {
           name: "String"
         }
@@ -368,7 +366,6 @@ export const JsonWebKey: coreHttp.CompositeMapper = {
       },
       use: {
         serializedName: "use",
-        required: true,
         type: {
           name: "String"
         }

--- a/sdk/attestation/attestation/swagger/readme.md
+++ b/sdk/attestation/attestation/swagger/readme.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/attestation"
-package-version: 1.0.0-beta.1
+package-version: 1.0.0-beta.2
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../


### PR DESCRIPTION
This is to address the issue https://github.com/Azure/sdk-release-request/issues/1047. This issue was raised on Dec 3, 2020. @deyaaeldeen actually released this package 4 days ago which should be sufficient.

But, when I regenerated the SDK, 3 fields have been marked as optional. This was done recently in swagger. So, the last release did not include these changes. Since, I think this might impact the user experience, I think it is safe to do a release today before a customer/other SDKs raise issue. 

@deyaaeldeen Please review and approve.

@ramya-rao-a FYI....