### PR TITLE
Add Document Key Retriever to Buffered Sender

### DIFF
--- a/sdk/search/search-documents/.eslintrc.json
+++ b/sdk/search/search-documents/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "@typescript-eslint/ban-ts-comment": "warn"
-  }
-}

--- a/sdk/search/search-documents/.eslintrc.json
+++ b/sdk/search/search-documents/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "@typescript-eslint/ban-ts-comment": "warn"
+  }
+}

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1653,7 +1653,7 @@ export interface SearchIndexerWarning {
 
 // @public
 export class SearchIndexingBufferedSender<T> {
-    constructor(client: IndexDocumentsClient<T>, options?: SearchIndexingBufferedSenderOptions);
+    constructor(client: IndexDocumentsClient<T>, documentKeyRetriever: (document: T) => string, options?: SearchIndexingBufferedSenderOptions);
     deleteDocuments(documents: T[], options?: SearchIndexingBufferedSenderDeleteDocumentsOptions): Promise<void>;
     dispose(): Promise<void>;
     flush(options?: SearchIndexingBufferedSenderFlushDocumentsOptions): Promise<void>;

--- a/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/autoFlushSizeBased.ts
+++ b/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/autoFlushSizeBased.ts
@@ -5,7 +5,7 @@ import {
   GeographyPoint,
   SearchIndexClient
 } from "@azure/search-documents";
-import { createIndex, WAIT_TIME } from "../../utils/setup";
+import { createIndex, documentKeyRetriever, WAIT_TIME } from "../../utils/setup";
 import { Hotel } from "../../utils/interfaces";
 import { delay } from "@azure/core-http";
 import * as dotenv from "dotenv";
@@ -65,9 +65,13 @@ export async function main() {
   await createIndex(indexClient, TEST_INDEX_NAME);
   await delay(WAIT_TIME);
 
-  const bufferedClient = new SearchIndexingBufferedSender<Hotel>(searchClient, {
-    autoFlush: true
-  });
+  const bufferedClient = new SearchIndexingBufferedSender<Hotel>(
+    searchClient,
+    documentKeyRetriever,
+    {
+      autoFlush: true
+    }
+  );
 
   bufferedClient.on("batchAdded", (response: any) => {
     console.log(`Batch Added Event has been receieved: ${response}`);

--- a/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/autoFlushTimerBased.ts
+++ b/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/autoFlushTimerBased.ts
@@ -6,7 +6,7 @@ import {
   SearchIndexClient,
   DEFAULT_FLUSH_WINDOW
 } from "@azure/search-documents";
-import { createIndex, WAIT_TIME } from "../../utils/setup";
+import { createIndex, documentKeyRetriever, WAIT_TIME } from "../../utils/setup";
 import { Hotel } from "../../utils/interfaces";
 import { delay } from "@azure/core-http";
 import * as dotenv from "dotenv";
@@ -39,6 +39,7 @@ export async function main() {
 
   const bufferedClient: SearchIndexingBufferedSender<Hotel> = new SearchIndexingBufferedSender(
     searchClient,
+    documentKeyRetriever,
     {
       autoFlush: true
     }

--- a/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/manualFlush.ts
+++ b/sdk/search/search-documents/samples/typescript/src/bufferedSender/uploadDocuments/manualFlush.ts
@@ -5,7 +5,7 @@ import {
   GeographyPoint,
   SearchIndexClient
 } from "@azure/search-documents";
-import { createIndex, WAIT_TIME } from "../../utils/setup";
+import { createIndex, documentKeyRetriever, WAIT_TIME } from "../../utils/setup";
 import { Hotel } from "../../utils/interfaces";
 import { delay } from "@azure/core-http";
 import * as dotenv from "dotenv";
@@ -36,6 +36,7 @@ export async function main() {
 
   const bufferedClient: SearchIndexingBufferedSender<Hotel> = new SearchIndexingBufferedSender(
     searchClient,
+    documentKeyRetriever,
     {
       autoFlush: false
     }

--- a/sdk/search/search-documents/samples/typescript/src/utils/setup.ts
+++ b/sdk/search/search-documents/samples/typescript/src/utils/setup.ts
@@ -2,8 +2,13 @@
 // Licensed under the MIT license.
 
 import { SearchIndexClient, SearchIndex, KnownAnalyzerNames } from "@azure/search-documents";
+import { Hotel } from "./interfaces";
 
 export const WAIT_TIME = 4000;
+
+export const documentKeyRetriever: (document: Hotel) => string = (document: Hotel): string => {
+  return document.hotelId;
+};
 
 // eslint-disable-next-line @azure/azure-sdk/ts-use-interface-parameters
 export async function createIndex(client: SearchIndexClient, name: string): Promise<void> {

--- a/sdk/search/search-documents/src/generated/data/searchClient.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClient.ts
@@ -10,7 +10,7 @@ import { Documents } from "./operations";
 import { SearchClientContext } from "./searchClientContext";
 import { SearchClientOptionalParams, ApiVersion20200630 } from "./models";
 
-/** @hidden */
+/** @internal */
 export class SearchClient extends SearchClientContext {
   /**
    * Initializes a new instance of the SearchClient class.

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -12,7 +12,7 @@ import { ApiVersion20200630, SearchClientOptionalParams } from "./models";
 const packageName = "@azure/search-documents";
 const packageVersion = "11.1.0-beta.2";
 
-/** @hidden */
+/** @internal */
 export class SearchClientContext extends coreHttp.ServiceClient {
   endpoint: string;
   indexName: string;

--- a/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
@@ -24,7 +24,7 @@ import {
   SearchServiceClientGetServiceStatisticsResponse
 } from "./models";
 
-/** @hidden */
+/** @internal */
 export class SearchServiceClient extends SearchServiceClientContext {
   /**
    * Initializes a new instance of the SearchServiceClient class.

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -15,7 +15,7 @@ import {
 const packageName = "@azure/search-documents";
 const packageVersion = "11.1.0-beta.2";
 
-/** @hidden */
+/** @internal */
 export class SearchServiceClientContext extends coreHttp.ServiceClient {
   endpoint: string;
   apiVersion: ApiVersion20200630;

--- a/sdk/search/search-documents/src/searchIndexingBufferedSender.ts
+++ b/sdk/search/search-documents/src/searchIndexingBufferedSender.ts
@@ -401,8 +401,7 @@ export class SearchIndexingBufferedSender<T> {
     const pruned: IndexDocumentsAction<T>[] = [];
 
     for (const document of batch) {
-      // @ts-ignore
-      const key = this.documentKeyRetriever(document);
+      const key = this.documentKeyRetriever((document as unknown) as T);
       if (hashSet.has(key)) {
         pruned.push(document);
       } else {


### PR DESCRIPTION
This PR Contains the following changes:

1. Change ```@hidden``` to ```@internal``` values. 
2. Fix the error ```code``` to ```statusCode```.
3. One new requirement is that in the batch sender before sending in the batch we need to check if there are any duplicates (based on the id retrieval logic  supplied by the user) and move them to the next batch. (It is ok if we send a batch that is less than the threshold size)
4. Change the autoflush to true by default.

@xirzec Please review and approve.