### PR TITLE
Add windows pool reference to cosmos ci matrix

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -31,7 +31,8 @@ stages:
           TestSamples: false
           Matrix:
             Windows_Node8:
-              OSVmImage: "windows-2019"
+              Pool: azsdk-pool-mms-win-2019-general
+              OSVmImage: MMS2019
               NodeTestVersion: "8.x"
               TestType: "node"
           PreIntegrationSteps: cosmos-integration-public

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -15,7 +15,8 @@ extends:
     ArmTemplateParameters: "@{ enableHsm = $true }"
     Matrix:
       Linux Node 10 with Managed HSM:
-        OSVmImage: "ubuntu-18.04"
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
         TestType: "node"
         NodeTestVersion: "10.x"
     EnvVars:


### PR DESCRIPTION
This adds a missing reference to the new windows pool from our 1es hosted agents.