### PR TITLE
[Docs] Fix the double tagging issue

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/src/tracing.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector/src/tracing.ts
@@ -8,7 +8,6 @@ import { OperationOptions } from "@azure/core-http";
 /**
  * Creates a span using the global tracer.
  * @internal
- * @hidden
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigCredential.ts
@@ -6,7 +6,6 @@ import { sha256Digest, sha256Hmac } from "./internal/cryptoHelpers";
 
 /**
  * @internal
- * @hidden
  */
 export class AppConfigCredential implements ServiceClientCredentials {
   private credential: string;

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -67,7 +67,6 @@ const packageName = "azsdk-js-app-configuration";
  * This constant should always be the same as the package.json's version - we use it when forming the
  * User - Agent header. There's a unit test that makes sure it always stays in sync.
  * @internal
- * @hidden
  */
 export const packageVersion = "1.1.1";
 const apiVersion = "1.0";
@@ -103,7 +102,6 @@ export interface AppConfigurationClientOptions {
 /**
  * Provides internal configuration options for AppConfigurationClient.
  * @internal
- * @hidden
  */
 export interface InternalAppConfigurationClientOptions extends AppConfigurationClientOptions {
   /**
@@ -526,7 +524,6 @@ export class AppConfigurationClient {
 /**
  * Gets the options for the generated AppConfigurationClient
  * @internal
- * @hidden
  */
 export function getGeneratedClientOptions(
   endpoint: string,
@@ -562,7 +559,6 @@ export function getGeneratedClientOptions(
 
 /**
  * @internal
- * @hidden
  */
 export function getUserAgentPrefix(userSuppliedUserAgent: string | undefined): string {
   const appConfigDefaultUserAgent = `${packageName}/${packageVersion} ${getCoreHttpDefaultUserAgentValue()}`;

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.browser.ts
@@ -5,7 +5,6 @@
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   const digest = await self.crypto.subtle.digest("SHA-256", new TextEncoder().encode(body || ""));
@@ -17,7 +16,6 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const key = await self.crypto.subtle.importKey(

--- a/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/cryptoHelpers.ts
@@ -5,7 +5,6 @@ import { createHash, createHmac } from "crypto";
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Digest(body: string | undefined): Promise<string> {
   return createHash("sha256")
@@ -15,7 +14,6 @@ export async function sha256Digest(body: string | undefined): Promise<string> {
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const decodedSecret = Buffer.from(secret, "base64");

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -17,7 +17,6 @@ import { AppConfigurationGetKeyValuesOptionalParams, KeyValue } from "../generat
 /**
  * Formats the etag so it can be used with a If-Match/If-None-Match header
  * @internal
- * @hidden
  */
 export function quoteETag(etag: string | undefined): string | undefined {
   // https://tools.ietf.org/html/rfc7232#section-3.1
@@ -41,7 +40,6 @@ export function quoteETag(etag: string | undefined): string | undefined {
  * and throws an Error. Otherwise, returns the properties properly quoted.
  * @param options - An options object with onlyIfChanged/onlyIfUnchanged fields
  * @internal
- * @hidden
  */
 export function checkAndFormatIfAndIfNoneMatch(
   configurationSetting: ConfigurationSettingId,
@@ -76,7 +74,6 @@ export function checkAndFormatIfAndIfNoneMatch(
  * - keyFilter and labelFilter are moved to key and label, respectively.
  *
  * @internal
- * @hidden
  */
 export function formatFiltersAndSelect(
   listConfigOptions: ListConfigurationSettingsOptions | ListRevisionsOptions
@@ -99,7 +96,6 @@ export function formatFiltersAndSelect(
  * Handles translating a Date acceptDateTime into a string as needed by the API
  * @param newOptions - A newer style options with acceptDateTime as a date (and with proper casing!)
  * @internal
- * @hidden
  */
 export function formatAcceptDateTime(newOptions: {
   acceptDateTime?: Date;
@@ -113,7 +109,6 @@ export function formatAcceptDateTime(newOptions: {
  * Take the URL that gets returned from next link and extract the 'after' token needed
  * to get the next page of results.
  * @internal
- * @hidden
  */
 export function extractAfterTokenFromNextLink(nextLink: string) {
   const parsedLink = URLBuilder.parse(nextLink);

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -14,7 +14,6 @@ import {
  * The sync token header, as described here:
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  * @internal
- * @hidden
  */
 export const SyncTokenHeaderName = "sync-token";
 
@@ -22,7 +21,6 @@ export const SyncTokenHeaderName = "sync-token";
  * A policy factory for injecting sync tokens properly into outgoing requests.
  * @param syncTokens - the sync tokens store to be used across requests.
  * @internal
- * @hidden
  */
 export function syncTokenPolicy(syncTokens: SyncTokens): RequestPolicyFactory {
   return {
@@ -62,7 +60,6 @@ class SyncTokenPolicy extends BaseRequestPolicy {
  * https://github.com/Azure/AppConfiguration/blob/master/docs/REST/consistency.md
  *
  * @internal
- * @hidden
  */
 export class SyncTokens {
   private _currentSyncTokens = new Map<string, SyncToken>();
@@ -140,7 +137,6 @@ interface SyncToken {
  * @param syncToken - A single sync token.
  *
  * @internal
- * @hidden
  */
 export function parseSyncToken(syncToken: string): SyncToken {
   const matches = syncToken.match(syncTokenRegex);

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -9,7 +9,6 @@ import { RestError } from "@azure/core-http";
 
 /**
  * @internal
- * @hidden
  */
 export interface Spannable {
   spanOptions?: SpanOptions;
@@ -17,7 +16,6 @@ export interface Spannable {
 
 /**
  * @internal
- * @hidden
  */
 export class Spanner<TClient> {
   constructor(private baseOperationName: string) {}

--- a/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/policies/throttlingRetryPolicy.ts
@@ -15,7 +15,6 @@ import {
 
 /**
  * @internal
- * @hidden
  */
 export function throttlingRetryPolicy(): RequestPolicyFactory {
   return {
@@ -31,7 +30,6 @@ export function throttlingRetryPolicy(): RequestPolicyFactory {
  * responding to 429 responses (which is to throw a RestError).
  *
  * @internal
- * @hidden
  */
 export class ThrottlingRetryPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -86,7 +84,6 @@ const RetryAfterMillisecondsHeaders: string[] = ["retry-after-ms", "x-ms-retry-a
  * Extracts the retry response header, checking against several
  * header names.
  * @internal
- * @hidden
  */
 export function getDelayInMs(responseHeaders: {
   get: (headerName: string) => string | undefined;

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -167,7 +167,6 @@ export const ConnectionConfig = {
 
 /**
  * @internal
- * @hidden
  */
 export function isSharedAccessSignature(connectionString: string): boolean {
   return connectionString.match(/;{0,1}SharedAccessSignature=SharedAccessSignature /) != null;

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -9,7 +9,6 @@ import { isNode, isNumber, isString } from "../src/util/utils";
  * Maps the conditions to the numeric AMQP Response status codes.
  * @enum {ConditionStatusMapper}
  * @internal
- * @hidden
  */
 export enum ConditionStatusMapper {
   "com.microsoft:timeout" = AmqpResponseStatusCode.RequestTimeout,
@@ -457,7 +456,6 @@ export interface NetworkSystemError {
 
 /**
  * @internal
- * @hidden
  */
 const systemErrorFieldsToCopy: (keyof Omit<NetworkSystemError, "name" | "message">)[] = [
   "address",
@@ -608,7 +606,6 @@ export function isSystemError(err: any): err is NetworkSystemError {
 
 /**
  * @internal
- * @hidden
  * Since browser doesn't differentiate between the various kinds of service communication errors,
  * this utility is used to look at the error target to identify such category of errors.
  * For more information refer to - https://html.spec.whatwg.org/multipage/comms.html#feedback-from-the-protocol
@@ -629,7 +626,6 @@ function isBrowserWebsocketError(err: any): boolean {
 
 /**
  * @internal
- * @hidden
  */
 const rheaPromiseErrors = [
   // OperationTimeoutError occurs when the service fails to respond within a given timeframe.
@@ -729,7 +725,6 @@ export function translate(err: AmqpError | Error): MessagingError | Error {
 
 /**
  * @internal
- * @hidden
  *
  * @param {*} error
  * @returns {error is AmqpError}

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -40,7 +40,6 @@ export interface SendRequestOptions {
 
 /**
  * @internal
- * @hidden
  */
 export interface DeferredPromiseWithCallback {
   resolve: (value?: any) => void;
@@ -230,7 +229,6 @@ export class RequestResponseLink implements ReqResLink {
 }
 /**
  * @internal
- * @hidden
  *
  * Type used in getCodeDescriptionAndError to get the normalized info from the responses emitted by EventHubs and ServiceBus.
  */
@@ -242,7 +240,6 @@ type NormalizedInfo = {
 
 /**
  * @internal
- * @hidden
  *
  * Handle different variations of property names in responses emitted by EventHubs and ServiceBus.
  *
@@ -271,7 +268,6 @@ export const getCodeDescriptionAndError = (props: any): NormalizedInfo => {
  * 5. User's code after the sendRequest continues.
  *
  * @internal
- * @hidden
  */
 export function onMessageReceived(
   context: Pick<EventContext, "message">,

--- a/sdk/core/core-amqp/src/util/runtimeInfo.browser.ts
+++ b/sdk/core/core-amqp/src/util/runtimeInfo.browser.ts
@@ -3,7 +3,6 @@
 
 /**
  * @internal
- * @hidden
  *
  * @interface Window
  */
@@ -11,13 +10,11 @@ interface Window {}
 
 /**
  * @internal
- * @hidden
  */
 declare let self: Window & typeof globalThis & { navigator: Navigator };
 
 /**
  * @internal
- * @hidden
  *
  * @interface Navigator
  */
@@ -48,7 +45,6 @@ export function getFrameworkInfo(): string {
 
 /**
  * @internal
- * @hidden
  *
  * @returns {string}
  */

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -8,7 +8,6 @@ import { WebSocketImpl } from "rhea-promise";
 export { AsyncLock };
 /**
  * @internal
- * @hidden
  *
  * Describes the options that can be provided to create an async lock.
  */
@@ -56,7 +55,6 @@ export interface WebSocketOptions {
 
 /**
  * @internal
- * @hidden
  *
  * A constant that indicates whether the environment is node.js or browser based.
  */
@@ -117,7 +115,6 @@ export function parseConnectionString<T>(connectionString: string): ParsedOutput
 
 /**
  * @internal
- * @hidden
  *
  * Gets a new instance of the async lock with desired settings.
  * @param {AsyncLockOptions} [options] The async lock options.
@@ -134,7 +131,6 @@ export const defaultLock: AsyncLock = new AsyncLock({ maxPending: 10000 });
 
 /**
  * @internal
- * @hidden
  *
  * Describes a Timeout class that can wait for the specified amount of time and then resolve/reject
  * the promise with the given value.
@@ -236,7 +232,6 @@ export function delay<T>(
 
 /**
  * @internal
- * @hidden
  *
  * Generates a random number between the given interval
  * @param {number} min Min number of the range (inclusive).
@@ -248,7 +243,6 @@ export function randomNumberFromInterval(min: number, max: number): number {
 
 /**
  * @internal
- * @hidden
  *
  * Type declaration for a Function type where T is the input to the function and V is the output
  * of the function.
@@ -257,7 +251,6 @@ export type Func<T, V> = (a: T) => V;
 
 /**
  * @internal
- * @hidden
  *
  * Executes an array of promises sequentially. Inspiration of this method is here:
  * https://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html. An awesome blog on promises!
@@ -282,7 +275,6 @@ export function executePromisesSequentially(
 
 /**
  * @internal
- * @hidden
  *
  * Determines whether the given connection string is an iothub connection string.
  * @param {string} connectionString The connection string.

--- a/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
+++ b/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
@@ -59,7 +59,6 @@ export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
 
 /**
  * @internal
- * @hidden
  * @param requestContext
  * @param next
  * @param on

--- a/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
+++ b/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
@@ -60,7 +60,6 @@ export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
 /**
  * @internal
  * @hidden
- * @hidden
  * @param requestContext
  * @param next
  * @param on

--- a/sdk/eventgrid/eventgrid/src/cryptoHelpers.browser.ts
+++ b/sdk/eventgrid/eventgrid/src/cryptoHelpers.browser.ts
@@ -5,7 +5,6 @@
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const key = await self.crypto.subtle.importKey(

--- a/sdk/eventgrid/eventgrid/src/cryptoHelpers.ts
+++ b/sdk/eventgrid/eventgrid/src/cryptoHelpers.ts
@@ -5,7 +5,6 @@ import { createHmac } from "crypto";
 
 /**
  * @internal
- * @hidden
  */
 export async function sha256Hmac(secret: string, stringToSign: string): Promise<string> {
   const decodedSecret = Buffer.from(secret, "base64");

--- a/sdk/eventgrid/eventgrid/src/tracing.ts
+++ b/sdk/eventgrid/eventgrid/src/tracing.ts
@@ -10,7 +10,6 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @internal
- * @hidden
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -25,7 +25,6 @@ import { SharedKeyCredential } from "./eventhubSharedKeyCredential";
 
 /**
  * @internal
- * @hidden
  * Provides contextual information like the underlying amqp connection, cbs session, management session,
  * tokenProvider, senders, receivers, etc. about the EventHub client.
  */
@@ -101,7 +100,6 @@ export interface ConnectionContextInternalMembers extends ConnectionContext {
 
 /**
  * @internal
- * @hidden
  */
 export interface ConnectionContextOptions extends EventHubClientOptions {
   managementSessionAddress?: string;
@@ -130,7 +128,6 @@ type ConnectionContextMethods = Omit<
 
 /**
  * @internal
- * @hidden
  */
 export namespace ConnectionContext {
   /**

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -39,7 +39,6 @@ export function instrumentEventData(eventData: EventData, span: Span): EventData
  * Extracts the `SpanContext` from an `EventData` if the context exists.
  * @param eventData An individual `EventData` object.
  * @internal
- * @hidden
  */
 export function extractSpanContextFromEventData(eventData: EventData): SpanContext | undefined {
   if (!eventData.properties || !eventData.properties[TRACEPARENT_PROPERTY]) {

--- a/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
@@ -7,7 +7,6 @@ import { EventHubConnectionConfig } from "../eventhubConnectionConfig";
 
 /**
  * @internal
- * @hidden
  */
 export function createMessageSpan(
   parentSpan?: Span | SpanContext | null,

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -28,7 +28,6 @@ const smallMessageMaxBytes = 255;
  * Checks if the provided eventDataBatch is an instance of `EventDataBatch`.
  * @param eventDataBatch The instance of `EventDataBatch` to verify.
  * @internal
- * @hidden
  */
 export function isEventDataBatch(eventDataBatch: unknown): eventDataBatch is EventDataBatch {
   return (
@@ -132,7 +131,6 @@ export interface EventDataBatch {
  *
  * @class
  * @internal
- * @hidden
  */
 export class EventDataBatchImpl implements EventDataBatch {
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -620,7 +620,6 @@ export class EventHubConsumerClient {
 
 /**
  * @internal
- * @hidden
  */
 export function isCheckpointStore(possible: CheckpointStore | any): possible is CheckpointStore {
   if (!possible) {
@@ -639,7 +638,6 @@ export function isCheckpointStore(possible: CheckpointStore | any): possible is 
 
 /**
  * @internal
- * @hidden
  */
 function isSubscriptionEventHandlers(
   possible: any | SubscriptionEventHandlers

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -10,7 +10,6 @@ import { MessagingError } from "@azure/core-amqp";
 
 /**
  * @internal
- * @hidden
  */
 export interface BasicPartitionProperties {
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -69,21 +69,18 @@ export interface LastEnqueuedEventProperties {
 /**
  * Describes the message handler signature.
  * @internal
- * @hidden
  */
 export type OnMessage = (eventData: ReceivedEventData) => void;
 
 /**
  * Describes the error handler signature.
  * @internal
- * @hidden
  */
 export type OnError = (error: MessagingError | Error) => void;
 
 /**
  * Describes the abort handler signature.
  * @internal
- * @hidden
  */
 export type OnAbort = () => void;
 
@@ -91,7 +88,6 @@ export type OnAbort = () => void;
  * Describes the EventHubReceiver that will receive event data from EventHub.
  * @class EventHubReceiver
  * @internal
- * @hidden
  */
 export class EventHubReceiver extends LinkEntity {
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -37,7 +37,6 @@ import { defaultDataTransformer } from "./dataTransformer";
  * Describes the EventHubSender that will send event data to EventHub.
  * @class EventHubSender
  * @internal
- * @hidden
  */
 export class EventHubSender extends LinkEntity {
   /**

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -45,7 +45,6 @@ export interface EventPosition {
 
 /**
  * @internal
- * @hidden
  * Gets the expression to be set as the filter clause when creating the receiver
  * @return {string} filterExpression
  */
@@ -79,7 +78,6 @@ export function getEventPositionFilter(eventPosition: EventPosition): string {
 
 /**
  * @internal
- * @hidden
  */
 export function isLatestPosition(eventPosition: EventPosition): boolean {
   if (eventPosition.offset === "@latest") {

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -126,7 +126,6 @@ export interface CheckpointStore {
  * }
  * ```
  * @internal
- * @hidden
  */
 export interface FullEventProcessorOptions extends CommonEventProcessorOptions {
   /**
@@ -175,7 +174,6 @@ export interface FullEventProcessorOptions extends CommonEventProcessorOptions {
  *
  * @class EventProcessor
  * @internal
- * @hidden
  */
 export class EventProcessor {
   private _processorOptions: FullEventProcessorOptions;

--- a/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
@@ -97,7 +97,6 @@ export class SharedKeyCredential {
  * `SharedAccessSignature sr=<resource>&sig=<signature>&se=<expiry>&skn=<keyname>`
  *
  * @internal
- * @hidden
  */
 export class SharedAccessSignatureCredential extends SharedKeyCredential {
   private _accessToken: AccessToken;

--- a/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
+++ b/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
@@ -10,7 +10,6 @@
  * continually steals/overwrites checkpointing and ownership with itself.
  *
  * @internal
- * @hidden
  */
 export class PartitionGate {
   private _partitions = new Set<string>();

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -17,7 +17,6 @@ import { throwTypeErrorIfParameterMissing } from "./util/error";
  *
  * @class
  * @internal
- * @hidden
  */
 export class InMemoryCheckpointStore implements CheckpointStore {
   private _partitionOwnershipMap: Map<string, PartitionOwnership> = new Map();

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -35,7 +35,6 @@ export interface LinkEntityOptions {
 /**
  * Describes the base class for entities like EventHub Sender, Receiver and Management link.
  * @internal
- * @hidden
  * @class LinkEntity
  */
 export class LinkEntity {

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
@@ -12,7 +12,6 @@ import { LoadBalancingStrategy, listAvailablePartitions } from "./loadBalancingS
  * by only returning a single partition to claim at a time.
  * This minimizes the number of times a partition should need to be stolen.
  * @internal
- * @hidden
  */
 export class BalancedLoadBalancingStrategy implements LoadBalancingStrategy {
   /**

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
@@ -6,7 +6,6 @@ import { LoadBalancingStrategy, listAvailablePartitions } from "./loadBalancingS
 
 /**
  * @internal
- * @hidden
  */
 export class GreedyLoadBalancingStrategy implements LoadBalancingStrategy {
   /**

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
@@ -7,7 +7,6 @@ import { logger } from "../log";
 /**
  * Determines which partitions to claim as part of load balancing.
  * @internal
- * @hidden
  */
 export interface LoadBalancingStrategy {
   /**
@@ -28,7 +27,6 @@ export interface LoadBalancingStrategy {
 /**
  * Counts of the EventProcessors that currently own partitions.
  * @internal
- * @hidden
  */
 interface EventProcessorCounts {
   /**
@@ -131,7 +129,6 @@ function calculateBalancedLoadCounts(
  * @param minPartitionsPerOwner The number of required partitions per EventProcessor.
  * @param ownerToOwnershipMap The current ownerships for partitions.
  * @internal
- * @hidden
  */
 function getEventProcessorCounts(
   minPartitionsPerOwner: number,
@@ -229,7 +226,6 @@ function getNumberOfPartitionsToClaim(
  * @param ourOwnerId The id of _our_ owner.
  * @param ownerToOwnershipMap The current ownerships for partitions.
  * @internal
- * @hidden
  */
 function findPartitionsToSteal(
   numberOfPartitionsToClaim: number,
@@ -291,7 +287,6 @@ function findPartitionsToSteal(
  * @param expirationIntervalInMs The length of time a partition claim is valid.
  * @returns Partition ids that may be claimed.
  * @internal
- * @hidden
  */
 export function listAvailablePartitions(
   ownerId: string,

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
@@ -9,7 +9,6 @@ import { LoadBalancingStrategy } from "./loadBalancingStrategy";
  * It is intended to be used when you want to avoid load balancing
  * and consume a set of partitions.
  * @internal
- * @hidden
  */
 export class UnbalancedLoadBalancingStrategy implements LoadBalancingStrategy {
   /**

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -89,7 +89,6 @@ export interface PartitionProperties {
 
 /**
  * @internal
- * @hidden
  */
 export interface ManagementClientOptions {
   address?: string;
@@ -99,7 +98,6 @@ export interface ManagementClientOptions {
 /**
  * @class ManagementClient
  * @internal
- * @hidden
  * Descibes the EventHubs Management Client that talks
  * to the $management endpoint over AMQP connection.
  */

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -32,13 +32,11 @@ export interface EventHubProducerOptions {
 
 /**
  * @internal
- * @hidden
  */
 export type OperationNames = "getEventHubProperties" | "getPartitionIds" | "getPartitionProperties";
 
 /**
  * @internal
- * @hidden
  */
 export interface CommonEventProcessorOptions
   extends Required<Pick<SubscribeOptions, "maxBatchSize" | "maxWaitTimeInSeconds">>,
@@ -92,7 +90,6 @@ export interface CommonEventProcessorOptions
  * }
  * ```
  * @internal
- * @hidden
  */
 export interface EventHubConsumerOptions {
   /**

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -61,7 +61,6 @@ export interface SendBatchOptions extends OperationOptions {
  * ```
  *
  * @internal
- * @hidden
  */
 export interface SendOptions extends OperationOptions {
   /**

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -60,7 +60,6 @@ export interface Checkpoint {
  * - Optionally override the `initialize()` method to implement any set up related tasks you would want to carry out before starting to receive events from the partition
  * - Optionally override the `close()` method to implement any tear down or clean up tasks you would want to carry out.
  * @internal
- * @hidden
  */
 export class PartitionProcessor implements PartitionContext {
   private _lastEnqueuedEventProperties?: LastEnqueuedEventProperties;

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -209,7 +209,6 @@ export class PartitionPump {
 
 /**
  * @internal
- * @hidden
  */
 export function createProcessingSpan(
   receivedEvents: ReceivedEventData[],

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -8,7 +8,6 @@ import { AbortSignalLike } from "@azure/abort-controller";
  * @param delayInMs The number of milliseconds to be delayed.
  * @param abortSignal The abortSignal associated with the containing operation.
  * @internal
- * @hidden
  */
 export async function delayWithoutThrow(
   delayInMs: number,

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -7,7 +7,6 @@ import { isDefined } from "./typeGuards";
 
 /**
  * @internal
- * @hidden
  * Logs and throws Error if the current AMQP connection is closed.
  * @param context The ConnectionContext associated with the current AMQP connection.
  */
@@ -23,7 +22,6 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is undefined or null
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param methodName Name of the method that was passed the parameter

--- a/sdk/eventhub/event-hubs/src/util/operationOptions.ts
+++ b/sdk/eventhub/event-hubs/src/util/operationOptions.ts
@@ -23,7 +23,6 @@ export interface OperationOptions {
 
 /**
  * @internal
- * @hidden
  */
 export function getParentSpan(
   options?: OperationTracingOptions

--- a/sdk/eventhub/event-hubs/src/util/retries.ts
+++ b/sdk/eventhub/event-hubs/src/util/retries.ts
@@ -6,7 +6,6 @@ import { isDefined } from "./typeGuards";
 
 /**
  * @internal
- * @hidden
  */
 export function getRetryAttemptTimeoutInMs(retryOptions: RetryOptions | undefined): number {
   const timeoutInMs =

--- a/sdk/eventhub/event-hubs/src/util/typeGuards.ts
+++ b/sdk/eventhub/event-hubs/src/util/typeGuards.ts
@@ -5,7 +5,6 @@
  * Helper TypeGuard that checks if something is defined or not.
  * @param thing Anything
  * @internal
- * @hidden
  */
 export function isDefined<T>(thing: T | undefined | null): thing is T {
   return typeof thing !== "undefined" && thing !== null;
@@ -16,7 +15,6 @@ export function isDefined<T>(thing: T | undefined | null): thing is T {
  * @param thing - Anything.
  * @param properties - The name of the properties that should appear in the object.
  * @internal
- * @hidden
  */
 export function isObjectWithProperties<Thing extends unknown, PropertyName extends string>(
   thing: Thing,
@@ -40,7 +38,6 @@ export function isObjectWithProperties<Thing extends unknown, PropertyName exten
  * @param thing - Any object.
  * @param property - The name of the property that should appear in the object.
  * @internal
- * @hidden
  */
 export function objectHasProperty<Thing extends unknown, PropertyName extends string>(
   thing: Thing,

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/util/error.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/util/error.ts
@@ -5,7 +5,6 @@ import { logger, logErrorStackTrace } from "../log";
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is undefined or null
  * @param methodName Name of the method that was passed the parameter
  * @param parameterName Name of the parameter to check

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/contentPoller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/contentPoller.ts
@@ -124,7 +124,6 @@ export class BeginRecognizeContentPoller extends Poller<
 /**
  * Creates a poll operation given the provided state.
  * @internal
- * @hidden
  */
 function makeBeginRecognizePollOperation(
   state: BeginRecognizeContentPollState

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/copy/poller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/copy/poller.ts
@@ -159,7 +159,6 @@ export class BeginCopyModelPoller extends Poller<BeginCopyModelPollState, Custom
 /**
  * Creates a poll operation given the provided state.
  * @internal
- * @hidden
  */
 function makeBeginCopyModelPollOperation(
   state: BeginCopyModelPollState

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/train/poller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/train/poller.ts
@@ -111,7 +111,6 @@ export class BeginTrainingPoller extends Poller<BeginTrainingPollState, CustomFo
 /**
  * Creates a poll operation given the provided state.
  * @internal
- * @hidden
  */
 function makeBeginTrainingPollOperation(
   client: TrainPollerClient,

--- a/sdk/formrecognizer/ai-form-recognizer/src/tracing.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/tracing.ts
@@ -8,7 +8,6 @@ import { OperationOptions } from "@azure/core-http";
 /**
  * Creates a span using the global tracer.
  * @internal
- * @hidden
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/formrecognizer/ai-form-recognizer/test/utils/matrix.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/utils/matrix.ts
@@ -3,7 +3,6 @@
 
 /**
  * @internal
- * @hidden
  * Takes a jagged 2D array and a function and runs the function with every
  * possible combination of elements of each of the arrays
  *

--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -44,7 +44,6 @@ export interface ErrorResponse {
 /**
  * Used for internal deserialization of OAuth responses. Public model is ErrorResponse
  * @internal
- * @hidden
  */
 export interface OAuthErrorResponse {
   error: string;

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -4,7 +4,6 @@
 /**
  * The default client ID for authentication
  * @internal
- * @hidden
  */
 // TODO: temporary - this is the Azure CLI clientID - we'll replace it when
 // Developer Sign On application is available
@@ -14,7 +13,6 @@ export const DeveloperSignOnClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
 /**
  * The default tenant for authentication
  * @internal
- * @hidden
  */
 export const DefaultTenantId = "common";
 

--- a/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/lro/restore/operation.ts
@@ -13,7 +13,6 @@ export interface BeginRestoreCertificateBackupOptions extends CertificatePollerO
 
 /**
  * @internal
- * @hidden
  * An interface representing the CertificateClient. For internal use.
  */
 export interface TestCertificateClientInterface {

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -31,7 +31,7 @@ export interface KeyClientOptions extends coreHttp.PipelineOptions {
 /**
  * The optional parameters accepted by the KeyVault's CryptographyClient
  */
-export interface CryptographyClientOptions extends KeyClientOptions { }
+export interface CryptographyClientOptions extends KeyClientOptions {}
 
 /**
  * As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
@@ -307,13 +307,13 @@ export interface KeyPollerOptions extends coreHttp.OperationOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link beginDeleteKey}
  */
-export interface BeginDeleteKeyOptions extends KeyPollerOptions { }
+export interface BeginDeleteKeyOptions extends KeyPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginRecoverDeletedKey}
  */
-export interface BeginRecoverDeletedKeyOptions extends KeyPollerOptions { }
+export interface BeginRecoverDeletedKeyOptions extends KeyPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
@@ -414,58 +414,56 @@ export interface GetKeyOptions extends coreHttp.OperationOptions {
 /**
  * An interface representing optional parameters for KeyClient paged operations passed to {@link listKeys}.
  */
-export interface ListKeysOptions extends coreHttp.OperationOptions { }
+export interface ListKeysOptions extends coreHttp.OperationOptions {}
 
 /**
  * An interface representing optional parameters for KeyClient paged operations passed to {@link listPropertiesOfKeys}.
  */
-export interface ListPropertiesOfKeysOptions extends coreHttp.OperationOptions { }
+export interface ListPropertiesOfKeysOptions extends coreHttp.OperationOptions {}
 
 /**
  * An interface representing optional parameters for KeyClient paged operations passed to {@link listPropertiesOfKeyVersions}.
  */
-export interface ListPropertiesOfKeyVersionsOptions extends coreHttp.OperationOptions { }
+export interface ListPropertiesOfKeyVersionsOptions extends coreHttp.OperationOptions {}
 
 /**
  * An interface representing optional parameters for KeyClient paged operations passed to {@link listDeletedKeys}.
  */
-export interface ListDeletedKeysOptions extends coreHttp.OperationOptions { }
+export interface ListDeletedKeysOptions extends coreHttp.OperationOptions {}
 
 /**
  * Options for {@link getDeletedKey}.
  */
-export interface GetDeletedKeyOptions extends coreHttp.OperationOptions { }
+export interface GetDeletedKeyOptions extends coreHttp.OperationOptions {}
 
 /**
  * Options for {@link purgeDeletedKey}.
  */
-export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions { }
+export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions {}
 
 /**
  * @internal
- * @hidden
  * Options for {@link recoverDeletedKey}.
  */
-export interface RecoverDeletedKeyOptions extends coreHttp.OperationOptions { }
+export interface RecoverDeletedKeyOptions extends coreHttp.OperationOptions {}
 
 /**
  * @internal
- * @hidden
  * Options for {@link deleteKey}.
  */
-export interface DeleteKeyOptions extends coreHttp.OperationOptions { }
+export interface DeleteKeyOptions extends coreHttp.OperationOptions {}
 
 /**
  * Options for {@link backupKey}.
  */
-export interface BackupKeyOptions extends coreHttp.OperationOptions { }
+export interface BackupKeyOptions extends coreHttp.OperationOptions {}
 
 /**
  * Options for {@link restoreKeyBackup}.
  */
-export interface RestoreKeyBackupOptions extends coreHttp.OperationOptions { }
+export interface RestoreKeyBackupOptions extends coreHttp.OperationOptions {}
 
 /**
  * An interface representing the options of the cryptography API methods, go to the {@link CryptographyClient} for more information.
  */
-export interface CryptographyOptions extends coreHttp.OperationOptions { }
+export interface CryptographyOptions extends coreHttp.OperationOptions {}

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/algorithms.browser.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/algorithms.browser.ts
@@ -12,7 +12,6 @@ import { LocalAssertion, LocalSupportedAlgorithmsRecord } from "./models";
 
 /**
  * @internal
- * @hidden
  * The list of known assertions so far.
  * Assertions verify that the requirements to execute a local cryptography operation are met.
  */

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/algorithms.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/algorithms.ts
@@ -32,7 +32,6 @@ import { createHash } from "./hash";
 
 /**
  * @internal
- * @hidden
  * The list of known assertions so far.
  * Assertions verify that the requirements to execute a local cryptography operation are met.
  */

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/conversions.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/conversions.ts
@@ -5,7 +5,6 @@ import { JsonWebKey } from "../keysModels";
 
 /**
  * @internal
- * @hidden
  * Encodes a length of a packet in DER format
  */
 function encodeLength(length: number): Uint8Array {
@@ -22,7 +21,6 @@ function encodeLength(length: number): Uint8Array {
 
 /**
  * @internal
- * @hidden
  * Encodes a buffer for DER, as sets the id to the given id
  */
 function encodeBuffer(buffer: Uint8Array, bufferId: number): Uint8Array {
@@ -90,7 +88,6 @@ function formatBase64Sequence(base64Sequence: string): string {
 
 /**
  * @internal
- * @hidden
  * Encode a JWK to PEM format. To do so, it internally repackages the JWK as a DER
  * that is then encoded as a PEM.
  */

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/hash.browser.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/hash.browser.ts
@@ -5,7 +5,6 @@ import { LocalCryptographyUnsupportedError } from "./models";
 
 /**
  * @internal
- * @hidden
  * Use the platform-local hashing functionality
  */
 export async function createHash(_algorithm: string, _data: Uint8Array): Promise<Buffer> {

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/hash.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/hash.ts
@@ -5,7 +5,6 @@ import { createHash as cryptoCreateHash } from "crypto";
 
 /**
  * @internal
- * @hidden
  * Use the platform-local hashing functionality
  */
 export async function createHash(algorithm: string, data: Uint8Array): Promise<Buffer> {

--- a/sdk/keyvault/keyvault-keys/src/localCryptography/models.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptography/models.ts
@@ -17,7 +17,6 @@ export type LocalCryptographyOperationName = "encrypt" | "wrapKey" | "createHash
 
 /**
  * @internal
- * @hidden
  * Abstract representation of a assertion.
  * Assertions verify that the requirements to execute a local cryptography operation are met.
  * @param key - The JSON Web Key that will be used during the local operation.

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -7,7 +7,6 @@ import { DeletedKey, KeyVaultKey, JsonWebKey, KeyOperation } from "./keysModels"
 
 /**
  * @internal
- * @hidden
  * Shapes the exposed {@link KeyVaultKey} based on either a received key bundle or deleted key bundle.
  */
 export function getKeyFromKeyBundle(

--- a/sdk/keyvault/keyvault-keys/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/lro/restore/operation.ts
@@ -13,7 +13,6 @@ export interface BeginRestoreKeyBackupOptions extends KeyPollerOptions {}
 
 /**
  * @internal
- * @hidden
  * An interface representing the KeyClient. For internal use.
  */
 export interface TestKeyClientInterface {

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -274,14 +274,12 @@ export interface RestoreSecretBackupOptions extends coreHttp.OperationOptions {}
 
 /**
  * @internal
- * @hidden
  * Options for {@link recoverDeletedSecret}.
  */
 export interface RecoverDeletedSecretOptions extends coreHttp.OperationOptions {}
 
 /**
  * @internal
- * @hidden
  * Options for {@link deleteSecret}.
  */
 export interface DeleteSecretOptions extends coreHttp.OperationOptions {}

--- a/sdk/keyvault/keyvault-secrets/src/transformations.ts
+++ b/sdk/keyvault/keyvault-secrets/src/transformations.ts
@@ -7,7 +7,6 @@ import { DeletedSecret, KeyVaultSecret } from "./secretsModels";
 
 /**
  * @internal
- * @hidden
  * Shapes the exposed {@link KeyVaultKey} based on either a received secret bundle or deleted secret bundle.
  */
 export function getSecretFromSecretBundle(

--- a/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/lro/restore/operation.ts
@@ -13,7 +13,6 @@ export interface BeginRestoreSecretBackupOptions extends SecretPollerOptions {}
 
 /**
  * @internal
- * @hidden
  * An interface representing the SecretClient. For internal use.
  */
 export interface TestSecretClientInterface {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/tracing.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/tracing.ts
@@ -8,7 +8,6 @@ import { OperationOptions } from "@azure/core-http";
 /**
  * Creates a span using the global tracer.
  * @internal
- * @hidden
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/search/search-documents/src/odataMetadataPolicy.ts
+++ b/sdk/search/search-documents/src/odataMetadataPolicy.ts
@@ -18,7 +18,6 @@ export type MetadataLevel = "none" | "minimal";
 /**
  * A policy factory for setting the Accept header to ignore odata metadata
  * @internal
- * @hidden
  */
 export function odataMetadataPolicy(metadataLevel: MetadataLevel): RequestPolicyFactory {
   return {

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -29,7 +29,6 @@ import { ReceiverType } from "./core/linkEntity";
 
 /**
  * @internal
- * @hidden
  * Provides contextual information like the underlying amqp connection, cbs session, management session,
  * tokenCredential, senders, receivers, etc. about the ServiceBus client.
  */
@@ -112,19 +111,16 @@ export interface ConnectionContextInternalMembers extends ConnectionContext {
 
 /**
  * @internal
- * @hidden
  * Helper type to get the names of all the functions on an object.
  */
 type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
 /**
  * @internal
- * @hidden
  * Helper type to get the types of all the functions on an object.
  */
 type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
 /**
  * @internal
- * @hidden
  * Helper type to get the types of all the functions on ConnectionContext
  * and the internal methods from ConnectionContextInternalMembers.
  * Note that this excludes the functions that ConnectionContext inherits.
@@ -138,7 +134,6 @@ type ConnectionContextMethods = Omit<
 
 /**
  * @internal
- * @hidden
  * Helper method to call onDetached on the receivers from the connection context upon seeing an error.
  */
 async function callOnDetachedOnReceivers(
@@ -176,7 +171,6 @@ async function callOnDetachedOnReceivers(
 
 /**
  * @internal
- * @hidden
  * Helper method to get the number of receivers of specified type from the connectionContext.
  */
 async function getNumberOfReceivers(
@@ -198,7 +192,6 @@ async function getNumberOfReceivers(
 
 /**
  * @internal
- * @hidden
  */
 export namespace ConnectionContext {
   export function create(

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -28,7 +28,6 @@ export interface ServiceBusClientOptions {
 
 /**
  * @internal
- * @hidden
  *
  * @param {string} connectionString
  * @param {(SharedKeyCredential | TokenCredential)} credential
@@ -52,7 +51,6 @@ export function createConnectionContext(
  * @param connectionString
  * @param options
  * @internal
- * @hidden
  */
 export function createConnectionContextForConnectionString(
   connectionString: string,
@@ -68,7 +66,6 @@ export function createConnectionContextForConnectionString(
  * @param host
  * @param options
  * @internal
- * @hidden
  */
 export function createConnectionContextForTokenCredential(
   credential: TokenCredential,
@@ -91,7 +88,6 @@ export function createConnectionContextForTokenCredential(
  * Parses a connection string and extracts the EntityPath named entity out.
  * @param connectionString An entity specific Service Bus connection string.
  * @internal
- * @hidden
  */
 export function getEntityNameFromConnectionString(connectionString: string): string {
   const entityPathMatch = connectionString.match(/^.+EntityPath=(.+?);{0,1}$/);

--- a/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
+++ b/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
@@ -10,7 +10,6 @@ import { OnErrorNoContext } from "./messageReceiver";
 
 /**
  * @internal
- * @hidden
  */
 export type RenewableMessageProperties = Readonly<
   Pick<ServiceBusMessageImpl, "lockToken" | "messageId">
@@ -20,7 +19,6 @@ export type RenewableMessageProperties = Readonly<
 
 /**
  * @internal
- * @hidden
  */
 type MinimalLink = Pick<LinkEntity<any>, "name" | "logPrefix" | "entityPath">;
 
@@ -28,7 +26,6 @@ type MinimalLink = Pick<LinkEntity<any>, "name" | "logPrefix" | "entityPath">;
  * Tracks locks for messages, renewing until a configurable duration.
  *
  * @internal
- * @hidden
  */
 export class LockRenewer {
   /**

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -26,7 +26,6 @@ import { ServiceBusError, translateServiceBusError } from "../serviceBusError";
  * Describes the batching receiver where the user can receive a specified number of messages for
  * a predefined time.
  * @internal
- * @hidden
  * @class BatchingReceiver
  * @extends MessageReceiver
  */
@@ -165,7 +164,6 @@ export class BatchingReceiver extends MessageReceiver {
  * @param maxTimeAfterFirstMessageInMs Maximum time to wait after the first message before completing the receive.
  *
  * @internal
- * @hidden
  */
 export function getRemainingWaitTimeInMsFn(
   maxWaitTimeInMs: number,
@@ -189,7 +187,6 @@ export function getRemainingWaitTimeInMsFn(
  * import the events definition (which is annoying with browsers).
  *
  * @internal
- * @hidden
  */
 type EventEmitterLike<T extends Receiver | Session> = Pick<T, "once" | "removeListener" | "on">;
 
@@ -198,7 +195,6 @@ type EventEmitterLike<T extends Receiver | Session> = Pick<T, "once" | "removeLi
  * message receiving.
  *
  * @internal
- * @hidden
  */
 export type MinimalReceiver = Pick<Receiver, "name" | "isOpen" | "credit" | "addCredit" | "drain"> &
   EventEmitterLike<Receiver> & {
@@ -211,13 +207,11 @@ export type MinimalReceiver = Pick<Receiver, "name" | "isOpen" | "credit" | "add
 
 /**
  * @internal
- * @hidden
  */
 type MessageAndDelivery = Pick<EventContext, "message" | "delivery">;
 
 /**
  * @internal
- * @hidden
  */
 interface ReceiveMessageArgs extends OperationOptionsBase {
   maxMessageCount: number;
@@ -232,7 +226,6 @@ interface ReceiveMessageArgs extends OperationOptionsBase {
  * Usable with both session and non-session receivers.
  *
  * @internal
- * @hidden
  */
 export class BatchingReceiverLite {
   /**

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -20,7 +20,6 @@ import { ServiceBusError } from "../serviceBusError";
 
 /**
  * @internal
- * @hidden
  * Options passed to the constructor of LinkEntity
  */
 export interface LinkEntityOptions {
@@ -39,7 +38,6 @@ export interface LinkEntityOptions {
  * with the ManagementClient today.
  *
  * @internal
- * @hidden
  */
 export interface RequestResponseLinkOptions {
   senderOptions: SenderOptions;
@@ -49,7 +47,6 @@ export interface RequestResponseLinkOptions {
 
 /**
  * @internal
- * @hidden
  */
 export type ReceiverType =
   | "batching" // batching receiver
@@ -58,7 +55,6 @@ export type ReceiverType =
 
 /**
  * @internal
- * @hidden
  */
 type LinkOptionsT<
   LinkT extends Receiver | AwaitableSender | RequestResponseLink
@@ -72,7 +68,6 @@ type LinkOptionsT<
 
 /**
  * @internal
- * @hidden
  */
 type LinkTypeT<
   LinkT extends Receiver | AwaitableSender | RequestResponseLink
@@ -86,7 +81,6 @@ type LinkTypeT<
 
 /**
  * @internal
- * @hidden
  * Describes the base class for entities like MessageSender, MessageReceiver and Management client.
  */
 export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | RequestResponseLink> {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -52,7 +52,6 @@ import { defaultDataTransformer } from "../dataTransformer";
 
 /**
  * @internal
- * @hidden
  */
 export interface SendManagementRequestOptions extends SendRequestOptions {
   /**
@@ -131,7 +130,6 @@ export interface CorrelationRuleFilter {
 
 /**
  * @internal
- * @hidden
  */
 const correlationProperties = [
   "correlationId",
@@ -147,7 +145,6 @@ const correlationProperties = [
 
 /**
  * @internal
- * @hidden
  * Options to set when updating the disposition status
  */
 export interface DispositionStatusOptions extends OperationOptionsBase {
@@ -174,7 +171,6 @@ export interface DispositionStatusOptions extends OperationOptionsBase {
 
 /**
  * @internal
- * @hidden
  * Options passed to the constructor of ManagementClient
  */
 export interface ManagementClientOptions {
@@ -184,7 +180,6 @@ export interface ManagementClientOptions {
 
 /**
  * @internal
- * @hidden
  * @class ManagementClient
  * Describes the ServiceBus Management Client that talks
  * to the $management endpoint over AMQP connection.

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -27,7 +27,6 @@ import { translateServiceBusError } from "../serviceBusError";
 
 /**
  * @internal
- * @hidden
  */
 export interface OnAmqpEventAsPromise extends OnAmqpEvent {
   (context: EventContext): Promise<void>;
@@ -35,7 +34,6 @@ export interface OnAmqpEventAsPromise extends OnAmqpEvent {
 
 /**
  * @internal
- * @hidden
  */
 export interface ReceiveOptions extends SubscribeOptions {
   /**
@@ -58,7 +56,6 @@ export interface ReceiveOptions extends SubscribeOptions {
 /**
  * Describes the signature of the message handler passed to `registerMessageHandler` method.
  * @internal
- * @hidden
  */
 export interface OnMessage {
   /**
@@ -71,7 +68,6 @@ export interface OnMessage {
  * Describes the signature of the error handler passed to `registerMessageHandler` method.
  *
  * @internal
- * @hidden
  */
 export interface OnError {
   /**
@@ -88,7 +84,6 @@ export interface OnError {
  * with an implicit ProcessErrorContext. Used by LockRenewer.
  *
  * @internal
- * @hidden
  */
 export interface OnErrorNoContext {
   (error: MessagingError | Error): void;
@@ -96,7 +91,6 @@ export interface OnErrorNoContext {
 
 /**
  * @internal
- * @hidden
  * Describes the MessageReceiver that will receive messages from ServiceBus.
  * @class MessageReceiver
  */

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -40,7 +40,6 @@ import { defaultDataTransformer } from "../dataTransformer";
 
 /**
  * @internal
- * @hidden
  * Describes the MessageSender that will send messages to ServiceBus.
  * @class MessageSender
  */

--- a/sdk/servicebus/service-bus/src/core/receiverHelper.ts
+++ b/sdk/servicebus/service-bus/src/core/receiverHelper.ts
@@ -9,7 +9,6 @@ import { receiverLogger as logger } from "../log";
  * like credits, draining, etc...
  *
  * @internal
- * @hidden
  */
 export class ReceiverHelper {
   private _isSuspended: boolean = false;

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -8,7 +8,6 @@ import { ReceiveMode } from "../models";
 
 /**
  * @internal
- * @hidden
  */
 export type ReceiverHandlers = Pick<
   ReceiverOptions,
@@ -35,7 +34,6 @@ export interface DeferredPromiseAndTimer {
  * 5. User's code after the settlement continues.
  *
  * @internal
- * @hidden
  */
 export function onMessageSettled(
   logPrefix: string,
@@ -82,7 +80,6 @@ export function onMessageSettled(
  * Creates the options that need to be specified while creating an AMQP receiver link.
  *
  * @internal
- * @hidden
  * @param {string} name
  * @param {ReceiveMode} receiveMode
  * @param {Source} source

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -32,7 +32,6 @@ import { ReceiverHandlers } from "./shared";
 
 /**
  * @internal
- * @hidden
  */
 export interface StreamingReceiverInitArgs
   extends ReceiveOptions,
@@ -42,7 +41,6 @@ export interface StreamingReceiverInitArgs
 
 /**
  * @internal
- * @hidden
  * Describes the streaming receiver where the user can receive the message
  * by providing handler functions.
  * @class StreamingReceiver

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -9,7 +9,6 @@ import { logErrorStackTrace, logger } from "./log";
 /**
  * The default data transformer that will be used by the Azure SDK.
  * @internal
- * @hidden
  */
 export const defaultDataTransformer = {
   /**

--- a/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
@@ -49,7 +49,6 @@ export function instrumentServiceBusMessage(
  * Extracts the `SpanContext` from an `ServiceBusMessage` if the context exists.
  * @param message An individual `ServiceBusMessage` object.
  * @internal
- * @hidden
  */
 export function extractSpanContextFromServiceBusMessage(
   message: ServiceBusMessage
@@ -68,7 +67,6 @@ export function extractSpanContextFromServiceBusMessage(
  *
  * @param receivedMessages A single message or a set of messages
  * @internal
- * @hidden
  */
 function* getReceivedMessages(
   receivedMessages: ServiceBusReceivedMessage | ServiceBusReceivedMessage[]
@@ -92,7 +90,6 @@ function* getReceivedMessages(
  * give the message to the user.
  *
  * @internal
- * @hidden
  */
 export function createProcessingSpan(
   receivedMessages: ServiceBusReceivedMessage | ServiceBusReceivedMessage[],
@@ -141,7 +138,6 @@ export function createProcessingSpan(
  * know the scope.
  *
  * @internal
- * @hidden
  */
 export function createAndEndProcessingSpan(
   receivedMessages: ServiceBusReceivedMessage | ServiceBusReceivedMessage[],

--- a/sdk/servicebus/service-bus/src/diagnostics/messageSpan.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/messageSpan.ts
@@ -7,7 +7,6 @@ import { Span, SpanContext, SpanKind } from "@opentelemetry/api";
 
 /**
  * @internal
- * @hidden
  */
 export function createMessageSpan(
   parentSpan?: Span | SpanContext | null,

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -8,49 +8,42 @@ import { AmqpError } from "rhea-promise";
  * The @azure/logger configuration for this package.
  * This will output logs using the `azure:service-bus` namespace prefix.
  * @internal
- * @hidden
  */
 export const logger = createServiceBusLogger("service-bus");
 
 /**
  * Logging for ServiceBusReceivers of any type (session, non-session)
  * @internal
- * @hidden
  */
 export const receiverLogger = createServiceBusLogger("service-bus:receiver");
 
 /**
  * Logging for ServiceBusSenders
  * @internal
- * @hidden
  */
 export const senderLogger = createServiceBusLogger("service-bus:sender");
 
 /**
  * Logging for connection management
  * @internal
- * @hidden
  */
 export const connectionLogger = createServiceBusLogger("service-bus:connection");
 
 /**
  * Logging for the ServiceBusAdministrationClient
  * @internal
- * @hidden
  */
 export const administrationLogger = createServiceBusLogger("service-bus:administration");
 
 /**
  * Logging related to message encoding/decoding.
  * @internal
- * @hidden
  */
 export const messageLogger = createServiceBusLogger("service-bus:messages");
 
 /**
  * Logging related to message encoding/decoding.
  * @internal
- * @hidden
  */
 export const managementClientLogger = createServiceBusLogger("service-bus:management");
 
@@ -58,7 +51,6 @@ export const managementClientLogger = createServiceBusLogger("service-bus:manage
  * Logs the error's stack trace to "verbose" if a stack trace is available.
  * @param error Error containing a stack trace.
  * @internal
- * @hidden
  */
 export function logErrorStackTrace(_logger: AzureLogger, error: any) {
   if (error && error.stack) {
@@ -68,7 +60,6 @@ export function logErrorStackTrace(_logger: AzureLogger, error: any) {
 
 /**
  * @internal
- * @hidden
  */
 export interface ServiceBusLogger extends AzureLogger {
   /**
@@ -88,7 +79,6 @@ export interface ServiceBusLogger extends AzureLogger {
 /**
  * Creates an AzureLogger with any additional methods for standardized logging (for example, with errors)
  * @internal
- * @hidden
  */
 export function createServiceBusLogger(namespace: string) {
   const _logger = createClientLogger(namespace) as ServiceBusLogger;
@@ -121,7 +111,6 @@ export function createServiceBusLogger(namespace: string) {
 
 /**
  * @internal
- * @hidden
  */
 function isError(err: Error | AmqpError | undefined): err is Error {
   return err != null && (err as any).name != null;

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -54,7 +54,6 @@ export interface MessageHandlers {
 
 /**
  * @internal
- * @hidden
  */
 export interface InternalMessageHandlers extends MessageHandlers {
   /**
@@ -68,7 +67,6 @@ export interface InternalMessageHandlers extends MessageHandlers {
 /**
  * Represents the possible receive modes for the receiver.
  * @internal
- * @hidden
  */
 export type ReceiveMode = "peekLock" | "receiveAndDelete";
 

--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -16,7 +16,6 @@ export type OperationOptionsBase = Pick<OperationOptions, "abortSignal" | "traci
 
 /**
  * @internal
- * @hidden
  */
 export function getParentSpan(
   options?: OperationTracingOptions
@@ -26,7 +25,6 @@ export function getParentSpan(
 
 /**
  * @internal
- * @hidden
  *
  * @param {(Span | SpanContext | null)} [parentSpan]
  * @param {SpanContext[]} [spanContextsToLink=[]]

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -270,7 +270,6 @@ export interface ServiceBusReceiver {
 
 /**
  * @internal
- * @hidden
  */
 export class ServiceBusReceiverImpl implements ServiceBusReceiver {
   private _retryOptions: RetryOptions;
@@ -765,6 +764,5 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
  * This timeout only applies to receiveMessages()
  *
  * @internal
- * @hidden
  */
 export const defaultMaxTimeAfterFirstMessageForBatchingMs = 1000;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -111,7 +111,6 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
 
 /**
  * @internal
- * @hidden
  */
 export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver {
   public sessionId: string;

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -19,7 +19,6 @@ import { MessageAlreadySettled } from "../util/errors";
 
 /**
  * @internal
- * @hidden
  */
 export function assertValidMessageHandlers(handlers: any) {
   if (
@@ -35,7 +34,6 @@ export function assertValidMessageHandlers(handlers: any) {
 
 /**
  * @internal
- * @hidden
  */
 export async function* getMessageIterator(
   receiver: Pick<ServiceBusReceiver, "receiveMessages">,
@@ -54,7 +52,6 @@ export async function* getMessageIterator(
 
 /**
  * @internal
- * @hidden
  */
 export function wrapProcessErrorHandler(
   handlers: Pick<MessageHandlers, "processError">,
@@ -72,7 +69,6 @@ export function wrapProcessErrorHandler(
 
 /**
  * @internal
- * @hidden
  *
  * @param {ServiceBusMessageImpl} message
  * @param {ConnectionContext} context
@@ -93,7 +89,6 @@ export function completeMessage(
 
 /**
  * @internal
- * @hidden
  *
  * @param {ServiceBusMessageImpl} message
  * @param {ConnectionContext} context
@@ -118,7 +113,6 @@ export function abandonMessage(
 
 /**
  * @internal
- * @hidden
  *
  * @param {ServiceBusMessageImpl} message
  * @param {ConnectionContext} context
@@ -143,7 +137,6 @@ export function deferMessage(
 
 /**
  * @internal
- * @hidden
  *
  * @param {ServiceBusMessageImpl} message
  * @param {ConnectionContext} context
@@ -187,7 +180,6 @@ export function deadLetterMessage(
 
 /**
  * @internal
- * @hidden
  *
  * @param {ServiceBusMessageImpl} message
  * @param {DispositionType} operation

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -130,7 +130,6 @@ export interface ServiceBusSender {
 
 /**
  * @internal
- * @hidden
  * @class ServiceBusSenderImpl
  * @implements {ServiceBusSender}
  */
@@ -342,7 +341,6 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
 
 /**
  * @internal
- * @hidden
  */
 export function isServiceBusMessageBatch(
   messageBatchOrAnything: any

--- a/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
@@ -43,7 +43,6 @@ export interface NamespaceProperties {
 
 /**
  * @internal
- * @hidden
  * Builds the namespace object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawNamespace
@@ -66,7 +65,6 @@ export function buildNamespace(rawNamespace: any): NamespaceProperties {
 
 /**
  * @internal
- * @hidden
  * Atom XML Serializer for Namespaces.
  */
 export class NamespaceResourceSerializer implements AtomXmlSerializer {

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -25,7 +25,6 @@ import {
 
 /**
  * @internal
- * @hidden
  * Builds the queue options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
@@ -56,7 +55,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
 
 /**
  * @internal
- * @hidden
  * Builds the queue object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawQueue
@@ -114,7 +112,6 @@ export function buildQueue(rawQueue: any): QueueProperties {
 
 /**
  * @internal
- * @hidden
  * Builds the queue runtime info object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawQueue
@@ -415,7 +412,6 @@ export interface QueueProperties {
 }
 /**
  * @internal
- * @hidden
  * Internal representation of settable options on a queue
  */
 export interface InternalQueueOptions {
@@ -616,7 +612,6 @@ export interface QueueRuntimeProperties {
 
 /**
  * @internal
- * @hidden
  * Atom XML Serializer for Queues.
  */
 export class QueueResourceSerializer implements AtomXmlSerializer {

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -13,7 +13,6 @@ import { getString, getStringOrUndefined } from "../util/utils";
 
 /**
  * @internal
- * @hidden
  * Builds the rule object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawRule
@@ -28,7 +27,6 @@ export function buildRule(rawRule: any): RuleProperties {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `filter` value from given input,
  * or undefined if not passed in.
  * @param value
@@ -62,7 +60,6 @@ function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve rule `action` value from given input.
  * @param value
  */
@@ -76,7 +73,6 @@ function getRuleAction(value: any): SqlRuleAction {
 /**
  * Represents the options to create a rule for a subscription.
  * @internal
- * @hidden
  */
 export interface CreateRuleOptions {
   /**
@@ -156,7 +152,6 @@ export interface SqlRuleFilter {
 
 /**
  * @internal
- * @hidden
  *
  * @interface InternalRuleOptions
  */
@@ -168,7 +163,6 @@ export interface InternalRuleOptions {
 
 /**
  * @internal
- * @hidden
  *
  * @param {CreateRuleOptions} rule
  */
@@ -246,7 +240,6 @@ export function buildInternalRuleResource(rule: CreateRuleOptions): InternalRule
 
 /**
  * @internal
- * @hidden
  * RuleResourceSerializer for serializing / deserializing Rule entities
  */
 export class RuleResourceSerializer implements AtomXmlSerializer {
@@ -261,7 +254,6 @@ export class RuleResourceSerializer implements AtomXmlSerializer {
 
 /**
  * @internal
- * @hidden
  */
 export function isSqlRuleAction(action: any): action is SqlRuleAction {
   return action != null && typeof action === "object" && "sqlExpression" in action;
@@ -272,7 +264,6 @@ export function isSqlRuleAction(action: any): action is SqlRuleAction {
  * the request would fail otherwise.
  *
  * @internal
- * @hidden
  */
 enum TypeMapForRequestSerialization {
   double = "l28:double",
@@ -284,7 +275,6 @@ enum TypeMapForRequestSerialization {
 
 /**
  * @internal
- * @hidden
  */
 enum TypeMapForResponseDeserialization {
   int = "int",
@@ -296,7 +286,6 @@ enum TypeMapForResponseDeserialization {
 
 /**
  * @internal
- * @hidden
  * Internal representation of key-value pair
  */
 type RawKeyValuePair = {
@@ -306,7 +295,6 @@ type RawKeyValuePair = {
 
 /**
  * @internal
- * @hidden
  */
 interface InternalRawKeyValuePairs {
   KeyValueOfstringanyType: RawKeyValuePair[];
@@ -316,13 +304,11 @@ interface InternalRawKeyValuePairs {
  * Key-value pairs are supposed to be wrapped with this tag in the XML request, they are ignored otherwise.
  *
  * @internal
- * @hidden
  */
 const keyValuePairXMLTag = "KeyValueOfstringanyType";
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve the key-value pairs from the RawKeyValue object from given input,
  * or undefined if not passed in.
  * @param value
@@ -380,7 +366,6 @@ function getKeyValuePairsOrUndefined(
 
 /**
  * @internal
- * @hidden
  * Helper utility to extract array of user properties key-value instances from given input,
  * or undefined if not passed in.
  * @param value

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -28,7 +28,6 @@ import {
 
 /**
  * @internal
- * @hidden
  * Builds the subscription options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
@@ -63,7 +62,6 @@ export function buildSubscriptionOptions(
 
 /**
  * @internal
- * @hidden
  * Builds the subscription object from the raw json object gotten after deserializing
  * the response from the service
  * @param rawSubscription
@@ -114,7 +112,6 @@ export function buildSubscription(rawSubscription: any): SubscriptionProperties 
 
 /**
  * @internal
- * @hidden
  * Builds the subscription runtime info object from the raw json object gotten after deserializing
  * the response from the service
  * @param rawSubscription
@@ -392,7 +389,6 @@ export interface SubscriptionProperties {
 
 /**
  * @internal
- * @hidden
  * Internal representation of settable options on a subscription
  */
 export interface InternalSubscriptionOptions {
@@ -560,7 +556,6 @@ export interface SubscriptionRuntimeProperties {
 
 /**
  * @internal
- * @hidden
  * SubscriptionResourceSerializer for serializing / deserializing Subscription entities
  */
 export class SubscriptionResourceSerializer implements AtomXmlSerializer {

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -25,7 +25,6 @@ import {
 
 /**
  * @internal
- * @hidden
  * Builds the topic options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
@@ -51,7 +50,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
 
 /**
  * @internal
- * @hidden
  * Builds the topic object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawTopic
@@ -96,7 +94,6 @@ export function buildTopic(rawTopic: any): TopicProperties {
 
 /**
  * @internal
- * @hidden
  * Builds the topic runtime info object from the raw json object gotten after deserializing the
  * response from the service
  * @param rawTopic
@@ -314,7 +311,6 @@ export interface TopicProperties {
 
 /**
  * @internal
- * @hidden
  * Internal representation of settable options on a topic
  */
 export interface InternalTopicOptions {
@@ -453,7 +449,6 @@ export interface TopicRuntimeProperties {
 
 /**
  * @internal
- * @hidden
  * TopicResourceSerializer for serializing / deserializing Topic entities
  */
 export class TopicResourceSerializer implements AtomXmlSerializer {

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -434,7 +434,6 @@ export class ServiceBusClient {
  * topic, subscription, options
  *
  * @internal
- * @hidden
  */
 export function extractReceiverArguments<OptionsT extends { receiveMode?: ReceiveMode }>(
   queueOrTopicName1: string,
@@ -479,7 +478,6 @@ export function extractReceiverArguments<OptionsT extends { receiveMode?: Receiv
  * queue or topic name passed to the methods that create senders and receivers.
  *
  * @internal
- * @hidden
  */
 function validateEntityPath(connectionConfig: ConnectionConfig, queueOrTopicName: string): void {
   if (connectionConfig.entityPath && connectionConfig.entityPath !== queueOrTopicName) {

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -67,7 +67,6 @@ export type ServiceBusErrorCode =
  * Translation between the MessagingErrorCodes into a ServiceBusCode
  *
  * @internal
- * @hidden
  */
 export const wellKnownMessageCodesToServiceBusCodes: Map<string, ServiceBusErrorCode> = new Map([
   ["MessagingEntityNotFoundError", "MessagingEntityNotFound"],
@@ -159,7 +158,6 @@ export class ServiceBusError extends MessagingError {
  * Service Bus specific handling of the error (falling back to default translate behavior otherwise).
  *
  * @internal
- * @hidden
  */
 export function translateServiceBusError(err: AmqpError | Error): ServiceBusError | Error {
   if (isServiceBusError(err)) {

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -18,7 +18,6 @@ import { reorderLockToken } from "./util/utils";
 
 /**
  * @internal
- * @hidden
  */
 export enum DispositionType {
   complete = "complete",
@@ -29,7 +28,6 @@ export enum DispositionType {
 
 /**
  * @internal
- * @hidden
  * Describes the delivery annotations for Service Bus.
  */
 export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
@@ -57,7 +55,6 @@ export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
 
 /**
  * @internal
- * @hidden
  * Describes the message annotations for Service Bus.
  */
 export interface ServiceBusMessageAnnotations extends MessageAnnotations {
@@ -217,7 +214,6 @@ export interface ServiceBusMessage {
 
 /**
  * @internal
- * @hidden
  * Gets the error message for when a property on given message is not of expected type
  */
 export function getMessagePropertyTypeMismatchError(msg: ServiceBusMessage): Error | undefined {
@@ -275,7 +271,6 @@ export function getMessagePropertyTypeMismatchError(msg: ServiceBusMessage): Err
 
 /**
  * @internal
- * @hidden
  * Converts given ServiceBusMessage to RheaMessage
  */
 export function toRheaMessage(msg: ServiceBusMessage): RheaMessage {
@@ -444,7 +439,6 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
 
 /**
  * @internal
- * @hidden
  * Converts given RheaMessage to ServiceBusReceivedMessage
  */
 export function fromRheaMessage(
@@ -563,7 +557,6 @@ export function fromRheaMessage(
 
 /**
  * @internal
- * @hidden
  */
 export function isServiceBusMessage(possible: any): possible is ServiceBusMessage {
   return possible != null && typeof possible === "object" && "body" in possible;
@@ -573,7 +566,6 @@ export function isServiceBusMessage(possible: any): possible is ServiceBusMessag
  * Describes the message received from Service Bus.
  *
  * @internal
- * @hidden
  * @class ServiceBusMessageImpl
  * @implements {ServiceBusReceivedMessage}
  */

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -25,19 +25,16 @@ import { defaultDataTransformer } from "./dataTransformer";
 
 /**
  * @internal
- * @hidden
  * The amount of bytes to reserve as overhead for a small message.
  */
 const smallMessageOverhead = 5;
 /**
  * @internal
- * @hidden
  * The amount of bytes to reserve as overhead for a large message.
  */
 const largeMessageOverhead = 8;
 /**
  * @internal
- * @hidden
  * The maximum number of bytes that a message may be to be considered small.
  */
 const smallMessageMaxBytes = 255;
@@ -104,7 +101,6 @@ export interface ServiceBusMessageBatch {
  *
  * @class
  * @internal
- * @hidden
  */
 export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   /**

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -10,7 +10,6 @@ import jssha from "jssha";
 /**
  * @class SharedKeyCredential
  * @internal
- * @hidden
  * Defines the SharedKeyCredential.
  */
 export class SharedKeyCredential {
@@ -99,7 +98,6 @@ export class SharedKeyCredential {
  * `SharedAccessSignature sr=<resource>&sig=<signature>&se=<expiry>&skn=<keyname>`
  *
  * @internal
- * @hidden
  */
 export class SharedAccessSignatureCredential extends SharedKeyCredential {
   private _accessToken: AccessToken;

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -39,7 +39,6 @@ import { abandonMessage, completeMessage } from "../receivers/shared";
 /**
  * Describes the options that need to be provided while creating a message session receiver link.
  * @internal
- * @hidden
  */
 export interface CreateMessageSessionReceiverLinkOptions {
   onClose: OnAmqpEventAsPromise;
@@ -52,7 +51,6 @@ export interface CreateMessageSessionReceiverLinkOptions {
 
 /**
  * @internal
- * @hidden
  * Describes all the options that can be set while instantiating a MessageSession object.
  */
 export type MessageSessionOptions = Pick<
@@ -64,7 +62,6 @@ export type MessageSessionOptions = Pick<
 
 /**
  * @internal
- * @hidden
  * Describes the receiver for a Message Session.
  */
 export class MessageSession extends LinkEntity<Receiver> {

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -23,7 +23,6 @@ import { isJSONLikeObject } from "./utils";
 
 /**
  * @internal
- * @hidden
  * Represents the internal ATOM XML serializer interface
  */
 export interface AtomXmlSerializer {
@@ -34,7 +33,6 @@ export interface AtomXmlSerializer {
 
 /**
  * @internal
- * @hidden
  * Utility to execute Atom XML operations as HTTP requests
  * @param webResource
  * @param serializer
@@ -94,7 +92,6 @@ export async function executeAtomXmlOperation(
 
 /**
  * @internal
- * @hidden
  * The key-value pairs having undefined/null as the values would lead to the empty tags in the serialized XML request.
  * Empty tags in the request body is problematic because of the following reasons.
  * - ATOM based management operations throw a "Bad Request" error if empty tags are included in the XML request body at top level.
@@ -116,7 +113,6 @@ export function sanitizeSerializableObject(resource: { [key: string]: any }) {
 
 /**
  * @internal
- * @hidden
  * Serializes input information to construct the Atom XML request
  * @param resourceName Name of the resource to be serialized like `QueueDescription`
  * @param resource The entity details
@@ -147,7 +143,6 @@ export function serializeToAtomXmlRequest(resourceName: string, resource: any): 
 
 /**
  * @internal
- * @hidden
  * Transforms response to contain the parsed data.
  * @param nameProperties The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
@@ -170,7 +165,6 @@ export async function deserializeAtomXmlResponse(
 
 /**
  * @internal
- * @hidden
  * Utility to deserialize the given JSON content in response body based on
  * if it's a single `entry` or `feed` and updates the `response.parsedBody` to hold the evaluated output.
  * @param response Response containing the JSON value in `response.parsedBody`
@@ -219,7 +213,6 @@ function parseAtomResult(response: HttpOperationResponse, nameProperties: string
 
 /**
  * @internal
- * @hidden
  * Utility to help parse given `entry` result
  * @param entry
  */
@@ -268,7 +261,6 @@ function parseEntryResult(entry: any): object | undefined {
 
 /**
  * @internal
- * @hidden
  * Utility to help parse link info from the given `feed` result
  * @param feedLink
  */
@@ -289,7 +281,6 @@ function parseLinkInfo(
 
 /**
  * @internal
- * @hidden
  * Utility to help parse given `feed` result
  * @param feed
  */
@@ -316,7 +307,6 @@ function parseFeedResult(feed: any): object[] & { nextLink?: string } {
 
 /**
  * @internal
- * @hidden
  * @param {number} statusCode
  * @returns {statusCode is keyof typeof Constants.HttpResponseCodes}
  */
@@ -328,7 +318,6 @@ function isKnownResponseCode(
 
 /**
  * @internal
- * @hidden
  * Extracts the applicable entity name(s) from the URL based on the known structure
  * and instantiates the corresponding name properties to the deserialized response
  *
@@ -388,7 +377,6 @@ function setName(entry: any, nameProperties: any): any {
 
 /**
  * @internal
- * @hidden
  * Utility to help construct the normalized `RestError` object based on given error
  * information and other data present in the received `response` object.
  * @param response
@@ -435,7 +423,6 @@ export function buildError(response: HttpOperationResponse): RestError {
 
 /**
  * @internal
- * @hidden
  * Helper utility to construct user friendly error codes based on based on given error
  * information and other data present in the received `response` object.
  * @param response

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -3,7 +3,6 @@
 
 /**
  * @internal
- * @hidden
  */
 export const packageJsonInfo = {
   name: "@azure/service-bus",
@@ -12,111 +11,95 @@ export const packageJsonInfo = {
 
 /**
  * @internal
- * @hidden
  */
 export const messageDispositionTimeout = 20000;
 
 /**
  * @internal
- * @hidden
  */
 export const max32BitNumber = Math.pow(2, 31) - 1;
 
 /**
  * Queue name identifier
  * @internal
- * @hidden
  */
 export const QUEUE_NAME = "QueueName";
 
 /**
  * Topic name identifier
  * @internal
- * @hidden
  */
 export const TOPIC_NAME = "TopicName";
 
 /**
  * Subscription name identifier
  * @internal
- * @hidden
  */
 export const SUBSCRIPTION_NAME = "SubscriptionName";
 
 /**
  * Rule name identifier
  * @internal
- * @hidden
  */
 export const RULE_NAME = "RuleName";
 
 /**
  * Accessed at field
  * @internal
- * @hidden
  */
 export const ACCESSED_AT = "AccessedAt";
 
 /**
  * Updated at field
  * @internal
- * @hidden
  */
 export const UPDATED_AT = "UpdatedAt";
 
 /**
  * Created at field
  * @internal
- * @hidden
  */
 export const CREATED_AT = "CreatedAt";
 
 /**
  * Authorization rules on the entity
  * @internal
- * @hidden
  */
 export const AUTHORIZATION_RULES = "AuthorizationRules";
 
 /**
  * Is Anonymous Accessible field
  * @internal
- * @hidden
  */
 export const IS_ANONYMOUS_ACCESSIBLE = "IsAnonymousAccessible";
 
 /**
  * Entity Availability Status field
  * @internal
- * @hidden
  */
 export const ENTITY_AVAILABILITY_STATUS = "EntityAvailabilityStatus";
 
 /**
  * Enable express option
  * @internal
- * @hidden
  */
 export const ENABLE_EXPRESS = "EnableExpress";
 
 /**
  * Is express option
  * @internal
- * @hidden
  */
 export const IS_EXPRESS = "IsExpress";
 
 /**
  * Enable Subscription Partitioning option
  * @internal
- * @hidden
  */
 export const ENABLE_SUBSCRIPTION_PARTITIONING = "EnableSubscriptionPartitioning";
 
 /**
  * Filtering Messages Before Publishing option
  * @internal
- * @hidden
  */
 export const FILTER_MESSAGES_BEFORE_PUBLISHING = "FilteringMessagesBeforePublishing";
 
@@ -124,7 +107,6 @@ export const FILTER_MESSAGES_BEFORE_PUBLISHING = "FilteringMessagesBeforePublish
  * The entity's size in bytes.
  *
  * @internal
- * @hidden
  */
 export const SIZE_IN_BYTES = "SizeInBytes";
 
@@ -132,7 +114,6 @@ export const SIZE_IN_BYTES = "SizeInBytes";
  * The entity's message count.
  *
  * @internal
- * @hidden
  */
 export const MESSAGE_COUNT = "MessageCount";
 
@@ -140,7 +121,6 @@ export const MESSAGE_COUNT = "MessageCount";
  * The topic's subscription count.
  *
  * @internal
- * @hidden
  */
 export const SUBSCRIPTION_COUNT = "SubscriptionCount";
 
@@ -148,7 +128,6 @@ export const SUBSCRIPTION_COUNT = "SubscriptionCount";
  * The topic / subscription's count details.
  *
  * @internal
- * @hidden
  */
 export const COUNT_DETAILS = "CountDetails";
 
@@ -156,7 +135,6 @@ export const COUNT_DETAILS = "CountDetails";
  * The default rule name.
  *
  * @internal
- * @hidden
  */
 export const DEFAULT_RULE_NAME = "$Default";
 
@@ -164,7 +142,6 @@ export const DEFAULT_RULE_NAME = "$Default";
  * Max idle time before entity is deleted.
  * This is specified in ISO-8601 duration format such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
  * @internal
- * @hidden
  */
 export const AUTO_DELETE_ON_IDLE = "AutoDeleteOnIdle";
 
@@ -172,7 +149,6 @@ export const AUTO_DELETE_ON_IDLE = "AutoDeleteOnIdle";
  * The status information on response
  *
  * @internal
- * @hidden
  */
 export const STATUS = "Status";
 
@@ -180,7 +156,6 @@ export const STATUS = "Status";
  * The URL of Service Bus entity to forward messages to.
  *
  * @internal
- * @hidden
  */
 export const FORWARD_TO = "ForwardTo";
 
@@ -188,7 +163,6 @@ export const FORWARD_TO = "ForwardTo";
  * The user meta data information
  *
  * @internal
- * @hidden
  */
 export const USER_METADATA = "UserMetadata";
 
@@ -196,7 +170,6 @@ export const USER_METADATA = "UserMetadata";
  * The maximum size in megabytes.
  *
  * @internal
- * @hidden
  */
 export const MAX_SIZE_IN_MEGABYTES = "MaxSizeInMegabytes";
 
@@ -204,7 +177,6 @@ export const MAX_SIZE_IN_MEGABYTES = "MaxSizeInMegabytes";
  * The default message time to live.
  * This is specified in ISO-8601 duration format such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
  * @internal
- * @hidden
  */
 export const DEFAULT_MESSAGE_TIME_TO_LIVE = "DefaultMessageTimeToLive";
 
@@ -212,7 +184,6 @@ export const DEFAULT_MESSAGE_TIME_TO_LIVE = "DefaultMessageTimeToLive";
  * The lock duration.
  * This is specified in ISO-8601 duration format such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
  * @internal
- * @hidden
  */
 export const LOCK_DURATION = "LockDuration";
 
@@ -220,7 +191,6 @@ export const LOCK_DURATION = "LockDuration";
  * The indication if session is required or not.
  *
  * @internal
- * @hidden
  */
 export const REQUIRES_SESSION = "RequiresSession";
 
@@ -228,7 +198,6 @@ export const REQUIRES_SESSION = "RequiresSession";
  * The indication if duplicate detection is required or not.
  *
  * @internal
- * @hidden
  */
 export const REQUIRES_DUPLICATE_DETECTION = "RequiresDuplicateDetection";
 
@@ -239,7 +208,6 @@ export const REQUIRES_DUPLICATE_DETECTION = "RequiresDuplicateDetection";
  * Settable only at entity creation time.
  *
  * @internal
- * @hidden
  */
 export const DEAD_LETTERING_ON_MESSAGE_EXPIRATION = "DeadLetteringOnMessageExpiration";
 
@@ -247,7 +215,6 @@ export const DEAD_LETTERING_ON_MESSAGE_EXPIRATION = "DeadLetteringOnMessageExpir
  * The indication if dead lettering on filter evaluation exceptions.
  *
  * @internal
- * @hidden
  */
 export const DEAD_LETTERING_ON_FILTER_EVALUATION_EXCEPTIONS =
   "DeadLetteringOnFilterEvaluationExceptions";
@@ -256,7 +223,6 @@ export const DEAD_LETTERING_ON_FILTER_EVALUATION_EXCEPTIONS =
  * The history time window for duplicate detection.
  * This is specified in ISO-8601 duration format such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
  * @internal
- * @hidden
  */
 export const DUPLICATE_DETECTION_HISTORY_TIME_WINDOW = "DuplicateDetectionHistoryTimeWindow";
 
@@ -264,7 +230,6 @@ export const DUPLICATE_DETECTION_HISTORY_TIME_WINDOW = "DuplicateDetectionHistor
  * The maximum delivery count of messages after which if it is still not settled, gets moved to the dead-letter sub-queue.
  *
  * @internal
- * @hidden
  */
 export const MAX_DELIVERY_COUNT = "MaxDeliveryCount";
 
@@ -272,7 +237,6 @@ export const MAX_DELIVERY_COUNT = "MaxDeliveryCount";
  * Indicates if the queue has enabled batch operations.
  *
  * @internal
- * @hidden
  */
 export const ENABLE_BATCHED_OPERATIONS = "EnableBatchedOperations";
 
@@ -280,7 +244,6 @@ export const ENABLE_BATCHED_OPERATIONS = "EnableBatchedOperations";
  * Indicates whether the topic can be ordered
  *
  * @internal
- * @hidden
  */
 export const SUPPORT_ORDERING = "SupportOrdering";
 
@@ -288,7 +251,6 @@ export const SUPPORT_ORDERING = "SupportOrdering";
  * Indicates whether the topic/queue should be split across multiple partitions
  *
  * @internal
- * @hidden
  */
 export const ENABLE_PARTITIONING = "EnablePartitioning";
 
@@ -296,7 +258,6 @@ export const ENABLE_PARTITIONING = "EnablePartitioning";
  * The URL of Service Bus entity to forward deadlettered messages to.
  *
  * @internal
- * @hidden
  */
 export const FORWARD_DEADLETTERED_MESSAGES_TO = "ForwardDeadLetteredMessagesTo";
 
@@ -304,7 +265,6 @@ export const FORWARD_DEADLETTERED_MESSAGES_TO = "ForwardDeadLetteredMessagesTo";
  * Query string parameter to set Service Bus API version
  *
  * @internal
- * @hidden
  */
 export const API_VERSION_QUERY_KEY = "api-version";
 
@@ -312,7 +272,6 @@ export const API_VERSION_QUERY_KEY = "api-version";
  * Current API version being sent to service bus
  *
  * @internal
- * @hidden
  */
 export const CURRENT_API_VERSION = "2017-04";
 
@@ -320,14 +279,12 @@ export const CURRENT_API_VERSION = "2017-04";
  * Constant representing the Odata Error 'message' property
  *
  * @internal
- * @hidden
  */
 export const ODATA_ERROR_MESSAGE = "message";
 /**
  * Constant representing the 'value' property of Odata Error 'message' property
  *
  * @internal
- * @hidden
  */
 export const ODATA_ERROR_MESSAGE_VALUE = "value";
 
@@ -335,7 +292,6 @@ export const ODATA_ERROR_MESSAGE_VALUE = "value";
  * Marker for atom metadata.
  *
  * @internal
- * @hidden
  */
 export const XML_METADATA_MARKER = "$";
 
@@ -343,7 +299,6 @@ export const XML_METADATA_MARKER = "$";
  * Marker for atom value.
  *
  * @internal
- * @hidden
  */
 export const XML_VALUE_MARKER = "_";
 
@@ -351,7 +306,6 @@ export const XML_VALUE_MARKER = "_";
  * Constant representing the property where the atom default elements are stored.
  *
  * @internal
- * @hidden
  */
 export const ATOM_METADATA_MARKER = "_";
 
@@ -359,7 +313,6 @@ export const ATOM_METADATA_MARKER = "_";
  * Known HTTP status codes as documented and referenced in ATOM based management API feature
  * https://docs.microsoft.com/dotnet/api/system.net.httpstatuscode?view=netframework-4.8
  * @internal
- * @hidden
  */
 export const HttpResponseCodes = {
   100: "Continue",

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -6,7 +6,6 @@
 
 /**
  * @internal
- * @hidden
  * @param {string} secret
  * @param {string} stringToSign
  * @returns {Promise<string>}
@@ -31,7 +30,6 @@ export async function generateKey(secret: string, stringToSign: string): Promise
 
 /**
  * @internal
- * @hidden
  * @param {string} value
  */
 function convertToUint8Array(value: string) {
@@ -46,7 +44,6 @@ function convertToUint8Array(value: string) {
  * Encodes a byte array in base64 format.
  * @param value the Uint8Aray to encode
  * @internal
- * @hidden
  * @param {Uint8Array} value
  * @returns {string}
  */

--- a/sdk/servicebus/service-bus/src/util/crypto.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.ts
@@ -8,7 +8,6 @@ import crypto from "crypto";
 
 /**
  * @internal
- * @hidden
  */
 export async function generateKey(secret: string, stringToSign: string) {
   const result = encodeURIComponent(

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -13,7 +13,6 @@ import { ReceiveMode } from "../models";
  * senders and receivers.
  *
  * @internal
- * @hidden
  */
 export const entityPathMisMatchError =
   "The queue or topic name provided does not match the EntityPath in the connection string passed to the ServiceBusClient constructor.";
@@ -22,13 +21,11 @@ export const entityPathMisMatchError =
  * Error message for when maxMessageCount provided is invalid.
  *
  * @internal
- * @hidden
  */
 export const InvalidMaxMessageCountError = "'maxMessageCount' must be a number greater than 0.";
 
 /**
  * @internal
- * @hidden
  * Logs and throws Error if the current AMQP connection is closed.
  * @param context The ConnectionContext associated with the current AMQP connection.
  */
@@ -43,7 +40,6 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
 
 /**
  * @internal
- * @hidden
  * Gets the error message when a sender is used when its already closed
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  */
@@ -56,7 +52,6 @@ export function getSenderClosedErrorMsg(entityPath: string): string {
 
 /**
  * @internal
- * @hidden
  * Gets the error message when a receiver is used when its already closed
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  * @param sessionId If using session receiver, then the id of the session
@@ -76,7 +71,6 @@ export function getReceiverClosedErrorMsg(entityPath: string, sessionId?: string
 
 /**
  * @internal
- * @hidden
  * @param entityPath Value of the `entityPath` property on the client which denotes its name
  * @param sessionId If using session receiver, then the id of the session
  */
@@ -89,7 +83,6 @@ export function getAlreadyReceivingErrorMsg(entityPath: string, sessionId?: stri
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is undefined or null
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to check
@@ -109,7 +102,6 @@ export function throwTypeErrorIfParameterMissing(
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is not of expected type
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -134,7 +126,6 @@ export function throwTypeErrorIfParameterTypeMismatch(
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is not of type `Long` or an array of type `Long`
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -158,7 +149,6 @@ export function throwTypeErrorIfParameterNotLong(
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is not an array of type `Long`
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -179,7 +169,6 @@ export function throwTypeErrorIfParameterNotLongArray(
 
 /**
  * @internal
- * @hidden
  * Logs and Throws TypeError if given parameter is an empty string
  * @param connectionId Id of the underlying AMQP connection used for logging
  * @param parameterName Name of the parameter to type check
@@ -200,7 +189,6 @@ export function throwTypeErrorIfParameterIsEmptyString(
 
 /**
  * @internal
- * @hidden
  * The error message for operations on the receiver that are invalid for a message received in receiveAndDelete mode.
  */
 export const InvalidOperationInReceiveAndDeleteMode =
@@ -208,7 +196,6 @@ export const InvalidOperationInReceiveAndDeleteMode =
 
 /**
  * @internal
- * @hidden
  * The error message for operations on the receiver that are invalid for a peeked message.
  */
 export const InvalidOperationForPeekedMessage =
@@ -216,7 +203,6 @@ export const InvalidOperationForPeekedMessage =
 
 /**
  * @internal
- * @hidden
  * The error message for when one attempts to settle an already settled message.
  */
 export const MessageAlreadySettled = "The message has either been deleted or already settled";
@@ -224,7 +210,6 @@ export const MessageAlreadySettled = "The message has either been deleted or alr
 /**
  * Throws error if the ServiceBusReceivedMessage cannot be settled.
  * @internal
- * @hidden
  */
 export function throwErrorIfInvalidOperationOnMessage(
   message: ServiceBusReceivedMessage,
@@ -254,7 +239,6 @@ export function throwErrorIfInvalidOperationOnMessage(
  * Error message for when the ServiceBusMessage provided by the user has different values
  * for partitionKey and sessionId.
  * @internal
- * @hidden
  * @throw
  */
 export const PartitionKeySessionIdMismatchError =
@@ -262,7 +246,6 @@ export const PartitionKeySessionIdMismatchError =
 /**
  * Throws error if the given object is not a valid ServiceBusMessage
  * @internal
- * @hidden
  * @param msg The object that needs to be validated as a ServiceBusMessage
  * @param errorMessageForWrongType The error message to use when given object is not a ServiceBusMessage
  */

--- a/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
@@ -6,7 +6,6 @@
 
 /**
  * @internal
- * @hidden
  * @param {string} rawUrl
  */
 export const parseURL = (rawUrl: string): any => {

--- a/sdk/servicebus/service-bus/src/util/parseUrl.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.ts
@@ -6,13 +6,11 @@
 
 /**
  * @internal
- * @hidden
  */
 const url = require("url");
 
 /**
  * @internal
- * @hidden
  * @param {string} rawUrl
  */
 export const parseURL = (rawUrl: string) => {

--- a/sdk/servicebus/service-bus/src/util/runtimeInfo.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/runtimeInfo.browser.ts
@@ -3,7 +3,6 @@
 
 /**
  * @internal
- * @hidden
  */
 interface NavigatorEx extends Navigator {
   // oscpu is not yet standards-compliant, but can not be undefined in TypeScript 3.6.2

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -11,7 +11,6 @@ import { generateKey } from "./crypto";
 
 /**
  * @internal
- * @hidden
  * @class SasServiceClientCredentials
  * @implements {ServiceClientCredentials}
  */

--- a/sdk/servicebus/service-bus/src/util/semaphore.ts
+++ b/sdk/servicebus/service-bus/src/util/semaphore.ts
@@ -3,7 +3,6 @@
 
 /**
  * @internal
- * @hidden
  * A simple Semaphore
  * @class Semaphore
  */

--- a/sdk/servicebus/service-bus/src/util/tracing.ts
+++ b/sdk/servicebus/service-bus/src/util/tracing.ts
@@ -7,7 +7,6 @@ import { CanonicalCode, Span, SpanKind, SpanOptions as OTSpanOptions } from "@op
 
 /**
  * @internal
- * @hidden
  * Creates a span using the global tracer.
  * @param name The name of the operation being performed.
  * @param operationOptions The options for the underlying http request.
@@ -48,7 +47,6 @@ export function createSpan(
 
 /**
  * @internal
- * @hidden
  */
 export function getCanonicalCode(err: Error) {
   if (err instanceof RestError) {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -27,7 +27,6 @@ declare const navigator: Navigator;
 
 /**
  * @internal
- * @hidden
  * Provides a uniue name by appending a string guid to the given string in the following format:
  * `{name}-{uuid}`.
  * @param name The nme of the entity
@@ -38,7 +37,6 @@ export function getUniqueName(name: string): string {
 
 /**
  * @internal
- * @hidden
  * If you try to turn a Guid into a Buffer in .NET, the bytes of the first three groups get
  * flipped within the group, but the last two groups don't get flipped, so we end up with a
  * different byte order. This is the order of bytes needed to make Service Bus recognize the token.
@@ -77,7 +75,6 @@ export function reorderLockToken(lockTokenBytes: Buffer): Buffer {
 
 /**
  * @internal
- * @hidden
  * Provides the time in milliseconds after which the lock renewal should occur.
  * @param lockedUntilUtc - The time until which the message is locked.
  */
@@ -99,7 +96,6 @@ export function calculateRenewAfterDuration(lockedUntilUtc: Date): number {
 
 /**
  * @internal
- * @hidden
  * Converts the .net ticks to a JS Date object.
  *
  * - The epoch for the DateTimeOffset type is `0000-01-01`, while the epoch for JS Dates is
@@ -126,7 +122,6 @@ export function convertTicksToDate(buf: number[]): Date {
 
 /**
  * @internal
- * @hidden
  * Returns the number of logical processors in the system.
  */
 export function getProcessorCount(): number {
@@ -140,7 +135,6 @@ export function getProcessorCount(): number {
 
 /**
  * @internal
- * @hidden
  * Converts any given input to a Buffer.
  * @param input The input that needs to be converted to a Buffer.
  */
@@ -175,7 +169,6 @@ export function toBuffer(input: any): Buffer {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `string` value from given string,
  * or throws error if undefined.
  * @param value
@@ -192,7 +185,6 @@ export function getString(value: any, nameOfProperty: string): string {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `string` value from given input,
  * or undefined if not passed in.
  * @param value
@@ -206,7 +198,6 @@ export function getStringOrUndefined(value: any): string | undefined {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `integer` value from given string,
  * or throws error if undefined.
  * @param value
@@ -223,7 +214,6 @@ export function getInteger(value: any, nameOfProperty: string): number {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `integer` value from given string,
  * or undefined if not passed in.
  * @param value
@@ -238,7 +228,6 @@ export function getIntegerOrUndefined(value: any): number | undefined {
 
 /**
  * @internal
- * @hidden
  * Helper utility to convert ISO-8601 time into Date type.
  * @param value
  */
@@ -248,7 +237,6 @@ export function getDate(value: string, nameOfProperty: string): Date {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `boolean` value from given string,
  * or throws error if undefined.
  * @param value
@@ -265,7 +253,6 @@ export function getBoolean(value: any, nameOfProperty: string): boolean {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve `boolean` value from given string,
  * or undefined if not passed in.
  * @param value
@@ -284,14 +271,12 @@ export function getBooleanOrUndefined(value: any): boolean | undefined {
 
 /**
  * @internal
- * @hidden
  * Helps in differentiating JSON like objects from other kinds of objects.
  */
 const EMPTY_JSON_OBJECT_CONSTRUCTOR = {}.constructor;
 
 /**
  * @internal
- * @hidden
  * Returns `true` if given input is a JSON like object.
  * @param value
  */
@@ -313,7 +298,6 @@ export function isJSONLikeObject(value: any): boolean {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve message count details from given input,
  * @param value
  */
@@ -334,7 +318,6 @@ export function getMessageCountDetails(value: any): MessageCountDetails {
 
 /**
  * @internal
- * @hidden
  * Gets the xmlns prefix from the root of the objects that are part of the parsed response body.
  */
 export function getXMLNSPrefix(value: any) {
@@ -375,7 +358,6 @@ export function getXMLNSPrefix(value: any) {
 /**
  * Represents type of message count details in ATOM based management operations.
  * @internal
- * @hidden
  */
 export type MessageCountDetails = {
   activeMessageCount: number;
@@ -413,7 +395,6 @@ export interface AuthorizationRule {
 
 /**
  * @internal
- * @hidden
  * Helper utility to retrieve array of `AuthorizationRule` from given input,
  * or undefined if not passed in.
  * @param value
@@ -443,7 +424,6 @@ export function getAuthorizationRulesOrUndefined(value: any): AuthorizationRule[
 
 /**
  * @internal
- * @hidden
  * Helper utility to build an instance of parsed authorization rule as `AuthorizationRule` from given input.
  * @param value
  */
@@ -469,7 +449,6 @@ function buildAuthorizationRule(value: any): AuthorizationRule {
 
 /**
  * @internal
- * @hidden
  * Helper utility to extract output containing array of `RawAuthorizationRule` instances from given input,
  * or undefined if not passed in.
  * @param value
@@ -498,7 +477,6 @@ export function getRawAuthorizationRules(authorizationRules: AuthorizationRule[]
 
 /**
  * @internal
- * @hidden
  * Helper utility to build an instance of raw authorization rule as RawAuthorizationRule from given `AuthorizationRule` input.
  * @param authorizationRule parsed Authorization Rule instance
  */
@@ -533,7 +511,6 @@ function buildRawAuthorizationRule(authorizationRule: AuthorizationRule): any {
 
 /**
  * @internal
- * @hidden
  * Helper utility to check if given string is an absolute URL
  * @param url
  */
@@ -568,7 +545,6 @@ export type EntityAvailabilityStatus =
 
 /**
  * @internal
- * @hidden
  */
 export const StandardAbortMessage = "The operation was aborted.";
 
@@ -583,7 +559,6 @@ export const StandardAbortMessage = "The operation was aborted.";
  * @returns {Promise<T>} - Resolved promise
  *
  * @internal
- * @hidden
  */
 export async function waitForTimeoutOrAbortOrResolve<T>(args: {
   actionFn: () => Promise<T>;
@@ -637,7 +612,6 @@ export async function waitForTimeoutOrAbortOrResolve<T>(args: {
  * the abortSignal was not defined.
  *
  * @internal
- * @hidden
  */
 export function checkAndRegisterWithAbortSignal(
   onAbortFn: (abortError: AbortError) => void,
@@ -663,7 +637,6 @@ export function checkAndRegisterWithAbortSignal(
 
 /**
  * @internal
- * @hidden
  * @property {string} libInfo The user agent prefix string for the ServiceBus client.
  * See guideline at https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
  */
@@ -671,7 +644,6 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
 
 /**
  * @internal
- * @hidden
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
  * @param {string} [prefix]
@@ -685,7 +657,6 @@ export function formatUserAgentPrefix(prefix?: string): string {
 
 /**
  * @internal
- * @hidden
  * Helper method which returns `HttpResponse` from an object of shape `HttpOperationResponse`.
  * @returns {HttpResponse}
  */

--- a/sdk/tables/data-tables/src/utils/tracing.ts
+++ b/sdk/tables/data-tables/src/utils/tracing.ts
@@ -10,7 +10,6 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @internal
- * @hidden
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
@@ -169,7 +169,6 @@ export function makeTextAnalyticsErrorResult(
 
 /**
  * @internal
- * @hidden
  * combines successful and erroneous results into a single array of results and
  * sort them so that the IDs order match that of the input documents array.
  * @param input - the array of documents sent to the service for processing.
@@ -184,7 +183,6 @@ export function combineSuccessfulAndErroneousDocuments<TSuccess extends TextAnal
 
 /**
  * @internal
- * @hidden
  * combines successful and erroneous results into a single array of results and
  * sort them so that the IDs order match that of the input documents array.
  * @param input - the array of documents sent to the service for processing.
@@ -211,7 +209,6 @@ export function processAndCombineSuccessfulAndErroneousDocuments<
 
 /**
  * @internal
- * @hidden
  * combines successful and erroneous results into a single array of results and
  * sort them so that the IDs order match that of the input documents array. It
  * also attaches statistics and modelVersion to the returned array.

--- a/sdk/textanalytics/ai-text-analytics/src/tracing.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/tracing.ts
@@ -9,7 +9,6 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 
 /**
  * @internal
- * @hidden
  * Creates a span using the global tracer.
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -15,7 +15,6 @@ export interface IdObject {
  * return a sorted array of results.
  *
  * @internal
- * @hidden
  * @param sortedArray - An array of entries sorted by `id`
  * @param unsortedArray - An array of entries that contain `id` but are not sorted
  */
@@ -116,7 +115,6 @@ export function getJobID(operationLocation: string): string {
 
 /**
  * @internal
- * @hidden
  * parses incoming errors from the service and if the inner error code is
  * InvalidDocumentBatch, it exposes that as the statusCode instead.
  * @param error - the incoming error


### PR DESCRIPTION
The docs team has been using `typedoc` with [`--stripInternal`](https://github.com/TypeStrong/typedoc/releases/tag/v0.15.2) flag for a while now which makes it enough to use `@internal` only for definitions that we want to not show up in docs.microsoft.com.