### PR TITLE
[Identity] Using service-bus for manual test with MSAL 2.0

### DIFF
--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -32,7 +32,7 @@ You will need to configure an AAD App Registration as follows:
 Grant access to this AAD application to your Service Bus by:
 
 - Creating a Service Bus namespace (if you haven't created one).
-- Either in the "Access policies" section of the creation form, or by going to the Service Bus namespace's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "principal", then click "Add", then click "Save" if applicable.
+- Either in the "Access policies" section of the creation form, or by going to the Service Bus namespace's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "Service Bus Data Owner", then click "Add", then click "Save" if applicable.
 - Then, in your Service Bus namespace, create a queue named `queue-identity-test`.
 
 With the AAD application and the Service Bus namespace configured, make sure `npm start` is running, then go to `http://localhost:8080`, then enter the Tenant ID, the Client ID of the AAD application and the Service Bus Endpoint, then go through the available options to configure the scenario in which you want the authentication to run, then click on the `Send Message` button. Information from the message sent will appear at the bottom.

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -26,6 +26,7 @@ You will need to configure an AAD App Registration as follows:
 - Click on the app that you want to use to authenticate.
 - Go to the Authentication tab of your AAD application.
 - Click on `+ Add a platform`, select `Single-page application`, enter `http://localhost:8080` as the redirect URI, then make sure to include implicit grant for "Access tokens" and "ID tokens".
+- Go to the `API permissions` tab of your AAD application. Click on `Add a permission`, then go to `APIs my organization uses` and search for `Microsoft.ServiceBus`, then add this permission.
 - Keep in mind that if you belong to an organization, other restrictions based on the organization configurations might prevent you from authenticating. If These steps don't end up being effective, try again on a personal account.
 
 Grant access to this AAD application to your Service Bus by:

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -2,7 +2,7 @@
 
 This package contains some simple manual verification for the use of Azure
 Identity with other Azure SDK libraries in the browser.  For now, it just tests
-that the `InteractiveBrowserCredential` works with the `@azure/keyvault-keys`
+that the `InteractiveBrowserCredential` works with the `@azure/service-bus`
 library.
 
 ## Usage
@@ -28,25 +28,14 @@ You will need to configure an AAD App Registration as follows:
 - Click on `+ Add a platform`, select `Single-page application`, enter `http://localhost:8080` as the redirect URI, then make sure to include implicit grant for "Access tokens" and "ID tokens".
 - Keep in mind that if you belong to an organization, other restrictions based on the organization configurations might prevent you from authenticating. If These steps don't end up being effective, try again on a personal account.
 
-Grant access to this AAD application to your Key Vault by:
+Grant access to this AAD application to your Service Bus by:
 
-- Creating a Key Vault (if you haven't created one).
-- Either in the "Access policies" section of the creation form, or by going to your Key Vault's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "principal", then click "Add", then click "Save" if applicable.
+- Creating a Service Bus namespace (if you haven't created one).
+- Either in the "Access policies" section of the creation form, or by going to the Service Bus namespace's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "principal", then click "Add", then click "Save" if applicable.
+- Then, in your Service Bus namespace, create a queue named `partitioned-queue`, then go into the queue and repeat the "Access policies" process to add a "principal".
 
-With the AAD application and the Key Vault configured, make sure `npm start` is running, then go to `http://localhost:8080`, then enter the Tenant ID, the Client ID of the AAD application and the name of the Key Vault, then click on the `Get Keys` button, and a list of the available keys will be presented after the form in the web page.
+With the AAD application and the Service Bus namespace configured, make sure `npm start` is running, then go to `http://localhost:8080`, then enter the Tenant ID, the Client ID of the AAD application and the Service Bus Endpoint, then go through the available options to configure the scenario in which you want the authentication to run, then click on the `Send Message` button. Information from the message sent will appear at the bottom.
 
-## Avoiding CORS errors
-
-Currently the Key Vault service does not provide a way to configure CORS origins
-so that requests against the service can be made from a browser (Storage and
-Cosmos DB services provide this capability).  To get around this issue, you can
-run Google Chrome with web security disabled:
-
-**NOTE:** Only do this for manual verification purposes!
-
-```
-google-chrome --disable-web-security
-```
-
+If something unexpected happens, make sure to open the console tab in the browser. The application will be logging as many things as they seemed relevant for debugging.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fidentity%2Fidentity%2Ftest%2Fmanual%2FREADME.png)

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -32,7 +32,7 @@ Grant access to this AAD application to your Service Bus by:
 
 - Creating a Service Bus namespace (if you haven't created one).
 - Either in the "Access policies" section of the creation form, or by going to the Service Bus namespace's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "principal", then click "Add", then click "Save" if applicable.
-- Then, in your Service Bus namespace, create a queue named `queue-identity-test`, then go into the queue and repeat the "Access policies" process to add a "principal".
+- Then, in your Service Bus namespace, create a queue named `queue-identity-test`.
 
 With the AAD application and the Service Bus namespace configured, make sure `npm start` is running, then go to `http://localhost:8080`, then enter the Tenant ID, the Client ID of the AAD application and the Service Bus Endpoint, then go through the available options to configure the scenario in which you want the authentication to run, then click on the `Send Message` button. Information from the message sent will appear at the bottom.
 

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -32,7 +32,7 @@ Grant access to this AAD application to your Service Bus by:
 
 - Creating a Service Bus namespace (if you haven't created one).
 - Either in the "Access policies" section of the creation form, or by going to the Service Bus namespace's "Access policies" page, click con `+ Add Access Policy`, select all permissions, then select your AAD application as the "principal", then click "Add", then click "Save" if applicable.
-- Then, in your Service Bus namespace, create a queue named `partitioned-queue`, then go into the queue and repeat the "Access policies" process to add a "principal".
+- Then, in your Service Bus namespace, create a queue named `queue-identity-test`, then go into the queue and repeat the "Access policies" process to add a "principal".
 
 With the AAD application and the Service Bus namespace configured, make sure `npm start` is running, then go to `http://localhost:8080`, then enter the Tenant ID, the Client ID of the AAD application and the Service Bus Endpoint, then go through the available options to configure the scenario in which you want the authentication to run, then click on the `Send Message` button. Information from the message sent will appear at the bottom.
 

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -27,7 +27,7 @@ You will need to configure an AAD App Registration as follows:
 - Go to the Authentication tab of your AAD application.
 - Click on `+ Add a platform`, select `Single-page application`, enter `http://localhost:8080` as the redirect URI, then make sure to include implicit grant for "Access tokens" and "ID tokens".
 - Go to the `API permissions` tab of your AAD application. Click on `Add a permission`, then go to `APIs my organization uses` and search for `Microsoft.ServiceBus`, then add this permission.
-- Keep in mind that if you belong to an organization, other restrictions based on the organization configurations might prevent you from authenticating. If These steps don't end up being effective, try again on a personal account.
+- Keep in mind that if you belong to an organization, other restrictions based on the organization configurations might prevent you from authenticating. If these steps don't end up being effective, try again on a personal account.
 
 Grant access to this AAD application to your Service Bus by:
 

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/identity": "../../azure-identity-1.2.3.tgz",
-    "@azure/service-bus": "^7.0.2",
+    "@azure/service-bus": "^7.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "tslib": "^1.9.3"

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -5,13 +5,14 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server",
+    "format": "prettier --write \"src/**/*.tsx\""
   },
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "@azure/identity": "1.2.0",
-    "@azure/keyvault-keys": "4.1.0",
+    "@azure/identity": "../../azure-identity-1.2.3.tgz",
+    "@azure/service-bus": "^7.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "tslib": "^1.9.3"
@@ -23,6 +24,7 @@
     "@types/react-dom": "^16.8.5",
     "@types/webpack": "^4.4.13",
     "@types/webpack-dev-middleware": "^2.0.2",
+    "prettier": "^2.2.1",
     "ts-loader": "^5.3.1",
     "typescript": "~3.6.4",
     "webpack": "^4.16.3",

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "@azure/identity": "../../azure-identity-1.2.3.tgz",
+    "@azure/identity": "^1.2.4-beta.1",
     "@azure/service-bus": "^7.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -231,7 +231,9 @@ async function sendMessage(
       JSON.stringify(cleanDetails),
       "--- Message End ---",
     ].join("\n");
+    console.log("Attempting to send a message...");
     await sender.sendMessages({ body });
+    console.log("Message sent successfully!");
     await sender.close();
     const receiver = client.createReceiver(queueName);
     const messages = await receiver.receiveMessages(10);

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -4,78 +4,108 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { InteractiveBrowserCredential, BrowserLoginStyle } from "@azure/identity";
-import { KeyClient, KeyVaultKey } from "@azure/keyvault-keys";
-import { ServiceBusClient } from "@azure/service-bus"
-
-const getRandomKeyName = () => `key${Math.random()}`.replace(/\./g, "");
+import {
+  InteractiveBrowserCredential,
+  BrowserLoginStyle,
+  InteractiveBrowserAuthenticationFlow,
+} from "@azure/identity";
+import { ServiceBusClient } from "@azure/service-bus";
 
 interface ClientDetails {
-  tenantId: string,
-  clientId: string,
-  loginStyle: BrowserLoginStyle,
-  keyName: string,
-  serviceBusEndpoint: string,
-  messageText: string
+  tenantId: string;
+  clientId: string;
+  queueName: string;
+  loginStyle: BrowserLoginStyle;
+  flow: InteractiveBrowserAuthenticationFlow;
+  numberOfExecutions: number;
+  cacheCredential: boolean;
+  parallel: boolean;
+  preAuthenticate: boolean;
+  serviceBusEndpoint: string;
+  output: string;
 }
 
 interface ClientDetailsEditorProps {
-  clientDetails: ClientDetails,
-  onSetClientDetails: React.Dispatch<React.SetStateAction<ClientDetails>>
+  clientDetails: ClientDetails;
+  onSetClientDetails: React.Dispatch<React.SetStateAction<ClientDetails>>;
 }
 
 function storeClientDetails(clientDetails: ClientDetails) {
-  localStorage.setItem('clientDetails', JSON.stringify(clientDetails));
+  localStorage.setItem("clientDetails", JSON.stringify(clientDetails));
 }
 
 function readClientDetails(): ClientDetails {
-  const detailsJson = localStorage.getItem('clientDetails')
+  const detailsJson = localStorage.getItem("clientDetails");
   if (detailsJson) {
-    const details = JSON.parse(detailsJson)
+    const details = JSON.parse(detailsJson);
     details.credential = undefined;
     return details;
   }
-
   return undefined;
 }
 
-function getCredential(clientDetails: ClientDetails): InteractiveBrowserCredential | undefined {
-  return clientDetails.tenantId.length > 0 && clientDetails.clientId.length > 0 ? new InteractiveBrowserCredential(clientDetails) : undefined;
+function Radio(options: {
+  values: string[];
+  checkedValue: string;
+  onChange: (value: string) => void;
+}) {
+  const { values, checkedValue, onChange } = options;
+  return (
+    <React.Fragment>
+      {values.map((value) => (
+        <label>
+          <input
+            type="radio"
+            value={value}
+            checked={checkedValue === value}
+            onChange={({ target }) => onChange(target.value)}
+          />
+          {value}
+        </label>
+      ))}
+    </React.Fragment>
+  );
+}
+
+let lastLoginStyle: BrowserLoginStyle | undefined;
+let cachedCredential: InteractiveBrowserCredential | undefined;
+function getCredential(
+  clientDetails: ClientDetails,
+  cacheCredential: boolean
+): InteractiveBrowserCredential | undefined {
+  if (!cacheCredential) {
+    cachedCredential = undefined;
+    lastLoginStyle = undefined;
+  }
+  if (cachedCredential && clientDetails.loginStyle === lastLoginStyle) return cachedCredential;
+
+  const { tenantId, clientId, loginStyle, flow } = clientDetails;
+
+  if (tenantId && clientId && loginStyle && flow) {
+    cachedCredential = new InteractiveBrowserCredential({
+      tenantId,
+      clientId,
+      loginStyle,
+      flow,
+    });
+    lastLoginStyle = clientDetails.loginStyle;
+    return cachedCredential;
+  }
 }
 
 function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetailsEditorProps) {
   const handleDetailsChange = (newDetails: ClientDetails) => {
-    storeClientDetails(newDetails)
-    onSetClientDetails(newDetails)
+    storeClientDetails(newDetails);
+    onSetClientDetails(newDetails);
   };
 
-  const setLoginStyle = (loginStyle: BrowserLoginStyle) => {
+  const setDetail = (name: keyof ClientDetails, changeValue?: (v: string) => any) => (
+    value: string
+  ) =>
     handleDetailsChange({
       ...clientDetails,
-      loginStyle
+      [name]: changeValue ? changeValue(value) : value,
     });
-  }
-
-  const setKeyName = (keyName: string) => {
-    handleDetailsChange({
-      ...clientDetails,
-      keyName
-    });
-  }
-
-  const setServiceBusEndpoint = (serviceBusEndpoint: string) => {
-    handleDetailsChange({
-      ...clientDetails,
-      serviceBusEndpoint
-    });
-  }
-
-  const setMessageText = (messageText: string) => {
-    handleDetailsChange({
-      ...clientDetails,
-      messageText
-    });
-  }
 
   return (
     <div>
@@ -83,235 +113,256 @@ function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetail
       <form>
         <label>
           Tenant Id:
-          <input type="text" value={clientDetails.tenantId} onChange={({ target }) => handleDetailsChange({ ...clientDetails, tenantId: target.value })} />
+          <input
+            type="text"
+            value={clientDetails.tenantId}
+            onChange={({ target }) =>
+              handleDetailsChange({ ...clientDetails, tenantId: target.value })
+            }
+          />
         </label>
         <br />
         <label>
           Client Id:
-          <input type="text" value={clientDetails.clientId} onChange={({ target }) => handleDetailsChange({ ...clientDetails, clientId: target.value })} />
+          <input
+            type="text"
+            value={clientDetails.clientId}
+            onChange={({ target }) =>
+              handleDetailsChange({ ...clientDetails, clientId: target.value })
+            }
+          />
         </label>
         <br />
         <label>
-          Fill to create a new key with this name:
-          <input type="text" value={getRandomKeyName()} onChange={({ target }) => setKeyName(target.value)} />
+          Queue Name:
+          <input
+            type="text"
+            value={clientDetails.queueName}
+            onChange={({ target }) =>
+              handleDetailsChange({ ...clientDetails, queueName: target.value })
+            }
+          />
         </label>
-        <h4>Login Flow Style</h4>
-        <div>
-          <label>
-            <input type="radio" value="popup" checked={clientDetails.loginStyle === "popup"} onChange={({ target }) => setLoginStyle(target.value as BrowserLoginStyle)} />
-            Popup
-          </label>
-        </div>
-        <div>
-          <label>
-            <input type="radio" value="redirect" checked={clientDetails.loginStyle === "redirect"} onChange={({ target }) => setLoginStyle(target.value as BrowserLoginStyle)} />
-            Redirect
-          </label>
-        </div>
+        <br />
+        <label>
+          Service Bus Endpoint:
+          <input
+            type="text"
+            value={clientDetails.serviceBusEndpoint}
+            onChange={({ target }) =>
+              handleDetailsChange({ ...clientDetails, serviceBusEndpoint: target.value })
+            }
+          />
+        </label>
+        <br />
+        <h4>Login Style</h4>
+        <Radio
+          values={["popup", "redirect"]}
+          checkedValue={clientDetails.loginStyle}
+          onChange={setDetail("loginStyle")}
+        />
+        <br />
+        <h4>Authentication flow</h4>
+        <Radio
+          values={["implicit-grant", "auth-code"]}
+          checkedValue={clientDetails.flow}
+          onChange={setDetail("flow")}
+        />
+        <br />
+        <h4>Number of executions</h4>
+        <Radio
+          values={["1", "2", "3"]}
+          checkedValue={clientDetails.numberOfExecutions.toString()}
+          onChange={setDetail("numberOfExecutions", (x) => Number(x))}
+        />
+        <br />
+        <h4>Re-use Credential?</h4>
+        <Radio
+          values={["yes", "no"]}
+          checkedValue={clientDetails.cacheCredential ? "yes" : "no"}
+          onChange={setDetail("cacheCredential", (x) => x === "yes")}
+        />
+        <br />
+        {clientDetails.numberOfExecutions > 1 ? (
+          <React.Fragment>
+            <h4>Run in parallel?</h4>
+            <Radio
+              values={["yes", "no"]}
+              checkedValue={clientDetails.parallel ? "yes" : "no"}
+              onChange={setDetail("parallel", (x) => x === "yes")}
+            />
+            <small>
+              Running in parallel the first time the authentication happens will cause errors. We're
+              allowing this behavior in the app for testing purposes.
+            </small>
+            <br />
+          </React.Fragment>
+        ) : null}
+        <h4>Authenticate before calling to any method?</h4>
+        <Radio
+          values={["yes", "no"]}
+          checkedValue={clientDetails.preAuthenticate ? "yes" : "no"}
+          onChange={setDetail("preAuthenticate", (x) => x === "yes")}
+        />
       </form>
     </div>
   );
 }
 
-function useKeyVaultKeys(vaultName: string, clientDetails: ClientDetails) {
-  const [running, setRunning] = React.useState(false)
-  const [keys, setKeys] = React.useState<KeyVaultKey[]>(undefined)
-  const [error, setErrorInner] = React.useState(undefined);
-  const url = `https://${vaultName}.vault.azure.net`;
+async function sendMessage(
+  serviceBusEndpoint: string,
+  clientDetails: ClientDetails
+): Promise<string | undefined> {
+  const credential = getCredential(clientDetails, clientDetails.cacheCredential);
+  const queueName = clientDetails.queueName;
 
-  const setError = (err) => {
-    setRunning(false)
-    setErrorInner(err)
+  if (credential === undefined) {
+    throw new Error("You must enter client details.");
   }
 
-  React.useEffect(() => {
-    const credential = getCredential(clientDetails);
-    if (vaultName.trim().length === 0) {
-      setError("You must enter a vault name to fetch keys.")
-    } else if (credential === undefined) {
-      setError("You must enter client details to fetch keys.")
-    } else if (running) {
-      // Kick off the request asynchronously.  The setKeys call will
-      // propagate the key list back to the UI state.
-      const keyClient = new KeyClient(url, credential);
-      (async () => {
-        const keyResult = [];
-        setKeys(keyResult);
+  if (clientDetails.preAuthenticate) {
+    const record = await credential.authenticate({
+      scopes: `https://servicebus.azure.net/.default`,
+    });
+    console.log({ record });
+  }
 
-        if (clientDetails.keyName) {
-          try {
-            await keyClient.createKey(clientDetails.keyName, "RSA");
-          } catch (e) {
-            console.info(e);
-          }
-        }
+  console.log("Working with", serviceBusEndpoint, clientDetails);
 
-        for await (const keyProperties of keyClient.listPropertiesOfKeys()) {
-          keyResult.push(await keyClient.getKey(keyProperties.name))
-        }
+  const client = new ServiceBusClient(serviceBusEndpoint, credential);
 
-        setKeys(keyResult);
-        setRunning(false)
-      })().catch(err => setError(err.toString()));
-    } else {
-      setError("")
+  try {
+    const sender = client.createSender(queueName);
+    const cleanDetails = {
+      ...clientDetails,
+    };
+    delete cleanDetails.output;
+    const body = [
+      "--- Message ---",
+      `Sent at: ${new Date()}`,
+      "Body:",
+      JSON.stringify(cleanDetails),
+      "--- Message End ---",
+    ].join("\n");
+    await sender.sendMessages({ body });
+    await sender.close();
+    const receiver = client.createReceiver(queueName);
+    const messages = await receiver.receiveMessages(10);
+    for (let message of messages) {
+      await receiver.completeMessage(message);
     }
-  }, [vaultName, clientDetails, running])
+    await receiver.close();
+    const output = `Received messages:\n${messages.map((m) => m.body.toString()).join("\n")}`;
+    console.log(output);
+    clientDetails.output = output;
 
-  return { keys, fetchKeys: () => setRunning(true), error }
+    // Scrolling to the bottom of the page.
+    window.scrollTo(0, document.body.scrollHeight);
+    return output;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  } finally {
+    await client.close();
+  }
 }
 
-interface KeyVaultTestProps {
-  storedVaultName?: string,
-  clientDetails: ClientDetails
-}
+function useServiceBus(clientDetails: ClientDetails) {
+  const [running, setRunning] = React.useState(false);
+  const [error, setErrorInner] = React.useState(undefined);
+  const [output, setOutput] = React.useState<string>(undefined);
 
-const KeyVaultTest = ({ storedVaultName, clientDetails }: KeyVaultTestProps) => {
-  const [vaultName, setVaultName] = React.useState(storedVaultName || "");
-  const { keys, fetchKeys, error } = useKeyVaultKeys(vaultName, clientDetails);
-
-  const handleVaultNameChange = (newVaultName) => {
-    localStorage.setItem('keyVaultName', newVaultName);
-    setVaultName(newVaultName);
+  const setError = (err: string) => {
+    setRunning(false);
+    setErrorInner(err);
   };
 
-  return (
-    <div>
-      <h3>List Key Vault Keys</h3>
-      <form onSubmit={e => { fetchKeys(); e.preventDefault(); }}>
-        <label>
-          Vault Name:
-          <input type="text" value={vaultName} onChange={({ target }) => handleVaultNameChange(target.value)} />
-        </label>
-        <input type="submit" value="Get Keys" />
-      </form>
-      {!error ? null : <h3 style={{ color: "red" }}>{error}</h3>}
-      {!keys ? null :
-        (
-          <table>
-            <thead>
-              <tr>
-                <th>Key Name</th>
-                <th>Enabled</th>
-                <th>Expires</th>
-              </tr>
-            </thead>
-            <tbody>
-              {keys.map(key => <tr key={key.name}><td>{key.name}</td><td>{key.properties.enabled.toString()}</td><td>{key.properties.expiresOn && key.properties.expiresOn.toDateString()}</td></tr>)}
-            </tbody>
-          </table>
-        )
-      }
-    </div>
-  );
-}
-
-function useServiceBus(serviceBusEndpoint: string, messageText: string, clientDetails: ClientDetails) {
-  const [running, setRunning] = React.useState(false)
-  const [error, setErrorInner] = React.useState(undefined);
-
-  const setError = (err) => {
-    setRunning(false)
-    setErrorInner(err)
-  }
-
   React.useEffect(() => {
-    const credential = getCredential(clientDetails);
-    if (serviceBusEndpoint.trim().length === 0) {
-      setError("You must enter a service bus endpoint to send a message.")
-    } else if (credential === undefined) {
-      setError("You must enter client details to fetch keys.")
+    if (clientDetails.serviceBusEndpoint.trim().length === 0) {
+      setError("You must enter a service bus endpoint to send a message.");
     } else if (running) {
       (async () => {
-        const body = clientDetails.messageText || messageText;
-        const queueName = "partitioned-queue";
-
-        if (body) {
-          console.log({ serviceBusEndpoint });
-          const serviceBusClient = new ServiceBusClient(serviceBusEndpoint, credential);
-
-          try {
-            const sender = serviceBusClient.createSender(queueName);
-            await sender.sendMessages({ body });
-            await sender.close();
-            const receiver = serviceBusClient.createReceiver(queueName);
-            const messages = await receiver.receiveMessages(10);
-            await receiver.close();
-            console.log("Received messages:\n", messages.map(m => m.body.toString()).join("\n"));
-          } catch (e) {
-            console.info(e);
-          } finally {
-            await serviceBusClient.close();
+        for (let i = 0; i < clientDetails.numberOfExecutions; i++) {
+          const promise = sendMessage(clientDetails.serviceBusEndpoint, clientDetails);
+          if (clientDetails.parallel) {
+            promise.then(setOutput);
+          } else {
+            setOutput(await promise);
           }
         }
-
-        setRunning(false)
-      })().catch(err => setError(err.toString()));
+        setRunning(false);
+      })().catch((err) => setError(err.toString()));
     } else {
-      setError("")
+      setError("");
     }
-  }, [serviceBusEndpoint, messageText, clientDetails, running])
+  }, [clientDetails.serviceBusEndpoint, clientDetails, running]);
 
-  return { sendMessage: () => setRunning(true), error }
+  // Triggering a first send if the redirection hash is present.
+  if (window.location.hash) {
+    setTimeout(() => setRunning(true), 1000);
+  }
+
+  return { output, sendMessage: () => setRunning(true), error };
 }
 
 interface ServiceBusTestProps {
-  storedServiceBusEndpoint?: string,
-  storedMessageText?: string,
-  clientDetails: ClientDetails
+  storedServiceBusEndpoint?: string;
+  clientDetails: ClientDetails;
 }
 
-const ServiceBusTest = ({ storedServiceBusEndpoint, storedMessageText, clientDetails }: ServiceBusTestProps) => {
-  const [serviceBusEndpoint, setServiceBusEndpoint] = React.useState(storedServiceBusEndpoint || "");
-  const [messageText, setMessageText] = React.useState(storedMessageText || "");
-  const { sendMessage, error } = useServiceBus(serviceBusEndpoint, messageText, clientDetails);
-
-  const handleServiceBusEndpointChange = (newServiceBusEndpoint) => {
-    localStorage.setItem('serviceBusEndpoint', newServiceBusEndpoint);
-    setServiceBusEndpoint(newServiceBusEndpoint);
-  };
-
-  const handleMessageText = (newMessageText) => {
-    localStorage.setItem('messageText', newMessageText);
-    setMessageText(newMessageText);
-  };
+const ServiceBusTest = ({ clientDetails }: ServiceBusTestProps) => {
+  const { sendMessage, output, error } = useServiceBus(clientDetails);
 
   return (
     <div>
       <h3>Send Service Bus Endpoint</h3>
-      <form onSubmit={e => { sendMessage(); e.preventDefault(); }}>
-        <label>
-          Service Bus Endpoint:
-          <input type="text" value={serviceBusEndpoint} onChange={({ target }) => handleServiceBusEndpointChange(target.value)} />
-        </label>
-        <label>
-          Message to send:
-          <input type="text" value={messageText} onChange={({ target }) => handleMessageText(target.value)} />
-        </label>
+      <form
+        onSubmit={(e) => {
+          sendMessage();
+          e.preventDefault();
+        }}
+      >
         <input type="submit" value="Send Message" />
       </form>
       {!error ? null : <h3 style={{ color: "red" }}>{error}</h3>}
+      <br />
+      <h3>
+        Messages
+        <br />
+        (each one with the serialized "clientDetails"):
+      </h3>
+      <pre>
+        <code>{output || clientDetails.output}</code>
+      </pre>
     </div>
   );
-}
+};
 
 function TestPage() {
-  const storedVaultName = localStorage.getItem('keyVaultName');
-  const storedServiceBusEndpoint = localStorage.getItem('serviceBusEndpoint');
-  const storedMessageText = localStorage.getItem('messageText');
-  const [clientDetails, setClientDetails] = React.useState<ClientDetails>(readClientDetails() || { tenantId: "", clientId: "", loginStyle: "popup", keyName: "", serviceBusEndpoint: "", messageText: "" })
+  const [clientDetails, setClientDetails] = React.useState<ClientDetails>(
+    readClientDetails() || {
+      tenantId: "",
+      clientId: "",
+      queueName: "partitioned-queue",
+      loginStyle: "popup",
+      flow: "auth-code",
+      numberOfExecutions: 1,
+      cacheCredential: true,
+      parallel: false,
+      preAuthenticate: true,
+      serviceBusEndpoint: "",
+      output: "",
+    }
+  );
+
   return (
     <div>
       <h1>Azure SDK Browser Manual Tests</h1>
       <hr />
       <ClientDetailsEditor clientDetails={clientDetails} onSetClientDetails={setClientDetails} />
-      <KeyVaultTest storedVaultName={storedVaultName} clientDetails={clientDetails} />
-      <ServiceBusTest storedServiceBusEndpoint={storedServiceBusEndpoint} storedMessageText={storedMessageText} clientDetails={clientDetails} />
+      <ServiceBusTest clientDetails={clientDetails} />
     </div>
   );
 }
 
-ReactDOM.render(
-  <TestPage />,
-  document.getElementById("app")
-);
+ReactDOM.render(<TestPage />, document.getElementById("app"));

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -329,7 +329,7 @@ function TestPage() {
     readClientDetails() || {
       tenantId: "",
       clientId: "",
-      queueName: "partitioned-queue",
+      queueName: "queue-identity-test",
       loginStyle: "popup",
       flow: "auth-code",
       numberOfExecutions: 1,

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -147,6 +147,7 @@ function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetail
           Service Bus Endpoint:
           <input
             type="text"
+            placeholder="yournamespace.servicebus.windows.net"
             value={clientDetails.serviceBusEndpoint}
             onChange={({ target }) =>
               handleDetailsChange({ ...clientDetails, serviceBusEndpoint: target.value })

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -20,7 +20,6 @@ interface ClientDetails {
   numberOfExecutions: number;
   cacheCredential: boolean;
   parallel: boolean;
-  preAuthenticate: boolean;
   serviceBusEndpoint: string;
   output: string;
 }
@@ -198,12 +197,6 @@ function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetail
             <br />
           </React.Fragment>
         ) : null}
-        <h4>Authenticate before calling to any method?</h4>
-        <Radio
-          values={["yes", "no"]}
-          checkedValue={clientDetails.preAuthenticate ? "yes" : "no"}
-          onChange={setDetail("preAuthenticate", (x) => x === "yes")}
-        />
       </form>
     </div>
   );
@@ -218,13 +211,6 @@ async function sendMessage(
 
   if (credential === undefined) {
     throw new Error("You must enter client details.");
-  }
-
-  if (clientDetails.preAuthenticate) {
-    const record = await credential.authenticate({
-      scopes: `https://servicebus.azure.net/.default`,
-    });
-    console.log({ record });
   }
 
   console.log("Working with", serviceBusEndpoint, clientDetails);
@@ -349,7 +335,6 @@ function TestPage() {
       numberOfExecutions: 1,
       cacheCredential: true,
       parallel: false,
-      preAuthenticate: true,
       serviceBusEndpoint: "",
       output: "",
     }

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -6,6 +6,7 @@ import * as ReactDOM from "react-dom";
 
 import { InteractiveBrowserCredential, BrowserLoginStyle } from "@azure/identity";
 import { KeyClient, KeyVaultKey } from "@azure/keyvault-keys";
+import { ServiceBusClient } from "@azure/service-bus"
 
 const getRandomKeyName = () => `key${Math.random()}`.replace(/\./g, "");
 
@@ -14,6 +15,8 @@ interface ClientDetails {
   clientId: string,
   loginStyle: BrowserLoginStyle,
   keyName: string,
+  serviceBusEndpoint: string,
+  messageText: string
 }
 
 interface ClientDetailsEditorProps {
@@ -57,6 +60,20 @@ function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetail
     handleDetailsChange({
       ...clientDetails,
       keyName
+    });
+  }
+
+  const setServiceBusEndpoint = (serviceBusEndpoint: string) => {
+    handleDetailsChange({
+      ...clientDetails,
+      serviceBusEndpoint
+    });
+  }
+
+  const setMessageText = (messageText: string) => {
+    handleDetailsChange({
+      ...clientDetails,
+      messageText
     });
   }
 
@@ -189,15 +206,107 @@ const KeyVaultTest = ({ storedVaultName, clientDetails }: KeyVaultTestProps) => 
   );
 }
 
+function useServiceBus(serviceBusEndpoint: string, messageText: string, clientDetails: ClientDetails) {
+  const [running, setRunning] = React.useState(false)
+  const [error, setErrorInner] = React.useState(undefined);
+
+  const setError = (err) => {
+    setRunning(false)
+    setErrorInner(err)
+  }
+
+  React.useEffect(() => {
+    const credential = getCredential(clientDetails);
+    if (serviceBusEndpoint.trim().length === 0) {
+      setError("You must enter a service bus endpoint to send a message.")
+    } else if (credential === undefined) {
+      setError("You must enter client details to fetch keys.")
+    } else if (running) {
+      (async () => {
+        const body = clientDetails.messageText || messageText;
+        const queueName = "partitioned-queue";
+
+        if (body) {
+          console.log({ serviceBusEndpoint });
+          const serviceBusClient = new ServiceBusClient(serviceBusEndpoint, credential);
+
+          try {
+            const sender = serviceBusClient.createSender(queueName);
+            await sender.sendMessages({ body });
+            await sender.close();
+            const receiver = serviceBusClient.createReceiver(queueName);
+            const messages = await receiver.receiveMessages(10);
+            await receiver.close();
+            console.log("Received messages:\n", messages.map(m => m.body.toString()).join("\n"));
+          } catch (e) {
+            console.info(e);
+          } finally {
+            await serviceBusClient.close();
+          }
+        }
+
+        setRunning(false)
+      })().catch(err => setError(err.toString()));
+    } else {
+      setError("")
+    }
+  }, [serviceBusEndpoint, messageText, clientDetails, running])
+
+  return { sendMessage: () => setRunning(true), error }
+}
+
+interface ServiceBusTestProps {
+  storedServiceBusEndpoint?: string,
+  storedMessageText?: string,
+  clientDetails: ClientDetails
+}
+
+const ServiceBusTest = ({ storedServiceBusEndpoint, storedMessageText, clientDetails }: ServiceBusTestProps) => {
+  const [serviceBusEndpoint, setServiceBusEndpoint] = React.useState(storedServiceBusEndpoint || "");
+  const [messageText, setMessageText] = React.useState(storedMessageText || "");
+  const { sendMessage, error } = useServiceBus(serviceBusEndpoint, messageText, clientDetails);
+
+  const handleServiceBusEndpointChange = (newServiceBusEndpoint) => {
+    localStorage.setItem('serviceBusEndpoint', newServiceBusEndpoint);
+    setServiceBusEndpoint(newServiceBusEndpoint);
+  };
+
+  const handleMessageText = (newMessageText) => {
+    localStorage.setItem('messageText', newMessageText);
+    setMessageText(newMessageText);
+  };
+
+  return (
+    <div>
+      <h3>Send Service Bus Endpoint</h3>
+      <form onSubmit={e => { sendMessage(); e.preventDefault(); }}>
+        <label>
+          Service Bus Endpoint:
+          <input type="text" value={serviceBusEndpoint} onChange={({ target }) => handleServiceBusEndpointChange(target.value)} />
+        </label>
+        <label>
+          Message to send:
+          <input type="text" value={messageText} onChange={({ target }) => handleMessageText(target.value)} />
+        </label>
+        <input type="submit" value="Send Message" />
+      </form>
+      {!error ? null : <h3 style={{ color: "red" }}>{error}</h3>}
+    </div>
+  );
+}
+
 function TestPage() {
   const storedVaultName = localStorage.getItem('keyVaultName');
-  const [clientDetails, setClientDetails] = React.useState<ClientDetails>(readClientDetails() || { tenantId: "", clientId: "", loginStyle: "popup", keyName: "" })
+  const storedServiceBusEndpoint = localStorage.getItem('serviceBusEndpoint');
+  const storedMessageText = localStorage.getItem('messageText');
+  const [clientDetails, setClientDetails] = React.useState<ClientDetails>(readClientDetails() || { tenantId: "", clientId: "", loginStyle: "popup", keyName: "", serviceBusEndpoint: "", messageText: "" })
   return (
     <div>
       <h1>Azure SDK Browser Manual Tests</h1>
       <hr />
       <ClientDetailsEditor clientDetails={clientDetails} onSetClientDetails={setClientDetails} />
       <KeyVaultTest storedVaultName={storedVaultName} clientDetails={clientDetails} />
+      <ServiceBusTest storedServiceBusEndpoint={storedServiceBusEndpoint} storedMessageText={storedMessageText} clientDetails={clientDetails} />
     </div>
   );
 }

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -144,7 +144,7 @@ function ClientDetailsEditor({ clientDetails, onSetClientDetails }: ClientDetail
         </label>
         <br />
         <label>
-          Service Bus Endpoint:
+          Service Bus hostname:
           <input
             type="text"
             placeholder="yournamespace.servicebus.windows.net"


### PR DESCRIPTION
Updates the Identity InteractiveBrowserCredential to work with MSAL 1 and 2, meaning with the Implicit Grant flow and the Auth Code Flow. Also moved it from using Key Vault to use Service Bus, since Key Vault doesn't allow CORS.

Relies on this update: https://github.com/Azure/azure-sdk-for-js/pull/13263

Fixes #13307