### PR TITLE
Upgrade V6 SDK Generator Version for Tables

### DIFF
--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -109,7 +109,7 @@ export interface GeoReplication {
 }
 
 // @public
-export type GeoReplicationStatusType = "live" | "bootstrap" | "unavailable" | string;
+export type GeoReplicationStatusType = string;
 
 // @public
 export interface GetAccessPolicyOptions extends coreHttp.OperationOptions {
@@ -173,6 +173,16 @@ export type GetTableEntityResponse<T extends object> = TableEntity<T> & {
         parsedHeaders: TableQueryEntitiesWithPartitionAndRowKeyHeaders;
     };
 };
+
+// @public
+export const enum KnownGeoReplicationStatusType {
+    // (undocumented)
+    Bootstrap = "bootstrap",
+    // (undocumented)
+    Live = "live",
+    // (undocumented)
+    Unavailable = "unavailable"
+}
 
 // @public
 export type ListEntitiesResponse<T extends object> = Array<TableEntity<T>> & {
@@ -355,15 +365,6 @@ export interface TableCreateHeaders {
 }
 
 // @public
-export interface TableCreateHeaders {
-    clientRequestId?: string;
-    date?: Date;
-    preferenceApplied?: string;
-    requestId?: string;
-    version?: string;
-}
-
-// @public
 export interface TableDeleteEntityHeaders {
     clientRequestId?: string;
     date?: Date;
@@ -411,17 +412,6 @@ export type TableEntityResult<T> = T & {
 export interface TableGetAccessPolicyHeaders {
     clientRequestId?: string;
     date?: Date;
-    requestId?: string;
-    version?: string;
-}
-
-// @public
-export interface TableInsertEntityHeaders {
-    clientRequestId?: string;
-    contentType?: string;
-    date?: Date;
-    etag?: string;
-    preferenceApplied?: string;
     requestId?: string;
     version?: string;
 }

--- a/sdk/tables/data-tables/src/generated/generatedClient.ts
+++ b/sdk/tables/data-tables/src/generated/generatedClient.ts
@@ -10,6 +10,7 @@ import { Table, Service } from "./operations";
 import { GeneratedClientContext } from "./generatedClientContext";
 import { GeneratedClientOptionalParams } from "./models";
 
+/** @hidden */
 export class GeneratedClient extends GeneratedClientContext {
   /**
    * Initializes a new instance of the GeneratedClient class.

--- a/sdk/tables/data-tables/src/generated/generatedClientContext.ts
+++ b/sdk/tables/data-tables/src/generated/generatedClientContext.ts
@@ -12,6 +12,7 @@ import { GeneratedClientOptionalParams } from "./models";
 const packageName = "@azure/data-tables";
 const packageVersion = "1.0.0-beta.5";
 
+/** @hidden */
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   url: string;
   version: string;

--- a/sdk/tables/data-tables/src/generated/models/index.ts
+++ b/sdk/tables/data-tables/src/generated/models/index.ts
@@ -8,1403 +8,818 @@
 
 import * as coreHttp from "@azure/core-http";
 
-/**
- * The properties for the table query response.
- */
+/** The properties for the table query response. */
 export interface TableQueryResponse {
-  /**
-   * The metadata response of the table.
-   */
+  /** The metadata response of the table. */
   odataMetadata?: string;
-  /**
-   * List of tables.
-   */
+  /** List of tables. */
   value?: TableResponseProperties[];
 }
 
-/**
- * The properties for the table response.
- */
+/** The properties for the table response. */
 export interface TableResponseProperties {
-  /**
-   * The name of the table.
-   */
+  /** The name of the table. */
   tableName?: string;
-  /**
-   * The odata type of the table.
-   */
+  /** The odata type of the table. */
   odataType?: string;
-  /**
-   * The id of the table.
-   */
+  /** The id of the table. */
   odataId?: string;
-  /**
-   * The edit link of the table.
-   */
+  /** The edit link of the table. */
   odataEditLink?: string;
 }
 
-/**
- * Table Service error.
- */
+/** Table Service error. */
 export interface TableServiceError {
-  /**
-   * The odata error.
-   */
+  /** The odata error. */
   odataError?: TableServiceErrorOdataError;
 }
 
-/**
- * The odata error.
- */
+/** The odata error. */
 export interface TableServiceErrorOdataError {
-  /**
-   * The service error code. The error codes possible are listed in: https://docs.microsoft.com/rest/api/storageservices/table-service-error-codes
-   */
+  /** The service error code. The error codes possible are listed in: https://docs.microsoft.com/rest/api/storageservices/table-service-error-codes */
   code?: string;
-  /**
-   * The service error message.
-   */
+  /** The service error message. */
   message?: TableServiceErrorOdataErrorMessage;
 }
 
-/**
- * The service error message.
- */
+/** The service error message. */
 export interface TableServiceErrorOdataErrorMessage {
-  /**
-   * Language code of the error message.
-   */
+  /** Language code of the error message. */
   lang?: string;
-  /**
-   * The error message.
-   */
+  /** The error message. */
   value?: string;
 }
 
-/**
- * The properties for creating a table.
- */
+/** The properties for creating a table. */
 export interface TableProperties {
-  /**
-   * The name of the table to create.
-   */
+  /** The name of the table to create. */
   tableName?: string;
 }
 
-/**
- * The properties for the table entity query response.
- */
+/** The properties for the table entity query response. */
 export interface TableEntityQueryResponse {
-  /**
-   * The metadata response of the table.
-   */
+  /** The metadata response of the table. */
   odataMetadata?: string;
-  /**
-   * List of table entities.
-   */
+  /** List of table entities. */
   value?: { [propertyName: string]: any }[];
 }
 
-/**
- * A signed identifier.
- */
+/** A signed identifier. */
 export interface SignedIdentifier {
-  /**
-   * A unique id.
-   */
+  /** A unique id. */
   id: string;
-  /**
-   * The access policy.
-   */
+  /** The access policy. */
   accessPolicy: AccessPolicy;
 }
 
-/**
- * An Access policy.
- */
+/** An Access policy. */
 export interface AccessPolicy {
-  /**
-   * The start datetime from which the policy is active.
-   */
+  /** The start datetime from which the policy is active. */
   start: Date;
-  /**
-   * The datetime that the policy expires.
-   */
+  /** The datetime that the policy expires. */
   expiry: Date;
-  /**
-   * The permissions for the acl policy.
-   */
+  /** The permissions for the acl policy. */
   permission: string;
 }
 
-/**
- * Table Service Properties.
- */
+/** Table Service Properties. */
 export interface TableServiceProperties {
-  /**
-   * Azure Analytics Logging settings.
-   */
+  /** Azure Analytics Logging settings. */
   logging?: Logging;
-  /**
-   * A summary of request statistics grouped by API in hourly aggregates for tables.
-   */
+  /** A summary of request statistics grouped by API in hourly aggregates for tables. */
   hourMetrics?: Metrics;
-  /**
-   * A summary of request statistics grouped by API in minute aggregates for tables.
-   */
+  /** A summary of request statistics grouped by API in minute aggregates for tables. */
   minuteMetrics?: Metrics;
-  /**
-   * The set of CORS rules.
-   */
+  /** The set of CORS rules. */
   cors?: CorsRule[];
 }
 
-/**
- * Azure Analytics Logging settings.
- */
+/** Azure Analytics Logging settings. */
 export interface Logging {
-  /**
-   * The version of Analytics to configure.
-   */
+  /** The version of Analytics to configure. */
   version: string;
-  /**
-   * Indicates whether all delete requests should be logged.
-   */
+  /** Indicates whether all delete requests should be logged. */
   delete: boolean;
-  /**
-   * Indicates whether all read requests should be logged.
-   */
+  /** Indicates whether all read requests should be logged. */
   read: boolean;
-  /**
-   * Indicates whether all write requests should be logged.
-   */
+  /** Indicates whether all write requests should be logged. */
   write: boolean;
-  /**
-   * The retention policy.
-   */
+  /** The retention policy. */
   retentionPolicy: RetentionPolicy;
 }
 
-/**
- * The retention policy.
- */
+/** The retention policy. */
 export interface RetentionPolicy {
-  /**
-   * Indicates whether a retention policy is enabled for the service.
-   */
+  /** Indicates whether a retention policy is enabled for the service. */
   enabled: boolean;
-  /**
-   * Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted.
-   */
+  /** Indicates the number of days that metrics or logging or soft-deleted data should be retained. All data older than this value will be deleted. */
   days?: number;
 }
 
-/**
- * A summary of request statistics grouped by API
- */
+/** A summary of request statistics grouped by API */
 export interface Metrics {
-  /**
-   * The version of Analytics to configure.
-   */
+  /** The version of Analytics to configure. */
   version?: string;
-  /**
-   * Indicates whether metrics are enabled for the Table service.
-   */
+  /** Indicates whether metrics are enabled for the Table service. */
   enabled: boolean;
-  /**
-   * Indicates whether metrics should generate summary statistics for called API operations.
-   */
+  /** Indicates whether metrics should generate summary statistics for called API operations. */
   includeAPIs?: boolean;
-  /**
-   * The retention policy.
-   */
+  /** The retention policy. */
   retentionPolicy?: RetentionPolicy;
 }
 
-/**
- * CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain.
- */
+/** CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain. */
 export interface CorsRule {
-  /**
-   * The origin domains that are permitted to make a request against the service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS.
-   */
+  /** The origin domains that are permitted to make a request against the service via CORS. The origin domain is the domain from which the request originates. Note that the origin must be an exact case-sensitive match with the origin that the user age sends to the service. You can also use the wildcard character '*' to allow all origin domains to make requests via CORS. */
   allowedOrigins: string;
-  /**
-   * The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated)
-   */
+  /** The methods (HTTP request verbs) that the origin domain may use for a CORS request. (comma separated) */
   allowedMethods: string;
-  /**
-   * The request headers that the origin domain may specify on the CORS request.
-   */
+  /** The request headers that the origin domain may specify on the CORS request. */
   allowedHeaders: string;
-  /**
-   * The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer.
-   */
+  /** The response headers that may be sent in the response to the CORS request and exposed by the browser to the request issuer. */
   exposedHeaders: string;
-  /**
-   * The maximum amount time that a browser should cache the preflight OPTIONS request.
-   */
+  /** The maximum amount time that a browser should cache the preflight OPTIONS request. */
   maxAgeInSeconds: number;
 }
 
-/**
- * Stats for the service.
- */
+/** Stats for the service. */
 export interface TableServiceStats {
-  /**
-   * Geo-Replication information for the Secondary Storage Service.
-   */
+  /** Geo-Replication information for the Secondary Storage Service. */
   geoReplication?: GeoReplication;
 }
 
-/**
- * Geo-Replication information for the Secondary Storage Service
- */
+/** Geo-Replication information for the Secondary Storage Service */
 export interface GeoReplication {
-  /**
-   * The status of the secondary location.
-   */
+  /** The status of the secondary location. */
   status: GeoReplicationStatusType;
-  /**
-   * A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.
-   */
+  /** A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads. */
   lastSyncTime: Date;
 }
 
-/**
- * The response for a single table.
- */
+/** The response for a single table. */
 export type TableResponse = TableResponseProperties & {
-  /**
-   * The metadata response of the table.
-   */
+  /** The metadata response of the table. */
   odataMetadata?: string;
 };
 
-/**
- * Defines headers for Table_query operation.
- */
+/** Defines headers for Table_query operation. */
 export interface TableQueryHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * This header contains the continuation token value.
-   */
+  /** This header contains the continuation token value. */
   xMsContinuationNextTableName?: string;
 }
 
-/**
- * Defines headers for Table_query operation.
- */
+/** Defines headers for Table_query operation. */
 export interface TableQueryExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_create operation.
- */
+/** Defines headers for Table_create operation. */
 export interface TableCreateHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content.
-   */
+  /** Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content. */
   preferenceApplied?: string;
 }
 
-/**
- * Defines headers for Table_create operation.
- */
-export interface TableCreateHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
-  clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
-  requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
-  version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
-  date?: Date;
-  /**
-   * Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content.
-   */
-  preferenceApplied?: string;
-}
-
-/**
- * Defines headers for Table_create operation.
- */
+/** Defines headers for Table_create operation. */
 export interface TableCreateExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_delete operation.
- */
+/** Defines headers for Table_delete operation. */
 export interface TableDeleteHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
 }
 
-/**
- * Defines headers for Table_delete operation.
- */
+/** Defines headers for Table_delete operation. */
 export interface TableDeleteExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_queryEntities operation.
- */
+/** Defines headers for Table_queryEntities operation. */
 export interface TableQueryEntitiesHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * This header contains the continuation token value for partition key.
-   */
+  /** This header contains the continuation token value for partition key. */
   xMsContinuationNextPartitionKey?: string;
-  /**
-   * This header contains the continuation token value for row key.
-   */
+  /** This header contains the continuation token value for row key. */
   xMsContinuationNextRowKey?: string;
 }
 
-/**
- * Defines headers for Table_queryEntities operation.
- */
+/** Defines headers for Table_queryEntities operation. */
 export interface TableQueryEntitiesExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_queryEntitiesWithPartitionAndRowKey operation.
- */
+/** Defines headers for Table_queryEntitiesWithPartitionAndRowKey operation. */
 export interface TableQueryEntitiesWithPartitionAndRowKeyHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated */
   etag?: string;
-  /**
-   * This header contains the continuation token value for partition key.
-   */
+  /** This header contains the continuation token value for partition key. */
   xMsContinuationNextPartitionKey?: string;
-  /**
-   * This header contains the continuation token value for row key.
-   */
+  /** This header contains the continuation token value for row key. */
   xMsContinuationNextRowKey?: string;
 }
 
-/**
- * Defines headers for Table_queryEntitiesWithPartitionAndRowKey operation.
- */
+/** Defines headers for Table_queryEntitiesWithPartitionAndRowKey operation. */
 export interface TableQueryEntitiesWithPartitionAndRowKeyExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_updateEntity operation.
- */
+/** Defines headers for Table_updateEntity operation. */
 export interface TableUpdateEntityHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the entity was last updated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the entity was last updated. */
   etag?: string;
 }
 
-/**
- * Defines headers for Table_updateEntity operation.
- */
+/** Defines headers for Table_updateEntity operation. */
 export interface TableUpdateEntityExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_mergeEntity operation.
- */
+/** Defines headers for Table_mergeEntity operation. */
 export interface TableMergeEntityHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the entity was last updated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the entity was last updated. */
   etag?: string;
 }
 
-/**
- * Defines headers for Table_mergeEntity operation.
- */
+/** Defines headers for Table_mergeEntity operation. */
 export interface TableMergeEntityExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_deleteEntity operation.
- */
+/** Defines headers for Table_deleteEntity operation. */
 export interface TableDeleteEntityHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
 }
 
-/**
- * Defines headers for Table_deleteEntity operation.
- */
+/** Defines headers for Table_deleteEntity operation. */
 export interface TableDeleteEntityExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_insertEntity operation.
- */
+/** Defines headers for Table_insertEntity operation. */
 export interface TableInsertEntityHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the entity was last updated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the entity was last updated. */
   etag?: string;
-  /**
-   * Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content.
-   */
+  /** Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content. */
   preferenceApplied?: string;
-  /**
-   * Indicates the content type of the payload. The value depends on the value specified for the Accept request header.
-   */
+  /** Indicates the content type of the payload. The value depends on the value specified for the Accept request header. */
   contentType?: string;
 }
 
-/**
- * Defines headers for Table_insertEntity operation.
- */
-export interface TableInsertEntityHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
-  clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
-  requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
-  version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
-  date?: Date;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the entity was last updated.
-   */
-  etag?: string;
-  /**
-   * Indicates whether the Prefer request header was honored. If the response does not include this header, then the Prefer header was not honored. If this header is returned, its value will either be return-content or return-no-content.
-   */
-  preferenceApplied?: string;
-  /**
-   * Indicates the content type of the payload. The value depends on the value specified for the Accept request header.
-   */
-  contentType?: string;
-}
-
-/**
- * Defines headers for Table_insertEntity operation.
- */
+/** Defines headers for Table_insertEntity operation. */
 export interface TableInsertEntityExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_getAccessPolicy operation.
- */
+/** Defines headers for Table_getAccessPolicy operation. */
 export interface TableGetAccessPolicyHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
 }
 
-/**
- * Defines headers for Table_getAccessPolicy operation.
- */
+/** Defines headers for Table_getAccessPolicy operation. */
 export interface TableGetAccessPolicyExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Table_setAccessPolicy operation.
- */
+/** Defines headers for Table_setAccessPolicy operation. */
 export interface TableSetAccessPolicyHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
 }
 
-/**
- * Defines headers for Table_setAccessPolicy operation.
- */
+/** Defines headers for Table_setAccessPolicy operation. */
 export interface TableSetAccessPolicyExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Service_setProperties operation.
- */
+/** Defines headers for Service_setProperties operation. */
 export interface ServiceSetPropertiesHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
 }
 
-/**
- * Defines headers for Service_setProperties operation.
- */
+/** Defines headers for Service_setProperties operation. */
 export interface ServiceSetPropertiesExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Service_getProperties operation.
- */
+/** Defines headers for Service_getProperties operation. */
 export interface ServiceGetPropertiesHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
 }
 
-/**
- * Defines headers for Service_getProperties operation.
- */
+/** Defines headers for Service_getProperties operation. */
 export interface ServiceGetPropertiesExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Defines headers for Service_getStatistics operation.
- */
+/** Defines headers for Service_getStatistics operation. */
 export interface ServiceGetStatisticsHeaders {
-  /**
-   * If a client request id header is sent in the request, this header will be present in the response with the same value.
-   */
+  /** If a client request id header is sent in the request, this header will be present in the response with the same value. */
   clientRequestId?: string;
-  /**
-   * This header uniquely identifies the request that was made and can be used for troubleshooting the request.
-   */
+  /** This header uniquely identifies the request that was made and can be used for troubleshooting the request. */
   requestId?: string;
-  /**
-   * Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
-   */
+  /** Indicates the version of the Table service used to execute the request. This header is returned for requests made against version 2009-09-19 and above. */
   version?: string;
-  /**
-   * UTC date/time value generated by the service that indicates the time at which the response was initiated.
-   */
+  /** UTC date/time value generated by the service that indicates the time at which the response was initiated. */
   date?: Date;
 }
 
-/**
- * Defines headers for Service_getStatistics operation.
- */
+/** Defines headers for Service_getStatistics operation. */
 export interface ServiceGetStatisticsExceptionHeaders {
   errorCode?: string;
 }
 
-/**
- * Parameter group
- */
+/** Parameter group */
 export interface QueryOptions {
-  /**
-   * Specifies the media type for the response.
-   */
+  /** Specifies the media type for the response. */
   format?: OdataMetadataFormat;
-  /**
-   * Maximum number of records to return.
-   */
+  /** Maximum number of records to return. */
   top?: number;
-  /**
-   * Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId, ResourceId".
-   */
+  /** Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId, ResourceId". */
   select?: string;
-  /**
-   * OData filter expression.
-   */
+  /** OData filter expression. */
   filter?: string;
 }
 
-/**
- * Defines values for OdataMetadataFormat.
- */
-export type OdataMetadataFormat =
-  | "application/json;odata=nometadata"
-  | "application/json;odata=minimalmetadata"
-  | "application/json;odata=fullmetadata"
-  | string;
-/**
- * Defines values for ResponseFormat.
- */
-export type ResponseFormat = "return-no-content" | "return-content" | string;
-/**
- * Defines values for GeoReplicationStatusType.
- */
-export type GeoReplicationStatusType =
-  | "live"
-  | "bootstrap"
-  | "unavailable"
-  | string;
-
-/**
- * Optional parameters.
- */
-export interface TableQueryOptionalParams extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
-  queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
-  requestId?: string;
-  /**
-   * A table query continuation token from a previous call.
-   */
-  nextTableName?: string;
+/** Known values of {@link OdataMetadataFormat} that the service accepts. */
+export const enum KnownOdataMetadataFormat {
+  ApplicationJsonOdataNometadata = "application/json;odata=nometadata",
+  ApplicationJsonOdataMinimalmetadata = "application/json;odata=minimalmetadata",
+  ApplicationJsonOdataFullmetadata = "application/json;odata=fullmetadata"
 }
 
 /**
- * Contains response data for the query operation.
+ * Defines values for OdataMetadataFormat. \
+ * {@link KnownOdataMetadataFormat} can be used interchangeably with OdataMetadataFormat,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **application/json;odata=nometadata** \
+ * **application/json;odata=minimalmetadata** \
+ * **application/json;odata=fullmetadata**
  */
+export type OdataMetadataFormat = string;
+
+/** Known values of {@link ResponseFormat} that the service accepts. */
+export const enum KnownResponseFormat {
+  ReturnNoContent = "return-no-content",
+  ReturnContent = "return-content"
+}
+
+/**
+ * Defines values for ResponseFormat. \
+ * {@link KnownResponseFormat} can be used interchangeably with ResponseFormat,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **return-no-content** \
+ * **return-content**
+ */
+export type ResponseFormat = string;
+
+/** Known values of {@link GeoReplicationStatusType} that the service accepts. */
+export const enum KnownGeoReplicationStatusType {
+  Live = "live",
+  Bootstrap = "bootstrap",
+  Unavailable = "unavailable"
+}
+
+/**
+ * Defines values for GeoReplicationStatusType. \
+ * {@link KnownGeoReplicationStatusType} can be used interchangeably with GeoReplicationStatusType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **live** \
+ * **bootstrap** \
+ * **unavailable**
+ */
+export type GeoReplicationStatusType = string;
+
+/** Optional parameters. */
+export interface TableQueryOptionalParams extends coreHttp.OperationOptions {
+  /** Parameter group */
+  queryOptions?: QueryOptions;
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
+  requestId?: string;
+  /** A table query continuation token from a previous call. */
+  nextTableName?: string;
+}
+
+/** Contains response data for the query operation. */
 export type TableQueryOperationResponse = TableQueryHeaders &
   TableQueryResponse & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: TableQueryResponse;
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: TableQueryHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableCreateOptionalParams extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content and return-content.
-   */
+  /** Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content and return-content. */
   responsePreference?: ResponseFormat;
 }
 
-/**
- * Contains response data for the create operation.
- */
+/** Contains response data for the create operation. */
 export type TableCreateResponse = TableCreateHeaders &
   TableResponse & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: TableResponse;
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: TableCreateHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableDeleteOptionalParams extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
 }
 
-/**
- * Contains response data for the delete operation.
- */
+/** Contains response data for the delete operation. */
 export type TableDeleteResponse = TableDeleteHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableDeleteHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableQueryEntitiesOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
-  /**
-   * An entity query continuation token from a previous call.
-   */
+  /** An entity query continuation token from a previous call. */
   nextPartitionKey?: string;
-  /**
-   * An entity query continuation token from a previous call.
-   */
+  /** An entity query continuation token from a previous call. */
   nextRowKey?: string;
 }
 
-/**
- * Contains response data for the queryEntities operation.
- */
+/** Contains response data for the queryEntities operation. */
 export type TableQueryEntitiesResponse = TableQueryEntitiesHeaders &
   TableEntityQueryResponse & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: TableEntityQueryResponse;
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: TableQueryEntitiesHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableQueryEntitiesWithPartitionAndRowKeyOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the queryEntitiesWithPartitionAndRowKey operation.
- */
+/** Contains response data for the queryEntitiesWithPartitionAndRowKey operation. */
 export type TableQueryEntitiesWithPartitionAndRowKeyResponse = TableQueryEntitiesWithPartitionAndRowKeyHeaders & {
   [propertyName: string]: any;
 } & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
+    /** The response body as text (string format) */
     bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
+    /** The response body as parsed JSON or XML */
     parsedBody: { [propertyName: string]: any };
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableQueryEntitiesWithPartitionAndRowKeyHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableUpdateEntityOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
-  /**
-   * The properties for the table entity.
-   */
+  /** The properties for the table entity. */
   tableEntityProperties?: { [propertyName: string]: any };
-  /**
-   * Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found.
-   */
+  /** Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found. */
   ifMatch?: string;
 }
 
-/**
- * Contains response data for the updateEntity operation.
- */
+/** Contains response data for the updateEntity operation. */
 export type TableUpdateEntityResponse = TableUpdateEntityHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableUpdateEntityHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableMergeEntityOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
-  /**
-   * The properties for the table entity.
-   */
+  /** The properties for the table entity. */
   tableEntityProperties?: { [propertyName: string]: any };
-  /**
-   * Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a merge will be performed if an existing entity is found.
-   */
+  /** Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a merge will be performed if an existing entity is found. */
   ifMatch?: string;
 }
 
-/**
- * Contains response data for the mergeEntity operation.
- */
+/** Contains response data for the mergeEntity operation. */
 export type TableMergeEntityResponse = TableMergeEntityHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableMergeEntityHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableDeleteEntityOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the deleteEntity operation.
- */
+/** Contains response data for the deleteEntity operation. */
 export type TableDeleteEntityResponse = TableDeleteEntityHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableDeleteEntityHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableInsertEntityOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Parameter group
-   */
+  /** Parameter group */
   queryOptions?: QueryOptions;
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content and return-content.
-   */
+  /** Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content and return-content. */
   responsePreference?: ResponseFormat;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
-  /**
-   * The properties for the table entity.
-   */
+  /** The properties for the table entity. */
   tableEntityProperties?: { [propertyName: string]: any };
 }
 
-/**
- * Contains response data for the insertEntity operation.
- */
+/** Contains response data for the insertEntity operation. */
 export type TableInsertEntityResponse = TableInsertEntityHeaders & {
   [propertyName: string]: any;
 } & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
+    /** The response body as text (string format) */
     bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
+    /** The response body as parsed JSON or XML */
     parsedBody: { [propertyName: string]: any };
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableInsertEntityHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableGetAccessPolicyOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the getAccessPolicy operation.
- */
+/** Contains response data for the getAccessPolicy operation. */
 export type TableGetAccessPolicyResponse = TableGetAccessPolicyHeaders &
   SignedIdentifier[] & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: SignedIdentifier[];
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: TableGetAccessPolicyHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface TableSetAccessPolicyOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
-  /**
-   * The acls for the table.
-   */
+  /** The acls for the table. */
   tableAcl?: SignedIdentifier[];
 }
 
-/**
- * Contains response data for the setAccessPolicy operation.
- */
+/** Contains response data for the setAccessPolicy operation. */
 export type TableSetAccessPolicyResponse = TableSetAccessPolicyHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: TableSetAccessPolicyHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface ServiceSetPropertiesOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the setProperties operation.
- */
+/** Contains response data for the setProperties operation. */
 export type ServiceSetPropertiesResponse = ServiceSetPropertiesHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
+  /** The underlying HTTP response. */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
+    /** The parsed HTTP response headers. */
     parsedHeaders: ServiceSetPropertiesHeaders;
   };
 };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface ServiceGetPropertiesOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the getProperties operation.
- */
+/** Contains response data for the getProperties operation. */
 export type ServiceGetPropertiesResponse = ServiceGetPropertiesHeaders &
   TableServiceProperties & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: TableServiceProperties;
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: ServiceGetPropertiesHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface ServiceGetStatisticsOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
-   */
+  /** Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled. */
   requestId?: string;
-  /**
-   * The timeout parameter is expressed in seconds.
-   */
+  /** The timeout parameter is expressed in seconds. */
   timeout?: number;
 }
 
-/**
- * Contains response data for the getStatistics operation.
- */
+/** Contains response data for the getStatistics operation. */
 export type ServiceGetStatisticsResponse = ServiceGetStatisticsHeaders &
   TableServiceStats & {
-    /**
-     * The underlying HTTP response.
-     */
+    /** The underlying HTTP response. */
     _response: coreHttp.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
+      /** The response body as text (string format) */
       bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
+      /** The response body as parsed JSON or XML */
       parsedBody: TableServiceStats;
-      /**
-       * The parsed HTTP response headers.
-       */
+      /** The parsed HTTP response headers. */
       parsedHeaders: ServiceGetStatisticsHeaders;
     };
   };
 
-/**
- * Optional parameters.
- */
+/** Optional parameters. */
 export interface GeneratedClientOptionalParams
   extends coreHttp.ServiceClientOptions {
-  /**
-   * Specifies the version of the operation to use for this request.
-   */
+  /** Specifies the version of the operation to use for this request. */
   version?: string;
-  /**
-   * Overrides client endpoint.
-   */
+  /** Overrides client endpoint. */
   endpoint?: string;
 }

--- a/sdk/tables/data-tables/src/generated/models/mappers.ts
+++ b/sdk/tables/data-tables/src/generated/models/mappers.ts
@@ -28,7 +28,10 @@ export const TableQueryResponse: coreHttp.CompositeMapper = {
         type: {
           name: "Sequence",
           element: {
-            type: { name: "Composite", className: "TableResponseProperties" }
+            type: {
+              name: "Composite",
+              className: "TableResponseProperties"
+            }
           }
         }
       }
@@ -178,7 +181,10 @@ export const TableEntityQueryResponse: coreHttp.CompositeMapper = {
         type: {
           name: "Sequence",
           element: {
-            type: { name: "Dictionary", value: { type: { name: "any" } } }
+            type: {
+              name: "Dictionary",
+              value: { type: { name: "any" } }
+            }
           }
         }
       }
@@ -286,7 +292,12 @@ export const TableServiceProperties: coreHttp.CompositeMapper = {
         xmlElementName: "CorsRule",
         type: {
           name: "Sequence",
-          element: { type: { name: "Composite", className: "CorsRule" } }
+          element: {
+            type: {
+              name: "Composite",
+              className: "CorsRule"
+            }
+          }
         }
       }
     }
@@ -453,7 +464,9 @@ export const CorsRule: coreHttp.CompositeMapper = {
         }
       },
       maxAgeInSeconds: {
-        constraints: {},
+        constraints: {
+          InclusiveMinimum: 0
+        },
         serializedName: "MaxAgeInSeconds",
         required: true,
         xmlName: "MaxAgeInSeconds",

--- a/sdk/tables/data-tables/src/generated/models/parameters.ts
+++ b/sdk/tables/data-tables/src/generated/models/parameters.ts
@@ -90,7 +90,9 @@ export const format: OperationQueryParameter = {
 export const top: OperationQueryParameter = {
   parameterPath: ["options", "queryOptions", "top"],
   mapper: {
-    constraints: {},
+    constraints: {
+      InclusiveMinimum: 0
+    },
     serializedName: "$top",
     xmlName: "$top",
     type: {
@@ -149,18 +151,6 @@ export const tableProperties: OperationParameter = {
   mapper: TablePropertiesMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json;odata=minimalmetadata",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const responsePreference: OperationParameter = {
   parameterPath: ["options", "responsePreference"],
   mapper: {
@@ -172,7 +162,7 @@ export const responsePreference: OperationParameter = {
   }
 };
 
-export const accept2: OperationParameter = {
+export const accept1: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/json",
@@ -199,7 +189,9 @@ export const table: OperationURLParameter = {
 export const timeout: OperationQueryParameter = {
   parameterPath: ["options", "timeout"],
   mapper: {
-    constraints: {},
+    constraints: {
+      InclusiveMinimum: 0
+    },
     serializedName: "timeout",
     xmlName: "timeout",
     type: {
@@ -278,18 +270,6 @@ export const tableEntityProperties: OperationParameter = {
   }
 };
 
-export const accept3: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const ifMatch: OperationParameter = {
   parameterPath: ["options", "ifMatch"],
   mapper: {
@@ -313,7 +293,7 @@ export const ifMatch1: OperationParameter = {
   }
 };
 
-export const accept4: OperationParameter = {
+export const accept2: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/xml",
@@ -358,12 +338,17 @@ export const tableAcl: OperationParameter = {
     xmlElementName: "SignedIdentifier",
     type: {
       name: "Sequence",
-      element: { type: { name: "Composite", className: "SignedIdentifier" } }
+      element: {
+        type: {
+          name: "Composite",
+          className: "SignedIdentifier"
+        }
+      }
     }
   }
 };
 
-export const accept5: OperationParameter = {
+export const accept3: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/xml",

--- a/sdk/tables/data-tables/src/generated/operations/service.ts
+++ b/sdk/tables/data-tables/src/generated/operations/service.ts
@@ -20,9 +20,7 @@ import {
   ServiceGetStatisticsResponse
 } from "../models";
 
-/**
- * Class representing a Service.
- */
+/** Class representing a Service. */
 export class Service {
   private readonly client: GeneratedClient;
 
@@ -44,11 +42,12 @@ export class Service {
     tableServiceProperties: TableServiceProperties,
     options?: ServiceSetPropertiesOptionalParams
   ): Promise<ServiceSetPropertiesResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      tableServiceProperties,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { tableServiceProperties, options: operationOptions },
+      operationArguments,
       setPropertiesOperationSpec
     ) as Promise<ServiceSetPropertiesResponse>;
   }
@@ -61,11 +60,11 @@ export class Service {
   getProperties(
     options?: ServiceGetPropertiesOptionalParams
   ): Promise<ServiceGetPropertiesResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { options: operationOptions },
+      operationArguments,
       getPropertiesOperationSpec
     ) as Promise<ServiceGetPropertiesResponse>;
   }
@@ -78,17 +77,16 @@ export class Service {
   getStatistics(
     options?: ServiceGetStatisticsOptionalParams
   ): Promise<ServiceGetStatisticsResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { options: operationOptions },
+      operationArguments,
       getStatisticsOperationSpec
     ) as Promise<ServiceGetStatisticsResponse>;
   }
 }
 // Operation Specifications
-
 const xmlSerializer = new coreHttp.Serializer(Mappers, /* isXml */ true);
 
 const setPropertiesOperationSpec: coreHttp.OperationSpec = {
@@ -110,7 +108,7 @@ const setPropertiesOperationSpec: coreHttp.OperationSpec = {
     Parameters.version,
     Parameters.requestId,
     Parameters.contentType2,
-    Parameters.accept5
+    Parameters.accept3
   ],
   isXML: true,
   contentType: "application/xml; charset=utf-8",
@@ -135,7 +133,7 @@ const getPropertiesOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [
     Parameters.version,
     Parameters.requestId,
-    Parameters.accept4
+    Parameters.accept2
   ],
   isXML: true,
   serializer: xmlSerializer
@@ -158,7 +156,7 @@ const getStatisticsOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [
     Parameters.version,
     Parameters.requestId,
-    Parameters.accept4
+    Parameters.accept2
   ],
   isXML: true,
   serializer: xmlSerializer

--- a/sdk/tables/data-tables/src/generated/operations/service.ts
+++ b/sdk/tables/data-tables/src/generated/operations/service.ts
@@ -21,6 +21,7 @@ import {
 } from "../models";
 
 /** Class representing a Service. */
+/** @hidden */
 export class Service {
   private readonly client: GeneratedClient;
 

--- a/sdk/tables/data-tables/src/generated/operations/table.ts
+++ b/sdk/tables/data-tables/src/generated/operations/table.ts
@@ -36,9 +36,7 @@ import {
   TableSetAccessPolicyResponse
 } from "../models";
 
-/**
- * Class representing a Table.
- */
+/** Class representing a Table. */
 export class Table {
   private readonly client: GeneratedClient;
 
@@ -57,11 +55,11 @@ export class Table {
   query(
     options?: TableQueryOptionalParams
   ): Promise<TableQueryOperationResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { options: operationOptions },
+      operationArguments,
       queryOperationSpec
     ) as Promise<TableQueryOperationResponse>;
   }
@@ -75,11 +73,12 @@ export class Table {
     tableProperties: TableProperties,
     options?: TableCreateOptionalParams
   ): Promise<TableCreateResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      tableProperties,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { tableProperties, options: operationOptions },
+      operationArguments,
       createOperationSpec
     ) as Promise<TableCreateResponse>;
   }
@@ -93,11 +92,12 @@ export class Table {
     table: string,
     options?: TableDeleteOptionalParams
   ): Promise<TableDeleteResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, options: operationOptions },
+      operationArguments,
       deleteOperationSpec
     ) as Promise<TableDeleteResponse>;
   }
@@ -111,11 +111,12 @@ export class Table {
     table: string,
     options?: TableQueryEntitiesOptionalParams
   ): Promise<TableQueryEntitiesResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, options: operationOptions },
+      operationArguments,
       queryEntitiesOperationSpec
     ) as Promise<TableQueryEntitiesResponse>;
   }
@@ -133,11 +134,14 @@ export class Table {
     rowKey: string,
     options?: TableQueryEntitiesWithPartitionAndRowKeyOptionalParams
   ): Promise<TableQueryEntitiesWithPartitionAndRowKeyResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      partitionKey,
+      rowKey,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, partitionKey, rowKey, options: operationOptions },
+      operationArguments,
       queryEntitiesWithPartitionAndRowKeyOperationSpec
     ) as Promise<TableQueryEntitiesWithPartitionAndRowKeyResponse>;
   }
@@ -155,11 +159,14 @@ export class Table {
     rowKey: string,
     options?: TableUpdateEntityOptionalParams
   ): Promise<TableUpdateEntityResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      partitionKey,
+      rowKey,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, partitionKey, rowKey, options: operationOptions },
+      operationArguments,
       updateEntityOperationSpec
     ) as Promise<TableUpdateEntityResponse>;
   }
@@ -177,11 +184,14 @@ export class Table {
     rowKey: string,
     options?: TableMergeEntityOptionalParams
   ): Promise<TableMergeEntityResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      partitionKey,
+      rowKey,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, partitionKey, rowKey, options: operationOptions },
+      operationArguments,
       mergeEntityOperationSpec
     ) as Promise<TableMergeEntityResponse>;
   }
@@ -203,11 +213,15 @@ export class Table {
     ifMatch: string,
     options?: TableDeleteEntityOptionalParams
   ): Promise<TableDeleteEntityResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      partitionKey,
+      rowKey,
+      ifMatch,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, partitionKey, rowKey, ifMatch, options: operationOptions },
+      operationArguments,
       deleteEntityOperationSpec
     ) as Promise<TableDeleteEntityResponse>;
   }
@@ -221,11 +235,12 @@ export class Table {
     table: string,
     options?: TableInsertEntityOptionalParams
   ): Promise<TableInsertEntityResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, options: operationOptions },
+      operationArguments,
       insertEntityOperationSpec
     ) as Promise<TableInsertEntityResponse>;
   }
@@ -240,11 +255,12 @@ export class Table {
     table: string,
     options?: TableGetAccessPolicyOptionalParams
   ): Promise<TableGetAccessPolicyResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, options: operationOptions },
+      operationArguments,
       getAccessPolicyOperationSpec
     ) as Promise<TableGetAccessPolicyResponse>;
   }
@@ -258,17 +274,17 @@ export class Table {
     table: string,
     options?: TableSetAccessPolicyOptionalParams
   ): Promise<TableSetAccessPolicyResponse> {
-    const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
-      options || {}
-    );
+    const operationArguments: coreHttp.OperationArguments = {
+      table,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
     return this.client.sendOperationRequest(
-      { table, options: operationOptions },
+      operationArguments,
       setAccessPolicyOperationSpec
     ) as Promise<TableSetAccessPolicyResponse>;
   }
 }
 // Operation Specifications
-
 const xmlSerializer = new coreHttp.Serializer(Mappers, /* isXml */ true);
 
 const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
@@ -322,11 +338,11 @@ const createOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.format],
   urlParameters: [Parameters.url],
   headerParameters: [
+    Parameters.accept,
     Parameters.version,
     Parameters.requestId,
     Parameters.dataServiceVersion,
     Parameters.contentType,
-    Parameters.accept1,
     Parameters.responsePreference
   ],
   mediaType: "json",
@@ -348,7 +364,7 @@ const deleteOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [
     Parameters.version,
     Parameters.requestId,
-    Parameters.accept2
+    Parameters.accept1
   ],
   serializer
 };
@@ -443,8 +459,8 @@ const updateEntityOperationSpec: coreHttp.OperationSpec = {
     Parameters.version,
     Parameters.requestId,
     Parameters.dataServiceVersion,
+    Parameters.accept1,
     Parameters.contentType1,
-    Parameters.accept3,
     Parameters.ifMatch
   ],
   mediaType: "json",
@@ -474,8 +490,8 @@ const mergeEntityOperationSpec: coreHttp.OperationSpec = {
     Parameters.version,
     Parameters.requestId,
     Parameters.dataServiceVersion,
+    Parameters.accept1,
     Parameters.contentType1,
-    Parameters.accept3,
     Parameters.ifMatch
   ],
   mediaType: "json",
@@ -531,11 +547,11 @@ const insertEntityOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.format, Parameters.timeout],
   urlParameters: [Parameters.url, Parameters.table],
   headerParameters: [
+    Parameters.accept,
     Parameters.version,
     Parameters.requestId,
     Parameters.dataServiceVersion,
     Parameters.contentType,
-    Parameters.accept1,
     Parameters.responsePreference
   ],
   mediaType: "json",
@@ -570,7 +586,7 @@ const getAccessPolicyOperationSpec: coreHttp.OperationSpec = {
   headerParameters: [
     Parameters.version,
     Parameters.requestId,
-    Parameters.accept4
+    Parameters.accept2
   ],
   isXML: true,
   serializer: xmlSerializer
@@ -594,7 +610,7 @@ const setAccessPolicyOperationSpec: coreHttp.OperationSpec = {
     Parameters.version,
     Parameters.requestId,
     Parameters.contentType2,
-    Parameters.accept5
+    Parameters.accept3
   ],
   isXML: true,
   contentType: "application/xml; charset=utf-8",

--- a/sdk/tables/data-tables/src/generated/operations/table.ts
+++ b/sdk/tables/data-tables/src/generated/operations/table.ts
@@ -37,6 +37,7 @@ import {
 } from "../models";
 
 /** Class representing a Table. */
+/** @hidden */
 export class Table {
   private readonly client: GeneratedClient;
 

--- a/sdk/tables/data-tables/src/generatedModels.ts
+++ b/sdk/tables/data-tables/src/generatedModels.ts
@@ -31,6 +31,7 @@ export {
   ServiceGetPropertiesHeaders,
   ServiceGetStatisticsHeaders,
   GeoReplicationStatusType,
+  KnownGeoReplicationStatusType,
   GeoReplication,
   TableServiceStats,
   TableQueryEntitiesHeaders,

--- a/sdk/tables/data-tables/swagger/README.md
+++ b/sdk/tables/data-tables/swagger/README.md
@@ -18,6 +18,7 @@ add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.2"
+hide-clients: true
 ```
 
 ```yaml

--- a/sdk/tables/data-tables/swagger/README.md
+++ b/sdk/tables/data-tables/swagger/README.md
@@ -17,7 +17,7 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/4a8cd09
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
-  "@autorest/typescript": "6.0.0-dev.20200817.1"
+  "@autorest/typescript": "6.0.0-dev.20210121.2"
 ```
 
 ```yaml


### PR DESCRIPTION
The last V6 SDK version that is used to generate Tables is 6.0.0-dev.20200817.1. This PR is to upgrade the V6 SDK version to the latest 6.0.0-dev.20210121.2 version.

@joheredi Please review and approve.

@ramya-rao-a FYI.......