### PR TITLE
[Storage Blob] Throw errors for unresolved imports in the browser

### DIFF
--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -151,7 +151,7 @@ export function browserConfig(test = false) {
       })
     ],
     onwarn(warning, warn) {
-      if (warning.code === "CIRCULAR_DEPENDENCY") {
+      if (warning.code === "CIRCULAR_DEPENDENCY" || warning.code === "UNRESOLVED_IMPORT") {
         throw new Error(warning.message);
       }
       warn(warning);

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -151,7 +151,12 @@ export function browserConfig(test = false) {
       })
     ],
     onwarn(warning, warn) {
-      if (warning.code === "CIRCULAR_DEPENDENCY" || warning.code === "UNRESOLVED_IMPORT") {
+      if (
+        warning.code === "CIRCULAR_DEPENDENCY" ||
+        warning.code === "UNRESOLVED_IMPORT"
+        // Unresolved imports in the browser may break apps with frameworks such as angular.
+        // Shim the modules with dummy src files for browser to avoid regressions.
+      ) {
         throw new Error(warning.message);
       }
       warn(warning);


### PR DESCRIPTION
As seen at https://github.com/Azure/azure-sdk-for-js/issues/13267#issuecomment-762757559, unresolved "crypto" module in the browser caused the angular app to break.
This could have been caught before if the build step with rollup had thrown an error instead of a warning for the unresolved imports in the browser. This PR attempts to throw an error instead of a warning for the unresolved imports.

https://github.com/Azure/azure-sdk-for-js/pull/13275 would fix the supposed rollup error.

Also, we don't publish the browser bundle, but this rollup error from the build step would be capable of catching regressions before we publish the library.