### PR TITLE
[app-configuration] Remove the `hidden` attribute for all spots, use `internal` only

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
@@ -51,7 +51,7 @@ import {
   AppConfigurationGetRevisionsNextResponse
 } from "./models";
 
-/** @hidden */
+/** @internal */
 export class AppConfiguration extends AppConfigurationContext {
   /**
    * Initializes a new instance of the AppConfiguration class.

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
@@ -12,7 +12,7 @@ import { ApiVersion10, AppConfigurationOptionalParams } from "./models";
 const packageName = "app-configuration";
 const packageVersion = "1.1.1";
 
-/** @hidden */
+/** @internal */
 export class AppConfigurationContext extends coreHttp.ServiceClient {
   endpoint: string;
   syncToken?: string;

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -147,7 +147,6 @@ export function makeConfigurationSettingEmpty(
 }
 
 /**
- * @hidden
  * @internal
  */
 export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
@@ -161,7 +160,6 @@ export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
 }
 
 /**
- * @hidden
  * @internal
  */
 export function transformKeyValueResponseWithStatusCode<
@@ -176,7 +174,6 @@ export function transformKeyValueResponseWithStatusCode<
 }
 
 /**
- * @hidden
  * @internal
  */
 export function transformKeyValueResponse<
@@ -210,7 +207,6 @@ function normalizeResponse<T extends HttpResponseField<any> & { eTag?: string }>
  * @param fieldNames fieldNames from users.
  * @returns The field names translated into the `select` field equivalents.
  *
- * @hidden
  * @internal
  */
 export function formatFieldsForSelect(

--- a/sdk/appconfiguration/app-configuration/tsdoc.json
+++ b/sdk/appconfiguration/app-configuration/tsdoc.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
-    "extends": [
-        "../../../tsdoc.json"
-    ]
-}


### PR DESCRIPTION
Remove the `hidden` attribute for all spots, use `internal` only. Also remove the tsdoc.json as it was only there to allow for the usage of the `hidden` attribute.

NOTE: I've also changed the generated clients. Next time we use the official autorest generator it should generate the exact same thing so this shouldn't be an issue.

Fixes #13445