### PR TITLE
[event-hubs][service-bus] re-export RetryMode

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -12,6 +12,10 @@
   allow communicating to the standard Event Hubs endpoint.
   Resolves [#12901](https://github.com/Azure/azure-sdk-for-js/issues/12901).
 
+- Re-exports `RetryMode` for use when setting the `RetryOptions.mode` field
+  in `EventHubConsumerClientOptions` or `EventHubClientOptions`.
+  Resolves [#13166](https://github.com/Azure/azure-sdk-for-js/issues/13166).
+
 - Updates documentation for `EventData` to call out that the `body` field
   must be converted to a byte array or `Buffer` when cross-language
   compatibility while receiving events is required.

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -7,6 +7,7 @@
 import { AbortSignalLike } from '@azure/abort-controller';
 import { MessagingError } from '@azure/core-amqp';
 import { OperationTracingOptions } from '@azure/core-tracing';
+import { RetryMode } from '@azure/core-amqp';
 import { RetryOptions } from '@azure/core-amqp';
 import { Span } from '@opentelemetry/api';
 import { SpanContext } from '@opentelemetry/api';
@@ -247,6 +248,8 @@ export interface ReceivedEventData {
         [key: string]: any;
     };
 }
+
+export { RetryMode }
 
 export { RetryOptions }
 

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -35,7 +35,7 @@ export { EventDataBatch, TryAddOptions } from "./eventDataBatch";
 export { Checkpoint } from "./partitionProcessor";
 export { CheckpointStore, PartitionOwnership } from "./eventProcessor";
 export { CloseReason } from "./models/public";
-export { MessagingError, RetryOptions, WebSocketOptions } from "@azure/core-amqp";
+export { MessagingError, RetryOptions, RetryMode, WebSocketOptions } from "@azure/core-amqp";
 export { TokenCredential } from "@azure/core-auth";
 export { logger } from "./log";
 export {

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -97,6 +97,14 @@ export enum CloseReason {
  *    - `webSocketConstructorOptions` : Options to pass to the Websocket constructor when you choose to make the connection
  * over a WebSocket.
  * - `retryOptions`     : The retry options for all the operations on the client/producer/consumer.
+ *    - `maxRetries` : The number of times the operation can be retried in case of a retryable error.
+ *    - `maxRetryDelayInMs`: The maximum delay between retries. Applicable only when performing exponential retries.
+ *    - `mode`: Which retry mode to apply, specified by the `RetryMode` enum. Options are `Exponential` and `Fixed`. Defaults to `Fixed`.
+ *    - `retryDelayInMs`: Amount of time to wait in milliseconds before making the next attempt. When `mode` is set to `Exponential`,
+ *       this is used to compute the exponentially increasing delays between retries. Default: 30000 milliseconds.
+ *    - `timeoutInMs`: Amount of time in milliseconds to wait before the operation times out. This will trigger a retry if there are any
+ *       retry attempts remaining. Minimum value: 60000 milliseconds.
+ *
  * A simple usage can be `{ "maxRetries": 4 }`.
  *
  * Example usage:
@@ -121,6 +129,7 @@ export interface EventHubClientOptions {
   /**
    * Options to configure the retry policy for all the operations on the client.
    * For example, `{ "maxRetries": 4 }` or `{ "maxRetries": 4, "retryDelayInMs": 30000 }`.
+   *
    */
   retryOptions?: RetryOptions;
   /**
@@ -143,7 +152,15 @@ export interface EventHubClientOptions {
  * over a WebSocket.
  *    - `webSocketConstructorOptions` : Options to pass to the Websocket constructor when you choose to make the connection
  * over a WebSocket.
- * - `retryOptions`     : The retry options for all the operations on the EventHubConsumerClient.
+ * - `retryOptions`     : The retry options for all the operations on the client/producer/consumer.
+ *    - `maxRetries` : The number of times the operation can be retried in case of a retryable error.
+ *    - `maxRetryDelayInMs`: The maximum delay between retries. Applicable only when performing exponential retries.
+ *    - `mode`: Which retry mode to apply, specified by the `RetryMode` enum. Options are `Exponential` and `Fixed`. Defaults to `Fixed`.
+ *    - `retryDelayInMs`: Amount of time to wait in milliseconds before making the next attempt. When `mode` is set to `Exponential`,
+ *       this is used to compute the exponentially increasing delays between retries. Default: 30000 milliseconds.
+ *    - `timeoutInMs`: Amount of time in milliseconds to wait before the operation times out. This will trigger a retry if there are any
+ *       retry attempts remaining. Minimum value: 60000 milliseconds.
+ *
  * A simple usage can be `{ "maxRetries": 4 }`.
  *
  * Example usage:

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.0.4 (Unreleased)
 
+- Re-exports `RetryMode` for use when setting the `RetryOptions.mode` field
+  in `ServiceBusClientOptions`.
+  Resolves [#13166](https://github.com/Azure/azure-sdk-for-js/issues/13166).
 
 ## 7.0.3 (2021-01-26)
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -14,6 +14,7 @@ import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PageSettings } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
+import { RetryMode } from '@azure/core-amqp';
 import { RetryOptions } from '@azure/core-amqp';
 import { ServiceClient } from '@azure/core-http';
 import { Span } from '@opentelemetry/api';
@@ -220,6 +221,8 @@ export interface QueueRuntimeProperties {
 export interface ReceiveMessagesOptions extends OperationOptionsBase {
     maxWaitTimeInMs?: number;
 }
+
+export { RetryMode }
 
 export { RetryOptions }
 

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -9,6 +9,20 @@ import { SharedKeyCredential } from "./servicebusSharedKeyCredential";
 
 /**
  * Describes the options that can be provided while creating the ServiceBusClient.
+ *
+ * - `webSocketOptions` : Options to configure the channelling of the AMQP connection over Web Sockets.
+ *    - `websocket`     : The WebSocket constructor used to create an AMQP connection if you choose to make the connection
+ * over a WebSocket.
+ *    - `webSocketConstructorOptions` : Options to pass to the Websocket constructor when you choose to make the connection
+ * over a WebSocket.
+ * - `retryOptions`     : The retry options for all the operations on the client.
+ *    - `maxRetries` : The number of times the operation can be retried in case of a retryable error.
+ *    - `maxRetryDelayInMs`: The maximum delay between retries. Applicable only when performing exponential retries.
+ *    - `mode`: Which retry mode to apply, specified by the `RetryMode` enum. Options are `Exponential` and `Fixed`. Defaults to `Fixed`.
+ *    - `retryDelayInMs`: Amount of time to wait in milliseconds before making the next attempt. When `mode` is set to `Exponential`,
+ *       this is used to compute the exponentially increasing delays between retries. Default: 30000 milliseconds.
+ *    - `timeoutInMs`: Amount of time in milliseconds to wait before the operation times out. This will trigger a retry if there are any
+ *       retry attempts remaining. Minimum value: 60000 milliseconds.
  */
 export interface ServiceBusClientOptions {
   /**

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -4,7 +4,14 @@
 /// <reference lib="es2015" />
 /// <reference lib="esnext.asynciterable" />
 
-export { delay, MessagingError, RetryOptions, TokenType, WebSocketOptions } from "@azure/core-amqp";
+export {
+  delay,
+  MessagingError,
+  RetryOptions,
+  RetryMode,
+  TokenType,
+  WebSocketOptions
+} from "@azure/core-amqp";
 export { TokenCredential } from "@azure/core-auth";
 export { OperationOptions } from "@azure/core-http";
 export { Delivery, WebSocketImpl } from "rhea-promise";


### PR DESCRIPTION
Fixed #13166

Both `@azure/event-hubs` and `@azure/service-bus` packages use `RetryOptions` from `@azure/core-amqp`. `RetryOptions` has a field - `mode` - that is an enum: `RetryMode`.

We needed to re-export `RetryMode` from the client packages, otherwise a user would need to import it from `@azure/core-amqp` (a package we don't want users to use directly) in order to change the mode from `Fixed` to `Exponential`.

I also noticed that the generated doc pages for our client options were poor in quality since we don't yet support linking across packages, so I spruced up the client options interfaces to better document `RetryOptions`.