### PR TITLE
[Quantum Jobs] Missing "types" in the files included

### DIFF
--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -81,6 +81,7 @@
     "dist/",
     "dist-esm/src/",
     "README.md",
+    "types/latest/quantum-jobs.d.ts",
     "LICENSE.txt"
   ],
   "scripts": {


### PR DESCRIPTION
We missed adding "types" folder in the "files" section at #13385 (needed for the published package) 