### PR TITLE
[event-hubs] investigate flaky tests

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -58,7 +58,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "cross-env AZURE_LOG_LEVEL=verbose nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o event-hubs-lintReport.html || exit 0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -58,7 +58,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
+    "integration-test:node": "cross-env DEBUG=azure:event-hubs:* nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o event-hubs-lintReport.html || exit 0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -58,7 +58,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "cross-env DEBUG=azure:event-hubs:* nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
+    "integration-test:node": "cross-env AZURE_LOG_LEVEL=verbose nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o event-hubs-lintReport.html || exit 0",

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -291,12 +291,14 @@ describe("EventHubConsumerClient", () => {
         const consumerClient1 = new EventHubConsumerClient(
           EventHubConsumerClient.defaultConsumerGroupName,
           service.connectionString,
-          service.path
+          service.path,
+          { loadBalancingOptions: { updateIntervalInMs: 1000 } }
         );
         const consumerClient2 = new EventHubConsumerClient(
           EventHubConsumerClient.defaultConsumerGroupName,
           service.connectionString,
-          service.path
+          service.path,
+          { loadBalancingOptions: { updateIntervalInMs: 1000 } }
         );
 
         clients.push(consumerClient1, consumerClient2);
@@ -386,7 +388,7 @@ describe("EventHubConsumerClient", () => {
         await subscription2.close();
 
         await loopUntil({
-          maxTimes: 20,
+          maxTimes: 10,
           name: "Wait for subscription1 to recover",
           timeBetweenRunsMs: 1000,
           async until() {

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -287,7 +287,7 @@ describe("EventHubConsumerClient", () => {
         handlerCalls.close.should.be.greaterThan(1);
       });
 
-      for (let i = 0; i < 1; i++) {
+      for (let i = 0; i < 20; i++) {
         it.only("when subscribed to multiple partitions", async function(): Promise<void> {
           const consumerClient1 = new EventHubConsumerClient(
             EventHubConsumerClient.defaultConsumerGroupName,
@@ -386,17 +386,11 @@ describe("EventHubConsumerClient", () => {
           // close subscription2 so subscription1 can recover.
           await subscription2.close();
 
-          debugModule.log(`Waiting for subscription1 to recover.`);
           await loopUntil({
             maxTimes: 20,
             name: "Wait for subscription1 to recover",
             timeBetweenRunsMs: 1000,
             async until() {
-              debugModule.log(
-                `Partitions actively being read: ${partitionIds
-                  .filter((id) => partitionHandlerCalls[id].processEvents)
-                  .join(", ")}`
-              );
               // wait until we've seen an additional processEvent for each partition.
               return (
                 partitionIds.filter((id) => {
@@ -405,8 +399,6 @@ describe("EventHubConsumerClient", () => {
               );
             }
           });
-
-          debugModule.log(`Finished waiting for subscription1 to recover.`);
 
           await subscription1.close();
 

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -386,11 +386,13 @@ describe("EventHubConsumerClient", () => {
           // close subscription2 so subscription1 can recover.
           await subscription2.close();
 
+          debugModule.log(`Waiting for subscription1 to recover.`);
           await loopUntil({
             maxTimes: 10,
             name: "Wait for subscription1 to recover",
             timeBetweenRunsMs: 1000,
             async until() {
+              debugModule.log(`Partitions actively being read: ${partitionIds.filter(id => partitionHandlerCalls[id].processEvents).join(', ')}`);
               // wait until we've seen an additional processEvent for each partition.
               return (
                 partitionIds.filter((id) => {
@@ -399,6 +401,8 @@ describe("EventHubConsumerClient", () => {
               );
             }
           });
+
+          debugModule.log(`Finished waiting for subscription1 to recover.`);
 
           await subscription1.close();
 

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -392,7 +392,11 @@ describe("EventHubConsumerClient", () => {
             name: "Wait for subscription1 to recover",
             timeBetweenRunsMs: 1000,
             async until() {
-              debugModule.log(`Partitions actively being read: ${partitionIds.filter(id => partitionHandlerCalls[id].processEvents).join(', ')}`);
+              debugModule.log(
+                `Partitions actively being read: ${partitionIds
+                  .filter((id) => partitionHandlerCalls[id].processEvents)
+                  .join(", ")}`
+              );
               // wait until we've seen an additional processEvent for each partition.
               return (
                 partitionIds.filter((id) => {

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -388,7 +388,7 @@ describe("EventHubConsumerClient", () => {
 
           debugModule.log(`Waiting for subscription1 to recover.`);
           await loopUntil({
-            maxTimes: 10,
+            maxTimes: 20,
             name: "Wait for subscription1 to recover",
             timeBetweenRunsMs: 1000,
             async until() {

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -287,133 +287,131 @@ describe("EventHubConsumerClient", () => {
         handlerCalls.close.should.be.greaterThan(1);
       });
 
-      for (let i = 0; i < 20; i++) {
-        it.only("when subscribed to multiple partitions", async function(): Promise<void> {
-          const consumerClient1 = new EventHubConsumerClient(
-            EventHubConsumerClient.defaultConsumerGroupName,
-            service.connectionString,
-            service.path
-          );
-          const consumerClient2 = new EventHubConsumerClient(
-            EventHubConsumerClient.defaultConsumerGroupName,
-            service.connectionString,
-            service.path
-          );
+      it("when subscribed to multiple partitions", async function(): Promise<void> {
+        const consumerClient1 = new EventHubConsumerClient(
+          EventHubConsumerClient.defaultConsumerGroupName,
+          service.connectionString,
+          service.path
+        );
+        const consumerClient2 = new EventHubConsumerClient(
+          EventHubConsumerClient.defaultConsumerGroupName,
+          service.connectionString,
+          service.path
+        );
 
-          clients.push(consumerClient1, consumerClient2);
+        clients.push(consumerClient1, consumerClient2);
 
-          const partitionHandlerCalls: {
-            [partitionId: string]: {
-              initialize: number;
-              processEvents: boolean;
-              close: number;
-            };
-          } = {};
+        const partitionHandlerCalls: {
+          [partitionId: string]: {
+            initialize: number;
+            processEvents: boolean;
+            close: number;
+          };
+        } = {};
 
-          // keep track of the handlers called on subscription 1
-          for (const id of partitionIds) {
-            partitionHandlerCalls[id] = { initialize: 0, processEvents: false, close: 0 };
+        // keep track of the handlers called on subscription 1
+        for (const id of partitionIds) {
+          partitionHandlerCalls[id] = { initialize: 0, processEvents: false, close: 0 };
+        }
+
+        const subscriptionHandlers1: SubscriptionEventHandlers = {
+          async processError() {
+            /* no-op */
+          },
+          async processEvents(_, context) {
+            partitionHandlerCalls[context.partitionId].processEvents = true;
+          },
+          async processClose(_, context) {
+            partitionHandlerCalls[context.partitionId].close++;
+            // reset processEvents count
+            partitionHandlerCalls[context.partitionId].processEvents = false;
+          },
+          async processInitialize(context) {
+            partitionHandlerCalls[context.partitionId].initialize++;
           }
+        };
 
-          const subscriptionHandlers1: SubscriptionEventHandlers = {
-            async processError() {
-              /* no-op */
-            },
-            async processEvents(_, context) {
-              partitionHandlerCalls[context.partitionId].processEvents = true;
-            },
-            async processClose(_, context) {
-              partitionHandlerCalls[context.partitionId].close++;
-              // reset processEvents count
-              partitionHandlerCalls[context.partitionId].processEvents = false;
-            },
-            async processInitialize(context) {
-              partitionHandlerCalls[context.partitionId].initialize++;
-            }
-          };
+        const subscription1 = consumerClient1.subscribe(subscriptionHandlers1, {
+          maxBatchSize: 1,
+          maxWaitTimeInSeconds: 1
+        });
 
-          const subscription1 = consumerClient1.subscribe(subscriptionHandlers1, {
-            maxBatchSize: 1,
-            maxWaitTimeInSeconds: 1
-          });
-
-          await loopUntil({
-            maxTimes: 10,
-            name: "Wait for subscription1 to read from all partitions",
-            timeBetweenRunsMs: 1000,
-            async until() {
-              // wait until we've seen processEvents invoked for each partition.
-              return (
-                partitionIds.filter((id) => {
-                  return partitionHandlerCalls[id].processEvents;
-                }).length === partitionIds.length
-              );
-            }
-          });
-
-          const partitionsReadFromSub2 = new Set<string>();
-          const subscriptionHandlers2: SubscriptionEventHandlers = {
-            async processError() {
-              /* no-op */
-            },
-            async processEvents(_, context) {
-              partitionsReadFromSub2.add(context.partitionId);
-            }
-          };
-
-          // start 2nd subscription with an ownerLevel so it triggers the close handlers on the 1st subscription.
-          const subscription2 = consumerClient2.subscribe(subscriptionHandlers2, {
-            maxBatchSize: 1,
-            maxWaitTimeInSeconds: 1,
-            ownerLevel: 1
-          });
-
-          await loopUntil({
-            maxTimes: 10,
-            name:
-              "Wait for subscription2 to read from all partitions and subscription1 to invoke close handlers",
-            timeBetweenRunsMs: 1000,
-            async until() {
-              const sub1CloseHandlersCalled = Boolean(
-                partitionIds.filter((id) => {
-                  return partitionHandlerCalls[id].close > 0;
-                }).length === partitionIds.length
-              );
-              return partitionsReadFromSub2.size === partitionIds.length && sub1CloseHandlersCalled;
-            }
-          });
-
-          // close subscription2 so subscription1 can recover.
-          await subscription2.close();
-
-          await loopUntil({
-            maxTimes: 20,
-            name: "Wait for subscription1 to recover",
-            timeBetweenRunsMs: 1000,
-            async until() {
-              // wait until we've seen an additional processEvent for each partition.
-              return (
-                partitionIds.filter((id) => {
-                  return partitionHandlerCalls[id].processEvents;
-                }).length === partitionIds.length
-              );
-            }
-          });
-
-          await subscription1.close();
-
-          for (const id of partitionIds) {
-            partitionHandlerCalls[id].initialize.should.be.greaterThan(
-              1,
-              `Initialize on partition ${id} was not called more than 1 time.`
-            );
-            partitionHandlerCalls[id].close.should.be.greaterThan(
-              1,
-              `Close on partition ${id} was not called more than 1 time.`
+        await loopUntil({
+          maxTimes: 10,
+          name: "Wait for subscription1 to read from all partitions",
+          timeBetweenRunsMs: 1000,
+          async until() {
+            // wait until we've seen processEvents invoked for each partition.
+            return (
+              partitionIds.filter((id) => {
+                return partitionHandlerCalls[id].processEvents;
+              }).length === partitionIds.length
             );
           }
         });
-      }
+
+        const partitionsReadFromSub2 = new Set<string>();
+        const subscriptionHandlers2: SubscriptionEventHandlers = {
+          async processError() {
+            /* no-op */
+          },
+          async processEvents(_, context) {
+            partitionsReadFromSub2.add(context.partitionId);
+          }
+        };
+
+        // start 2nd subscription with an ownerLevel so it triggers the close handlers on the 1st subscription.
+        const subscription2 = consumerClient2.subscribe(subscriptionHandlers2, {
+          maxBatchSize: 1,
+          maxWaitTimeInSeconds: 1,
+          ownerLevel: 1
+        });
+
+        await loopUntil({
+          maxTimes: 10,
+          name:
+            "Wait for subscription2 to read from all partitions and subscription1 to invoke close handlers",
+          timeBetweenRunsMs: 1000,
+          async until() {
+            const sub1CloseHandlersCalled = Boolean(
+              partitionIds.filter((id) => {
+                return partitionHandlerCalls[id].close > 0;
+              }).length === partitionIds.length
+            );
+            return partitionsReadFromSub2.size === partitionIds.length && sub1CloseHandlersCalled;
+          }
+        });
+
+        // close subscription2 so subscription1 can recover.
+        await subscription2.close();
+
+        await loopUntil({
+          maxTimes: 20,
+          name: "Wait for subscription1 to recover",
+          timeBetweenRunsMs: 1000,
+          async until() {
+            // wait until we've seen an additional processEvent for each partition.
+            return (
+              partitionIds.filter((id) => {
+                return partitionHandlerCalls[id].processEvents;
+              }).length === partitionIds.length
+            );
+          }
+        });
+
+        await subscription1.close();
+
+        for (const id of partitionIds) {
+          partitionHandlerCalls[id].initialize.should.be.greaterThan(
+            1,
+            `Initialize on partition ${id} was not called more than 1 time.`
+          );
+          partitionHandlerCalls[id].close.should.be.greaterThan(
+            1,
+            `Close on partition ${id} was not called more than 1 time.`
+          );
+        }
+      });
     });
 
     it("Receive from specific partitions, no coordination", async function(): Promise<void> {


### PR DESCRIPTION
A single test has been failing sporadically in most of our pipeline runs:
```
 EventHubConsumerClient
       functional tests
         Reinitialize partition processing after error
           when subscribed to multiple partitions:
     Error: Waited way too long for Wait for subscription1 to recover
```
### What does the test do?

This test is meant to ensure that a running subscription will recover across all partitions after encountering an error.

The way we do this is to:
- Start subscription __1__
- Wait for subscription __1__ to be reading events from all partitions.
- Start subscription __2__ with an ownerLevel
  - The ownerLevel will force subscription __1__ to disconnect from all partitions.
- Wait for subscription __1__ to have _processClose_ called on all partitions.
- Stop subscription __2__.
   - This removes the receiver links with ownerLevels, so subscription __1__ should be able to connect to partitions again.
- Wait for subscription __1__ to be reading events from all partitions.

### What's the problem?

In some test runs, we would see it take too long for subscription __1__ to recover.

### Root cause

It is possible for subscription __1__ to attempt to read from partitions at the same time subscription __2__ is closing.
When this happens, some of the partitions can be read by subscription __1__, but some may still have an ownerLevel associated with them, causing subscription __1__ to encounter an error when attempting to read from that partition.

This is an expected scenario, and subscription __1__ will simply wait 10 seconds before trying to read the partition again.

As it turns out, we were also waiting a maximum of 10 seconds for subscription __1__ to recover. So in rare cases (less rarely on the mac agents...) we'd end up waiting 'too long'.

https://github.com/Azure/azure-sdk-for-js/blob/b960def0719ca52aa4491bce0612f7ff3a6f23ea/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts#L385-L400

### Fix?

The simple fix is to increase the maximum time to wait to 20 seconds. Then I thought about it some more and realized we could simply update the `updateIntervalInMs` loadBalancing property to something smaller than 10 seconds. This fixes the issue while not allowing the test to take more time to complete.

Note that we don't necessarily care _how long_ it takes for the subscription to recover, only that it does.