### PR TITLE
service bus internal method rename #13390

### DIFF
--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -92,7 +92,7 @@ export class BatchingReceiver extends MessageReceiver {
       );
     }
 
-    this._batchingReceiverLite.close(connectionError);
+    this._batchingReceiverLite.terminate(connectionError);
   }
 
   /**
@@ -301,7 +301,7 @@ export class BatchingReceiverLite {
    *
    * @param connectionError An optional error (rhea doesn't always deliver one for certain disconnection events)
    */
-  close(connectionError?: Error | AmqpError) {
+  terminate(connectionError?: Error | AmqpError) {
     if (this._closeHandler) {
       this._closeHandler(connectionError);
       this._closeHandler = undefined;

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -545,7 +545,7 @@ export class MessageSession extends LinkEntity<Receiver> {
 
       await super.close();
 
-      await this._batchingReceiverLite.close();
+      await this._batchingReceiverLite.terminate();
     } catch (err) {
       logger.logError(
         err,

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -624,7 +624,7 @@ describe("BatchingReceiver unit tests", () => {
       await receiveIsReady;
       assert.exists(receiver["_closeHandler"]);
 
-      await receiver.close(new Error("actual error"));
+      await receiver.terminate(new Error("actual error"));
 
       try {
         await receiveMessagesPromise;
@@ -670,7 +670,7 @@ describe("BatchingReceiver unit tests", () => {
       assert.isFalse(resolveWasCalled);
       assert.isFalse(rejectWasCalled);
 
-      receiver.close();
+      receiver.terminate();
 
       // these are still false because we used setTimeout() (and we're using sinon)
       // so the clock is "frozen"


### PR DESCRIPTION
Renamed `close` to `terminate` to resolve issue #13390.