### PR TITLE
[Monitor] Ship type declarations

### DIFF
--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-beta.2 (2021-01-20)
+
+- Ship the correct type declaration file
+
 ## 1.0.0-beta.1 (2021-01-13)
 
 - OT Exporter retry when there are network issues

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/api-extractor.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/latest/opentelemetry-exporter-azure-monitor.d.ts"
+    "publicTrimmedFilePath": "./types/opentelemetry-exporter-azure-monitor.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/opentelemetry-exporter-azure-monitor",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
@@ -6,7 +6,7 @@
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
-  "types": "types/latest/opentelemetry-exporter-azure-monitor.d.ts",
+  "types": "types/opentelemetry-exporter-azure-monitor.d.ts",
   "scripts": {
     "clean": "rimraf dist-esm types dist",
     "build:autorest": "autorest ./swagger/README.md --typescript --v3",
@@ -41,7 +41,7 @@
     "dist-esm/src/",
     "dist/src/",
     "browser/src/",
-    "types/src/",
+    "types/opentelemetry-exporter-azure-monitor.d.ts",
     "README.md",
     "SECURITY.md",
     "LICENSE"

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/generated/applicationInsightsClientContext.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/generated/applicationInsightsClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApplicationInsightsClientOptionalParams } from "./models";
 
 const packageName = "@azure/opentelemetry-exporter-azure-monitor";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.0-beta.2";
 
 export class ApplicationInsightsClientContext extends coreHttp.ServiceClient {
   host: string;

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/constants/applicationinsights.ts
@@ -10,4 +10,4 @@ export const MS_LINKS = "_MS.links";
 export const INPROC = "InProc";
 export const ENQUEUED_TIME = "enqueuedTime";
 export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
-export const packageVersion = "1.0.0-beta.1";
+export const packageVersion = "1.0.0-beta.2";


### PR DESCRIPTION
@azure/opentelemetry-exporter-azure-monitor@1.0.0-beta.1  does not have any typescript definition file and causes the following failure for the docs team: `types/latest/opentelemetry-exporter-azure-monitor.d.ts doesn't exist, which is defined in package.json.`. This PR fixes the issue by including a types declaration file and prepares for the release of version 1.0.0-beta.2.

