### PR TITLE
[KeyVault] - Address arch board feedback for Admin package

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.4 (Unreleased)
 
+- Bug fix: Fix an issue where a call to update might return stale state if the update implementation reassigns `operation.state`.
 
 ## 1.0.3 (2021-01-07)
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.4 (Unreleased)
 
-- Bug fix: Fix an issue where a call to update might return stale state if the update implementation reassigns `operation.state`.
+- Bug fix: Fix an issue where we might return stale state if the `update` implementation reassigns `operation.state`.
 
 ## 1.0.3 (2021-01-07)
 

--- a/sdk/core/core-lro/src/poller.ts
+++ b/sdk/core/core-lro/src/poller.ts
@@ -312,7 +312,6 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
    * @param options - Optional properties passed to the operation's update method.
    */
   private async pollOnce(options: { abortSignal?: AbortSignalLike } = {}): Promise<void> {
-    const state: PollOperationState<TResult> = this.operation.state;
     try {
       if (!this.isDone()) {
         this.operation = await this.operation.update({
@@ -325,11 +324,11 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
           // we are not expecting a result anyway. To assert that we might not
           // have a result eventually after finishing polling, we cast the result
           // to TResult.
-          this.resolve(state.result as TResult);
+          this.resolve(this.operation.state.result as TResult);
         }
       }
     } catch (e) {
-      state.error = e;
+      this.operation.state.error = e;
       if (this.reject) {
         this.reject(e);
       }

--- a/sdk/core/core-lro/test/utils/testOperation.ts
+++ b/sdk/core/core-lro/test/utils/testOperation.ts
@@ -42,19 +42,20 @@ async function update(
 
   let response: HttpOperationResponse;
   const doFinalResponse = previousResponse && previousResponse.parsedBody.doFinalResponse;
+  const newState = { ...this.state };
 
   if (!initialResponse) {
     response = await client!.sendInitialRequest(new TestWebResource(abortSignal));
-    this.state.initialResponse = response;
-    this.state.isStarted = true;
+    newState.initialResponse = response;
+    newState.isStarted = true;
   } else if (doFinalResponse) {
     response = await client!.sendFinalRequest(new TestWebResource(abortSignal));
-    this.state.isCompleted = true;
-    this.state.result = "Done";
-    this.state.previousResponse = response;
+    newState.isCompleted = true;
+    newState.result = "Done";
+    newState.previousResponse = response;
   } else {
     response = await client!.sendRequest(new TestWebResource(abortSignal));
-    this.state.previousResponse = response;
+    newState.previousResponse = response;
   }
 
   if (!response) {
@@ -63,10 +64,10 @@ async function update(
 
   // Progress only after the poller has started and before the poller is done
   if (initialResponse && !doFinalResponse && options.fireProgress) {
-    options.fireProgress(this.state);
+    options.fireProgress(newState);
   }
 
-  return makeOperation(this.state);
+  return makeOperation(newState);
 }
 
 async function cancel(

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
 - Updated the Key Vault Admin Long Running Operation Pollers to follow a more compact and meaningful approach moving forward.
 - Bug fix: The logging of HTTP requests wasn't properly working - now it has been fixed and tests have been written that verify the fix.
+- Return `BackupResult` and `RestoreResult` from backup/restore long running operations which will contain additional information about the operation as well any relevant data.
+- Backup / Restore polling will now correctly propagate any errors to the awaited call.
 
 ## 4.0.0-beta.1 (2020-09-11)
 

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -99,6 +99,7 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/chai": "^4.1.6",
+    "@types/chai-as-promised": "^7.1.0",
     "@types/sinon": "^9.0.4",
     "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^7.0.2",
@@ -106,6 +107,7 @@
     "@types/uuid": "^8.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
@@ -124,8 +126,6 @@
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
     "uuid": "^8.3.0",
-    "typedoc": "0.15.2",
-    "chai-as-promised": "^7.1.1",
-    "@types/chai-as-promised": "^7.1.0"
+    "typedoc": "0.15.2"
   }
 }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -124,6 +124,8 @@
     "source-map-support": "^0.5.9",
     "typescript": "4.1.2",
     "uuid": "^8.3.0",
-    "typedoc": "0.15.2"
+    "typedoc": "0.15.2",
+    "chai-as-promised": "^7.1.1",
+    "@types/chai-as-promised": "^7.1.0"
   }
 }

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -91,10 +91,10 @@ export class KeyVaultBackupClient {
 
 // @public
 export interface KeyVaultPermission {
-    allowedActions?: string[];
-    allowedDataActions?: string[];
-    deniedActions?: string[];
-    deniedDataActions?: string[];
+    actions?: string[];
+    dataActions?: string[];
+    notActions?: string[];
+    notDataActions?: string[];
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -91,10 +91,10 @@ export class KeyVaultBackupClient {
 
 // @public
 export interface KeyVaultPermission {
-    actions?: string[];
-    dataActions?: string[];
-    denyActions?: string[];
-    denyDataActions?: string[];
+    allowedActions?: string[];
+    allowedDataActions?: string[];
+    deniedActions?: string[];
+    deniedDataActions?: string[];
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -21,12 +21,19 @@ export interface BackupClientOptions extends coreHttp.PipelineOptions {
 }
 
 // @public
-export type BackupOperationState = KeyVaultAdminPollOperationState<string>;
+export type BackupOperationState = KeyVaultAdminPollOperationState<BackupResult>;
 
 // @public
 export interface BackupPollerOptions extends coreHttp.OperationOptions {
     intervalInMs?: number;
     resumeFrom?: string;
+}
+
+// @public
+export interface BackupResult {
+    backupFolderUri?: string;
+    endTime?: Date;
+    startTime: Date;
 }
 
 // @public
@@ -76,7 +83,7 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 // @public
 export class KeyVaultBackupClient {
     constructor(vaultUrl: string, credential: TokenCredential, pipelineOptions?: BackupClientOptions);
-    beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, string>>;
+    beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, BackupResult>>;
     beginRestore(blobStorageUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, undefined>>;
     beginSelectiveRestore(blobStorageUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, undefined>>;
     readonly vaultUrl: string;

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -62,7 +62,7 @@ export interface GetRoleAssignmentOptions extends coreHttp.OperationOptions {
 
 // @public
 export class KeyVaultAccessControlClient {
-    constructor(vaultUrl: string, credential: TokenCredential, pipelineOptions?: AccessControlClientOptions);
+    constructor(vaultUrl: string, credential: TokenCredential, options?: AccessControlClientOptions);
     createRoleAssignment(roleScope: RoleAssignmentScope, name: string, roleDefinitionId: string, principalId: string, options?: CreateRoleAssignmentOptions): Promise<KeyVaultRoleAssignment>;
     deleteRoleAssignment(roleScope: RoleAssignmentScope, name: string, options?: DeleteRoleAssignmentOptions): Promise<KeyVaultRoleAssignment>;
     getRoleAssignment(roleScope: RoleAssignmentScope, name: string, options?: GetRoleAssignmentOptions): Promise<KeyVaultRoleAssignment>;
@@ -102,7 +102,7 @@ export interface KeyVaultRoleAssignment {
     readonly id: string;
     readonly name: string;
     properties: KeyVaultRoleAssignmentPropertiesWithScope;
-    readonly type: string;
+    readonly roleAssignmentType: string;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -84,7 +84,7 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 export class KeyVaultBackupClient {
     constructor(vaultUrl: string, credential: TokenCredential, pipelineOptions?: BackupClientOptions);
     beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, BackupResult>>;
-    beginRestore(blobStorageUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, undefined>>;
+    beginRestore(blobStorageUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, RestoreResult>>;
     beginSelectiveRestore(blobStorageUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, undefined>>;
     readonly vaultUrl: string;
 }
@@ -152,7 +152,13 @@ export interface ListRoleDefinitionsPageSettings {
 }
 
 // @public
-export interface RestoreOperationState extends KeyVaultAdminPollOperationState<undefined> {
+export interface RestoreOperationState extends KeyVaultAdminPollOperationState<RestoreResult> {
+}
+
+// @public
+export interface RestoreResult {
+    endTime?: Date;
+    startTime: Date;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -93,8 +93,8 @@ export class KeyVaultBackupClient {
 export interface KeyVaultPermission {
     actions?: string[];
     dataActions?: string[];
-    notActions?: string[];
-    notDataActions?: string[];
+    denyActions?: string[];
+    denyDataActions?: string[];
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-admin/rollup.base.config.js
@@ -118,8 +118,8 @@ export function browserConfig(test = false) {
       }),
       cjs({
         namedExports: {
-          chai: ["assert"],
-          assert: ["ok", "equal", "strictEqual", "deepEqual"],
+          chai: ["assert", "use"],
+          assert: ["ok", "equal", "strictEqual", "deepEqual", "isRejected"],
           "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"]
         }
       })

--- a/sdk/keyvault/keyvault-admin/samples/javascript/accessControlHelloWorld.js
+++ b/sdk/keyvault/keyvault-admin/samples/javascript/accessControlHelloWorld.js
@@ -26,13 +26,16 @@ async function main() {
   }
 
   const globalScope = "/";
-  const roleDefinition = (await client.listRoleDefinitions(globalScope).next()).value;
+
+  // Please refer to https://docs.microsoft.com/azure/key-vault/managed-hsm/built-in-roles
+  // For information about built-in roles. This sample uses the Managed HSM Backup role definition ID
+  const managedHsmBackupRoleDefinitionId = "7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8";
 
   const roleAssignmentName = uuidv4();
   let assignment = await client.createRoleAssignment(
     globalScope,
     roleAssignmentName,
-    roleDefinition.id,
+    managedHsmBackupRoleDefinitionId,
     process.env["CLIENT_OBJECT_ID"]
   );
   console.log(assignment);

--- a/sdk/keyvault/keyvault-admin/samples/typescript/src/accessControlHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples/typescript/src/accessControlHelloWorld.ts
@@ -26,13 +26,16 @@ export async function main(): Promise<void> {
   }
 
   const globalScope = "/";
-  const roleDefinition = (await client.listRoleDefinitions(globalScope).next()).value;
+
+  // Please refer to https://docs.microsoft.com/azure/key-vault/managed-hsm/built-in-roles
+  // For information about built-in roles. This sample uses the Managed HSM Backup role definition ID
+  const managedHsmBackupRoleDefinitionId = "7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8";
 
   const roleAssignmentName = uuidv4();
   let assignment = await client.createRoleAssignment(
     globalScope,
     roleAssignmentName,
-    roleDefinition.id,
+    managedHsmBackupRoleDefinitionId,
     process.env["CLIENT_OBJECT_ID"]
   );
   console.log(assignment);

--- a/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlClient.ts
@@ -77,15 +77,15 @@ export class KeyVaultAccessControlClient {
   constructor(
     vaultUrl: string,
     credential: TokenCredential,
-    pipelineOptions: AccessControlClientOptions = {}
+    options: AccessControlClientOptions = {}
   ) {
     this.vaultUrl = vaultUrl;
 
     const libInfo = `azsdk-js-keyvault-admin/${SDK_VERSION}`;
 
-    const userAgentOptions = pipelineOptions.userAgentOptions;
+    const userAgentOptions = options.userAgentOptions;
 
-    pipelineOptions.userAgentOptions = {
+    options.userAgentOptions = {
       userAgentPrefix:
         userAgentOptions && userAgentOptions.userAgentPrefix
           ? `${userAgentOptions.userAgentPrefix} ${libInfo}`
@@ -97,7 +97,7 @@ export class KeyVaultAccessControlClient {
       : signingPolicy(credential);
 
     const internalPipelineOptions: InternalPipelineOptions = {
-      ...pipelineOptions,
+      ...options,
       loggingOptions: {
         logger: logger.info,
         allowedHeaderNames: [
@@ -112,7 +112,7 @@ export class KeyVaultAccessControlClient {
       internalPipelineOptions,
       authPolicy
     );
-    params.apiVersion = pipelineOptions.serviceVersion || LATEST_API_VERSION;
+    params.apiVersion = options.serviceVersion || LATEST_API_VERSION;
     this.client = new KeyVaultClient(params);
   }
 

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -43,19 +43,19 @@ export interface KeyVaultPermission {
   /**
    * Allowed actions.
    */
-  actions?: string[];
+  allowedActions?: string[];
   /**
    * Denied actions.
    */
-  denyActions?: string[];
+  deniedActions?: string[];
   /**
    * Allowed Data actions.
    */
-  dataActions?: string[];
+  allowedDataActions?: string[];
   /**
    * Denied Data actions.
    */
-  denyDataActions?: string[];
+  deniedDataActions?: string[];
 }
 
 /**

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -43,19 +43,19 @@ export interface KeyVaultPermission {
   /**
    * Allowed actions.
    */
-  allowedActions?: string[];
+  actions?: string[];
   /**
    * Denied actions.
    */
-  deniedActions?: string[];
+  notActions?: string[];
   /**
    * Allowed Data actions.
    */
-  allowedDataActions?: string[];
+  dataActions?: string[];
   /**
    * Denied Data actions.
    */
-  deniedDataActions?: string[];
+  notDataActions?: string[];
 }
 
 /**

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -29,7 +29,7 @@ export interface KeyVaultRoleAssignment {
   /**
    * The role assignment type.
    */
-  readonly type: string;
+  readonly roleAssignmentType: string;
   /**
    * Role assignment properties.
    */
@@ -47,7 +47,7 @@ export interface KeyVaultPermission {
   /**
    * Denied actions.
    */
-  notActions?: string[];
+  denyActions?: string[];
   /**
    * Allowed Data actions.
    */
@@ -55,7 +55,7 @@ export interface KeyVaultPermission {
   /**
    * Denied Data actions.
    */
-  notDataActions?: string[];
+  denyDataActions?: string[];
 }
 
 /**

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -16,7 +16,8 @@ import {
   BackupClientOptions,
   BackupResult,
   BeginBackupOptions,
-  BeginRestoreOptions
+  BeginRestoreOptions,
+  RestoreResult
 } from "./backupClientModels";
 import { LATEST_API_VERSION, SDK_VERSION } from "./constants";
 import { logger } from "./log";
@@ -211,7 +212,7 @@ export class KeyVaultBackupClient {
     sasToken: string,
     folderName: string,
     options: BeginRestoreOptions = {}
-  ): Promise<PollerLike<RestoreOperationState, undefined>> {
+  ): Promise<PollerLike<RestoreOperationState, RestoreResult>> {
     if (!(blobStorageUri && sasToken && folderName)) {
       throw new Error(
         "beginRestore requires non-empty strings for the parameters: blobStorageUri, sasToken and folderName."

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -12,7 +12,12 @@ import { PollerLike } from "@azure/core-lro";
 
 import { challengeBasedAuthenticationPolicy } from "../../keyvault-common";
 import { KeyVaultClient } from "./generated/keyVaultClient";
-import { BackupClientOptions, BeginBackupOptions, BeginRestoreOptions } from "./backupClientModels";
+import {
+  BackupClientOptions,
+  BackupResult,
+  BeginBackupOptions,
+  BeginRestoreOptions
+} from "./backupClientModels";
 import { LATEST_API_VERSION, SDK_VERSION } from "./constants";
 import { logger } from "./log";
 import { BackupPoller } from "./lro/backup/poller";
@@ -144,7 +149,7 @@ export class KeyVaultBackupClient {
     blobStorageUri: string,
     sasToken: string,
     options: BeginBackupOptions = {}
-  ): Promise<PollerLike<BackupOperationState, string>> {
+  ): Promise<PollerLike<BackupOperationState, BackupResult>> {
     if (!(blobStorageUri && sasToken)) {
       throw new Error(
         "beginBackup requires non-empty strings for the parameters: blobStorageUri and sasToken."

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -48,7 +48,7 @@ export interface BeginRestoreOptions extends BackupPollerOptions {}
 export interface BeginSelectiveRestoreOptions extends BackupPollerOptions {}
 
 /**
- * An interface representing the result of a log running backup operation.
+ * An interface representing the result of a backup operation.
  */
 export interface BackupResult {
   /**
@@ -56,6 +56,21 @@ export interface BackupResult {
    */
   backupFolderUri?: string;
 
+  /**
+   * The start time of the backup operation.
+   */
+  startTime: Date;
+
+  /**
+   * The end time of the backup operation.
+   */
+  endTime?: Date;
+}
+
+/**
+ * An interface representing the result of a restore operation.
+ */
+export interface RestoreResult {
   /**
    * The start time of the backup operation.
    */

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -46,3 +46,23 @@ export interface BeginRestoreOptions extends BackupPollerOptions {}
  * passed to {@link beginSelectiveRestore}
  */
 export interface BeginSelectiveRestoreOptions extends BackupPollerOptions {}
+
+/**
+ * An interface representing the result of a log running backup operation.
+ */
+export interface BackupResult {
+  /**
+   * The location of the full backup.
+   */
+  backupFolderUri?: string;
+
+  /**
+   * The start time of the backup operation.
+   */
+  startTime: Date;
+
+  /**
+   * The end time of the backup operation.
+   */
+  endTime?: Date;
+}

--- a/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
@@ -104,7 +104,7 @@ export const Permission: coreHttp.CompositeMapper = {
           element: { type: { name: "String" } }
         }
       },
-      denyActions: {
+      notActions: {
         serializedName: "notActions",
         type: {
           name: "Sequence",
@@ -118,7 +118,7 @@ export const Permission: coreHttp.CompositeMapper = {
           element: { type: { name: "String" } }
         }
       },
-      denyDataActions: {
+      notDataActions: {
         serializedName: "notDataActions",
         type: {
           name: "Sequence",

--- a/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
@@ -104,7 +104,7 @@ export const Permission: coreHttp.CompositeMapper = {
           element: { type: { name: "String" } }
         }
       },
-      notActions: {
+      denyActions: {
         serializedName: "notActions",
         type: {
           name: "Sequence",
@@ -118,7 +118,7 @@ export const Permission: coreHttp.CompositeMapper = {
           element: { type: { name: "String" } }
         }
       },
-      notDataActions: {
+      denyDataActions: {
         serializedName: "notDataActions",
         type: {
           name: "Sequence",

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -5,12 +5,13 @@ import { AbortSignalLike } from "@azure/abort-controller";
 import { RequestOptionsBase } from "@azure/core-http";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import {
+  FullBackupOperation,
   KeyVaultClientFullBackupOptionalParams,
   KeyVaultClientFullBackupResponse,
   KeyVaultClientFullBackupStatusResponse
 } from "../../generated/models";
 import { createSpan, setParentSpan } from "../../../../keyvault-common/src";
-import { BeginBackupOptions } from "../../backupClientModels";
+import { BackupResult, BeginBackupOptions } from "../../backupClientModels";
 import {
   KeyVaultAdminPollOperation,
   KeyVaultAdminPollOperationState
@@ -19,12 +20,12 @@ import {
 /**
  * An interface representing the publicly available properties of the state of a backup Key Vault's poll operation.
  */
-export type BackupOperationState = KeyVaultAdminPollOperationState<string>;
+export type BackupOperationState = KeyVaultAdminPollOperationState<BackupResult>;
 
 /**
  * An internal interface representing the state of a backup Key Vault's poll operation.
  */
-export interface BackupPollOperationState extends KeyVaultAdminPollOperationState<string> {
+export interface BackupPollOperationState extends KeyVaultAdminPollOperationState<BackupResult> {
   /**
    * The URI of the blob storage account.
    */
@@ -105,35 +106,7 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
         }
       });
 
-      const {
-        startTime,
-        jobId,
-        azureStorageBlobContainerUri,
-        endTime,
-        error,
-        status,
-        statusDetails
-      } = serviceOperation;
-
-      if (!startTime) {
-        state.error = new Error(`Missing "startTime" from the full backup operation.`);
-        state.isCompleted = true;
-        return this;
-      }
-
-      state.isStarted = true;
-      state.jobId = jobId;
-      state.endTime = endTime;
-      state.startTime = startTime;
-      state.status = status;
-      state.statusDetails = statusDetails;
-      state.result = azureStorageBlobContainerUri;
-
-      state.isCompleted = !!(endTime || error?.message);
-
-      if (error?.message || statusDetails) {
-        state.error = new Error(error?.message || statusDetails);
-      }
+      this.state = this.mapState(serviceOperation);
     }
 
     if (!state.jobId) {
@@ -144,26 +117,50 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
 
     if (!state.isCompleted) {
       const serviceOperation = await this.fullBackupStatus(state.jobId, this.requestOptions);
-      const {
-        azureStorageBlobContainerUri,
-        endTime,
-        status,
-        statusDetails,
-        error
-      } = serviceOperation;
-
-      state.endTime = endTime;
-      state.status = status;
-      state.statusDetails = statusDetails;
-      state.result = azureStorageBlobContainerUri;
-
-      state.isCompleted = !!(endTime || error?.message);
-
-      if (error?.message || statusDetails) {
-        state.error = new Error(error?.message || statusDetails);
-      }
+      this.state = this.mapState(serviceOperation);
     }
 
     return this;
+  }
+
+  mapState(serviceOperation: FullBackupOperation): BackupPollOperationState {
+    const state = { ...this.state };
+    const {
+      startTime,
+      jobId,
+      azureStorageBlobContainerUri,
+      endTime,
+      error,
+      status,
+      statusDetails
+    } = serviceOperation;
+
+    if (!startTime) {
+      state.error = new Error(`Missing "startTime" from the full backup operation.`);
+      state.isCompleted = true;
+      return state;
+    }
+
+    state.isStarted = true;
+    state.jobId = jobId;
+    state.endTime = endTime;
+    state.startTime = startTime;
+    state.status = status;
+    state.statusDetails = statusDetails;
+
+    state.isCompleted = !!(endTime || error?.message);
+
+    if (state.isCompleted && azureStorageBlobContainerUri) {
+      state.result = {
+        backupFolderUri: azureStorageBlobContainerUri,
+        startTime: startTime,
+        endTime: endTime
+      };
+    }
+    if (error?.message || statusDetails) {
+      state.error = new Error(error?.message || statusDetails);
+    }
+
+    return state;
   }
 }

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -110,9 +110,7 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     }
 
     if (!state.jobId) {
-      state.error = new Error(`Missing "jobId" from the full backup operation.`);
-      state.isCompleted = true;
-      return this;
+      throw new Error(`Missing "jobId" from the full backup operation.`);
     }
 
     if (!state.isCompleted) {
@@ -136,9 +134,9 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     } = serviceOperation;
 
     if (!startTime) {
-      state.error = new Error(`Missing "startTime" from the full backup operation.`);
-      state.isCompleted = true;
-      return state;
+      throw new Error(
+        `Missing "startTime" from the full backup operation. Full backup did not start successfully.`
+      );
     }
 
     state.isStarted = true;
@@ -148,6 +146,10 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     state.status = status;
     state.statusDetails = statusDetails;
 
+    if (error?.message || statusDetails) {
+      throw new Error(error?.message || statusDetails);
+    }
+
     state.isCompleted = !!(endTime || error?.message);
 
     if (state.isCompleted && azureStorageBlobContainerUri) {
@@ -156,9 +158,6 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
         startTime,
         endTime
       };
-    }
-    if (error?.message || statusDetails) {
-      state.error = new Error(error?.message || statusDetails);
     }
 
     return state;

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -123,7 +123,7 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     return this;
   }
 
-  mapState(serviceOperation: FullBackupOperation): BackupPollOperationState {
+  private mapState(serviceOperation: FullBackupOperation): BackupPollOperationState {
     const state = { ...this.state };
     const {
       startTime,
@@ -153,8 +153,8 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     if (state.isCompleted && azureStorageBlobContainerUri) {
       state.result = {
         backupFolderUri: azureStorageBlobContainerUri,
-        startTime: startTime,
-        endTime: endTime
+        startTime,
+        endTime
       };
     }
     if (error?.message || statusDetails) {

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
@@ -3,6 +3,7 @@
 
 import { BackupPollOperation, BackupOperationState, BackupPollOperationState } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
+import { BackupResult } from "../../backupClientModels";
 
 export interface BackupPollerOptions extends KeyVaultAdminPollerOptions {
   blobStorageUri: string;
@@ -12,7 +13,7 @@ export interface BackupPollerOptions extends KeyVaultAdminPollerOptions {
 /**
  * Class that creates a poller that waits until the backup of a Key Vault ends up being generated.
  */
-export class BackupPoller extends KeyVaultAdminPoller<BackupOperationState, string> {
+export class BackupPoller extends KeyVaultAdminPoller<BackupOperationState, BackupResult> {
   constructor(options: BackupPollerOptions) {
     const {
       client,

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -120,9 +120,7 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
     }
 
     if (!state.jobId) {
-      state.error = new Error(`Missing "jobId" from the full restore operation.`);
-      state.isCompleted = true;
-      return this;
+      throw new Error(`Missing "jobId" from the full restore operation.`);
     }
 
     if (!state.isCompleted) {
@@ -138,9 +136,9 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
     const { startTime, jobId, endTime, error, status, statusDetails } = serviceOperation;
 
     if (!startTime) {
-      state.error = new Error(`Missing "startTime" from the full restore operation.`);
-      state.isCompleted = true;
-      return state;
+      throw new Error(
+        `Missing "startTime" from the full restore operation. Restore did not start successfully.`
+      );
     }
 
     state.isStarted = true;
@@ -152,15 +150,15 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
 
     state.isCompleted = !!(endTime || error?.message);
 
+    if (error?.message || statusDetails) {
+      throw new Error(error?.message || statusDetails);
+    }
+
     if (state.isCompleted) {
       state.result = {
         startTime,
         endTime
       };
-    }
-
-    if (error?.message || statusDetails) {
-      state.error = new Error(error?.message || statusDetails);
     }
 
     return state;

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
@@ -7,6 +7,7 @@ import {
   RestorePollOperationState
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
+import { RestoreResult } from "../../backupClientModels";
 
 export interface RestorePollerOptions extends KeyVaultAdminPollerOptions {
   blobStorageUri: string;
@@ -17,7 +18,7 @@ export interface RestorePollerOptions extends KeyVaultAdminPollerOptions {
 /**
  * Class that creates a poller that waits until a Key Vault ends up being restored.
  */
-export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, undefined> {
+export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, RestoreResult> {
   constructor(options: RestorePollerOptions) {
     const {
       client,

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -44,13 +44,7 @@ export const mappings = {
         roleName: roleName!,
         description: description!,
         roleType: roleType!,
-        permissions:
-          permissions?.map((permission) => ({
-            allowedActions: permission.actions,
-            deniedActions: permission.notActions,
-            allowedDataActions: permission.dataActions,
-            deniedDataActions: permission.notDataActions
-          })) || [],
+        permissions: permissions!,
         assignableScopes: assignableScopes!
       };
     }

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -44,7 +44,13 @@ export const mappings = {
         roleName: roleName!,
         description: description!,
         roleType: roleType!,
-        permissions: permissions!,
+        permissions:
+          permissions?.map((permission) => ({
+            allowedActions: permission.actions,
+            deniedActions: permission.notActions,
+            allowedDataActions: permission.dataActions,
+            deniedDataActions: permission.notDataActions
+          })) || [],
         assignableScopes: assignableScopes!
       };
     }

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -16,7 +16,7 @@ export const mappings = {
       return {
         id: id!,
         name: name!,
-        type: type!,
+        roleAssignmentType: type!,
         properties: {
           scope: scope as RoleAssignmentScope,
           roleDefinitionId: roleDefinitionId!,

--- a/sdk/keyvault/keyvault-admin/test/internal/logger.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/logger.spec.ts
@@ -26,6 +26,7 @@ describe("The keyvault-admin clients logging options should work", () => {
           request: httpRequest,
           parsedBody: {
             id: `${keyVaultUrl}${path}`,
+            startTime: new Date(),
             attributes: {}
           }
         };

--- a/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
@@ -23,6 +23,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
           request: httpRequest,
           parsedBody: {
             id: `${env.KEYVAULT_URI}${path}`,
+            startTime: new Date(),
             attributes: {}
           }
         };

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
@@ -61,7 +61,7 @@ describe("KeyVaultAccessControlClient", () => {
       //     // ...
       //   }
       //
-      assert.equal(roleAssignment.type, expectedType);
+      assert.equal(roleAssignment.roleAssignmentType, expectedType);
       receivedRoles.push(roleAssignment.name);
     }
 

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
 import { Recorder } from "@azure/test-utils-recorder";
 
 import { KeyVaultBackupClient } from "../../src";
@@ -9,6 +11,7 @@ import { authenticate } from "../utils/authentication";
 import { testPollerProperties } from "../utils/recorder";
 import { getFolderName, getSasToken } from "../utils/common";
 import { delay } from "@azure/core-http";
+import { assert } from "chai";
 
 describe("KeyVaultBackupClient", () => {
   let client: KeyVaultBackupClient;
@@ -51,11 +54,7 @@ describe("KeyVaultBackupClient", () => {
         "invalid_sas_token",
         testPollerProperties
       );
-      const backupResult = await backupPoller.pollUntilDone();
-      assert.notExists(backupResult);
-      const operationState = backupPoller.getOperationState();
-      assert.isDefined(operationState.error);
-      assert.isNotEmpty(operationState.error?.message);
+      assert.isRejected(backupPoller.pollUntilDone());
     });
   });
 
@@ -122,10 +121,7 @@ describe("KeyVaultBackupClient", () => {
         "bad_folder",
         testPollerProperties
       );
-      await restorePoller.pollUntilDone();
-      const operationState = restorePoller.getOperationState();
-      assert.equal(operationState.isCompleted, true);
-      assert.isNotEmpty(operationState.error?.message);
+      assert.isRejected(restorePoller.pollUntilDone());
     });
   });
 });

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -39,7 +39,10 @@ describe("KeyVaultBackupClient", () => {
       );
       const backupResult = await backupPoller.pollUntilDone();
       assert.notExists(backupPoller.getOperationState().error);
-      assert.match(backupResult, new RegExp(blobStorageUri));
+      assert.exists(backupResult.backupFolderUri);
+      assert.equal(backupResult.startTime, backupPoller.getOperationState().startTime);
+      assert.equal(backupResult.endTime, backupPoller.getOperationState().endTime);
+      assert.match(backupResult.backupFolderUri!, new RegExp(blobStorageUri));
     });
 
     it("returns the correct backup result when fails to authenticate", async function() {
@@ -50,6 +53,8 @@ describe("KeyVaultBackupClient", () => {
       );
       const backupResult = await backupPoller.pollUntilDone();
       assert.notExists(backupResult);
+      assert.equal(backupResult.startTime, backupPoller.getOperationState().startTime);
+      assert.equal(backupResult.endTime, backupPoller.getOperationState().endTime);
       const operationState = backupPoller.getOperationState();
       assert.isDefined(operationState.error);
       assert.isNotEmpty(operationState.error?.message);
@@ -64,7 +69,8 @@ describe("KeyVaultBackupClient", () => {
         testPollerProperties
       );
       const backupURI = await backupPoller.pollUntilDone();
-      const folderName = getFolderName(backupURI);
+      assert.exists(backupURI.backupFolderUri);
+      const folderName = getFolderName(backupURI.backupFolderUri!);
 
       const restorePoller = await client.beginRestore(
         blobStorageUri,
@@ -92,7 +98,8 @@ describe("KeyVaultBackupClient", () => {
         testPollerProperties
       );
       const backupURI = await backupPoller.pollUntilDone();
-      const folderName = getFolderName(backupURI);
+      assert.exists(backupURI.backupFolderUri);
+      const folderName = getFolderName(backupURI.backupFolderUri!);
 
       const keyName = "rsa-1";
       const selectiveRestorePoller = await client.beginSelectiveRestore(

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -53,8 +53,6 @@ describe("KeyVaultBackupClient", () => {
       );
       const backupResult = await backupPoller.pollUntilDone();
       assert.notExists(backupResult);
-      assert.equal(backupResult.startTime, backupPoller.getOperationState().startTime);
-      assert.equal(backupResult.endTime, backupPoller.getOperationState().endTime);
       const operationState = backupPoller.getOperationState();
       assert.isDefined(operationState.error);
       assert.isNotEmpty(operationState.error?.message);
@@ -68,9 +66,9 @@ describe("KeyVaultBackupClient", () => {
         blobSasToken,
         testPollerProperties
       );
-      const backupURI = await backupPoller.pollUntilDone();
-      assert.exists(backupURI.backupFolderUri);
-      const folderName = getFolderName(backupURI.backupFolderUri!);
+      const backupResult = await backupPoller.pollUntilDone();
+      assert.exists(backupResult.backupFolderUri);
+      const folderName = getFolderName(backupResult.backupFolderUri!);
 
       const restorePoller = await client.beginRestore(
         blobStorageUri,
@@ -78,8 +76,10 @@ describe("KeyVaultBackupClient", () => {
         folderName,
         testPollerProperties
       );
-      await restorePoller.pollUntilDone();
+      const restoreResult = await restorePoller.pollUntilDone();
       const operationState = restorePoller.getOperationState();
+      assert.equal(restoreResult.startTime, operationState.startTime);
+      assert.equal(restoreResult.endTime, operationState.endTime);
       assert.equal(operationState.isCompleted, true);
       assert.notExists(operationState.error);
       // Restore is eventually consistent so while we work


### PR DESCRIPTION
## What

- Fix core-lro stale state bug
- beginBackup and beginRestore now return a *Result object
- Various renames (roleAssignment.type, options)
- Update the sample code
- Reject / bubble up errors when polling for backup / restore operations

## Why

- Admin changes line up our public API with other libraries and addresses recent architecture board review feedback
- operation.state can become stale if someone was to modify or splat it out during the `update` call. That can cause a drift between the logic that checks if we resolve the promise and the value we return when we do. This fix ensures that we return the right data.

## Todo:

- [x] CHANGELOG
- [x] Sync up with FC on the public API of beginBackup (whether it takes a folder name or full sas token)
- [x] Come to conclusion on notActions / notDataActions

Resolves #12319