### PR TITLE
Identity readme updates for more clarity upfront

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -7,7 +7,7 @@ This library currently provides credentials for:
 - [Service principal authentication](https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals)
 - [Managed identity authentication](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview)
 - [Device code authentication](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code)
-- Interactive browser authentication, based on [OAuth2 authentication code](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+- Interactive browser authentication, based on OAuth2 authentication code that uses the default system browser.
 - [Username + password authentication](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth-ropc)
 - Visual Studio Code authentication, with the login information saved in Azure plugin for Visual Studio Code
 - Azure CLI authentication, with the login information saved in Azure CLI

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -1,8 +1,18 @@
 ## Azure Identity client library for JavaScript
 
-This library simplifies authentication against Azure Active Directory for Azure SDK libraries.
-It provides a set of `TokenCredential` implementations which can be passed into SDK libraries
-to authenticate API requests. It supports token authentication using an Azure Active Directory [service principal](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli) or [managed identity](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview).
+The Azure Identity library provides Azure Active Directory token authentication support across the Azure SDK. It provides a set of [TokenCredential](https://docs.microsoft.com/javascript/api/@azure/core-auth/tokencredential) implementations which can be used to construct Azure SDK clients which support AAD token authentication.
+
+This library currently provides credentials for:
+
+- [Service principal authentication](https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals)
+- [Managed identity authentication](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview)
+- [Device code authentication](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code)
+- Interactive browser authentication, based on [OAuth2 authentication code](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+- [Username + password authentication](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth-ropc)
+- Visual Studio Code authentication, with the login information saved in Azure plugin for Visual Studio Code
+- Azure CLI authentication, with the login information saved in Azure CLI
+
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) | [Package (npm)](https://www.npmjs.com/package/@azure/identity) | [API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/identity) | [Product documentation](https://azure.microsoft.com/services/active-directory/) | [Samples](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples)
 
 ## Getting started
 
@@ -21,9 +31,9 @@ npm install --save @azure/identity
   - You can sign up for a [free account](https://azure.microsoft.com/free/).
 - The [Azure CLI][azure_cli] can also be useful for authenticating in a development environment, creating accounts, and managing account roles.
 
-### Authenticate the client
+### Authenticate the client in development environment
 
-When debugging and executing code locally it is typical for a developer to use their own account for authenticating calls to Azure services. There are several developer tools which can be used to perform this authentication in your development environment.
+While we recommend using managed identity or service principal authentication in your production application, it is typical for a developer to use their own account for authenticating calls to Azure services when debugging and executing code locally. There are several developer tools which can be used to perform this authentication in your development environment.
 
 #### Authenticating via Visual Studio Code
 
@@ -44,6 +54,10 @@ To authenticate with the [Azure CLI][azure_cli] users can run the command `az lo
 For systems without a default web browser, the `az login` command will use the device code authentication flow. The user can also force the Azure CLI to use the device code flow rather than launching a browser by specifying the `--use-device-code` argument.
 
 ![Azure CLI Account Device Code Sign In][azureclilogindevicecode_image]
+
+### Authenticate the client in browsers
+
+To authenticate Azure SDKs within web browsers, we currently offer the `InteractiveBrowserCredential`, which can be set to use redirection or popups to complete the authentication flow. It is necessary to [create an Azure App Registration](https://docs.microsoft.com/azure/active-directory/develop/scenario-spa-app-registration) in the portal for your web application first.
 
 ## Key concepts
 


### PR DESCRIPTION
This PR updates the readme for Identity with details on the different authentication options upfront. This makes it easier to link to this page from #13403 instead of going through the same text there

I have used the Java and .Net readmes for Azure Identity along with #12878 as reference