### PR TITLE
[Identity] InteractiveBrowserCredential - Fix Azure Stack support

### DIFF
--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -65,7 +65,11 @@ export class InteractiveBrowserCredential implements TokenCredential {
     }
 
     this.msalClient = new MsalClient(
-      { clientId, authority: authorityHost },
+      {
+        clientId,
+        authority: authorityHost,
+        knownAuthorities: tenantId === "adfs" ? (authorityHost ? [authorityHost] : []) : []
+      },
       false,
       undefined,
       options


### PR DESCRIPTION
Fixes #11220

This PR ensures InteractiveBrowserCredential (the Node version) works for Azure Stack.

This PR is compatible with the other InteractiveBrowserCredential PR: https://github.com/Azure/azure-sdk-for-js/pull/13263 <- This PR does some heavy updates to the browser side of this credential. I also tested Azure Stack with all of these changes together to confirm that it worked once everything is merged.