### PR TITLE
IoT Central regenerated with support for @azure/identity

### DIFF
--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -1,93 +1,87 @@
 ## Azure IotCentralClient SDK for JavaScript
 
-This package contains an isomorphic SDK for IotCentralClient.
+This package contains an isomorphic SDK (runs both in node.js and in browsers) for IotCentralClient.
 
 ### Currently supported environments
 
-- Node.js version 6.x.x or higher
+- Node.js version 8.x.x or higher
 - Browser JavaScript
 
-### How to Install
+### How to install
 
+To use this SDK in your project, you will need to install two packages.
+- `@azure/arm-iotcentral` that contains the client.
+- `@azure/identity` that contains different credentials for you to authenticate the client using Azure Active Directory.
+Install both packages using the below commands.
+Alternatively, you can add these to the dependencies section in your package.json and then run `npm install`.
 ```bash
 npm install @azure/arm-iotcentral
+npm install @azure/identity
 ```
+Please note that while the credentials from the older `@azure/ms-rest-nodeauth` and `@azure/ms-rest-browserauth` packages are still supported, these packages are in maintenance mode receiving critical bug fixes, but no new features.
+We strongly encourage you to use the credentials from `@azure/identity` where the latest versions of Azure Active Directory and MSAL APIs are used and more authentication options are provided.
 
 ### How to use
 
-#### nodejs - client creation and get apps as an example written in TypeScript.
-
-##### Install @azure/ms-rest-nodeauth
-
-- Please install minimum version of `"@azure/ms-rest-nodeauth": "^3.0.0"`.
-```bash
-npm install @azure/ms-rest-nodeauth@"^3.0.0"
-```
+There are multiple credentials available in the `@azure/identity` package to suit your different needs.
+Read about them in detail in [readme for @azure/identity package](https://www.npmjs.com/package/@azure/identity).
+To get started you can use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential) which tries different credentials internally until one of them succeeds.
+Most of the credentials would require you to [create an Azure App Registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration) first.
+#### nodejs - Authentication, client creation, and get apps as an example written in JavaScript.
 
 ##### Sample code
 
-While the below sample uses the interactive login, other authentication options can be found in the [README.md file of @azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) package
-```typescript
-const msRestNodeAuth = require("@azure/ms-rest-nodeauth");
+```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
 const { IotCentralClient } = require("@azure/arm-iotcentral");
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
-msRestNodeAuth.interactiveLogin().then((creds) => {
-  const client = new IotCentralClient(creds, subscriptionId);
-  const resourceGroupName = "testresourceGroupName";
-  const resourceName = "testresourceName";
-  client.apps.get(resourceGroupName, resourceName).then((result) => {
-    console.log("The result is:");
-    console.log(result);
-  });
+const creds = new DefaultAzureCredential();
+const client = new IotCentralClient(creds, subscriptionId);
+const resourceGroupName = "testresourceGroupName";
+const resourceName = "testresourceName";
+client.apps.get(resourceGroupName, resourceName).then((result) => {
+  console.log("The result is:");
+  console.log(result);
 }).catch((err) => {
+  console.log("An error occurred:");
   console.error(err);
 });
 ```
 
-#### browser - Authentication, client creation and get apps as an example written in JavaScript.
+#### browser - Authentication, client creation, and get apps as an example written in JavaScript.
 
-##### Install @azure/ms-rest-browserauth
-
-```bash
-npm install @azure/ms-rest-browserauth
-```
+In browser applications, we recommend using the `InteractiveBrowserCredential` that interactively authenticates using the default system browser.
+It is necessary to [create an Azure App Registration](https://docs.microsoft.com/azure/active-directory/develop/scenario-spa-app-registration) in the portal for your web application first.
 
 ##### Sample code
 
-See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to Azure in the browser.
-
 - index.html
+
 ```html
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <title>@azure/arm-iotcentral sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
     <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
-    <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
+    <script src="node_modules/@azure/identity/dist/index.js"></script>
     <script src="node_modules/@azure/arm-iotcentral/dist/arm-iotcentral.js"></script>
     <script type="text/javascript">
       const subscriptionId = "<Subscription_Id>";
-      const authManager = new msAuth.AuthManager({
+      const credential = new InteractiveBrowserCredential(
+      {
         clientId: "<client id for your Azure AD app>",
         tenant: "<optional tenant for your organization>"
       });
-      authManager.finalizeLogin().then((res) => {
-        if (!res.isLoggedIn) {
-          // may cause redirects
-          authManager.login();
-        }
-        const client = new Azure.ArmIotcentral.IotCentralClient(res.creds, subscriptionId);
-        const resourceGroupName = "testresourceGroupName";
-        const resourceName = "testresourceName";
-        client.apps.get(resourceGroupName, resourceName).then((result) => {
-          console.log("The result is:");
-          console.log(result);
-        }).catch((err) => {
-          console.log("An error occurred:");
-          console.error(err);
-        });
+      const client = new Azure.ArmIotcentral.IotCentralClient(res.creds, subscriptionId);
+      const resourceGroupName = "testresourceGroupName";
+      const resourceName = "testresourceName";
+      client.apps.get(resourceGroupName, resourceName).then((result) => {
+        console.log("The result is:");
+        console.log(result);
+      }).catch((err) => {
+        console.log("An error occurred:");
+        console.error(err);
       });
     </script>
   </head>
@@ -99,4 +93,4 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/iotcentral/arm-iotcentral/README.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/README.png)

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -12,8 +12,8 @@ This package contains an isomorphic SDK (runs both in node.js and in browsers) f
 To use this SDK in your project, you will need to install two packages.
 - `@azure/arm-iotcentral` that contains the client.
 - `@azure/identity` that contains different credentials for you to authenticate the client using Azure Active Directory.
+
 Install both packages using the below commands.
-Alternatively, you can add these to the dependencies section in your package.json and then run `npm install`.
 ```bash
 npm install @azure/arm-iotcentral
 npm install @azure/identity
@@ -23,7 +23,7 @@ We strongly encourage you to use the credentials from `@azure/identity` where th
 
 ### How to use
 
-There are multiple credentials available in the `@azure/identity` package to suit your different needs.
+There are multiple credentials available in the `@azure/identity` package to suit your different authentication needs.
 Read about them in detail in [readme for @azure/identity package](https://www.npmjs.com/package/@azure/identity).
 To get started you can use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential) which tries different credentials internally until one of them succeeds.
 Most of the credentials would require you to [create an Azure App Registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration) first.

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -36,9 +36,9 @@ const { DefaultAzureCredential } = require("@azure/identity");
 const { IotCentralClient } = require("@azure/arm-iotcentral");
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
+// Create credentials using the `@azure/identity` package.
+// Please note that you can also use credentials from the `@azure/ms-rest-nodeauth` package instead.
 const creds = new DefaultAzureCredential();
-// Pass the credentials from `@azure/identity` to the client constructor.
-// Please note that the credentials from `@azure/ms-rest-nodeauth` are supported here as well.
 const client = new IotCentralClient(creds, subscriptionId);
 const resourceGroupName = "testresourceGroupName";
 const resourceName = "testresourceName";
@@ -70,13 +70,13 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
     <script src="node_modules/@azure/arm-iotcentral/dist/arm-iotcentral.js"></script>
     <script type="text/javascript">
       const subscriptionId = "<Subscription_Id>";
+      // Create credentials using the `@azure/identity` package.
+      // Please note that you can also use credentials from the `@azure/ms-rest-browserauth` package instead.
       const credential = new InteractiveBrowserCredential(
       {
         clientId: "<client id for your Azure AD app>",
         tenant: "<optional tenant for your organization>"
       });
-      // Pass the credentials from `@azure/identity` to the client constructor.
-      // Please note that the credentials from `@azure/ms-rest-browserauth` are supported here as well.
       const client = new Azure.ArmIotcentral.IotCentralClient(creds, subscriptionId);
       const resourceGroupName = "testresourceGroupName";
       const resourceName = "testresourceName";

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -93,4 +93,4 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/README.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/iotcentral/arm-iotcentral/README.png)

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -18,7 +18,7 @@ Install both packages using the below commands.
 npm install @azure/arm-iotcentral
 npm install @azure/identity
 ```
-Please note that while the credentials from the older `@azure/ms-rest-nodeauth` and `@azure/ms-rest-browserauth` packages are still supported, these packages are in maintenance mode receiving critical bug fixes, but no new features.
+Please note that while the credentials from the older [`@azure/ms-rest-nodeauth`](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) and [`@azure/ms-rest-browserauth`](https://www.npmjs.com/package/@azure/ms-rest-browserauth) packages are still supported, these packages are in maintenance mode receiving critical bug fixes, but no new features.
 We strongly encourage you to use the credentials from `@azure/identity` where the latest versions of Azure Active Directory and MSAL APIs are used and more authentication options are provided.
 
 ### How to use
@@ -37,6 +37,8 @@ const { IotCentralClient } = require("@azure/arm-iotcentral");
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
 const creds = new DefaultAzureCredential();
+// Pass the credentials from `@azure/identity` to the client constructor.
+// Please note that the credentials from `@azure/ms-rest-nodeauth` are supported here as well.
 const client = new IotCentralClient(creds, subscriptionId);
 const resourceGroupName = "testresourceGroupName";
 const resourceName = "testresourceName";
@@ -73,6 +75,8 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
         clientId: "<client id for your Azure AD app>",
         tenant: "<optional tenant for your organization>"
       });
+      // Pass the credentials from `@azure/identity` to the client constructor.
+      // Please note that the credentials from `@azure/ms-rest-nodeauth` are supported here as well.
       const client = new Azure.ArmIotcentral.IotCentralClient(creds, subscriptionId);
       const resourceGroupName = "testresourceGroupName";
       const resourceName = "testresourceName";

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -73,7 +73,7 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
         clientId: "<client id for your Azure AD app>",
         tenant: "<optional tenant for your organization>"
       });
-      const client = new Azure.ArmIotcentral.IotCentralClient(res.creds, subscriptionId);
+      const client = new Azure.ArmIotcentral.IotCentralClient(creds, subscriptionId);
       const resourceGroupName = "testresourceGroupName";
       const resourceName = "testresourceName";
       client.apps.get(resourceGroupName, resourceName).then((result) => {

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -76,7 +76,7 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
         tenant: "<optional tenant for your organization>"
       });
       // Pass the credentials from `@azure/identity` to the client constructor.
-      // Please note that the credentials from `@azure/ms-rest-nodeauth` are supported here as well.
+      // Please note that the credentials from `@azure/ms-rest-browserauth` are supported here as well.
       const client = new Azure.ArmIotcentral.IotCentralClient(creds, subscriptionId);
       const resourceGroupName = "testresourceGroupName";
       const resourceName = "testresourceName";

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/iotcentral/arm-iotcentral",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -4,8 +4,9 @@
   "description": "IotCentralClient Library with typescript type definitions for node.js and browser.",
   "version": "4.0.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^2.0.1",
-    "@azure/ms-rest-js": "^2.0.4",
+    "@azure/ms-rest-azure-js": "^2.1.0",
+    "@azure/ms-rest-js": "^2.2.0",
+    "@azure/core-auth": "^1.1.4",
     "tslib": "^1.10.0"
   },
   "keywords": [
@@ -20,13 +21,13 @@
   "module": "./esm/iotCentralClient.js",
   "types": "./esm/iotCentralClient.d.ts",
   "devDependencies": {
-    "typescript": "^3.5.3",
+    "typescript": "^3.6.0",
     "rollup": "^1.18.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.6.0"
   },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/iotcentral/arm-iotcentral",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Azure/azure-sdk-for-js.git"

--- a/sdk/iotcentral/arm-iotcentral/src/iotCentralClient.ts
+++ b/sdk/iotcentral/arm-iotcentral/src/iotCentralClient.ts
@@ -8,6 +8,7 @@
  */
 
 import * as msRest from "@azure/ms-rest-js";
+import { TokenCredential } from "@azure/core-auth";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -21,11 +22,21 @@ class IotCentralClient extends IotCentralClientContext {
 
   /**
    * Initializes a new instance of the IotCentralClient class.
-   * @param credentials Credentials needed for the client to connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure. Credentials needed to
+   * authenticate the client using Azure Active Directory. Credentials implementing the
+   * TokenCredential interface from the @azure/identity package are recommended. Credentials
+   * implementing the ServiceClientCredentials interface from the older packages
+   * @azure/ms-rest-nodeauth and @azure/ms-rest-browserauth are also supported. The simplest
+   * TokenCredential credential can be obtained as follows:
+   * ```js
+   * const { DefaultAzureCredential } = require("@azure/identity");
+   * const credential = new DefaultAzureCredential();
+   * ```
+   * For more information about these credentials, see {@link http://aka.ms/AAaz61x}
    * @param subscriptionId The subscription identifier.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.IotCentralClientOptions) {
+  constructor(credentials: msRest.ServiceClientCredentials | TokenCredential, subscriptionId: string, options?: Models.IotCentralClientOptions) {
     super(credentials, subscriptionId, options);
     this.apps = new operations.Apps(this);
     this.operations = new operations.Operations(this);

--- a/sdk/iotcentral/arm-iotcentral/src/iotCentralClient.ts
+++ b/sdk/iotcentral/arm-iotcentral/src/iotCentralClient.ts
@@ -22,17 +22,12 @@ class IotCentralClient extends IotCentralClientContext {
 
   /**
    * Initializes a new instance of the IotCentralClient class.
-   * @param credentials Credentials needed for the client to connect to Azure. Credentials needed to
-   * authenticate the client using Azure Active Directory. Credentials implementing the
-   * TokenCredential interface from the @azure/identity package are recommended. Credentials
-   * implementing the ServiceClientCredentials interface from the older packages
-   * @azure/ms-rest-nodeauth and @azure/ms-rest-browserauth are also supported. The simplest
-   * TokenCredential credential can be obtained as follows:
-   * ```js
-   * const { DefaultAzureCredential } = require("@azure/identity");
-   * const credential = new DefaultAzureCredential();
-   * ```
-   * For more information about these credentials, see {@link http://aka.ms/AAaz61x}
+   * @param credentials Credentials needed for the client to connect to Azure. Credentials
+   * implementing the TokenCredential interface from the @azure/identity package are recommended. For
+   * more information about these credentials, see
+   * {@link https://www.npmjs.com/package/@azure/identity}. Credentials implementing the
+   * ServiceClientCredentials interface from the older packages @azure/ms-rest-nodeauth and
+   * @azure/ms-rest-browserauth are also supported.
    * @param subscriptionId The subscription identifier.
    * @param [options] The parameter options
    */

--- a/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
+++ b/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
@@ -42,7 +42,7 @@ export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
     if (!options) {
       options = {};
     }
-    if(!options.userAgent) {
+    if (!options.userAgent) {
       const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
@@ -57,10 +57,10 @@ export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
     this.credentials = credentials;
     this.subscriptionId = subscriptionId;
 
-    if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
+    if (options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
       this.acceptLanguage = options.acceptLanguage;
     }
-    if(options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
+    if (options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
       this.longRunningOperationRetryTimeout = options.longRunningOperationRetryTimeout;
     }
   }

--- a/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
+++ b/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
@@ -22,17 +22,12 @@ export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
 
   /**
    * Initializes a new instance of the IotCentralClient class.
-   * @param credentials Credentials needed for the client to connect to Azure. Credentials needed to
-   * authenticate the client using Azure Active Directory. Credentials implementing the
-   * TokenCredential interface from the @azure/identity package are recommended. Credentials
-   * implementing the ServiceClientCredentials interface from the older packages
-   * @azure/ms-rest-nodeauth and @azure/ms-rest-browserauth are also supported. The simplest
-   * TokenCredential credential can be obtained as follows:
-   * ```js
-   * const { DefaultAzureCredential } = require("@azure/identity");
-   * const credential = new DefaultAzureCredential();
-   * ```
-   * For more information about these credentials, see {@link http://aka.ms/AAaz61x}
+   * @param credentials Credentials needed for the client to connect to Azure. Credentials
+   * implementing the TokenCredential interface from the @azure/identity package are recommended. For
+   * more information about these credentials, see
+   * {@link https://www.npmjs.com/package/@azure/identity}. Credentials implementing the
+   * ServiceClientCredentials interface from the older packages @azure/ms-rest-nodeauth and
+   * @azure/ms-rest-browserauth are also supported.
    * @param subscriptionId The subscription identifier.
    * @param [options] The parameter options
    */

--- a/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
+++ b/sdk/iotcentral/arm-iotcentral/src/iotCentralClientContext.ts
@@ -10,22 +10,33 @@
 import * as Models from "./models";
 import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
+import { TokenCredential } from "@azure/core-auth";
 
 const packageName = "@azure/arm-iotcentral";
 const packageVersion = "4.0.0";
 
 export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+  credentials: msRest.ServiceClientCredentials | TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
   /**
    * Initializes a new instance of the IotCentralClient class.
-   * @param credentials Credentials needed for the client to connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure. Credentials needed to
+   * authenticate the client using Azure Active Directory. Credentials implementing the
+   * TokenCredential interface from the @azure/identity package are recommended. Credentials
+   * implementing the ServiceClientCredentials interface from the older packages
+   * @azure/ms-rest-nodeauth and @azure/ms-rest-browserauth are also supported. The simplest
+   * TokenCredential credential can be obtained as follows:
+   * ```js
+   * const { DefaultAzureCredential } = require("@azure/identity");
+   * const credential = new DefaultAzureCredential();
+   * ```
+   * For more information about these credentials, see {@link http://aka.ms/AAaz61x}
    * @param subscriptionId The subscription identifier.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.IotCentralClientOptions) {
+  constructor(credentials: msRest.ServiceClientCredentials | TokenCredential, subscriptionId: string, options?: Models.IotCentralClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -36,7 +47,7 @@ export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
     if (!options) {
       options = {};
     }
-    if (!options.userAgent) {
+    if(!options.userAgent) {
       const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
@@ -51,10 +62,10 @@ export class IotCentralClientContext extends msRestAzure.AzureServiceClient {
     this.credentials = credentials;
     this.subscriptionId = subscriptionId;
 
-    if (options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
+    if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
       this.acceptLanguage = options.acceptLanguage;
     }
-    if (options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
+    if(options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
       this.longRunningOperationRetryTimeout = options.longRunningOperationRetryTimeout;
     }
   }


### PR DESCRIPTION
Regenerates the IoT Central package using the v4 of the code generator updated with support for `@azure/identity` as a proof of concept.

[Link to the swagger file used](https://github.com/Azure/azure-rest-api-specs/blob/b2310d613219670729b7dcd5db1cd217f3f21e4c/specification/iotcentral/resource-manager/Microsoft.IoTCentral/stable/2018-09-01/iotcentral.json).