### PR TITLE
[service-bus] Make stress/perf easier to run with separate scripts and improve telemetry

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/runcontainer.js
+++ b/sdk/servicebus/service-bus/test/stress/runcontainer.js
@@ -1,5 +1,9 @@
 const dotenv = require("dotenv");
+const minimist = require("minimist");
+const fs = require("fs");
+const path = require("path");
 const { spawnSync } = require("child_process");
+const { OptionsComponent } = require("typedoc/dist/lib/utils/options/options");
 
 dotenv.config();
 
@@ -11,7 +15,6 @@ const registryPassword = process.env.REGISTRY_PASSWORD
 const registryName = process.env.REGISTRY_NAME;
 
 const imageName = `${registryName}/sb-stressperf:test`;
-const containerInstanceName = `${resourceGroup}-sb-stressperf`;
 
 function spawn(command) {
     const ret = spawnSync(command, { shell: true, stdio: "inherit" });
@@ -20,6 +23,23 @@ function spawn(command) {
         throw new Error(`${command} failed with exit code ${ret.status}`);
     }
 }
+
+// which script do we want to run?
+/** @type {{testToRun: string}} */
+const options = minimist(process.argv, {
+    string: ["testToRun"]
+});
+
+if (!options.testToRun || !fs.existsSync(path.join("dist", options.testToRun))) {
+    console.error("Usage: runcontainer.js --testToRun <name of file in `dist`>");
+    process.exit(1);
+}
+
+const { name: testFileNameWithoutExtension } = path.parse(options.testToRun);
+const containerInstanceName = `${resourceGroup}-sb-stressperf-${testFileNameWithoutExtension.toLowerCase()}`;
+
+console.log(`Running \`npm run build\``);
+spawn(`npm run build`);
 
 console.log(`Building container image: ${imageName}...`);
 spawn(`docker build -t "${imageName}" --no-cache .`);
@@ -30,14 +50,14 @@ spawn(`docker push "${imageName}"`);
 console.log(`Deleting Azure Container Instance (if exists)`);
 spawn(`az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
 
-console.log(`Creating Azure Container Instance for stress/perf...`);
+console.log(`Creating Azure Container Instance for stress/perf that runs ${options.testToRun}`);
 spawn(`az container create --resource-group "${resourceGroup}" --name "${containerInstanceName}" ` +
-    `--image ${registryName}/sb-perfstress:test ` +
+    `--image ${imageName}  ` +
     "--cpu 1 --memory 0.7 " +
     "--restart-policy Never " +
     `--registry-username ${registryUserName} ` +
     `--registry-password "${registryPassword}" ` +
-    `--command-line "node /src/scenarioBatchReceive.js" ` +
+    `--command-line "node /src/${options.testToRun}" ` +
     `--secure-environment-variables "SERVICEBUS_CONNECTION_STRING=${serviceBusConnectionString}" "APPINSIGHTS_INSTRUMENTATIONKEY=${appInsightsInstrumentationKey}"`);
 
 console.log(`Done - there will be a new Azure Container Instance named '${containerInstanceName}' in the '${resourceGroup}' resource group.\n`);

--- a/sdk/servicebus/service-bus/test/stress/runcontainer.js
+++ b/sdk/servicebus/service-bus/test/stress/runcontainer.js
@@ -3,36 +3,35 @@ const minimist = require("minimist");
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
-const { OptionsComponent } = require("typedoc/dist/lib/utils/options/options");
 
 dotenv.config();
 
 const serviceBusConnectionString = process.env.SERVICEBUS_CONNECTION_STRING;
 const appInsightsInstrumentationKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY;
 const resourceGroup = process.env.RESOURCE_GROUP;
-const registryUserName = process.env.REGISTRY_USERNAME
-const registryPassword = process.env.REGISTRY_PASSWORD
+const registryUserName = process.env.REGISTRY_USERNAME;
+const registryPassword = process.env.REGISTRY_PASSWORD;
 const registryName = process.env.REGISTRY_NAME;
 
 const imageName = `${registryName}/sb-stressperf:test`;
 
 function spawn(command) {
-    const ret = spawnSync(command, { shell: true, stdio: "inherit" });
+  const ret = spawnSync(command, { shell: true, stdio: "inherit" });
 
-    if (ret.status !== 0) {
-        throw new Error(`${command} failed with exit code ${ret.status}`);
-    }
+  if (ret.status !== 0) {
+    throw new Error(`${command} failed with exit code ${ret.status}`);
+  }
 }
 
 // which script do we want to run?
 /** @type {{testToRun: string}} */
 const options = minimist(process.argv, {
-    string: ["testToRun"]
+  string: ["testToRun"]
 });
 
 if (!options.testToRun || !fs.existsSync(path.join("dist", options.testToRun))) {
-    console.error("Usage: runcontainer.js --testToRun <name of file in `dist`>");
-    process.exit(1);
+  console.error("Usage: runcontainer.js --testToRun <name of file in `dist`>");
+  process.exit(1);
 }
 
 const { name: testFileNameWithoutExtension } = path.parse(options.testToRun);
@@ -51,18 +50,28 @@ console.log(`Deleting Azure Container Instance (if exists)`);
 spawn(`az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
 
 console.log(`Creating Azure Container Instance for stress/perf that runs ${options.testToRun}`);
-spawn(`az container create --resource-group "${resourceGroup}" --name "${containerInstanceName}" ` +
+spawn(
+  `az container create --resource-group "${resourceGroup}" --name "${containerInstanceName}" ` +
     `--image ${imageName}  ` +
     "--cpu 1 --memory 0.7 " +
     "--restart-policy Never " +
     `--registry-username ${registryUserName} ` +
     `--registry-password "${registryPassword}" ` +
     `--command-line "node /src/${options.testToRun}" ` +
-    `--secure-environment-variables "SERVICEBUS_CONNECTION_STRING=${serviceBusConnectionString}" "APPINSIGHTS_INSTRUMENTATIONKEY=${appInsightsInstrumentationKey}"`);
+    `--secure-environment-variables "SERVICEBUS_CONNECTION_STRING=${serviceBusConnectionString}" "APPINSIGHTS_INSTRUMENTATIONKEY=${appInsightsInstrumentationKey}"`
+);
 
-console.log(`Done - there will be a new Azure Container Instance named '${containerInstanceName}' in the '${resourceGroup}' resource group.\n`);
+console.log(
+  `Done - there will be a new Azure Container Instance named '${containerInstanceName}' in the '${resourceGroup}' resource group.\n`
+);
 
 console.log(`Some other commands you might find useful to manage your container:\n`);
-console.log(`az container stop --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
-console.log(`az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
-console.log(`az container logs --resource-group "${resourceGroup}" --name "${containerInstanceName}" --follow`);
+console.log(
+  `az container stop --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
+);
+console.log(
+  `az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
+);
+console.log(
+  `az container logs --resource-group "${resourceGroup}" --name "${containerInstanceName}" --follow`
+);

--- a/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
@@ -71,6 +71,7 @@ export async function scenarioReceiveBatch() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "batchAndReceive",
     snapshotFocus: ["send-info", "receive-info"]
   });
   const sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
@@ -1,4 +1,8 @@
-import { ServiceBusClient, ServiceBusReceiver, ServiceBusReceiverOptions } from "@azure/service-bus";
+import {
+  ServiceBusClient,
+  ServiceBusReceiver,
+  ServiceBusReceiverOptions
+} from "@azure/service-bus";
 import { SBStressTestsBase } from "./stressTestsBase";
 import { delay } from "rhea-promise";
 import parsedArgs from "minimist";

--- a/sdk/servicebus/service-bus/test/stress/scenarioCloseOpen.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioCloseOpen.ts
@@ -49,6 +49,7 @@ export async function scenarioClose() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "closeOpen",
     snapshotFocus: ["send-info", "receive-info", "close-info"]
   });
   let sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/test/stress/scenarioPeekMessages.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioPeekMessages.ts
@@ -50,6 +50,7 @@ export async function scenarioPeekMessages() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "peekMessages",
     snapshotFocus: ["send-info", "receive-info"]
   });
   const sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/test/stress/scenarioRenewMessageLock.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioRenewMessageLock.ts
@@ -58,6 +58,7 @@ export async function main() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "renewMessageLock",
     snapshotFocus: ["send-info", "receive-info", "message-lock-renewal-info"]
   });
   const sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/test/stress/scenarioRenewSessionLock.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioRenewSessionLock.ts
@@ -73,6 +73,7 @@ export async function scenarioRenewSessionLock() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "renewSessionLock",
     snapshotFocus: ["send-info", "receive-info", "session-lock-renewal-info"]
   });
 

--- a/sdk/servicebus/service-bus/test/stress/scenarioSend.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioSend.ts
@@ -42,7 +42,7 @@ async function main() {
     totalNumberOfMessagesToSend,
     useScheduleApi
   } = testOptions;
-  const stressBase = new SBStressTestsBase({ snapshotFocus: ["send-info"] });
+  const stressBase = new SBStressTestsBase({ testName: "send", snapshotFocus: ["send-info"] });
   const sbClient = new ServiceBusClient(connectionString);
 
   await stressBase.init(undefined, undefined, testOptions);

--- a/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
@@ -74,6 +74,7 @@ export async function scenarioStreamingReceive() {
   const startedAt = new Date();
 
   const stressBase = new SBStressTestsBase({
+    testName: "streamingReceive",
     snapshotFocus: ["send-info", "receive-info", "message-lock-renewal-info"]
   });
   const sbClient = new ServiceBusClient(connectionString);

--- a/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
@@ -1,4 +1,8 @@
-import { ServiceBusClient, ServiceBusReceiver, ServiceBusReceiverOptions } from "@azure/service-bus";
+import {
+  ServiceBusClient,
+  ServiceBusReceiver,
+  ServiceBusReceiverOptions
+} from "@azure/service-bus";
 import { SBStressTestsBase } from "./stressTestsBase";
 import { delay } from "rhea-promise";
 import parsedArgs from "minimist";

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -363,8 +363,6 @@ export class SBStressTestsBase {
   }
 
   public async snapshot(): Promise<void> {
-    // TODO: get the options being set in the logs
-    // TODO: Get a title passed from the scenario file
     const eventProperties: Record<string, string | number> = {};
     const elapsedTimeInSeconds = (new Date().valueOf() - this.startedAt.valueOf()) / 1000;
 
@@ -406,8 +404,8 @@ export class SBStressTestsBase {
       this.sessionLockRenewalInfo.errors
     );
 
-    // TODO: it would be nicer to report the errors as they occur rather than
-    // doing this big dump of errors at the end.
+    // TODO: it would be nicer to report the errors as they occur rather than only doing
+    // this on snapshot boundaries.
     for (const err of errors) {
       defaultClient.trackException({
         exception: err

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -27,10 +27,11 @@ const writeFile = util.promisify(fs.writeFile);
 import * as dotenv from "dotenv";
 dotenv.config();
 
-appInsights.setup()
+appInsights
+  .setup()
   .setUseDiskRetryCaching(true)
   .start();
-    
+
 export const defaultClient = appInsights.defaultClient;
 
 export class SBStressTestsBase {
@@ -104,9 +105,9 @@ export class SBStressTestsBase {
       properties: {
         ...testOptions,
         ...options,
-        queueName: this.queueName        
+        queueName: this.queueName
       }
-    })
+    });
 
     await this.serviceBusAdministrationClient.createQueue(this.queueName, options);
   }
@@ -365,8 +366,8 @@ export class SBStressTestsBase {
   public async snapshot(): Promise<void> {
     // TODO: get the options being set in the logs
     // TODO: Get a title passed from the scenario file
-    const eventProperties: Record<string,string | number> = {};
-    const elapsedTimeInSeconds = (new Date().valueOf() - this.startedAt.valueOf()) / 1000;    
+    const eventProperties: Record<string, string | number> = {};
+    const elapsedTimeInSeconds = (new Date().valueOf() - this.startedAt.valueOf()) / 1000;
 
     eventProperties["elapsedTimeInSeconds"] = elapsedTimeInSeconds;
     eventProperties["messsages.sent"] = this.messagesSent.length;
@@ -381,7 +382,7 @@ export class SBStressTestsBase {
       eventProperties["receive.pass"] = this.receiveInfo.numberOfSuccesses;
       eventProperties["receive.fail"] = this.receiveInfo.numberOfFailures;
     }
-    
+
     if (this.snapshotOptions.snapshotFocus.includes("message-lock-renewal-info")) {
       eventProperties["lockRenewal.pass"] = this.messageLockRenewalInfo.numberOfSuccesses;
       eventProperties["lockRenewal.fail"] = this.messageLockRenewalInfo.numberOfFailures;
@@ -393,7 +394,7 @@ export class SBStressTestsBase {
     }
 
     if (this.snapshotOptions.snapshotFocus.includes("close-info")) {
-      eventProperties["close.sender.pass"] = - this.closeInfo.sender.numberOfSuccesses;
+      eventProperties["close.sender.pass"] = -this.closeInfo.sender.numberOfSuccesses;
       eventProperties["close.sender.fail"] = this.closeInfo.sender.numberOfFailures;
       eventProperties["close.receiver.pass"] = this.closeInfo.receiver.numberOfSuccesses;
       eventProperties["close.receiver.fail"] = this.closeInfo.receiver.numberOfFailures;
@@ -423,7 +424,7 @@ export class SBStressTestsBase {
       name: "summary",
       properties: eventProperties
     });
-    
+
     defaultClient.flush();
 
     console.log(JSON.stringify(eventProperties, undefined, 2));
@@ -431,11 +432,9 @@ export class SBStressTestsBase {
 
   public async end() {
     await this.snapshot();
-      
+
     if (this.snapshotOptions.snapshotFocus.includes("receive-info")) {
-      const output = await saveDiscrepanciesFromTrackedMessages(
-        this.trackedMessageIds
-      );
+      const output = await saveDiscrepanciesFromTrackedMessages(this.trackedMessageIds);
 
       defaultClient.trackEvent({
         name: "discrepencies",
@@ -443,12 +442,16 @@ export class SBStressTestsBase {
           messages_sent_but_never_received: output.messages_sent_but_never_received.join(","),
           messages_not_sent_but_received: output.messages_not_sent_but_received.join(","),
           messages_sent_multiple_times: output.messages_sent_multiple_times.join(","),
-          messages_sent_once_but_received_multiple_times: output.messages_sent_once_but_received_multiple_times.join(","),
-          messages_sent_once_and_received_once: output.messages_sent_once_and_received_once.join(","),
+          messages_sent_once_but_received_multiple_times: output.messages_sent_once_but_received_multiple_times.join(
+            ","
+          ),
+          messages_sent_once_and_received_once: output.messages_sent_once_and_received_once.join(
+            ","
+          )
         }
-      })
+      });
     }
-    
+
     // TODO: Log tracked messages in JSON
     // TODO: Have a copy of sentMessages and match them with receivedMessages, have the leftover 'message-id's in the logged file maybe
     // TODO: Add an argument to "end()" to not delete the resource

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -22,7 +22,6 @@ import {
   TrackedMessageIdsInfo
 } from "./utils";
 import * as appInsights from "applicationinsights";
-const writeFile = util.promisify(fs.writeFile);
 
 import * as dotenv from "dotenv";
 dotenv.config();

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -24,20 +24,14 @@ import {
 import * as appInsights from "applicationinsights";
 const writeFile = util.promisify(fs.writeFile);
 
+import * as dotenv from "dotenv";
+dotenv.config();
+
 appInsights.setup()
   .setUseDiskRetryCaching(true)
   .start();
     
-const defaultClient = appInsights.defaultClient;
-
-async function appendFile(reportFileName: string, text: string) {
-  defaultClient.trackTrace({
-    message: text,
-    properties: {
-      type: "stresstest"
-    }
-  });
-}
+export const defaultClient = appInsights.defaultClient;
 
 export class SBStressTestsBase {
   messagesSent: ServiceBusMessage[] = [];
@@ -97,12 +91,23 @@ export class SBStressTestsBase {
   ) {
     this.queueName =
       (!queueNamePrefix ? `queue` : queueNamePrefix) + `-${Math.ceil(Math.random() * 100000)}`;
-    this.reportFileName = `temp/report-${this.queueName}.txt`;
-    this.errorsFileName = `temp/errors-${this.queueName}.txt`;
     this.messagesReportFileName = `temp/messages-${this.queueName}.json`;
     if (testOptions) console.log(testOptions);
 
-    await appendFile(this.reportFileName, JSON.stringify(testOptions, null, 2));
+    defaultClient.commonProperties = {
+      // these will be reported with each event
+      testName: this.snapshotOptions.testName
+    };
+
+    defaultClient.trackEvent({
+      name: "start",
+      properties: {
+        ...testOptions,
+        ...options,
+        queueName: this.queueName        
+      }
+    })
+
     await this.serviceBusAdministrationClient.createQueue(this.queueName, options);
   }
 
@@ -360,105 +365,90 @@ export class SBStressTestsBase {
   public async snapshot(): Promise<void> {
     // TODO: get the options being set in the logs
     // TODO: Get a title passed from the scenario file
-    const elapsedTimeInSeconds = (new Date().valueOf() - this.startedAt.valueOf()) / 1000;
-    const memoryUsage = process.memoryUsage();
-    const currentSnapshot = [
-      `Time: ${new Date().toJSON()}`,
-      `Elapsed time in seconds: ${elapsedTimeInSeconds}`,
-      `Queue name: ${this.queueName}`,
-      `Space occupied for the process(rss): ${memoryUsage.rss}`,
-      `Memory Consumed(heapUsed): ${memoryUsage.heapUsed}`,
-      `Number of messages sent so far: ${this.messagesSent.length}`,
-      `Number of messages received so far: ${this.messagesReceived.length}`
-    ]
-      .concat(
-        this.snapshotOptions.snapshotFocus.includes("send-info")
-          ? [
-              `Number of successful sends so far: ${this.sendInfo.numberOfSuccesses}`,
-              `Number of failed sends so far: ${this.sendInfo.numberOfFailures}`,
-              `(Avg)Number of sends per sec: ${this.sendInfo.numberOfSuccesses /
-                elapsedTimeInSeconds}`
-            ]
-          : []
-      )
-      .concat(
-        this.snapshotOptions.snapshotFocus.includes("receive-info")
-          ? [
-              `Number of successful receives so far: ${this.receiveInfo.numberOfSuccesses}`,
-              `Number of failed receives so far: ${this.receiveInfo.numberOfFailures}`,
-              `(Avg)Number of receives per sec: ${this.receiveInfo.numberOfSuccesses /
-                elapsedTimeInSeconds}`
-            ]
-          : []
-      )
-      .concat(
-        this.snapshotOptions.snapshotFocus.includes("message-lock-renewal-info")
-          ? [
-              `Number of successful message lock renewals so far: ${this.messageLockRenewalInfo.numberOfSuccesses}`,
-              `Number of failed message lock renewals so far: ${this.messageLockRenewalInfo.numberOfFailures}`,
-              `(Avg)Number of message lock renewals per sec: ${this.messageLockRenewalInfo
-                .numberOfSuccesses / elapsedTimeInSeconds}`
-            ]
-          : []
-      )
-      .concat(
-        this.snapshotOptions.snapshotFocus.includes("session-lock-renewal-info")
-          ? [
-              `Number of successful session lock renewals so far: ${this.sessionLockRenewalInfo.numberOfSuccesses}`,
-              `Number of failed session lock renewals so far: ${this.sessionLockRenewalInfo.numberOfFailures}`,
-              `(Avg)Number of session lock renewals per sec: ${this.sessionLockRenewalInfo
-                .numberOfSuccesses / elapsedTimeInSeconds}`
-            ]
-          : []
-      )
-      .concat(
-        this.snapshotOptions.snapshotFocus.includes("close-info")
-          ? [
-              `Number of successful closes for sender so far: ${this.closeInfo.sender.numberOfSuccesses}`,
-              `Number of failed closes for sender so far: ${this.closeInfo.sender.numberOfFailures}`,
-              `Number of successful closes for receiver so far: ${this.closeInfo.receiver.numberOfSuccesses}`,
-              `Number of failed closes for receiver so far: ${this.closeInfo.receiver.numberOfFailures}`
-            ]
-          : []
-      )
-      .reduce((output, entry) => output + "\n" + entry)
-      .concat("\n\n");
+    const eventProperties: Record<string,string | number> = {};
+    const elapsedTimeInSeconds = (new Date().valueOf() - this.startedAt.valueOf()) / 1000;    
+
+    eventProperties["elapsedTimeInSeconds"] = elapsedTimeInSeconds;
+    eventProperties["messsages.sent"] = this.messagesSent.length;
+    eventProperties["messages.received"] = this.messagesReceived.length;
+
+    if (this.snapshotOptions.snapshotFocus.includes("send-info")) {
+      eventProperties["send.pass"] = this.sendInfo.numberOfSuccesses;
+      eventProperties["send.fail"] = this.sendInfo.numberOfFailures;
+    }
+
+    if (this.snapshotOptions.snapshotFocus.includes("receive-info")) {
+      eventProperties["receive.pass"] = this.receiveInfo.numberOfSuccesses;
+      eventProperties["receive.fail"] = this.receiveInfo.numberOfFailures;
+    }
     
-    await appendFile(this.reportFileName, currentSnapshot);
-    defaultClient.flush();
+    if (this.snapshotOptions.snapshotFocus.includes("message-lock-renewal-info")) {
+      eventProperties["lockRenewal.pass"] = this.messageLockRenewalInfo.numberOfSuccesses;
+      eventProperties["lockRenewal.fail"] = this.messageLockRenewalInfo.numberOfFailures;
+    }
 
-    console.log(currentSnapshot);
-  }
+    if (this.snapshotOptions.snapshotFocus.includes("session-lock-renewal-info")) {
+      eventProperties["sessionLockRenewal.pass"] = this.sessionLockRenewalInfo.numberOfSuccesses;
+      eventProperties["sessionLockRenewal.fail"] = this.sessionLockRenewalInfo.numberOfFailures;
+    }
 
-  public async end() {
+    if (this.snapshotOptions.snapshotFocus.includes("close-info")) {
+      eventProperties["close.sender.pass"] = - this.closeInfo.sender.numberOfSuccesses;
+      eventProperties["close.sender.fail"] = this.closeInfo.sender.numberOfFailures;
+      eventProperties["close.receiver.pass"] = this.closeInfo.receiver.numberOfSuccesses;
+      eventProperties["close.receiver.fail"] = this.closeInfo.receiver.numberOfFailures;
+    }
 
-    defaultClient.flush();
-
-    // Logging all the errors to a file
     const errors = [].concat(
       this.sendInfo.errors,
       this.receiveInfo.errors,
       this.messageLockRenewalInfo.errors,
       this.sessionLockRenewalInfo.errors
     );
+
+    // TODO: it would be nicer to report the errors as they occur rather than
+    // doing this big dump of errors at the end.
+    for (const err of errors) {
+      defaultClient.trackException({
+        exception: err
+      });
+    }
+
+    this.sendInfo.errors = [];
+    this.receiveInfo.errors = [];
+    this.messageLockRenewalInfo.errors = [];
+    this.sessionLockRenewalInfo.errors = [];
+
+    defaultClient.trackEvent({
+      name: "summary",
+      properties: eventProperties
+    });
+    
+    defaultClient.flush();
+
+    console.log(JSON.stringify(eventProperties, undefined, 2));
+  }
+
+  public async end() {
+    await this.snapshot();
+      
     if (this.snapshotOptions.snapshotFocus.includes("receive-info")) {
-      await saveDiscrepanciesFromTrackedMessages(
-        this.trackedMessageIds,
-        this.messagesReportFileName
+      const output = await saveDiscrepanciesFromTrackedMessages(
+        this.trackedMessageIds
       );
+
+      defaultClient.trackEvent({
+        name: "discrepencies",
+        properties: {
+          messages_sent_but_never_received: output.messages_sent_but_never_received.join(","),
+          messages_not_sent_but_received: output.messages_not_sent_but_received.join(","),
+          messages_sent_multiple_times: output.messages_sent_multiple_times.join(","),
+          messages_sent_once_but_received_multiple_times: output.messages_sent_once_but_received_multiple_times.join(","),
+          messages_sent_once_and_received_once: output.messages_sent_once_and_received_once.join(","),
+        }
+      })
     }
-    if (errors.length) {
-      await writeFile(
-        `errors-logged-${this.queueName}.txt`,
-        errors.reduce((output, entry) => output + "\n" + entry)
-      );
-    }
-    if (this.closeInfo) {
-      await writeFile(
-        `temp/close-calls-logged-${this.queueName}.json`,
-        JSON.stringify(this.closeInfo, null, 2) // Third argument prettifies
-      );
-    }
+    
     // TODO: Log tracked messages in JSON
     // TODO: Have a copy of sentMessages and match them with receivedMessages, have the leftover 'message-id's in the logged file maybe
     // TODO: Add an argument to "end()" to not delete the resource

--- a/sdk/servicebus/service-bus/test/stress/utils.ts
+++ b/sdk/servicebus/service-bus/test/stress/utils.ts
@@ -24,7 +24,8 @@ export interface LockRenewalOperationInfo extends OperationInfo {
 export interface SnapshotOptions {
   /**
    * The name of this test. Used when reporting telemetry in customDimensions['testName'].
-   */testName: string; 
+   */
+  testName: string;
   snapshotFocus?: (
     | "send-info"
     | "receive-info"
@@ -65,7 +66,7 @@ export function generateMessage(useSessions: boolean, numberOfSessions: number) 
 }
 
 export async function saveDiscrepanciesFromTrackedMessages(
-  trackedMessageIds: TrackedMessageIdsInfo,
+  trackedMessageIds: TrackedMessageIdsInfo
 ) {
   const output = {
     messages_sent_but_never_received: [],

--- a/sdk/servicebus/service-bus/test/stress/utils.ts
+++ b/sdk/servicebus/service-bus/test/stress/utils.ts
@@ -1,8 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import util from "util";
 import fs from "fs";
-import { defaultClient } from "applicationinsights";
-const writeFile = util.promisify(fs.writeFile);
 
 export interface OperationInfo {
   numberOfSuccesses: number;

--- a/sdk/servicebus/service-bus/test/stress/utils.ts
+++ b/sdk/servicebus/service-bus/test/stress/utils.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import util from "util";
 import fs from "fs";
+import { defaultClient } from "applicationinsights";
 const writeFile = util.promisify(fs.writeFile);
 
 export interface OperationInfo {
@@ -21,6 +22,9 @@ export interface LockRenewalOperationInfo extends OperationInfo {
 }
 
 export interface SnapshotOptions {
+  /**
+   * The name of this test. Used when reporting telemetry in customDimensions['testName'].
+   */testName: string; 
   snapshotFocus?: (
     | "send-info"
     | "receive-info"
@@ -62,7 +66,6 @@ export function generateMessage(useSessions: boolean, numberOfSessions: number) 
 
 export async function saveDiscrepanciesFromTrackedMessages(
   trackedMessageIds: TrackedMessageIdsInfo,
-  fileName: string
 ) {
   const output = {
     messages_sent_but_never_received: [],
@@ -93,6 +96,5 @@ export async function saveDiscrepanciesFromTrackedMessages(
       output.messages_sent_once_and_received_once.push(id);
     }
   }
-
-  await writeFile(fileName, JSON.stringify(output));
+  return output;
 }


### PR DESCRIPTION
Made it so runContainer.js can run any scenario test, not just scenarioBatchReceiver.ts.

Also made it so the telemetry is queryable by moving the telemetry into properties, rather than just being a trace message.