### PR TITLE
Replace only first  azure-  to generate package name

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -152,8 +152,7 @@ stages:
                     steps:
                       - checkout: self
                       - pwsh: |
-                          [regex]$pattern = "azure-"
-                          $adjustedName = $pattern.replace("${{artifact.name}}", "", 1)
+                          $adjustedName = "${{artifact.name}}" -replace "^azure-", ""
                           Write-Host "##vso[task.setvariable variable=Documentation.Zip]$adjustedName"
                         displayName: Set Documentation File Name
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -152,7 +152,8 @@ stages:
                     steps:
                       - checkout: self
                       - pwsh: |
-                          $adjustedName = "${{artifact.name}}".Replace("azure-", "")
+                          [regex]$pattern = "azure-"
+                          $adjustedName = $pattern.replace("${{artifact.name}}", "", 1)
                           Write-Host "##vso[task.setvariable variable=Documentation.Zip]$adjustedName"
                         displayName: Set Documentation File Name
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml


### PR DESCRIPTION
artifact name for Opentelemetry-exporter-azure-monitor package is azure-opentelemetry-exporter-azure-monitor. Github docs release step replaces "azure-" to generate package name which is usually present as prefix only. Due to recent naming changes, monitor package has got "azure-" within package name also and this also got replaced which lead to invalid doc name to stage. Fix is to replace only first "azure-"