### PR TITLE
[Perf] Include running average in per-second output 

### DIFF
--- a/sdk/test-utils/ci.yml
+++ b/sdk/test-utils/ci.yml
@@ -29,3 +29,5 @@ extends:
     Artifacts:
       - name: azure-test-utils-recorder
         safeName: azuretestutilsrecorder
+      - name: azure-test-utils-perfstress
+        safeName: azuretestutilsperfstress

--- a/sdk/test-utils/ci.yml
+++ b/sdk/test-utils/ci.yml
@@ -29,5 +29,3 @@ extends:
     Artifacts:
       - name: azure-test-utils-recorder
         safeName: azuretestutilsrecorder
-      - name: azure-test-utils-perfstress
-        safeName: azuretestutilsperfstress

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@azure/test-utils-perfstress",
   "version": "1.0.0",
+  "sdk-type": "client",
   "description": "Performance and stress test framework for the Azure SDK for JavaScript and TypeScript",
   "main": "dist-esm/src/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -97,11 +97,17 @@ export class PerfStressProgram {
     const secondsPerOperation = 1 / operationsPerSecond;
     const weightedAverage = totalOperations / operationsPerSecond;
     console.log(
-      `Completed ${totalOperations.toLocaleString(undefined, { maximumFractionDigits: 0})} ` +
-      `operations in a weighted-average of ` +
-      `${weightedAverage.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2})}s ` +
-      `(${operationsPerSecond.toLocaleString(undefined, { maximumFractionDigits: 2})} ops/s, ` +
-      `${secondsPerOperation.toLocaleString(undefined, { maximumFractionDigits: 3, minimumFractionDigits: 3})} s/op)`
+      `Completed ${totalOperations.toLocaleString(undefined, { maximumFractionDigits: 0 })} ` +
+        `operations in a weighted-average of ` +
+        `${weightedAverage.toLocaleString(undefined, {
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2
+        })}s ` +
+        `(${operationsPerSecond.toLocaleString(undefined, { maximumFractionDigits: 2 })} ops/s, ` +
+        `${secondsPerOperation.toLocaleString(undefined, {
+          maximumFractionDigits: 3,
+          minimumFractionDigits: 3
+        })} s/op)`
     );
   }
 

--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -61,6 +61,10 @@ export class PerfStressProgram {
     }
   }
 
+  private getCompletedOperations(parallels: PerfStressParallel[]): number {
+    return parallels.reduce((sum, i) => sum + i.completedOperations, 0);
+  }
+
   /**
    * Does some calculations based on the parallel executions provided,
    * then logs them in a friendly way.
@@ -82,7 +86,7 @@ export class PerfStressProgram {
    * @param parallels Parallel executions
    */
   private logResults(parallels: PerfStressParallel[]): void {
-    const totalOperations = parallels.reduce((sum, i) => sum + i.completedOperations, 0);
+    const totalOperations = this.getCompletedOperations(parallels);
     const operationsPerSecond = parallels.reduce((sum, parallel) => {
       return sum + parallel.completedOperations / (parallel.lastMillisecondsElapsed / 1000);
     }, 0);
@@ -207,7 +211,7 @@ export class PerfStressProgram {
     console.log(`Since Last Log\t\tTotal`);
     let lastInIteration = 0;
     const logInterval = setInterval(() => {
-      const inTotal = parallels.reduce((sum, i) => sum + i.completedOperations, 0);
+      const inTotal = this.getCompletedOperations(parallels);
       const sinceLastLog = inTotal - lastInIteration;
       console.log(sinceLastLog + "\t\t\t" + inTotal);
       lastInIteration = inTotal;

--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -97,9 +97,11 @@ export class PerfStressProgram {
     const secondsPerOperation = 1 / operationsPerSecond;
     const weightedAverage = totalOperations / operationsPerSecond;
     console.log(
-      `Completed ${totalOperations} operations in a weighted-average of ${weightedAverage.toFixed(
-        2
-      )}s` + ` (${operationsPerSecond.toFixed(2)} ops/s, ${secondsPerOperation.toFixed(3)} s/op)`
+      `Completed ${totalOperations.toLocaleString(undefined, { maximumFractionDigits: 0})} ` +
+      `operations in a weighted-average of ` +
+      `${weightedAverage.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2})}s ` +
+      `(${operationsPerSecond.toLocaleString(undefined, { maximumFractionDigits: 2})} ops/s, ` +
+      `${secondsPerOperation.toLocaleString(undefined, { maximumFractionDigits: 3, minimumFractionDigits: 3})} s/op)`
     );
   }
 

--- a/sdk/test-utils/perfstress/src/program.ts
+++ b/sdk/test-utils/perfstress/src/program.ts
@@ -228,7 +228,7 @@ export class PerfStressProgram {
       const averageCompleted = this.getOperationsPerSecond(parallels);
 
       lastCompleted = totalCompleted;
-      console.log(`${totalCompleted}\t\t${currentCompleted}\t\t${averageCompleted.toFixed(2)}`);
+      console.log(`${currentCompleted}\t\t${totalCompleted}\t\t${averageCompleted.toFixed(2)}`);
     }, millisecondsToLog);
 
     const isAsync = !this.parsedDefaultOptions.sync.value;


### PR DESCRIPTION
Same change in .NET: Azure/azure-sdk-for-net#18071