### PR TITLE
[Identity] Move Axios to validate status locally

### DIFF
--- a/sdk/identity/identity/src/client/msalClient.ts
+++ b/sdk/identity/identity/src/client/msalClient.ts
@@ -161,8 +161,7 @@ export enum HttpMethod {
  * This class implements the API for network requests.
  */
 export class HttpClient implements INetworkModule {
-  constructor() {
-  }
+  constructor() {}
 
   /**
    * Http Get request

--- a/sdk/identity/identity/src/client/msalClient.ts
+++ b/sdk/identity/identity/src/client/msalClient.ts
@@ -162,7 +162,6 @@ export enum HttpMethod {
  */
 export class HttpClient implements INetworkModule {
   constructor() {
-    axios.defaults.validateStatus = () => true;
   }
 
   /**
@@ -177,7 +176,8 @@ export class HttpClient implements INetworkModule {
     const request: AxiosRequestConfig = {
       method: HttpMethod.GET,
       url: url,
-      headers: options && options.headers
+      headers: options && options.headers,
+      validateStatus: () => true
     };
 
     const response = await axios(request);
@@ -202,7 +202,8 @@ export class HttpClient implements INetworkModule {
       method: HttpMethod.POST,
       url: url,
       data: (options && options.body) || "",
-      headers: options && options.headers
+      headers: options && options.headers,
+      validateStatus: () => true
     };
 
     const response = await axios(request);

--- a/sdk/identity/identity/src/client/msalClient.ts
+++ b/sdk/identity/identity/src/client/msalClient.ts
@@ -161,8 +161,6 @@ export enum HttpMethod {
  * This class implements the API for network requests.
  */
 export class HttpClient implements INetworkModule {
-  constructor() {}
-
   /**
    * Http Get request
    * @param url -


### PR DESCRIPTION
Originally reported in https://github.com/Azure/azure-sdk-for-js/issues/13343, Identity had been setting the global Axios setting rather than using a local setting. This could have unintended impacts on other users of Axios in a project.

With this PR, Identity switches to setting the "validate status" setting locally rather than globally.