### PR TITLE
[Service Bus] Flaky test - Add delay to make sure the expiry time upon renewlock gets updated

### DIFF
--- a/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
+++ b/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
@@ -3,7 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ServiceBusMessage } from "../src";
+import { delay, ServiceBusMessage } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import { ServiceBusReceiver, ServiceBusReceiverImpl } from "../src/receivers/receiver";
 import { ServiceBusSender } from "../src/sender";
@@ -357,6 +357,7 @@ describe("Message settlement After Receiver is Closed - Through ManagementLink",
 
     let errorWasThrown = false;
     try {
+      await delay(2000); // Add a delay after receiving the messages to make sure the msg.lockedUntil gets updated after the renewlock operation
       const lockedUntilBeforeRenewlock = msg.lockedUntilUtc;
       const lockedUntilAfterRenewlock = await receiver.renewMessageLock(msg);
       should.equal(

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ServiceBusMessage } from "../src";
+import { delay, ServiceBusMessage } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
 import {
   createServiceBusClientForTests,
@@ -263,6 +263,7 @@ describe("Deferred Messages", () => {
     if (!sequenceNumber) {
       throw "Sequence Number can not be null";
     }
+    await delay(2000); // Add a delay after receiving the messages to make sure the msg.lockedUntil gets updated after the renewlock operation
     const lockedUntilBeforeRenewlock = deferredMsg.lockedUntilUtc;
     const lockedUntilAfterRenewlock = await receiver.renewMessageLock(deferredMsg);
     should.equal(


### PR DESCRIPTION
Hundreds of iterations of this test succeeded here https://github.com/Azure/azure-sdk-for-js/pull/13325