### PR TITLE
[Service Bus] Revert core-amqp to 2.0.0

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -47,6 +47,9 @@
     // "@azure/storage-blob": ["^12.3.0"],
 
     "@azure/ms-rest-js": ["^2.0.0"],
+    // The following is required for service-bus 7.0.3 release,
+    // To be reverted once the 7.0.3 is released
+    "@azure/core-amqp": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.1.0",
+    "@azure/core-amqp": "^2.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",


### PR DESCRIPTION
Since core-amqp 2.1.0 is not released, reverting to 2.0.0 so that service-bus 7.0.3 can be released.
This PR will be reverted after the 7.0.3 release.