### PR TITLE
Update pnpm lock file

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1033,12 +1033,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
-  /@types/yargs/15.0.12:
+  /@types/yargs/15.0.13:
     dependencies:
       '@types/yargs-parser': 20.2.0
     dev: false
     resolution:
-      integrity: sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
+      integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   /@types/yauzl/2.9.1:
     dependencies:
       '@types/node': 8.10.66
@@ -9109,12 +9109,14 @@ packages:
       '@rollup/plugin-node-resolve': 8.4.0_rollup@1.32.1
       '@rollup/plugin-replace': 2.3.4_rollup@1.32.1
       '@types/chai': 4.2.14
+      '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.10
       assert: 1.5.0
       chai: 4.2.0
+      chai-as-promised: 7.1.1_chai@4.2.0
       cross-env: 7.0.3
       dotenv: 8.2.0
       eslint: 7.18.0
@@ -9153,7 +9155,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-FBv4UmvUcBH10v1TQRJfbHSFUUn+nrnjceC4jClIpp2QrEUbN5YXKuI9uOU2J1RYXLWY4CaV2rSWd20b3xVw4g==
+      integrity: sha512-2T3z2w3gA8WLmpZNCAXxQPEkyE3yiO6cOBHKt/UEXwCris9pvqpkfbMcEmkaX+gWwiNt0ptXJlnysziiiB7Auw==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -9580,7 +9582,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-WzR4R9h7IwmBSij3j7ToynpbAFvjcHMt669AvyVEaTLYqbWXjx1zK+kfOO8t/S5ZVhYBBdNj4U1PDt8UWBfj3Q==
+      integrity: sha512-b8OV32wgLusNRZu6kmj7oWTYA+TvRxcYd6UHZX9Z1QTOUueIrZEVzGLqU2/+kTptItqxIyj0vyalKBIIODwvcA==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
@@ -10175,7 +10177,7 @@ packages:
       '@azure/event-hubs': 2.1.4
       '@types/node': 8.10.66
       '@types/uuid': 8.3.0
-      '@types/yargs': 15.0.12
+      '@types/yargs': 15.0.13
       async-lock: 1.2.8
       death: 1.1.0
       debug: 4.3.1


### PR DESCRIPTION
build is failing with following error. 
ERROR: Internal Error: Unable to find dependency chai-as-promised with version 7.1.1 in shrinkwrap.

Rush update to update lock file.