### PR TITLE
Increment version for monitor releases

### DIFF
--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
 ## 1.0.0-beta.2 (2021-01-20)
 
 - Ship the correct type declaration file
@@ -11,12 +13,6 @@
 - Rename package to `@azure/opentelemetry-exporter-azure-monitor`
 - [BREAKING] Deprecate all configuration options except for `connectionString`
 - [BREAKING] Removed support for `TelemetryProcessor`
-
-## 1.0.0-preview.6 (2020-10-09)
-
 - (internal) Migrate to autorest generated HttpClient and Envelope Interfaces
-
-## 1.0.0-preview.5 (2020-09-01)
-
 - Migrate to Azure SDK for JS repository
 - Adds support for Event Hubs Distributed Tracing [#10575](https://github.com/Azure/azure-sdk-for-js/pull/10575)

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/opentelemetry-exporter-azure-monitor",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/opentelemetry-exporter-azure-monitor/src/utils/constants/applicationinsights.ts
@@ -10,4 +10,4 @@ export const MS_LINKS = "_MS.links";
 export const INPROC = "InProc";
 export const ENQUEUED_TIME = "enqueuedTime";
 export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
-export const packageVersion = "1.0.0-beta.2";
+export const packageVersion = "1.0.0-beta.3";


### PR DESCRIPTION
Increment package version after release of azure-opentelemetry-exporter-azure-monitor

Merged the release notes for 1.0.0-preview.5 and 1.0.0-preview.6 into 1.0.0-beta.1 as the preview versions were not released under the current package name.