### PR TITLE
[service-bus] Hit low-hanging fruit with linting errors

### DIFF
--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -34,26 +34,26 @@ import { ReceiverType } from "./core/linkEntity";
  */
 export interface ConnectionContext extends ConnectionContextBase {
   /**
-   * @property {SharedKeyCredential | TokenCredential} [tokenCredential] The credential to be used for Authentication.
+   * The credential to be used for Authentication.
    * Default value: SharedKeyCredentials.
    */
   tokenCredential: SharedKeyCredential | TokenCredential;
   /**
-   * @property A map of active Service Bus Senders with sender name as key.
+   * A map of active Service Bus Senders with sender name as key.
    */
   senders: { [name: string]: MessageSender };
   /**
-   * @property A map of active Service Bus receivers for non session enabled queues/subscriptions
+   * A map of active Service Bus receivers for non session enabled queues/subscriptions
    * with receiver name as key.
    */
   messageReceivers: { [name: string]: MessageReceiver };
   /**
-   * @property A map of active Service Bus receivers for session enabled queues/subscriptions
+   * A map of active Service Bus receivers for session enabled queues/subscriptions
    * with receiver name as key.
    */
   messageSessions: { [name: string]: MessageSession };
   /**
-   * @property A map of ManagementClient instances for operations over the $management link
+   * A map of ManagementClient instances for operations over the $management link
    * with key as the entity path.
    */
   managementClients: { [name: string]: ManagementClient };

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -42,9 +42,9 @@ export interface ServiceBusClientOptions {
 /**
  * @internal
  *
- * @param connectionString
- * @param credential
- * @param options
+ * @param connectionString -
+ * @param credential -
+ * @param options -
  */
 export function createConnectionContext(
   connectionString: string,
@@ -61,8 +61,8 @@ export function createConnectionContext(
 }
 
 /**
- * @param connectionString
- * @param options
+ * @param connectionString -
+ * @param options -
  * @internal
  */
 export function createConnectionContextForConnectionString(
@@ -75,9 +75,9 @@ export function createConnectionContextForConnectionString(
 
 /**
  *
- * @param credential
- * @param host
- * @param options
+ * @param credential -
+ * @param host -
+ * @param options -
  * @internal
  */
 export function createConnectionContextForTokenCredential(

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -42,9 +42,6 @@ export interface ServiceBusClientOptions {
 /**
  * @internal
  *
- * @param connectionString -
- * @param credential -
- * @param options -
  */
 export function createConnectionContext(
   connectionString: string,
@@ -61,8 +58,6 @@ export function createConnectionContext(
 }
 
 /**
- * @param connectionString -
- * @param options -
  * @internal
  */
 export function createConnectionContextForConnectionString(
@@ -75,9 +70,6 @@ export function createConnectionContextForConnectionString(
 
 /**
  *
- * @param credential -
- * @param host -
- * @param options -
  * @internal
  */
 export function createConnectionContextForTokenCredential(

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -42,9 +42,9 @@ export interface ServiceBusClientOptions {
 /**
  * @internal
  *
- * @param {string} connectionString
- * @param {(SharedKeyCredential | TokenCredential)} credential
- * @param {ServiceBusClientOptions} options
+ * @param connectionString
+ * @param credential
+ * @param options
  */
 export function createConnectionContext(
   connectionString: string,

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -30,7 +30,6 @@ export interface ServiceBusClientOptions {
    */
   retryOptions?: RetryOptions;
   /**
-   * @property
    * Options to configure the channelling of the AMQP connection over Web Sockets.
    */
   webSocketOptions?: WebSocketOptions;

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -100,7 +100,7 @@ export function createConnectionContextForTokenCredential(
 
 /**
  * Parses a connection string and extracts the EntityPath named entity out.
- * @param connectionString An entity specific Service Bus connection string.
+ * @param connectionString - An entity specific Service Bus connection string.
  * @internal
  */
 export function getEntityNameFromConnectionString(connectionString: string): string {

--- a/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
+++ b/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
@@ -50,9 +50,9 @@ export class LockRenewer {
   /**
    * Creates an AutoLockRenewer.
    *
-   * @param linkEntity Your link entity instance (probably 'this')
-   * @param context The connection context for your link entity (probably 'this._context')
-   * @param options The ReceiveOptions passed through to your message receiver.
+   * @param linkEntity - Your link entity instance (probably 'this')
+   * @param context - The connection context for your link entity (probably 'this._context')
+   * @param options - The ReceiveOptions passed through to your message receiver.
    * @returns if the lock mode is peek lock (or if is unspecified, thus defaulting to peekLock)
    * and the options.maxAutoLockRenewalDurationInMs is > 0..Otherwise, returns undefined.
    */
@@ -96,7 +96,7 @@ export class LockRenewer {
   /**
    * Stops lock renewal for a single message.
    *
-   * @param bMessage The message whose lock renewal we will stop.
+   * @param bMessage - The message whose lock renewal we will stop.
    */
   stop(linkEntity: MinimalLink, bMessage: RenewableMessageProperties) {
     const messageId = bMessage.messageId as string;
@@ -113,7 +113,7 @@ export class LockRenewer {
   /**
    * Starts lock renewal for a single message.
    *
-   * @param bMessage The message whose lock renewal we will start.
+   * @param bMessage - The message whose lock renewal we will start.
    */
   start(linkEntity: MinimalLink, bMessage: RenewableMessageProperties, onError: OnErrorNoContext) {
     try {

--- a/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
+++ b/sdk/servicebus/service-bus/src/core/autoLockRenewer.ts
@@ -29,7 +29,7 @@ type MinimalLink = Pick<LinkEntity<any>, "name" | "logPrefix" | "entityPath">;
  */
 export class LockRenewer {
   /**
-   * @property _messageRenewLockTimers A map of link names to individual maps for each
+   * A map of link names to individual maps for each
    * link that map a message ID to its auto-renewal timer.
    */
   private _messageRenewLockTimers: Map<string, Map<string, NodeJS.Timer | undefined>> = new Map<

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -26,14 +26,11 @@ import { ServiceBusError, translateServiceBusError } from "../serviceBusError";
  * Describes the batching receiver where the user can receive a specified number of messages for
  * a predefined time.
  * @internal
- * @class BatchingReceiver
- * @extends MessageReceiver
  */
 export class BatchingReceiver extends MessageReceiver {
   /**
    * Instantiate a new BatchingReceiver.
    *
-   * @constructor
    * @param context - The client entity context.
    * @param options - Options for how you'd like to connect.
    */

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -35,7 +35,7 @@ export class BatchingReceiver extends MessageReceiver {
    *
    * @constructor
    * @param context The client entity context.
-   * @param [options]  Options for how you'd like to connect.
+   * @param options  Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "batching", options);
@@ -80,7 +80,7 @@ export class BatchingReceiver extends MessageReceiver {
 
   /**
    * To be called when connection is disconnected to gracefully close ongoing receive request.
-   * @param [connectionError] The connection error if any.
+   * @param connectionError The connection error if any.
    * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(connectionError?: AmqpError | Error): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -97,10 +97,10 @@ export class BatchingReceiver extends MessageReceiver {
 
   /**
    * Receives a batch of messages from a ServiceBus Queue/Topic.
-   * @param maxMessageCount The maximum number of messages to receive.
+   * @param maxMessageCount - The maximum number of messages to receive.
    * In Peeklock mode, this number is capped at 2047 due to constraints of the underlying buffer.
-   * @param maxWaitTimeInMs The total wait time in milliseconds until which the receiver will attempt to receive specified number of messages.
-   * @param maxTimeAfterFirstMessageInMs The total amount of time to wait after the first message
+   * @param maxWaitTimeInMs - The total wait time in milliseconds until which the receiver will attempt to receive specified number of messages.
+   * @param maxTimeAfterFirstMessageInMs - The total amount of time to wait after the first message
    * has been received. Defaults to 1 second.
    * If this time elapses before the `maxMessageCount` is reached, then messages collected till then will be returned to the user.
    * @returns {Promise<ServiceBusMessageImpl[]>} A promise that resolves with an array of Message objects.
@@ -160,8 +160,8 @@ export class BatchingReceiver extends MessageReceiver {
  * taking into account elapsed time from when getRemainingWaitTimeInMsFn
  * was called.
  *
- * @param maxWaitTimeInMs Maximum time to wait for the first message
- * @param maxTimeAfterFirstMessageInMs Maximum time to wait after the first message before completing the receive.
+ * @param maxWaitTimeInMs - Maximum time to wait for the first message
+ * @param maxTimeAfterFirstMessageInMs - Maximum time to wait after the first message before completing the receive.
  *
  * @internal
  */
@@ -299,7 +299,7 @@ export class BatchingReceiverLite {
   /**
    * Closes the receiver (optionally with an error), cancelling any current operations.
    *
-   * @param connectionError An optional error (rhea doesn't always deliver one for certain disconnection events)
+   * @param connectionError - An optional error (rhea doesn't always deliver one for certain disconnection events)
    */
   terminate(connectionError?: Error | AmqpError) {
     if (this._closeHandler) {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -34,8 +34,8 @@ export class BatchingReceiver extends MessageReceiver {
    * Instantiate a new BatchingReceiver.
    *
    * @constructor
-   * @param context The client entity context.
-   * @param options  Options for how you'd like to connect.
+   * @param context - The client entity context.
+   * @param options - Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "batching", options);
@@ -80,7 +80,7 @@ export class BatchingReceiver extends MessageReceiver {
 
   /**
    * To be called when connection is disconnected to gracefully close ongoing receive request.
-   * @param connectionError The connection error if any.
+   * @param connectionError - The connection error if any.
    * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(connectionError?: AmqpError | Error): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -34,8 +34,8 @@ export class BatchingReceiver extends MessageReceiver {
    * Instantiate a new BatchingReceiver.
    *
    * @constructor
-   * @param {ClientEntityContext} context The client entity context.
-   * @param {ReceiveOptions} [options]  Options for how you'd like to connect.
+   * @param context The client entity context.
+   * @param [options]  Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "batching", options);
@@ -80,7 +80,7 @@ export class BatchingReceiver extends MessageReceiver {
 
   /**
    * To be called when connection is disconnected to gracefully close ongoing receive request.
-   * @param {AmqpError | Error} [connectionError] The connection error if any.
+   * @param [connectionError] The connection error if any.
    * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(connectionError?: AmqpError | Error): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -164,10 +164,10 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   /**
    * Creates a new ClientEntity instance.
    * @constructor
-   * @param baseName The base name to use for the link. A unique ID will be appended to this.
-   * @param entityPath The entity path (ex: 'your-queue')
-   * @param context The connection context.
-   * @param options Options that can be provided while creating the LinkEntity.
+   * @param baseName - The base name to use for the link. A unique ID will be appended to this.
+   * @param entityPath - The entity path (ex: 'your-queue')
+   * @param context - The connection context.
+   * @param options - Options that can be provided while creating the LinkEntity.
    */
   constructor(
     public readonly baseName: string,

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -163,7 +163,6 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Creates a new ClientEntity instance.
-   * @constructor
    * @param baseName - The base name to use for the link. A unique ID will be appended to this.
    * @param entityPath - The entity path (ex: 'your-queue')
    * @param context - The connection context.

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -366,7 +366,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Negotiates the cbs claim for the ClientEntity.
-   * @param {boolean} [setTokenRenewal] Set the token renewal timer. Default false.
+   * @param [setTokenRenewal] Set the token renewal timer. Default false.
    * @return {Promise<void>} Promise<void>
    */
   private async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -24,11 +24,11 @@ import { ServiceBusError } from "../serviceBusError";
  */
 export interface LinkEntityOptions {
   /**
-   * @property {string} address The client entity address in one of the following forms:
+   * The client entity address in one of the following forms:
    */
   address?: string;
   /**
-   * @property {string} audience The client entity token audience in one of the following forms:
+   * The client entity token audience in one of the following forms:
    */
   audience?: string;
 }
@@ -85,12 +85,12 @@ type LinkTypeT<
  */
 export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | RequestResponseLink> {
   /**
-   * @property {string} id The unique name for the entity in the format:
+   * The unique name for the entity in the format:
    * `${name of the entity}-${guid}`.
    */
   name: string;
   /**
-   * @property {string} address The client entity address in one of the following forms:
+   * The client entity address in one of the following forms:
    *
    * **Sender**
    * - `"<queue-name>"`.
@@ -105,7 +105,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    */
   address: string;
   /**
-   * @property {string} audience The client entity token audience in one of the following forms:
+   * The client entity token audience in one of the following forms:
    *
    * **Sender**
    * - `"sb://<yournamespace>.servicebus.windows.net/<queue-name>"`
@@ -121,17 +121,17 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    */
   audience: string;
   /**
-   * @property _context Provides relevant information about the amqp connection,
+   * Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
    */
   protected _context: ConnectionContext;
   /**
-   * @property {NodeJS.Timer} _tokenRenewalTimer The token renewal timer that keeps track of when
+   * The token renewal timer that keeps track of when
    * the Client Entity is due for token renewal.
    */
   private _tokenRenewalTimer?: NodeJS.Timer;
   /**
-   * @property _tokenTimeout Indicates token timeout
+   * Indicates token timeout
    */
   protected _tokenTimeout?: number;
 

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -186,7 +186,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Determines whether the AMQP link is open. If open then returns true else returns false.
-   * @return {boolean} boolean
+   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this._link ? this._link.isOpen() : false;
@@ -345,7 +345,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Provides the current type of the ClientEntity.
-   * @return {string} The entity type.
+   * @returns The entity type.
    */
   private get _type(): string {
     let result = "LinkEntity";
@@ -366,7 +366,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   /**
    * Negotiates the cbs claim for the ClientEntity.
    * @param setTokenRenewal - Set the token renewal timer. Default false.
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   private async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {
     this._logger.verbose(`${this._logPrefix} negotiateclaim() has been called`);

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -304,7 +304,6 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    * NOTE: This method should be implemented by any child classes to actually create the underlying
    * Rhea link (AwaitableSender or Receiver or RequestResponseLink)
    *
-   * @param _options -
    */
   protected abstract createRheaLink(_options: LinkOptionsT<LinkT>): Promise<LinkT>;
 

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -305,7 +305,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    * NOTE: This method should be implemented by any child classes to actually create the underlying
    * Rhea link (AwaitableSender or Receiver or RequestResponseLink)
    *
-   * @param _options
+   * @param _options -
    */
   protected abstract createRheaLink(_options: LinkOptionsT<LinkT>): Promise<LinkT>;
 

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -366,7 +366,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Negotiates the cbs claim for the ClientEntity.
-   * @param [setTokenRenewal] Set the token renewal timer. Default false.
+   * @param setTokenRenewal Set the token renewal timer. Default false.
    * @return {Promise<void>} Promise<void>
    */
   private async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -366,7 +366,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Negotiates the cbs claim for the ClientEntity.
-   * @param setTokenRenewal Set the token renewal timer. Default false.
+   * @param setTokenRenewal - Set the token renewal timer. Default false.
    * @return {Promise<void>} Promise<void>
    */
   private async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -200,7 +200,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param context - The connection context
    * @param entityPath - The name/path of the entity (queue/topic/subscription name)
    * for which the management request needs to be made.
-   * @param [options] Options to be provided for creating the
+   * @param options Options to be provided for creating the
    * "$management" client.
    */
   constructor(context: ConnectionContext, entityPath: string, options?: ManagementClientOptions) {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -200,7 +200,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param context - The connection context
    * @param entityPath - The name/path of the entity (queue/topic/subscription name)
    * for which the management request needs to be made.
-   * @param {ManagementClientOptions} [options] Options to be provided for creating the
+   * @param [options] Options to be provided for creating the
    * "$management" client.
    */
   constructor(context: ConnectionContext, entityPath: string, options?: ManagementClientOptions) {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -180,7 +180,6 @@ export interface ManagementClientOptions {
 
 /**
  * @internal
- * @class ManagementClient
  * Describes the ServiceBus Management Client that talks
  * to the $management endpoint over AMQP connection.
  */
@@ -195,7 +194,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   private _lastPeekedSequenceNumber: Long = Long.ZERO;
 
   /**
-   * @constructor
    * Instantiates the management client.
    * @param context - The connection context
    * @param entityPath - The name/path of the entity (queue/topic/subscription name)

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1205,7 +1205,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
 
   /**
    * Removes the rule on the Subscription identified by the given rule name.
-   * @param ruleName -
    */
   async removeRule(
     ruleName: string,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -349,7 +349,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Closes the AMQP management session to the ServiceBus namespace for this client,
    * returning a promise that will be resolved when disconnection is completed.
-   * @return Promise<void>
+   * @returns Promise<void>
    */
   async close(): Promise<void> {
     try {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -200,7 +200,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param context - The connection context
    * @param entityPath - The name/path of the entity (queue/topic/subscription name)
    * for which the management request needs to be made.
-   * @param options Options to be provided for creating the
+   * @param options - Options to be provided for creating the
    * "$management" client.
    */
   constructor(context: ConnectionContext, entityPath: string, options?: ManagementClientOptions) {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -1207,7 +1207,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
 
   /**
    * Removes the rule on the Subscription identified by the given rule name.
-   * @param ruleName
+   * @param ruleName -
    */
   async removeRule(
     ruleName: string,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -197,7 +197,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * @constructor
    * Instantiates the management client.
-   * @param context The connection context
+   * @param context - The connection context
    * @param entityPath - The name/path of the entity (queue/topic/subscription name)
    * for which the management request needs to be made.
    * @param {ManagementClientOptions} [options] Options to be provided for creating the
@@ -381,7 +381,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * and hence it cannot be `Completed/Abandoned/Deferred/Deadlettered/Renewed`. This method will
    * also fetch even Deferred messages (but not Deadlettered message).
    *
-   * @param messageCount The number of messages to retrieve. Default value `1`.
+   * @param messageCount - The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedSBMessage[]>
    */
   async peek(
@@ -406,8 +406,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * and hence it cannot be `Completed/Abandoned/Deferred/Deadlettered/Renewed`.  This method will
    * also fetch even Deferred messages (but not Deadlettered message).
    *
-   * @param sessionId The sessionId from which messages need to be peeked.
-   * @param messageCount The number of messages to retrieve. Default value `1`.
+   * @param sessionId - The sessionId from which messages need to be peeked.
+   * @param messageCount - The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedMessageInfo[]>
    */
   async peekMessagesBySession(
@@ -427,9 +427,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Peeks the desired number of messages from the specified sequence number.
    *
-   * @param fromSequenceNumber The sequence number from where to read the message.
-   * @param messageCount The number of messages to retrieve. Default value `1`.
-   * @param sessionId The sessionId from which messages need to be peeked.
+   * @param fromSequenceNumber - The sequence number from where to read the message.
+   * @param messageCount - The number of messages to retrieve. Default value `1`.
+   * @param sessionId - The sessionId from which messages need to be peeked.
    * @returns Promise<ReceivedMessageInfo[]>
    */
   async peekBySequenceNumber(
@@ -527,8 +527,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * lock needs to be renewed. For each renewal, it resets the time the message is locked by the
    * LockDuration set on the Entity.
    *
-   * @param lockToken Lock token of the message
-   * @param options Options that can be set while sending the request.
+   * @param lockToken - Lock token of the message
+   * @param options - Options that can be set while sending the request.
    * @returns Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewLock(lockToken: string, options?: SendManagementRequestOptions): Promise<Date> {
@@ -739,8 +739,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Receives a list of deferred messages identified by `sequenceNumbers`.
    *
-   * @param sequenceNumbers A list containing the sequence numbers to receive.
-   * @param receiveMode The mode in which the receiver was created.
+   * @param sequenceNumbers - A list containing the sequence numbers to receive.
+   * @param receiveMode - The mode in which the receiver was created.
    * @returns Promise<ServiceBusMessage[]>
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
@@ -832,9 +832,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Updates the disposition status of deferred messages.
    *
-   * @param lockTokens Message lock tokens to update disposition status.
-   * @param dispositionStatus The disposition status to be set
-   * @param options Optional parameters that can be provided while updating the disposition status.
+   * @param lockTokens - Message lock tokens to update disposition status.
+   * @param dispositionStatus - The disposition status to be set
+   * @param options - Optional parameters that can be provided while updating the disposition status.
    *
    * @returns Promise<void>
    */
@@ -901,8 +901,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Renews the lock for the specified session.
    *
-   * @param sessionId Id of the session for which the lock needs to be renewed
-   * @param options Options that can be set while sending the request.
+   * @param sessionId - Id of the session for which the lock needs to be renewed
+   * @param options - Options that can be set while sending the request.
    * @returns Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewSessionLock(
@@ -951,8 +951,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Sets the state of the specified session.
    *
-   * @param sessionId The session for which the state needs to be set
-   * @param state The state that needs to be set.
+   * @param sessionId - The session for which the state needs to be set
+   * @param state - The state that needs to be set.
    * @returns Promise<void>
    */
   async setSessionState(
@@ -996,7 +996,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Gets the state of the specified session.
    *
-   * @param sessionId The session for which the state needs to be retrieved.
+   * @param sessionId - The session for which the state needs to be retrieved.
    * @returns Promise<any> The state of that session
    */
   async getSessionState(
@@ -1039,9 +1039,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
 
   /**
    * Lists the sessions on the ServiceBus Queue/Topic.
-   * @param lastUpdateTime Filter to include only sessions updated after a given time.
-   * @param skip The number of sessions to skip
-   * @param top Maximum numer of sessions.
+   * @param lastUpdateTime - Filter to include only sessions updated after a given time.
+   * @param skip - The number of sessions to skip
+   * @param top - Maximum numer of sessions.
    * @returns Promise<string[]> A list of session ids.
    */
   async listMessageSessions(
@@ -1248,9 +1248,9 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
 
   /**
    * Adds a rule on the subscription as defined by the given rule name, filter and action
-   * @param ruleName Name of the rule
-   * @param filter A Boolean, SQL expression or a Correlation filter
-   * @param sqlRuleActionExpression Action to perform if the message satisfies the filtering expression
+   * @param ruleName - Name of the rule
+   * @param filter - A Boolean, SQL expression or a Correlation filter
+   * @param sqlRuleActionExpression - Action to perform if the message satisfies the filtering expression
    */
   async addRule(
     ruleName: string,

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -149,17 +149,17 @@ const correlationProperties = [
  */
 export interface DispositionStatusOptions extends OperationOptionsBase {
   /**
-   * @property [propertiesToModify] A map of Service Bus brokered message properties
+   * A map of Service Bus brokered message properties
    * to modify.
    */
   propertiesToModify?: { [key: string]: any };
   /**
-   * @property [deadLetterReason] The deadletter reason. May be set if disposition status
+   * The deadletter reason. May be set if disposition status
    * is set to suspended.
    */
   deadLetterReason?: string;
   /**
-   * @property [deadLetterDescription] The deadletter description. May be set if disposition status
+   * The deadletter description. May be set if disposition status
    * is set to suspended.
    */
   deadLetterDescription?: string;
@@ -186,11 +186,11 @@ export interface ManagementClientOptions {
  */
 export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
-   * @property {string} replyTo The reply to Guid for the management client.
+   * The reply to Guid for the management client.
    */
   replyTo: string = generate_uuid();
   /**
-   * @property _lastPeekedSequenceNumber Provides the sequence number of the last peeked message.
+   * Provides the sequence number of the last peeked message.
    */
   private _lastPeekedSequenceNumber: Long = Long.ZERO;
 

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -216,7 +216,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
   /**
    * React to receiver being detached due to given error.
    * You may want to set up retries to recover the broken link and/or report error to user.
-   * @param error The error accompanying the receiver/session error or connection disconnected events
+   * @param error - The error accompanying the receiver/session error or connection disconnected events
    */
   abstract onDetached(error?: AmqpError | Error): Promise<void>;
 
@@ -232,9 +232,9 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
 
   /**
    * Settles the message with the specified disposition.
-   * @param message The ServiceBus Message that needs to be settled.
-   * @param operation The disposition type.
-   * @param options Optional parameters that can be provided while disposing the message.
+   * @param message - The ServiceBus Message that needs to be settled.
+   * @param operation - The disposition type.
+   * @param options - Optional parameters that can be provided while disposing the message.
    */
   async settleMessage(
     message: ServiceBusMessageImpl,

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -92,7 +92,6 @@ export interface OnErrorNoContext {
 /**
  * @internal
  * Describes the MessageReceiver that will receive messages from ServiceBus.
- * @class MessageReceiver
  */
 export abstract class MessageReceiver extends LinkEntity<Receiver> {
   /**

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -37,7 +37,7 @@ export interface OnAmqpEventAsPromise extends OnAmqpEvent {
  */
 export interface ReceiveOptions extends SubscribeOptions {
   /**
-   * @property {number} [receiveMode] The mode in which messages should be received.
+   * The mode in which messages should be received.
    */
   receiveMode: ReceiveMode;
   /**
@@ -96,22 +96,22 @@ export interface OnErrorNoContext {
  */
 export abstract class MessageReceiver extends LinkEntity<Receiver> {
   /**
-   * @property {string} receiverType The type of receiver: "batching" or "streaming".
+   * The type of receiver: "batching" or "streaming".
    */
   receiverType: ReceiverType;
   /**
-   * @property {number} [receiveMode] The mode in which messages should be received.
+   * The mode in which messages should be received.
    * Default: ReceiveMode.peekLock
    */
   receiveMode: ReceiveMode;
   /**
-   * @property {boolean} autoComplete Indicates whether `Message.complete()` should be called
+   * Indicates whether `Message.complete()` should be called
    * automatically after the message processing is complete while receiving messages with handlers.
    * Default: false.
    */
   autoComplete: boolean;
   /**
-   * @property {Map<number, Promise<any>>} _deliveryDispositionMap Maintains a map of deliveries that
+   * Maintains a map of deliveries that
    * are being actively disposed. It acts as a store for correlating the responses received for
    * active dispositions.
    */
@@ -120,12 +120,12 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
     DeferredPromiseAndTimer
   >();
   /**
-   * @property {OnMessage} _onMessage The message handler provided by the user that will be wrapped
+   * The message handler provided by the user that will be wrapped
    * inside _onAmqpMessage.
    */
   protected _onMessage!: OnMessage;
   /**
-   * @property {OnMessage} _onError The error handler provided by the user that will be wrapped
+   * The error handler provided by the user that will be wrapped
    * inside _onAmqpError.
    */
   protected _onError?: OnError;

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -222,7 +222,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
   /**
    * Clears lock renewal timers on all active messages, clears token remewal for current receiver,
    * removes current MessageReceiver instance from cache, and closes the underlying AMQP receiver.
-   * @return {Promise<void>} Promise<void>.
+   * @returns Promise<void>.
    */
   async close(): Promise<void> {
     this._lockRenewer?.stopAll(this);

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -348,7 +348,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   /**
    * Sends the given message, with the given options on this link
    *
-   * @param {ServiceBusMessage} data Message to send.  Will be sent as UTF8-encoded JSON string.
+   * @param data Message to send. Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<void>}
    */
   async send(data: ServiceBusMessage, options?: OperationOptionsBase): Promise<void> {
@@ -389,7 +389,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * Send a batch of Message to the ServiceBus in a single AMQP message. The "message_annotations",
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
-   * @param {Array<Message>} inputMessages  An array of Message objects to be sent in a
+   * @param inputMessages An array of Message objects to be sent in a
    * Batch message.
    * @return {Promise<void>}
    */
@@ -477,7 +477,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    *     retryOptions: { maxRetries: 5; timeoutInMs: 10 }
    * }
    * ```
-   * @param {{retryOptions?: RetryOptions}} [options={}]
+   * @param options -
    * @returns {Promise<number>}
    */
   async getMaxMessageSize(

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -476,7 +476,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    *     retryOptions: { maxRetries: 5; timeoutInMs: 10 }
    * }
    * ```
-   * @param options -
    * @returns {Promise<number>}
    */
   async getMaxMessageSize(

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -158,7 +158,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    *
    * @param encodedMessage - The encoded message to be sent to ServiceBus.
    * @param sendBatch - Boolean indicating whether the encoded message represents a batch of messages or not
-   * @return {Promise<Delivery>} Promise<Delivery>
+   * @returns Promise<Delivery>
    */
   private _trySend(
     encodedMessage: Buffer,
@@ -330,7 +330,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
 
   /**
    * Determines whether the AMQP sender link is open. If open then returns true else returns false.
-   * @return {boolean} boolean
+   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this.link == null ? false : this.link.isOpen();
@@ -390,7 +390,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * of the envelope (batch message).
    * @param inputMessages - An array of Message objects to be sent in a
    * Batch message.
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    */
   async sendMessages(
     inputMessages: ServiceBusMessage[],

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -41,7 +41,6 @@ import { defaultDataTransformer } from "../dataTransformer";
 /**
  * @internal
  * Describes the MessageSender that will send messages to ServiceBus.
- * @class MessageSender
  */
 export class MessageSender extends LinkEntity<AwaitableSender> {
   /**

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -157,8 +157,8 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * We have implemented a synchronous send over here in the sense that we shall be waiting
    * for the message to be accepted or rejected and accordingly resolve or reject the promise.
    *
-   * @param encodedMessage The encoded message to be sent to ServiceBus.
-   * @param sendBatch Boolean indicating whether the encoded message represents a batch of messages or not
+   * @param encodedMessage - The encoded message to be sent to ServiceBus.
+   * @param sendBatch - Boolean indicating whether the encoded message represents a batch of messages or not
    * @return {Promise<Delivery>} Promise<Delivery>
    */
   private _trySend(

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -45,24 +45,24 @@ import { defaultDataTransformer } from "../dataTransformer";
  */
 export class MessageSender extends LinkEntity<AwaitableSender> {
   /**
-   * @property {OnAmqpEvent} _onAmqpError The handler function to handle errors that happen on the
+   * The handler function to handle errors that happen on the
    * underlying sender.
    * @readonly
    */
   private readonly _onAmqpError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onAmqpClose The handler function to handle "sender_close" event
+   * The handler function to handle "sender_close" event
    * that happens on the underlying sender.
    * @readonly
    */
   private readonly _onAmqpClose: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_error" event.
    */
   private _onSessionError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionClose The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_close" event.
    */
   private _onSessionClose: OnAmqpEvent;

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -348,7 +348,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   /**
    * Sends the given message, with the given options on this link
    *
-   * @param data Message to send. Will be sent as UTF8-encoded JSON string.
+   * @param data - Message to send. Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<void>}
    */
   async send(data: ServiceBusMessage, options?: OperationOptionsBase): Promise<void> {
@@ -389,7 +389,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * Send a batch of Message to the ServiceBus in a single AMQP message. The "message_annotations",
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
-   * @param inputMessages An array of Message objects to be sent in a
+   * @param inputMessages - An array of Message objects to be sent in a
    * Batch message.
    * @return {Promise<void>}
    */

--- a/sdk/servicebus/service-bus/src/core/receiverHelper.ts
+++ b/sdk/servicebus/service-bus/src/core/receiverHelper.ts
@@ -22,7 +22,7 @@ export class ReceiverHelper {
    * indicates the receiver is closed or should not continue
    * to receive more messages.
    *
-   * @param credits Number of credits to add.
+   * @param credits - Number of credits to add.
    * @returns true if credits were added, false if there is no current receiver instance
    * or `stopReceivingMessages` has been called.
    */

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -80,10 +80,10 @@ export function onMessageSettled(
  * Creates the options that need to be specified while creating an AMQP receiver link.
  *
  * @internal
- * @param name
- * @param receiveMode
- * @param source
- * @param handlers
+ * @param name -
+ * @param receiveMode -
+ * @param source -
+ * @param handlers -
  */
 export function createReceiverOptions(
   name: string,

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -80,10 +80,10 @@ export function onMessageSettled(
  * Creates the options that need to be specified while creating an AMQP receiver link.
  *
  * @internal
- * @param {string} name
- * @param {ReceiveMode} receiveMode
- * @param {Source} source
- * @param {ReceiverHandlers} handlers
+ * @param name
+ * @param receiveMode
+ * @param source
+ * @param handlers
  */
 export function createReceiverOptions(
   name: string,

--- a/sdk/servicebus/service-bus/src/core/shared.ts
+++ b/sdk/servicebus/service-bus/src/core/shared.ts
@@ -80,10 +80,6 @@ export function onMessageSettled(
  * Creates the options that need to be specified while creating an AMQP receiver link.
  *
  * @internal
- * @param name -
- * @param receiveMode -
- * @param source -
- * @param handlers -
  */
 export function createReceiverOptions(
   name: string,

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -450,7 +450,7 @@ export class StreamingReceiver extends MessageReceiver {
 
   /**
    * Will reconnect the receiver link if necessary.
-   * @param receiverError The receiver error or connection error, if any.
+   * @param receiverError - The receiver error or connection error, if any.
    * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(receiverError?: AmqpError | Error): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -117,8 +117,8 @@ export class StreamingReceiver extends MessageReceiver {
    * Instantiate a new Streaming receiver for receiving messages with handlers.
    *
    * @constructor
-   * @param context                      The client entity context.
-   * @param options                         Options for how you'd like to connect.
+   * @param context - The client entity context.
+   * @param options - Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "streaming", options);
@@ -436,8 +436,8 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session.
    *
-   * @param onMessage The message handler to receive servicebus messages.
-   * @param onError The error handler to receive an error that occurs while receivin messages.
+   * @param onMessage - The message handler to receive servicebus messages.
+   * @param onError - The error handler to receive an error that occurs while receivin messages.
    */
   subscribe(onMessage: OnMessage, onError: OnError): void {
     throwErrorIfConnectionClosed(this._context);

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -117,8 +117,8 @@ export class StreamingReceiver extends MessageReceiver {
    * Instantiate a new Streaming receiver for receiving messages with handlers.
    *
    * @constructor
-   * @param {ClientEntityContext} context                      The client entity context.
-   * @param {ReceiveOptions} [options]                         Options for how you'd like to connect.
+   * @param context                      The client entity context.
+   * @param [options]                         Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "streaming", options);
@@ -436,8 +436,8 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session.
    *
-   * @param {OnMessage} onMessage The message handler to receive servicebus messages.
-   * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
+   * @param onMessage The message handler to receive servicebus messages.
+   * @param onError The error handler to receive an error that occurs while receivin messages.
    */
   subscribe(onMessage: OnMessage, onError: OnError): void {
     throwErrorIfConnectionClosed(this._context);

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -48,7 +48,7 @@ export interface StreamingReceiverInitArgs
  */
 export class StreamingReceiver extends MessageReceiver {
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
+   * The maximum number of messages that should be
    * processed concurrently while in streaming mode. Once this limit has been reached, more
    * messages will not be received until the user's message handler has completed processing current message.
    * Default: 1
@@ -75,30 +75,30 @@ export class StreamingReceiver extends MessageReceiver {
   private _retry: typeof retry;
 
   /**
-   * @property {OnAmqpEventAsPromise} _onAmqpClose The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_close" event.
    */
   private _onAmqpClose: OnAmqpEventAsPromise;
 
   /**
-   * @property {OnAmqpEventAsPromise} _onSessionClose The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_close" event.
    */
   private _onSessionClose: OnAmqpEventAsPromise;
 
   /**
-   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_error" event.
    */
   private _onSessionError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_error" event.
    */
   private _onAmqpError: OnAmqpEvent;
 
   /**
-   * @property {OnAmqpEventAsPromise} _onAmqpMessage The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "message" event.
    */
   protected _onAmqpMessage: OnAmqpEventAsPromise;

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -43,8 +43,6 @@ export interface StreamingReceiverInitArgs
  * @internal
  * Describes the streaming receiver where the user can receive the message
  * by providing handler functions.
- * @class StreamingReceiver
- * @extends MessageReceiver
  */
 export class StreamingReceiver extends MessageReceiver {
   /**
@@ -116,7 +114,6 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Instantiate a new Streaming receiver for receiving messages with handlers.
    *
-   * @constructor
    * @param context - The client entity context.
    * @param options - Options for how you'd like to connect.
    */

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -118,7 +118,7 @@ export class StreamingReceiver extends MessageReceiver {
    *
    * @constructor
    * @param context                      The client entity context.
-   * @param [options]                         Options for how you'd like to connect.
+   * @param options                         Options for how you'd like to connect.
    */
   constructor(context: ConnectionContext, entityPath: string, options: ReceiveOptions) {
     super(context, entityPath, "streaming", options);

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -48,7 +48,7 @@ export const defaultDataTransformer = {
   },
 
   /**
-   * @property {Function} [decode] A function that takes the body property from an AMQP message
+   * A function that takes the body property from an AMQP message
    * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
    * If it cannot decode the body then it returns the body
    * as-is.

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -15,7 +15,7 @@ export const defaultDataTransformer = {
    * A function that takes the body property from an EventData object
    * and returns an encoded body (some form of AMQP type).
    *
-   * @param body The AMQP message body
+   * @param body - The AMQP message body
    * @return {DataSection} encodedBody - The encoded AMQP message body as an AMQP Data type
    * (data section in rhea terms). Section object with following properties:
    * - typecode: 117 (0x75)
@@ -52,7 +52,7 @@ export const defaultDataTransformer = {
    * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
    * If it cannot decode the body then it returns the body
    * as-is.
-   * @param body The AMQP message body
+   * @param body - The AMQP message body
    * @return {*} decoded body or the given body as-is.
    */
   decode(body: any): any {

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -16,7 +16,7 @@ export const defaultDataTransformer = {
    * and returns an encoded body (some form of AMQP type).
    *
    * @param body - The AMQP message body
-   * @return {DataSection} encodedBody - The encoded AMQP message body as an AMQP Data type
+   * @returns The encoded AMQP message body as an AMQP Data type
    * (data section in rhea terms). Section object with following properties:
    * - typecode: 117 (0x75)
    * - content: The given AMQP message body as a Buffer.
@@ -53,7 +53,7 @@ export const defaultDataTransformer = {
    * If it cannot decode the body then it returns the body
    * as-is.
    * @param body - The AMQP message body
-   * @return {*} decoded body or the given body as-is.
+   * @returns decoded body or the given body as-is.
    */
   decode(body: any): any {
     let processedBody: any = body;

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -15,7 +15,7 @@ export const defaultDataTransformer = {
    * A function that takes the body property from an EventData object
    * and returns an encoded body (some form of AMQP type).
    *
-   * @param {*} body The AMQP message body
+   * @param body The AMQP message body
    * @return {DataSection} encodedBody - The encoded AMQP message body as an AMQP Data type
    * (data section in rhea terms). Section object with following properties:
    * - typecode: 117 (0x75)
@@ -52,7 +52,7 @@ export const defaultDataTransformer = {
    * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
    * If it cannot decode the body then it returns the body
    * as-is.
-   * @param {DataSection} body The AMQP message body
+   * @param body The AMQP message body
    * @return {*} decoded body or the given body as-is.
    */
   decode(body: any): any {

--- a/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
@@ -21,8 +21,8 @@ export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
  * Populates the `ServiceBusMessage` with `SpanContext` info to support trace propagation.
  * Creates and returns a copy of the passed in `ServiceBusMessage` unless the `ServiceBusMessage`
  * has already been instrumented.
- * @param message The `ServiceBusMessage` to instrument.
- * @param span The `Span` containing the context to propagate tracing information.
+ * @param message - The `ServiceBusMessage` to instrument.
+ * @param span - The `Span` containing the context to propagate tracing information.
  * @hidden
  * @internal
  */
@@ -47,7 +47,7 @@ export function instrumentServiceBusMessage(
 
 /**
  * Extracts the `SpanContext` from an `ServiceBusMessage` if the context exists.
- * @param message An individual `ServiceBusMessage` object.
+ * @param message - An individual `ServiceBusMessage` object.
  * @internal
  */
 export function extractSpanContextFromServiceBusMessage(
@@ -65,7 +65,7 @@ export function extractSpanContextFromServiceBusMessage(
  * Provides an iterable over messages, whether it is a single message or multiple
  * messages.
  *
- * @param receivedMessages A single message or a set of messages
+ * @param receivedMessages - A single message or a set of messages
  * @internal
  */
 function* getReceivedMessages(

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -49,7 +49,7 @@ export const managementClientLogger = createServiceBusLogger("service-bus:manage
 
 /**
  * Logs the error's stack trace to "verbose" if a stack trace is available.
- * @param error Error containing a stack trace.
+ * @param error - Error containing a stack trace.
  * @internal
  */
 export function logErrorStackTrace(_logger: AzureLogger, error: any) {

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -70,8 +70,6 @@ export interface ServiceBusLogger extends AzureLogger {
    *   receiverLogger.logError(new Error("hello, this is the error"), "this is my message");
    * will output:
    *   azure:service-bus:receiver:warning this is my message : Error: hello, this is the error
-   * @param err -
-   * @param args -
    */
   logError(err: Error | AmqpError | undefined, ...args: any[]): void;
 }

--- a/sdk/servicebus/service-bus/src/log.ts
+++ b/sdk/servicebus/service-bus/src/log.ts
@@ -70,8 +70,8 @@ export interface ServiceBusLogger extends AzureLogger {
    *   receiverLogger.logError(new Error("hello, this is the error"), "this is my message");
    * will output:
    *   azure:service-bus:receiver:warning this is my message : Error: hello, this is the error
-   * @param err
-   * @param args
+   * @param err -
+   * @param args -
    */
   logError(err: Error | AmqpError | undefined, ...args: any[]): void;
 }

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -124,7 +124,6 @@ export interface ServiceBusReceiverOptions {
  */
 export interface CreateMessageBatchOptions extends OperationOptionsBase {
   /**
-   * @property
    * The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    */
   maxSizeInBytes?: number;

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -41,12 +41,12 @@ export interface MessageHandlers {
   /**
    * Handler that processes messages from service bus.
    *
-   * @param message A message received from Service Bus.
+   * @param message - A message received from Service Bus.
    */
   processMessage(message: ServiceBusReceivedMessage): Promise<void>;
   /**
    * Handler that processes errors that occur during receiving.
-   * @param args The error and additional context to indicate where
+   * @param args - The error and additional context to indicate where
    * the error originated.
    */
   processError(args: ProcessErrorArgs): Promise<void>;

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -151,7 +151,7 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {}
  */
 export interface SubscribeOptions extends OperationOptionsBase {
   /**
-   * @property Indicates whether the message should be settled using the `completeMessage()`
+   * Indicates whether the message should be settled using the `completeMessage()`
    * method on the receiver automatically after it executes the user provided message callback.
    * Doing so removes the message from the queue/subscription.
    *
@@ -162,7 +162,7 @@ export interface SubscribeOptions extends OperationOptionsBase {
    */
   autoCompleteMessages?: boolean;
   /**
-   * @property The maximum number of concurrent calls that the library
+   * The maximum number of concurrent calls that the library
    * can make to the user's message handler. Once this limit has been reached, more messages will
    * not be received until atleast one of the calls to the user's message handler has completed.
    * - **Default**: `1`.
@@ -196,7 +196,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    */
   receiveMode?: "peekLock" | "receiveAndDelete";
   /**
-   * @property The maximum duration in milliseconds
+   * The maximum duration in milliseconds
    * until which, the lock on the session will be renewed automatically by the sdk.
    * - **Default**: `300000` milliseconds (5 minutes).
    * - **To disable autolock renewal**, set this to `0`.
@@ -209,7 +209,7 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
  */
 export interface PeekMessagesOptions extends OperationOptionsBase {
   /**
-   * @property The sequence number to start peeking messages from (inclusive).
+   * The sequence number to start peeking messages from (inclusive).
    */
   fromSequenceNumber?: Long;
 }

--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -26,10 +26,6 @@ export function getParentSpan(
 /**
  * @internal
  *
- * @param parentSpan -
- * @param spanContextsToLink -
- * @param entityPath -
- * @param host -
  */
 export function createSendSpan(
   parentSpan?: Span | SpanContext | null,

--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -26,10 +26,10 @@ export function getParentSpan(
 /**
  * @internal
  *
- * @param {(Span | SpanContext | null)} [parentSpan]
- * @param {SpanContext[]} [spanContextsToLink=[]]
- * @param {string} [entityPath]
- * @param {string} [host]
+ * @param parentSpan -
+ * @param spanContextsToLink -
+ * @param entityPath -
+ * @param host -
  */
 export function createSendSpan(
   parentSpan?: Span | SpanContext | null,

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -190,7 +190,7 @@ export interface ServiceBusReceiver {
    *
    * @param propertiesToModify - The properties of the message to modify while abandoning the message.
    *
-   * @return Promise<void>.
+   * @returns Promise<void>.
    */
   abandonMessage(
     message: ServiceBusReceivedMessage,

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -49,8 +49,8 @@ import { translateServiceBusError } from "../serviceBusError";
 export interface ServiceBusReceiver {
   /**
    * Streams messages to message handlers.
-   * @param handlers A handler that gets called for messages and errors.
-   * @param options Options for subscribe.
+   * @param handlers - A handler that gets called for messages and errors.
+   * @param options - Options for subscribe.
    * @returns An object that can be closed, sending any remaining messages to `handlers` and
    * stopping new messages from arriving.
    */
@@ -68,7 +68,7 @@ export interface ServiceBusReceiver {
    * Returns an iterator that can be used to receive messages from Service Bus.
    * If the iterator is not able to fetch a new message in over a minute, `undefined` will be returned.
    *
-   * @param options A set of options to control the receive operation.
+   * @param options - A set of options to control the receive operation.
    * - `maxWaitTimeInMs`: The time to wait to receive the message in each iteration.
    * - `abortSignal`: The signal to use to abort the ongoing operation.
    *
@@ -83,8 +83,8 @@ export interface ServiceBusReceiver {
   /**
    * Returns a promise that resolves to an array of messages received from Service Bus.
    *
-   * @param maxMessageCount The maximum number of messages to receive.
-   * @param options A set of options to control the receive operation.
+   * @param maxMessageCount - The maximum number of messages to receive.
+   * @param options - A set of options to control the receive operation.
    * - `maxWaitTimeInMs`: The maximum time to wait for the first message before returning an empty array if no messages are available.
    * - `abortSignal`: The signal to use to abort the ongoing operation.
    * @returns Promise<ServiceBusReceivedMessage[]> A promise that resolves with an array of messages.
@@ -99,7 +99,7 @@ export interface ServiceBusReceiver {
 
   /**
    * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
-   * @param sequenceNumbers The sequence number or an array of sequence numbers for the messages that need to be received.
+   * @param sequenceNumbers - The sequence number or an array of sequence numbers for the messages that need to be received.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {Promise<ServiceBusMessage[]>}
    * - Returns a list of messages identified by the given sequenceNumbers.
@@ -119,8 +119,8 @@ export interface ServiceBusReceiver {
    * subsequent message.
    * - Unlike a "received" message, "peeked" message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`.
-   * @param maxMessageCount The maximum number of messages to peek.
-   * @param options Options that allow to specify the maximum number of messages to peek,
+   * @param maxMessageCount - The maximum number of messages to peek.
+   * @param options - Options that allow to specify the maximum number of messages to peek,
    * the sequenceNumber to start peeking from or an abortSignal to abort the operation.
    */
   peekMessages(
@@ -188,7 +188,7 @@ export interface ServiceBusReceiver {
    * @throws `ServiceBusError` with the code `ServiceTimeout` if Service Bus does not acknowledge the request to settle
    * the message in time. The message may or may not have been settled successfully.
    *
-   * @param propertiesToModify The properties of the message to modify while abandoning the message.
+   * @param propertiesToModify - The properties of the message to modify while abandoning the message.
    *
    * @return Promise<void>.
    */
@@ -216,7 +216,7 @@ export interface ServiceBusReceiver {
    * @throws `ServiceBusError` with the code `ServiceTimeout` if Service Bus does not acknowledge the request to settle
    * the message in time. The message may or may not have been settled successfully.
    *
-   * @param propertiesToModify The properties of the message to modify while deferring the message
+   * @param propertiesToModify - The properties of the message to modify while deferring the message
    *
    * @returns Promise<void>
    */
@@ -244,7 +244,7 @@ export interface ServiceBusReceiver {
    * @throws `ServiceBusError` with the code `ServiceTimeout` if Service Bus does not acknowledge the request to settle
    * the message in time. The message may or may not have been settled successfully.
    *
-   * @param options The DeadLetter options that can be provided while
+   * @param options - The DeadLetter options that can be provided while
    * rejecting the message.
    *
    * @returns Promise<void>

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -136,7 +136,7 @@ export interface ServiceBusReceiver {
    */
   receiveMode: "peekLock" | "receiveAndDelete";
   /**
-   * @property Returns `true` if either the receiver or the client that created it has been closed.
+   * Returns `true` if either the receiver or the client that created it has been closed.
    * @readonly
    */
   isClosed: boolean;
@@ -274,7 +274,7 @@ export interface ServiceBusReceiver {
 export class ServiceBusReceiverImpl implements ServiceBusReceiver {
   private _retryOptions: RetryOptions;
   /**
-   * @property {boolean} [_isClosed] Denotes if close() was called on this receiver
+   * Denotes if close() was called on this receiver
    */
   private _isClosed: boolean = false;
 

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -103,7 +103,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.
    *
-   * @param {*} state
+   * @param state
    * @returns {Promise<void>}
    */
   setSessionState(state: any, options?: OperationOptionsBase): Promise<void>;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -53,7 +53,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
   readonly sessionId: string;
 
   /**
-   * @property The time in UTC until which the session is locked.
+   * The time in UTC until which the session is locked.
    * Every time `renewSessionLock()` is called, this time gets updated to current time plus the lock
    * duration as specified during the Queue/Subscription creation.
    *
@@ -116,7 +116,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
   public sessionId: string;
 
   /**
-   * @property {boolean} [_isClosed] Denotes if close() was called on this receiver
+   * Denotes if close() was called on this receiver
    */
   private _isClosed: boolean = false;
 
@@ -178,7 +178,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
   }
 
   /**
-   * @property The time in UTC until which the session is locked.
+   * The time in UTC until which the session is locked.
    * Every time `renewSessionLock()` is called, this time gets updated to current time plus the lock
    * duration as specified during the Queue/Subscription creation.
    *

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -103,7 +103,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.
    *
-   * @param state
+   * @param state -
    * @returns {Promise<void>}
    */
   setSessionState(state: any, options?: OperationOptionsBase): Promise<void>;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -103,7 +103,6 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.
    *
-   * @param state -
    * @returns {Promise<void>}
    */
   setSessionState(state: any, options?: OperationOptionsBase): Promise<void>;

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -65,8 +65,8 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
 
   /**
    * Streams messages to message handlers.
-   * @param handlers A handler that gets called for messages and errors.
-   * @param options Options for subscribe.
+   * @param handlers - A handler that gets called for messages and errors.
+   * @param options - Options for subscribe.
    * @returns An object that can be closed, sending any remaining messages to `handlers` and
    * stopping new messages from arriving.
    */
@@ -98,7 +98,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
   /**
    * Sets the state on the Session. For more on session states, see
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
-   * @param state The state that needs to be set.
+   * @param state - The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.
@@ -235,7 +235,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
   /**
    * Sets the state on the Session. For more on session states, see
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
-   * @param state The state that needs to be set.
+   * @param state - The state that needs to be set.
    * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -70,9 +70,9 @@ export function wrapProcessErrorHandler(
 /**
  * @internal
  *
- * @param message
- * @param context
- * @param entityPath
+ * @param message -
+ * @param context -
+ * @param entityPath -
  */
 export function completeMessage(
   message: ServiceBusMessageImpl,
@@ -90,10 +90,10 @@ export function completeMessage(
 /**
  * @internal
  *
- * @param message
- * @param context
- * @param entityPath
- * @param propertiesToModify
+ * @param message -
+ * @param context -
+ * @param entityPath -
+ * @param propertiesToModify -
  */
 export function abandonMessage(
   message: ServiceBusMessageImpl,
@@ -114,10 +114,10 @@ export function abandonMessage(
 /**
  * @internal
  *
- * @param message
- * @param context
- * @param entityPath
- * @param propertiesToModify
+ * @param message -
+ * @param context -
+ * @param entityPath -
+ * @param propertiesToModify -
  */
 export function deferMessage(
   message: ServiceBusMessageImpl,
@@ -138,10 +138,10 @@ export function deferMessage(
 /**
  * @internal
  *
- * @param message
- * @param context
- * @param entityPath
- * @param propertiesToModify
+ * @param message -
+ * @param context -
+ * @param entityPath -
+ * @param propertiesToModify -
  */
 export function deadLetterMessage(
   message: ServiceBusMessageImpl,
@@ -181,11 +181,11 @@ export function deadLetterMessage(
 /**
  * @internal
  *
- * @param message
- * @param operation
- * @param context
- * @param entityPath
- * @param options
+ * @param message -
+ * @param operation -
+ * @param context -
+ * @param entityPath -
+ * @param options -
  */
 function settleMessage(
   message: ServiceBusMessageImpl,

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -93,7 +93,7 @@ export function completeMessage(
  * @param message
  * @param context
  * @param entityPath
- * @param [propertiesToModify]
+ * @param propertiesToModify
  */
 export function abandonMessage(
   message: ServiceBusMessageImpl,
@@ -117,7 +117,7 @@ export function abandonMessage(
  * @param message
  * @param context
  * @param entityPath
- * @param [propertiesToModify]
+ * @param propertiesToModify
  */
 export function deferMessage(
   message: ServiceBusMessageImpl,
@@ -185,7 +185,7 @@ export function deadLetterMessage(
  * @param operation
  * @param context
  * @param entityPath
- * @param [options]
+ * @param options
  */
 function settleMessage(
   message: ServiceBusMessageImpl,

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -70,9 +70,9 @@ export function wrapProcessErrorHandler(
 /**
  * @internal
  *
- * @param {ServiceBusMessageImpl} message
- * @param {ConnectionContext} context
- * @param {string} entityPath
+ * @param message
+ * @param context
+ * @param entityPath
  */
 export function completeMessage(
   message: ServiceBusMessageImpl,
@@ -90,10 +90,10 @@ export function completeMessage(
 /**
  * @internal
  *
- * @param {ServiceBusMessageImpl} message
- * @param {ConnectionContext} context
- * @param {string} entityPath
- * @param {{ [key: string]: any }} [propertiesToModify]
+ * @param message
+ * @param context
+ * @param entityPath
+ * @param [propertiesToModify]
  */
 export function abandonMessage(
   message: ServiceBusMessageImpl,
@@ -114,10 +114,10 @@ export function abandonMessage(
 /**
  * @internal
  *
- * @param {ServiceBusMessageImpl} message
- * @param {ConnectionContext} context
- * @param {string} entityPath
- * @param {{ [key: string]: any }} [propertiesToModify]
+ * @param message
+ * @param context
+ * @param entityPath
+ * @param [propertiesToModify]
  */
 export function deferMessage(
   message: ServiceBusMessageImpl,
@@ -138,10 +138,10 @@ export function deferMessage(
 /**
  * @internal
  *
- * @param {ServiceBusMessageImpl} message
- * @param {ConnectionContext} context
- * @param {string} entityPath
- * @param {(DeadLetterOptions & { [key: string]: any })} [propertiesToModify]
+ * @param message
+ * @param context
+ * @param entityPath
+ * @param propertiesToModify
  */
 export function deadLetterMessage(
   message: ServiceBusMessageImpl,
@@ -181,11 +181,11 @@ export function deadLetterMessage(
 /**
  * @internal
  *
- * @param {ServiceBusMessageImpl} message
- * @param {DispositionType} operation
- * @param {ConnectionContext} context
- * @param {string} entityPath
- * @param {DispositionStatusOptions} [options]
+ * @param message
+ * @param operation
+ * @param context
+ * @param entityPath
+ * @param [options]
  */
 function settleMessage(
   message: ServiceBusMessageImpl,

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -70,9 +70,6 @@ export function wrapProcessErrorHandler(
 /**
  * @internal
  *
- * @param message -
- * @param context -
- * @param entityPath -
  */
 export function completeMessage(
   message: ServiceBusMessageImpl,
@@ -90,10 +87,6 @@ export function completeMessage(
 /**
  * @internal
  *
- * @param message -
- * @param context -
- * @param entityPath -
- * @param propertiesToModify -
  */
 export function abandonMessage(
   message: ServiceBusMessageImpl,
@@ -114,10 +107,6 @@ export function abandonMessage(
 /**
  * @internal
  *
- * @param message -
- * @param context -
- * @param entityPath -
- * @param propertiesToModify -
  */
 export function deferMessage(
   message: ServiceBusMessageImpl,
@@ -138,10 +127,6 @@ export function deferMessage(
 /**
  * @internal
  *
- * @param message -
- * @param context -
- * @param entityPath -
- * @param propertiesToModify -
  */
 export function deadLetterMessage(
   message: ServiceBusMessageImpl,
@@ -181,11 +166,6 @@ export function deadLetterMessage(
 /**
  * @internal
  *
- * @param message -
- * @param operation -
- * @param context -
- * @param entityPath -
- * @param options -
  */
 function settleMessage(
   message: ServiceBusMessageImpl,

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -55,7 +55,7 @@ export interface ServiceBusSender {
   /**
    * Creates an instance of `ServiceBusMessageBatch` to which one can add messages until the maximum supported size is reached.
    * The batch can be passed to the {@link send} method to send the messages to Azure Service Bus.
-   * @param options  Configures the behavior of the batch.
+   * @param options - Configures the behavior of the batch.
    * - `maxSizeInBytes`: The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    *
    * @param {CreateMessageBatchOptions} [options]

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -58,7 +58,6 @@ export interface ServiceBusSender {
    * @param options - Configures the behavior of the batch.
    * - `maxSizeInBytes`: The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    *
-   * @param options -
    * @returns {Promise<ServiceBusMessageBatch>}
    * @throws `ServiceBusError` if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -130,8 +130,6 @@ export interface ServiceBusSender {
 
 /**
  * @internal
- * @class ServiceBusSenderImpl
- * @implements {ServiceBusSender}
  */
 export class ServiceBusSenderImpl implements ServiceBusSender {
   private _retryOptions: RetryOptions;

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -42,7 +42,7 @@ export interface ServiceBusSender {
    * @param messages - A single message or an array of messages or a batch of messages created via the createBatch()
    * method to send.
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @return Promise<void>
+   * @returns Promise<void>
    * @throws `ServiceBusError` with the code `MessageSizeExceeded` if the provided messages do not fit in a single `ServiceBusMessageBatch`.
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws `ServiceBusError` if the service returns an error while sending messages to the service.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -58,7 +58,7 @@ export interface ServiceBusSender {
    * @param options - Configures the behavior of the batch.
    * - `maxSizeInBytes`: The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    *
-   * @param {CreateMessageBatchOptions} [options]
+   * @param options -
    * @returns {Promise<ServiceBusMessageBatch>}
    * @throws `ServiceBusError` if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -78,7 +78,7 @@ export interface ServiceBusSender {
   // open(options?: OperationOptionsBase): Promise<void>;
 
   /**
-   * @property Returns `true` if either the sender or the client that created it has been closed.
+   * Returns `true` if either the sender or the client that created it has been closed.
    * @readonly
    */
   isClosed: boolean;
@@ -136,7 +136,7 @@ export interface ServiceBusSender {
 export class ServiceBusSenderImpl implements ServiceBusSender {
   private _retryOptions: RetryOptions;
   /**
-   * @property Denotes if close() was called on this sender
+   * Denotes if close() was called on this sender
    */
   private _isClosed: boolean = false;
   private _sender: MessageSender;

--- a/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
@@ -43,7 +43,6 @@ export interface NamespaceProperties {
  * @internal
  * Builds the namespace object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawNamespace -
  */
 export function buildNamespace(rawNamespace: any): NamespaceProperties {
   const messagingSku = <"Basic" | "Premium" | "Standard">(

--- a/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
@@ -12,8 +12,6 @@ import { getInteger, getString, getDate } from "../util/utils";
 /**
  * Represents the metadata related to a service bus namespace.
  *
- * @export
- * @interface NamespaceProperties
  */
 export interface NamespaceProperties {
   /**

--- a/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/namespaceResourceSerializer.ts
@@ -45,7 +45,7 @@ export interface NamespaceProperties {
  * @internal
  * Builds the namespace object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawNamespace
+ * @param rawNamespace -
  */
 export function buildNamespace(rawNamespace: any): NamespaceProperties {
   const messagingSku = <"Basic" | "Premium" | "Standard">(

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -28,7 +28,7 @@ import {
  * Builds the queue options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param queue
+ * @param queue -
  */
 export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptions {
   return {
@@ -57,7 +57,7 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
  * @internal
  * Builds the queue object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawQueue
+ * @param rawQueue -
  */
 export function buildQueue(rawQueue: any): QueueProperties {
   return {
@@ -114,7 +114,7 @@ export function buildQueue(rawQueue: any): QueueProperties {
  * @internal
  * Builds the queue runtime info object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawQueue
+ * @param rawQueue -
  */
 export function buildQueueRuntimeProperties(rawQueue: any): QueueRuntimeProperties {
   const messageCountDetails = getMessageCountDetails(rawQueue[Constants.COUNT_DETAILS]);

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -28,7 +28,6 @@ import {
  * Builds the queue options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param queue -
  */
 export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptions {
   return {
@@ -57,7 +56,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
  * @internal
  * Builds the queue object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawQueue -
  */
 export function buildQueue(rawQueue: any): QueueProperties {
   return {
@@ -114,7 +112,6 @@ export function buildQueue(rawQueue: any): QueueProperties {
  * @internal
  * Builds the queue runtime info object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawQueue -
  */
 export function buildQueueRuntimeProperties(rawQueue: any): QueueRuntimeProperties {
   const messageCountDetails = getMessageCountDetails(rawQueue[Constants.COUNT_DETAILS]);

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -269,8 +269,6 @@ export interface CreateQueueOptions extends OperationOptions {
 /**
  * Represents the input for updateQueue.
  *
- * @export
- * @interface QueueProperties
  */
 export interface QueueProperties {
   /**

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -164,7 +164,7 @@ export interface InternalRuleOptions {
 /**
  * @internal
  *
- * @param {CreateRuleOptions} rule
+ * @param rule
  */
 export function buildInternalRuleResource(rule: CreateRuleOptions): InternalRuleOptions {
   const resource: InternalRuleOptions = {

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -15,7 +15,6 @@ import { getString, getStringOrUndefined } from "../util/utils";
  * @internal
  * Builds the rule object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawRule -
  */
 export function buildRule(rawRule: any): RuleProperties {
   return {
@@ -29,7 +28,6 @@ export function buildRule(rawRule: any): RuleProperties {
  * @internal
  * Helper utility to retrieve `filter` value from given input,
  * or undefined if not passed in.
- * @param value -
  */
 function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
   let result: SqlRuleFilter | CorrelationRuleFilter;
@@ -61,7 +59,6 @@ function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
 /**
  * @internal
  * Helper utility to retrieve rule `action` value from given input.
- * @param value -
  */
 function getRuleAction(value: any): SqlRuleAction {
   return {
@@ -163,7 +160,6 @@ export interface InternalRuleOptions {
 /**
  * @internal
  *
- * @param rule -
  */
 export function buildInternalRuleResource(rule: CreateRuleOptions): InternalRuleOptions {
   const resource: InternalRuleOptions = {
@@ -310,7 +306,6 @@ const keyValuePairXMLTag = "KeyValueOfstringanyType";
  * @internal
  * Helper utility to retrieve the key-value pairs from the RawKeyValue object from given input,
  * or undefined if not passed in.
- * @param value -
  */
 function getKeyValuePairsOrUndefined(
   value: any,
@@ -367,7 +362,6 @@ function getKeyValuePairsOrUndefined(
  * @internal
  * Helper utility to extract array of user properties key-value instances from given input,
  * or undefined if not passed in.
- * @param value -
  */
 export function buildInternalRawKeyValuePairs(
   parameters: { [key: string]: any } | undefined,

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -153,7 +153,6 @@ export interface SqlRuleFilter {
 /**
  * @internal
  *
- * @interface InternalRuleOptions
  */
 export interface InternalRuleOptions {
   Name: string;

--- a/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/ruleResourceSerializer.ts
@@ -15,7 +15,7 @@ import { getString, getStringOrUndefined } from "../util/utils";
  * @internal
  * Builds the rule object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawRule
+ * @param rawRule -
  */
 export function buildRule(rawRule: any): RuleProperties {
   return {
@@ -29,7 +29,7 @@ export function buildRule(rawRule: any): RuleProperties {
  * @internal
  * Helper utility to retrieve `filter` value from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
   let result: SqlRuleFilter | CorrelationRuleFilter;
@@ -61,7 +61,7 @@ function getTopicFilter(value: any): SqlRuleFilter | CorrelationRuleFilter {
 /**
  * @internal
  * Helper utility to retrieve rule `action` value from given input.
- * @param value
+ * @param value -
  */
 function getRuleAction(value: any): SqlRuleAction {
   return {
@@ -164,7 +164,7 @@ export interface InternalRuleOptions {
 /**
  * @internal
  *
- * @param rule
+ * @param rule -
  */
 export function buildInternalRuleResource(rule: CreateRuleOptions): InternalRuleOptions {
   const resource: InternalRuleOptions = {
@@ -311,7 +311,7 @@ const keyValuePairXMLTag = "KeyValueOfstringanyType";
  * @internal
  * Helper utility to retrieve the key-value pairs from the RawKeyValue object from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 function getKeyValuePairsOrUndefined(
   value: any,
@@ -368,7 +368,7 @@ function getKeyValuePairsOrUndefined(
  * @internal
  * Helper utility to extract array of user properties key-value instances from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function buildInternalRawKeyValuePairs(
   parameters: { [key: string]: any } | undefined,

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -269,8 +269,6 @@ export interface CreateSubscriptionOptions extends OperationOptions {
 /**
  * Represents the input for updateSubscription.
  *
- * @export
- * @interface SubscriptionProperties
  */
 export interface SubscriptionProperties {
   /**

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -31,7 +31,6 @@ import {
  * Builds the subscription options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param subscription -
  */
 export function buildSubscriptionOptions(
   subscription: CreateSubscriptionOptions
@@ -64,7 +63,6 @@ export function buildSubscriptionOptions(
  * @internal
  * Builds the subscription object from the raw json object gotten after deserializing
  * the response from the service
- * @param rawSubscription -
  */
 export function buildSubscription(rawSubscription: any): SubscriptionProperties {
   return {
@@ -114,7 +112,6 @@ export function buildSubscription(rawSubscription: any): SubscriptionProperties 
  * @internal
  * Builds the subscription runtime info object from the raw json object gotten after deserializing
  * the response from the service
- * @param rawSubscription -
  */
 export function buildSubscriptionRuntimeProperties(
   rawSubscription: any

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -31,7 +31,7 @@ import {
  * Builds the subscription options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param subscription
+ * @param subscription -
  */
 export function buildSubscriptionOptions(
   subscription: CreateSubscriptionOptions
@@ -64,7 +64,7 @@ export function buildSubscriptionOptions(
  * @internal
  * Builds the subscription object from the raw json object gotten after deserializing
  * the response from the service
- * @param rawSubscription
+ * @param rawSubscription -
  */
 export function buildSubscription(rawSubscription: any): SubscriptionProperties {
   return {
@@ -114,7 +114,7 @@ export function buildSubscription(rawSubscription: any): SubscriptionProperties 
  * @internal
  * Builds the subscription runtime info object from the raw json object gotten after deserializing
  * the response from the service
- * @param rawSubscription
+ * @param rawSubscription -
  */
 export function buildSubscriptionRuntimeProperties(
   rawSubscription: any

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -28,7 +28,6 @@ import {
  * Builds the topic options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param topic -
  */
 export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptions {
   return {
@@ -52,7 +51,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
  * @internal
  * Builds the topic object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawTopic -
  */
 export function buildTopic(rawTopic: any): TopicProperties {
   return {
@@ -96,7 +94,6 @@ export function buildTopic(rawTopic: any): TopicProperties {
  * @internal
  * Builds the topic runtime info object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawTopic -
  */
 export function buildTopicRuntimeProperties(rawTopic: any): TopicRuntimeProperties {
   return {

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -209,8 +209,6 @@ export interface CreateTopicOptions extends OperationOptions {
 /**
  * Represents the input for updateTopic.
  *
- * @export
- * @interface TopicProperties
  */
 export interface TopicProperties {
   /**

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -28,7 +28,7 @@ import {
  * Builds the topic options object from the user provided options.
  * Handles the differences in casing for the property names,
  * converts values to string and ensures the right order as expected by the service
- * @param topic
+ * @param topic -
  */
 export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptions {
   return {
@@ -52,7 +52,7 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
  * @internal
  * Builds the topic object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawTopic
+ * @param rawTopic -
  */
 export function buildTopic(rawTopic: any): TopicProperties {
   return {
@@ -96,7 +96,7 @@ export function buildTopic(rawTopic: any): TopicProperties {
  * @internal
  * Builds the topic runtime info object from the raw json object gotten after deserializing the
  * response from the service
- * @param rawTopic
+ * @param rawTopic -
  */
 export function buildTopicRuntimeProperties(rawTopic: any): TopicRuntimeProperties {
   return {

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -217,7 +217,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the metadata related to a service bus namespace.
-   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    */
@@ -250,7 +249,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a queue with given name, configured using the given options
-   * @param queueName -
    * @param options - Options to configure the Queue being created(For example, you can configure a queue to support partitions or sessions)
    *  and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -300,7 +298,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Queue and its properties.
    * If you want to get the Queue runtime info like message count details, use `getQueueRuntimeProperties` API.
-   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -342,7 +339,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Queue runtime info like message count details.
-   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -454,7 +450,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    *
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     QueueProperties,
    *     EntitiesResponse<QueueProperties>,
@@ -561,7 +556,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the queues in pages.
    *
    *
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     QueueRuntimeProperties,
    *     EntitiesResponse<QueueRuntimeProperties>,
@@ -664,7 +658,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a queue.
-   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -706,7 +699,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given queue exists or not.
-   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async queueExists(queueName: string, operationOptions?: OperationOptions): Promise<boolean> {
@@ -738,7 +730,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a topic with given name, configured using the given options
-   * @param topicName -
    * @param options - Options to configure the Topic being created(For example, you can configure a topic to support partitions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -788,7 +779,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Topic and its properties.
    * If you want to get the Topic runtime info like subscription count details, use `getTopicRuntimeProperties` API.
-   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -830,7 +820,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Topic runtime info like subscription count.
-   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -943,7 +932,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list the topics in pages.
    *
    *
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     TopicProperties,
    *     EntitiesResponse<TopicProperties>,
@@ -1050,7 +1038,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the topics in pages.
    *
    *
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     TopicRuntimeProperties,
    *     EntitiesResponse<TopicRuntimeProperties>,
@@ -1157,7 +1144,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a topic.
-   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1199,7 +1185,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given topic exists or not.
-   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async topicExists(topicName: string, operationOptions?: OperationOptions): Promise<boolean> {
@@ -1231,8 +1216,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a subscription with given name, configured using the given options
-   * @param topicName -
-   * @param subscriptionName -
    * @param options - Options to configure the Subscription being created(For example, you can configure a Subscription to support partitions or sessions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -1284,8 +1267,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Subscription and its properties.
    * If you want to get the Subscription runtime info like message count details, use `getSubscriptionRuntimeProperties` API.
-   * @param topicName -
-   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1331,8 +1312,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Subscription runtime info like message count details.
-   * @param topicName -
-   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1379,7 +1358,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns a list of objects, each representing a Subscription along with its properties.
    * If you want to get the runtime info of the subscriptions like message count, use `getSubscriptionsRuntimeProperties` API instead.
-   * @param topicName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1455,8 +1433,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the subscriptions in pages.
    *
-   * @param topicName -
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionProperties,
    *     EntitiesResponse<SubscriptionProperties>
@@ -1496,7 +1472,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns a list of objects, each representing a Subscription's runtime info like message count details.
-   * @param topicName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1575,8 +1550,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list runtime info of subscriptions in pages.
    *
-   * @param topicName -
-   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionRuntimeProperties,
    *     EntitiesResponse<SubscriptionRuntimeProperties>,
@@ -1689,8 +1662,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a subscription.
-   * @param topicName -
-   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1736,8 +1707,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given subscription exists in the topic or not.
-   * @param topicName -
-   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async subscriptionExists(
@@ -1775,9 +1744,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a rule with given name, configured using the given options.
-   * @param topicName -
-   * @param subscriptionName -
-   * @param ruleName -
    * @param ruleFilter - Defines the filter expression that the rule evaluates.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -1800,9 +1766,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   ): Promise<WithResponse<RuleProperties>>;
   /**
    * Creates a rule with given name, configured using the given options.
-   * @param topicName -
-   * @param subscriptionName -
-   * @param ruleName -
    * @param ruleFilter - Defines the filter expression that the rule evaluates.
    * @param ruleAction - The SQL like expression that can be executed on the message should the associated filter apply.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
@@ -1877,9 +1840,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Rule with the given name along with all its properties.
-   * @param topicName -
-   * @param subscriptionName -
-   * @param ruleName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1924,8 +1884,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Lists existing rules.
-   * @param topicName -
-   * @param subscriptionName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -2001,9 +1959,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the rules in pages.
    *
-   * @param topicName -
-   * @param subscriptionName -
-   * @param options -
    * @returns {PagedAsyncIterableIterator<RuleProperties, EntitiesResponse<RuleProperties>>} An asyncIterableIterator that supports paging.
    */
   public listRules(
@@ -2041,8 +1996,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * All rule properties must be set even if one of them is being updated.
    * Therefore, the suggested flow is to use the output from `getRule()`, update the desired properties in it, and then pass the modified object to `updateRule()`.
    *
-   * @param topicName -
-   * @param subscriptionName -
    * @param rule - Options to configure the Rule being updated and the raw response.
    * For example, you can configure the filter to apply on associated Topic/Subscription.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
@@ -2105,9 +2058,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a rule.
-   * @param topicName -
-   * @param subscriptionName -
-   * @param ruleName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -2153,10 +2103,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Checks whether a given rule exists or not.
    *
-   * @param topicName -
-   * @param subscriptionName -
-   * @param ruleName -
-   * @param operationOptions -
    */
   async ruleExists(
     topicName: string,
@@ -2192,10 +2138,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates or updates a resource based on `isUpdate` parameter.
-   * @param name -
-   * @param entityFields -
-   * @param isUpdate -
-   * @param serializer -
    */
   private async putResource(
     name: string,
@@ -2265,8 +2207,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Gets a resource.
-   * @param name -
-   * @param serializer -
    */
   private async getResource(
     name: string,
@@ -2313,9 +2253,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Lists existing resources
-   * @param name -
-   * @param options -
-   * @param serializer -
    */
   private async listResources(
     name: string,
@@ -2353,7 +2290,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a resource.
-   * @param name -
    */
   private async deleteResource(
     name: string,

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -459,7 +459,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *     QueueProperties,
    *     EntitiesResponse<QueueProperties>,
    *   >} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listQueues(
     options?: OperationOptions
@@ -468,19 +467,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listQueuesAll(options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -570,7 +566,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *     QueueRuntimeProperties,
    *     EntitiesResponse<QueueRuntimeProperties>,
    *   >} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listQueuesRuntimeProperties(
     options?: OperationOptions
@@ -582,19 +577,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listQueuesRuntimePropertiesAll(options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -956,7 +948,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *     TopicProperties,
    *     EntitiesResponse<TopicProperties>,
    *   >} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listTopics(
     options?: OperationOptions
@@ -965,19 +956,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listTopicsAll(options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -1068,7 +1056,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *     EntitiesResponse<TopicRuntimeProperties>,
 
    *   >} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listTopicsRuntimeProperties(
     options?: OperationOptions
@@ -1080,19 +1067,19 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listTopicsRuntimePropertiesAll(options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
+       * The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
+       * The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
+       * Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -1468,14 +1455,12 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the subscriptions in pages.
    *
-   * @memberof ServiceBusAdministrationClient
    * @param {string} topicName
    * @param {OperationOptions} [options]
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionProperties,
    *     EntitiesResponse<SubscriptionProperties>
    *   >} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listSubscriptions(
     topicName: string,
@@ -1488,19 +1473,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listSubscriptionsAll(topicName, options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -1600,7 +1582,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *     EntitiesResponse<SubscriptionRuntimeProperties>,
 
    *   >}  An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listSubscriptionsRuntimeProperties(
     topicName: string,
@@ -1616,19 +1597,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listSubscriptionsRuntimePropertiesAll(topicName, options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);
@@ -2027,7 +2005,6 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * @param {string} subscriptionName
    * @param {OperationOptions} [options]
    * @returns {PagedAsyncIterableIterator<RuleProperties, EntitiesResponse<RuleProperties>>} An asyncIterableIterator that supports paging.
-   * @memberof ServiceBusAdministrationClient
    */
   public listRules(
     topicName: string,
@@ -2038,19 +2015,16 @@ export class ServiceBusAdministrationClient extends ServiceClient {
     const iter = this.listRulesAll(topicName, subscriptionName, options);
     return {
       /**
-       * @member {Promise} [next] The next method, part of the iteration protocol
        */
       next() {
         return iter.next();
       },
       /**
-       * @member {Symbol} [asyncIterator] The connection to the async iterator, part of the iteration protocol
        */
       [Symbol.asyncIterator]() {
         return this;
       },
       /**
-       * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
         this.throwIfInvalidContinuationToken(settings.continuationToken);

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -454,7 +454,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    *
-   * @param {OperationOptions} [options]
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     QueueProperties,
    *     EntitiesResponse<QueueProperties>,
@@ -561,7 +561,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the queues in pages.
    *
    *
-   * @param {OperationOptions} [options]
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     QueueRuntimeProperties,
    *     EntitiesResponse<QueueRuntimeProperties>,
@@ -943,7 +943,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list the topics in pages.
    *
    *
-   * @param {OperationOptions} [options]
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     TopicProperties,
    *     EntitiesResponse<TopicProperties>,
@@ -1050,7 +1050,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the topics in pages.
    *
    *
-   * @param {OperationOptions} [options]
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     TopicRuntimeProperties,
    *     EntitiesResponse<TopicRuntimeProperties>,
@@ -1455,8 +1455,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the subscriptions in pages.
    *
-   * @param {string} topicName
-   * @param {OperationOptions} [options]
+   * @param topicName
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionProperties,
    *     EntitiesResponse<SubscriptionProperties>
@@ -1575,8 +1575,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list runtime info of subscriptions in pages.
    *
-   * @param {string} topicName
-   * @param {OperationOptions} [options]
+   * @param topicName
+   * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionRuntimeProperties,
    *     EntitiesResponse<SubscriptionRuntimeProperties>,
@@ -2001,9 +2001,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the rules in pages.
    *
-   * @param {string} topicName
-   * @param {string} subscriptionName
-   * @param {OperationOptions} [options]
+   * @param topicName
+   * @param subscriptionName
+   * @param options -
    * @returns {PagedAsyncIterableIterator<RuleProperties, EntitiesResponse<RuleProperties>>} An asyncIterableIterator that supports paging.
    */
   public listRules(
@@ -2153,10 +2153,10 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Checks whether a given rule exists or not.
    *
-   * @param {string} topicName
-   * @param {string} subscriptionName
-   * @param {string} ruleName
-   * @param {OperationOptions} [operationOptions]
+   * @param topicName
+   * @param subscriptionName
+   * @param ruleName
+   * @param operationOptions -
    */
   async ruleExists(
     topicName: string,

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -141,19 +141,19 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Initializes a new instance of the ServiceBusAdministrationClient class.
-   * @param connectionString The connection string needed for the client to connect to Azure.
-   * @param options PipelineOptions
+   * @param connectionString - The connection string needed for the client to connect to Azure.
+   * @param options - PipelineOptions
    */
   constructor(connectionString: string, options?: PipelineOptions);
   /**
    *
-   * @param fullyQualifiedNamespace The fully qualified namespace of your Service Bus instance which is
+   * @param fullyQualifiedNamespace - The fully qualified namespace of your Service Bus instance which is
    * likely to be similar to <yournamespace>.servicebus.windows.net.
-   * @param credential A credential object used by the client to get the token to authenticate the connection
+   * @param credential - A credential object used by the client to get the token to authenticate the connection
    * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
    * If you're using your own implementation of the `TokenCredential` interface against AAD, then set the "scopes" for service-bus
    * to be `["https://servicebus.azure.net//user_impersonation"]` to get the appropriate token.
-   * @param options PipelineOptions
+   * @param options - PipelineOptions
    */
   constructor(
     fullyQualifiedNamespace: string,
@@ -218,7 +218,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the metadata related to a service bus namespace.
    * @param queueName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    */
   async getNamespaceProperties(
@@ -251,7 +251,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Creates a queue with given name, configured using the given options
    * @param queueName
-   * @param options Options to configure the Queue being created(For example, you can configure a queue to support partitions or sessions)
+   * @param options - Options to configure the Queue being created(For example, you can configure a queue to support partitions or sessions)
    *  and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -301,7 +301,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Returns an object representing the Queue and its properties.
    * If you want to get the Queue runtime info like message count details, use `getQueueRuntimeProperties` API.
    * @param queueName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -343,7 +343,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Queue runtime info like message count details.
    * @param queueName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -387,7 +387,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns a list of objects, each representing a Queue along with its properties.
    * If you want to get the runtime info of the queues like message count, use `getQueuesRuntimeProperties` API instead.
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -494,7 +494,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns a list of objects, each representing a Queue's runtime info like message count details.
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -613,9 +613,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * See https://docs.microsoft.com/rest/api/servicebus/update-queue for more details.
    *
-   * @param queue Object representing the properties of the queue and the raw response.
+   * @param queue - Object representing the properties of the queue and the raw response.
    * `requiresSession`, `requiresDuplicateDetection`, `enablePartitioning`, and `name` can't be updated after creating the queue.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -673,7 +673,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Deletes a queue.
    * @param queueName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -715,7 +715,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Checks whether a given queue exists or not.
    * @param queueName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async queueExists(queueName: string, operationOptions?: OperationOptions): Promise<boolean> {
     const { span, updatedOperationOptions } = createSpan(
@@ -747,7 +747,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Creates a topic with given name, configured using the given options
    * @param topicName
-   * @param options Options to configure the Topic being created(For example, you can configure a topic to support partitions)
+   * @param options - Options to configure the Topic being created(For example, you can configure a topic to support partitions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -797,7 +797,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Returns an object representing the Topic and its properties.
    * If you want to get the Topic runtime info like subscription count details, use `getTopicRuntimeProperties` API.
    * @param topicName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -839,7 +839,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Topic runtime info like subscription count.
    * @param topicName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -883,7 +883,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns a list of objects, each representing a Topic along with its properties.
    * If you want to get the runtime info of the topics like subscription count, use `getTopicsRuntimeProperties` API instead.
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -991,7 +991,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns a list of objects, each representing a Topic's runtime info like subscription count.
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1111,9 +1111,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * See https://docs.microsoft.com/rest/api/servicebus/update-topic for more details.
    *
-   * @param topic Object representing the properties of the topic and the raw response.
+   * @param topic - Object representing the properties of the topic and the raw response.
    * `requiresDuplicateDetection`, `enablePartitioning`, and `name` can't be updated after creating the topic.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1171,7 +1171,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Deletes a topic.
    * @param topicName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1213,7 +1213,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Checks whether a given topic exists or not.
    * @param topicName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async topicExists(topicName: string, operationOptions?: OperationOptions): Promise<boolean> {
     const { span, updatedOperationOptions } = createSpan(
@@ -1246,7 +1246,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Creates a subscription with given name, configured using the given options
    * @param topicName
    * @param subscriptionName
-   * @param options Options to configure the Subscription being created(For example, you can configure a Subscription to support partitions or sessions)
+   * @param options - Options to configure the Subscription being created(For example, you can configure a Subscription to support partitions or sessions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1299,7 +1299,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * If you want to get the Subscription runtime info like message count details, use `getSubscriptionRuntimeProperties` API.
    * @param topicName
    * @param subscriptionName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1346,7 +1346,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Returns an object representing the Subscription runtime info like message count details.
    * @param topicName
    * @param subscriptionName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1393,7 +1393,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Returns a list of objects, each representing a Subscription along with its properties.
    * If you want to get the runtime info of the subscriptions like message count, use `getSubscriptionsRuntimeProperties` API instead.
    * @param topicName
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1515,7 +1515,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns a list of objects, each representing a Subscription's runtime info like message count details.
    * @param topicName
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1645,9 +1645,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * All subscription properties must be set even though only a subset of them are actually updatable.
    * Therefore, the suggested flow is to use the output from `getSubscription()`, update the desired properties in it, and then pass the modified object to `updateSubscription()`.
    *
-   * @param subscription Object representing the properties of the subscription and the raw response.
+   * @param subscription - Object representing the properties of the subscription and the raw response.
    * `subscriptionName`, `topicName`, and `requiresSession` can't be updated after creating the subscription.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1713,7 +1713,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Deletes a subscription.
    * @param topicName
    * @param subscriptionName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1760,7 +1760,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Checks whether a given subscription exists in the topic or not.
    * @param topicName
    * @param subscriptionName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async subscriptionExists(
     topicName: string,
@@ -1800,8 +1800,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * @param topicName
    * @param subscriptionName
    * @param ruleName
-   * @param ruleFilter Defines the filter expression that the rule evaluates.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param ruleFilter - Defines the filter expression that the rule evaluates.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1825,9 +1825,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * @param topicName
    * @param subscriptionName
    * @param ruleName
-   * @param ruleFilter Defines the filter expression that the rule evaluates.
-   * @param ruleAction The SQL like expression that can be executed on the message should the associated filter apply.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param ruleFilter - Defines the filter expression that the rule evaluates.
+   * @param ruleAction - The SQL like expression that can be executed on the message should the associated filter apply.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1902,7 +1902,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * @param topicName
    * @param subscriptionName
    * @param ruleName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -1948,7 +1948,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * Lists existing rules.
    * @param topicName
    * @param subscriptionName
-   * @param options The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -2069,9 +2069,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * @param topicName
    * @param subscriptionName
-   * @param rule Options to configure the Rule being updated and the raw response.
+   * @param rule - Options to configure the Rule being updated and the raw response.
    * For example, you can configure the filter to apply on associated Topic/Subscription.
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,
@@ -2134,7 +2134,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * @param topicName
    * @param subscriptionName
    * @param ruleName
-   * @param operationOptions The options that can be used to abort, trace and control other configurations on the HTTP request.
+   * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
    * @throws `RestError` with code `UnauthorizedRequestError` when given request fails due to authorization problems,

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -217,7 +217,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the metadata related to a service bus namespace.
-   * @param queueName
+   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    */
@@ -250,7 +250,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a queue with given name, configured using the given options
-   * @param queueName
+   * @param queueName -
    * @param options - Options to configure the Queue being created(For example, you can configure a queue to support partitions or sessions)
    *  and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -300,7 +300,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Queue and its properties.
    * If you want to get the Queue runtime info like message count details, use `getQueueRuntimeProperties` API.
-   * @param queueName
+   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -342,7 +342,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Queue runtime info like message count details.
-   * @param queueName
+   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -664,7 +664,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a queue.
-   * @param queueName
+   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -706,7 +706,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given queue exists or not.
-   * @param queueName
+   * @param queueName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async queueExists(queueName: string, operationOptions?: OperationOptions): Promise<boolean> {
@@ -738,7 +738,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a topic with given name, configured using the given options
-   * @param topicName
+   * @param topicName -
    * @param options - Options to configure the Topic being created(For example, you can configure a topic to support partitions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -788,7 +788,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Topic and its properties.
    * If you want to get the Topic runtime info like subscription count details, use `getTopicRuntimeProperties` API.
-   * @param topicName
+   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -830,7 +830,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Topic runtime info like subscription count.
-   * @param topicName
+   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1157,7 +1157,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a topic.
-   * @param topicName
+   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1199,7 +1199,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given topic exists or not.
-   * @param topicName
+   * @param topicName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async topicExists(topicName: string, operationOptions?: OperationOptions): Promise<boolean> {
@@ -1231,8 +1231,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a subscription with given name, configured using the given options
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param options - Options to configure the Subscription being created(For example, you can configure a Subscription to support partitions or sessions)
    * and the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -1284,8 +1284,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns an object representing the Subscription and its properties.
    * If you want to get the Subscription runtime info like message count details, use `getSubscriptionRuntimeProperties` API.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1331,8 +1331,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Subscription runtime info like message count details.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1379,7 +1379,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Returns a list of objects, each representing a Subscription along with its properties.
    * If you want to get the runtime info of the subscriptions like message count, use `getSubscriptionsRuntimeProperties` API instead.
-   * @param topicName
+   * @param topicName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1455,7 +1455,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the subscriptions in pages.
    *
-   * @param topicName
+   * @param topicName -
    * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionProperties,
@@ -1496,7 +1496,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns a list of objects, each representing a Subscription's runtime info like message count details.
-   * @param topicName
+   * @param topicName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1575,7 +1575,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list runtime info of subscriptions in pages.
    *
-   * @param topicName
+   * @param topicName -
    * @param options -
    * @returns {PagedAsyncIterableIterator<
    *     SubscriptionRuntimeProperties,
@@ -1689,8 +1689,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a subscription.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1736,8 +1736,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Checks whether a given subscription exists in the topic or not.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    */
   async subscriptionExists(
@@ -1775,9 +1775,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates a rule with given name, configured using the given options.
-   * @param topicName
-   * @param subscriptionName
-   * @param ruleName
+   * @param topicName -
+   * @param subscriptionName -
+   * @param ruleName -
    * @param ruleFilter - Defines the filter expression that the rule evaluates.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
@@ -1800,9 +1800,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   ): Promise<WithResponse<RuleProperties>>;
   /**
    * Creates a rule with given name, configured using the given options.
-   * @param topicName
-   * @param subscriptionName
-   * @param ruleName
+   * @param topicName -
+   * @param subscriptionName -
+   * @param ruleName -
    * @param ruleFilter - Defines the filter expression that the rule evaluates.
    * @param ruleAction - The SQL like expression that can be executed on the message should the associated filter apply.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
@@ -1877,9 +1877,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Returns an object representing the Rule with the given name along with all its properties.
-   * @param topicName
-   * @param subscriptionName
-   * @param ruleName
+   * @param topicName -
+   * @param subscriptionName -
+   * @param ruleName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -1924,8 +1924,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Lists existing rules.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param options - The options include the maxCount and the count of entities to skip, the operation options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -2001,8 +2001,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the rules in pages.
    *
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param options -
    * @returns {PagedAsyncIterableIterator<RuleProperties, EntitiesResponse<RuleProperties>>} An asyncIterableIterator that supports paging.
    */
@@ -2041,8 +2041,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * All rule properties must be set even if one of them is being updated.
    * Therefore, the suggested flow is to use the output from `getRule()`, update the desired properties in it, and then pass the modified object to `updateRule()`.
    *
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName -
+   * @param subscriptionName -
    * @param rule - Options to configure the Rule being updated and the raw response.
    * For example, you can configure the filter to apply on associated Topic/Subscription.
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
@@ -2105,9 +2105,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a rule.
-   * @param topicName
-   * @param subscriptionName
-   * @param ruleName
+   * @param topicName -
+   * @param subscriptionName -
+   * @param ruleName -
    * @param operationOptions - The options that can be used to abort, trace and control other configurations on the HTTP request.
    *
    * Following are errors that can be expected from this operation
@@ -2153,9 +2153,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
   /**
    * Checks whether a given rule exists or not.
    *
-   * @param topicName
-   * @param subscriptionName
-   * @param ruleName
+   * @param topicName -
+   * @param subscriptionName -
+   * @param ruleName -
    * @param operationOptions -
    */
   async ruleExists(
@@ -2192,10 +2192,10 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Creates or updates a resource based on `isUpdate` parameter.
-   * @param name
-   * @param entityFields
-   * @param isUpdate
-   * @param serializer
+   * @param name -
+   * @param entityFields -
+   * @param isUpdate -
+   * @param serializer -
    */
   private async putResource(
     name: string,
@@ -2265,8 +2265,8 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Gets a resource.
-   * @param name
-   * @param serializer
+   * @param name -
+   * @param serializer -
    */
   private async getResource(
     name: string,
@@ -2313,9 +2313,9 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Lists existing resources
-   * @param name
-   * @param options
-   * @param serializer
+   * @param name -
+   * @param options -
+   * @param serializer -
    */
   private async listResources(
     name: string,
@@ -2353,7 +2353,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
 
   /**
    * Deletes a resource.
-   * @param name
+   * @param name -
    */
   private async deleteResource(
     name: string,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -35,18 +35,18 @@ export class ServiceBusClient {
    * Creates an instance of the ServiceBusClient class which can be used to create senders and receivers to
    * the Azure Service Bus namespace provided in the connection string. No connection is made to the service
    * until the senders/receivers created with the client are used to send/receive messages.
-   * @param connectionString A connection string for Azure Service Bus namespace.
+   * @param connectionString - A connection string for Azure Service Bus namespace.
    * NOTE: this connection string can contain an EntityPath, which is ignored.
-   * @param options Options for the service bus client.
+   * @param options - Options for the service bus client.
    */
   constructor(connectionString: string, options?: ServiceBusClientOptions);
   /**
    * Creates an instance of the ServiceBusClient class which can be used to create senders and receivers to
    * the Azure Service Bus namespace provided. No connection is made to the service until
    * the senders/receivers created with the client are used to send/receive messages.
-   * @param fullyQualifiedNamespace The full namespace of your Service Bus instance which is
+   * @param fullyQualifiedNamespace - The full namespace of your Service Bus instance which is
    * likely to be similar to <yournamespace>.servicebus.windows.net.
-   * @param credential A credential object used by the client to get the token to authenticate the connection
+   * @param credential - A credential object used by the client to get the token to authenticate the connection
    * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
    * If you're using an own implementation of the `TokenCredential` interface against AAD, then set the "scopes" for service-bus
    * to be `["https://servicebus.azure.net//user_impersonation"]` to get the appropriate token.
@@ -119,8 +119,8 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options to pass the receiveMode, defaulted to peekLock.
+   * @param queueName - The name of the queue to receive from.
+   * @param options - Options to pass the receiveMode, defaulted to peekLock.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   createReceiver(queueName: string, options?: ServiceBusReceiverOptions): ServiceBusReceiver;
@@ -147,9 +147,9 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options to pass the receiveMode, defaulted to peekLock.
+   * @param topicName - Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName - Name of the subscription (under the `topic`) that we want to receive from.
+   * @param options - Options to pass the receiveMode, defaulted to peekLock.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   createReceiver(
@@ -216,9 +216,9 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param queueName The name of the queue to receive from.
-   * @param sessionId The id of the session from which messages need to be received
-   * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
+   * @param queueName - The name of the queue to receive from.
+   * @param sessionId - The id of the session from which messages need to be received
+   * @param options - Options include receiveMode(defaulted to peekLock), options to create session receiver.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptSession(
@@ -240,10 +240,10 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param sessionId The id of the session from which messages need to be received
-   * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
+   * @param topicName - Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName - Name of the subscription (under the `topic`) that we want to receive from.
+   * @param sessionId - The id of the session from which messages need to be received
+   * @param options - Options include receiveMode(defaulted to peekLock), options to create session receiver.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptSession(
@@ -333,8 +333,8 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param queueName The name of the queue to receive from.
-   * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
+   * @param queueName - The name of the queue to receive from.
+   * @param options - Options include receiveMode(defaulted to peekLock), options to create session receiver.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptNextSession(
@@ -355,9 +355,9 @@ export class ServiceBusClient {
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
-   * @param topicName Name of the topic for the subscription we want to receive from.
-   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param options Options include receiveMode(defaulted to peekLock), options to create session receiver.
+   * @param topicName - Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName - Name of the subscription (under the `topic`) that we want to receive from.
+   * @param options - Options include receiveMode(defaulted to peekLock), options to create session receiver.
    * @returns A receiver that can be used to receive, peek and settle messages.
    */
   acceptNextSession(
@@ -404,7 +404,7 @@ export class ServiceBusClient {
    * Creates a Sender which can be used to send messages, schedule messages to be
    * sent at a later time and cancel such scheduled messages. No connection is made
    * to the service until one of the methods on the sender is called.
-   * @param queueOrTopicName The name of a queue or topic to send messages to.
+   * @param queueOrTopicName - The name of a queue or topic to send messages to.
    */
   createSender(queueOrTopicName: string): ServiceBusSender {
     validateEntityPath(this._connectionContext.config, queueOrTopicName);

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { isMessagingError, MessagingError, translate } from "@azure/core-amqp";
 import { AmqpError } from "rhea-promise";
 

--- a/sdk/servicebus/service-bus/src/serviceBusError.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusError.ts
@@ -114,12 +114,12 @@ export class ServiceBusError extends MessagingError {
   code: ServiceBusErrorCode;
 
   /**
-   * @param message The error message that provides more information about the error.
-   * @param code The reason for the failure.
+   * @param message - The error message that provides more information about the error.
+   * @param code - The reason for the failure.
    */
   constructor(message: string, code: ServiceBusErrorCode);
   /**
-   * @param messagingError An error whose properties will be copied to the ServiceBusError.
+   * @param messagingError - An error whose properties will be copied to the ServiceBusError.
    */
   constructor(messagingError: MessagingError);
   constructor(messageOrError: string | MessagingError, code?: ServiceBusErrorCode) {
@@ -179,7 +179,7 @@ export function translateServiceBusError(err: AmqpError | Error): ServiceBusErro
 /**
  * Determines if an error is of type `ServiceBusError`
  *
- * @param err An error to check to see if it's of type ServiceBusError
+ * @param err - An error to check to see if it's of type ServiceBusError
  */
 export function isServiceBusError(err: any): err is ServiceBusError {
   return err?.name === "ServiceBusError";

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -353,7 +353,6 @@ export function toRheaMessage(msg: ServiceBusMessage): RheaMessage {
 
 /**
  * Describes the message received from Service Bus during peek operations and so cannot be settled.
- * @class ServiceBusReceivedMessage
  */
 export interface ServiceBusReceivedMessage extends ServiceBusMessage {
   /**

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -32,23 +32,23 @@ export enum DispositionType {
  */
 export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
   /**
-   * @property {string} [last_enqueued_offset] The offset of the last event.
+   * The offset of the last event.
    */
   last_enqueued_offset?: string;
   /**
-   * @property {number} [last_enqueued_sequence_number] The sequence number of the last event.
+   * The sequence number of the last event.
    */
   last_enqueued_sequence_number?: number;
   /**
-   * @property {number} [last_enqueued_time_utc] The enqueued time of the last event.
+   * The enqueued time of the last event.
    */
   last_enqueued_time_utc?: number;
   /**
-   * @property {number} [runtime_info_retrieval_time_utc] The retrieval time of the last event.
+   * The retrieval time of the last event.
    */
   runtime_info_retrieval_time_utc?: number;
   /**
-   * @property {string} Any unknown delivery annotations.
+   * Any unknown delivery annotations.
    */
   [x: string]: any;
 }
@@ -59,23 +59,23 @@ export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
  */
 export interface ServiceBusMessageAnnotations extends MessageAnnotations {
   /**
-   * @property {string | null} [x-opt-partition-key] Annotation for the partition key set for the event.
+   * Annotation for the partition key set for the event.
    */
   "x-opt-partition-key"?: string | null;
   /**
-   * @property {number} [x-opt-sequence-number] Annontation for the sequence number of the event.
+   * Annontation for the sequence number of the event.
    */
   "x-opt-sequence-number"?: number;
   /**
-   * @property {number} [x-opt-enqueued-time] Annotation for the enqueued time of the event.
+   * Annotation for the enqueued time of the event.
    */
   "x-opt-enqueued-time"?: number;
   /**
-   * @property {string} [x-opt-offset] Annotation for the offset of the event.
+   * Annotation for the offset of the event.
    */
   "x-opt-offset"?: string;
   /**
-   * @property {string} [x-opt-locked-until] Annotation for the message being locked until.
+   * Annotation for the message being locked until.
    */
   "x-opt-locked-until"?: Date | number;
 }
@@ -86,11 +86,11 @@ export interface ServiceBusMessageAnnotations extends MessageAnnotations {
  */
 export interface DeadLetterOptions {
   /**
-   * @property The reason for deadlettering the message.
+   * The reason for deadlettering the message.
    */
   deadLetterReason: string;
   /**
-   * @property The error description for deadlettering the message.
+   * The error description for deadlettering the message.
    */
   deadLetterErrorDescription: string;
 }
@@ -100,34 +100,34 @@ export interface DeadLetterOptions {
  */
 export interface ServiceBusMessage {
   /**
-   * @property The message body that needs to be sent or is received.
+   * The message body that needs to be sent or is received.
    * If the application receiving the message is not using this SDK,
    * convert your body payload to a byte array or Buffer for better
    * cross-language compatibility.
    */
   body: any;
   /**
-   * @property The message identifier is an
+   * The message identifier is an
    * application-defined value that uniquely identifies the message and its payload.
    *
    * Note: Numbers that are not whole integers are not allowed.
    */
   messageId?: string | number | Buffer;
   /**
-   * @property The content type of the message. Optionally describes
+   * The content type of the message. Optionally describes
    * the payload of the message, with a descriptor following the format of RFC2045, Section 5, for
    * example "application/json".
    */
   contentType?: string;
   /**
-   * @property The correlation identifier that allows an
+   * The correlation identifier that allows an
    * application to specify a context for the message for the purposes of correlation, for example
    * reflecting the MessageId of a message that is being replied to.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   correlationId?: string | number | Buffer;
   /**
-   * @property The partition key for sending a message to a partitioned entity.
+   * The partition key for sending a message to a partitioned entity.
    * Maximum length is 128 characters. For {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning partitioned entities},
    * setting this value enables assigning related messages to the same internal partition,
    * so that submission sequence order is correctly recorded. The partition is chosen by a hash
@@ -138,7 +138,7 @@ export interface ServiceBusMessage {
    */
   partitionKey?: string;
   /**
-   * @property The partition key for sending a message into an entity
+   * The partition key for sending a message into an entity
    * via a partitioned transfer queue. Maximum length is 128 characters. If a message is sent via a
    * transfer queue in the scope of a transaction, this value selects the transfer queue partition:
    * This is functionally equivalent to `partitionKey` property and ensures that messages are kept
@@ -150,7 +150,7 @@ export interface ServiceBusMessage {
   // viaPartitionKey?: string;
 
   /**
-   * @property The session identifier for a session-aware entity. Maximum
+   * The session identifier for a session-aware entity. Maximum
    * length is 128 characters. For session-aware entities, this application-defined value specifies
    * the session affiliation of the message. Messages with the same session identifier are subject
    * to summary locking and enable exact in-order processing and demultiplexing. For
@@ -159,14 +159,14 @@ export interface ServiceBusMessage {
    */
   sessionId?: string;
   /**
-   * @property The session identifier augmenting the `replyTo` address.
+   * The session identifier augmenting the `replyTo` address.
    * Maximum length is 128 characters. This value augments the ReplyTo information and specifies
    * which SessionId should be set for the reply when sent to the reply entity.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   replyToSessionId?: string;
   /**
-   * @property The message’s time to live value. This value is the relative
+   * The message’s time to live value. This value is the relative
    * duration after which the message expires, starting from the instant the message has been
    * accepted and stored by the broker, as captured in `enqueuedTimeUtc`. When not set explicitly,
    * the assumed value is the DefaultTimeToLive for the respective queue or topic. A message-level
@@ -176,20 +176,20 @@ export interface ServiceBusMessage {
    */
   timeToLive?: number;
   /**
-   * @property The application specific label. This property enables the
+   * The application specific label. This property enables the
    * application to indicate the purpose of the message to the receiver in a standardized. fashion,
    * similar to an email subject line. The mapped AMQP property is "subject".
    */
   subject?: string;
   /**
-   * @property The "to" address. This property is reserved for future use in routing
+   * The "to" address. This property is reserved for future use in routing
    * scenarios and presently ignored by the broker itself. Applications can use this value in
    * rule-driven {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding auto-forward chaining}
    * scenarios to indicate the intended logical destination of the message.
    */
   to?: string;
   /**
-   * @property The address of an entity to send replies to. This optional and
+   * The address of an entity to send replies to. This optional and
    * application-defined value is a standard way to express a reply path to the receiver of the
    * message. When a sender expects a reply, it sets the value to the absolute or relative path of
    * the queue or topic it expects the reply to be sent to. See
@@ -197,7 +197,7 @@ export interface ServiceBusMessage {
    */
   replyTo?: string;
   /**
-   * @property The date and time in UTC at which the message will
+   * The date and time in UTC at which the message will
    * be enqueued. This property returns the time in UTC; when setting the property, the
    * supplied DateTime value must also be in UTC. This value is for delayed message sending.
    * It is utilized to delay messages sending to a specific time in the future. Message enqueuing
@@ -206,7 +206,7 @@ export interface ServiceBusMessage {
    */
   scheduledEnqueueTimeUtc?: Date;
   /**
-   * @property The application specific properties which can be
+   * The application specific properties which can be
    * used for custom message metadata.
    */
   applicationProperties?: { [key: string]: number | boolean | string | Date };
@@ -357,17 +357,17 @@ export function toRheaMessage(msg: ServiceBusMessage): RheaMessage {
  */
 export interface ServiceBusReceivedMessage extends ServiceBusMessage {
   /**
-   * @property The reason for deadlettering the message.
+   * The reason for deadlettering the message.
    * @readonly
    */
   readonly deadLetterReason?: string;
   /**
-   * @property The error description for deadlettering the message.
+   * The error description for deadlettering the message.
    * @readonly
    */
   readonly deadLetterErrorDescription?: string;
   /**
-   * @property The lock token is a reference to the lock that is being held by the broker in
+   * The lock token is a reference to the lock that is being held by the broker in
    * `peekLock` receive mode. Locks are used internally settle messages as explained in the
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
    * - Not applicable when the message is received in `receiveAndDelete` receive mode.
@@ -376,25 +376,25 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
    */
   readonly lockToken?: string;
   /**
-   * @property Number of deliveries that have been attempted for this message. The count is
+   * Number of deliveries that have been attempted for this message. The count is
    * incremented when a message lock expires, or the message is explicitly abandoned using the
    * `abandon()` method on the message.
    * @readonly
    */
   readonly deliveryCount?: number;
   /**
-   * @property The UTC instant at which the message has been accepted and stored in Service Bus.
+   * The UTC instant at which the message has been accepted and stored in Service Bus.
    * @readonly
    */
   readonly enqueuedTimeUtc?: Date;
   /**
-   * @property The UTC instant at which the message is marked for removal and no longer available for
+   * The UTC instant at which the message is marked for removal and no longer available for
    * retrieval from the entity due to expiration. This property is computed from 2 other properties
    * on the message: `enqueuedTimeUtc` + `timeToLive`.
    */
   readonly expiresAtUtc?: Date;
   /**
-   * @property The UTC instant until which the message is held locked in the queue/subscription.
+   * The UTC instant until which the message is held locked in the queue/subscription.
    * When the lock expires, the `deliveryCount` is incremented and the message is again available
    * for retrieval.
    * - Not applicable when the message is received in `receiveAndDelete` receive mode.
@@ -402,14 +402,14 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
    */
   lockedUntilUtc?: Date;
   /**
-   * @property The original sequence number of the message. For
+   * The original sequence number of the message. For
    * messages that have been auto-forwarded, this property reflects the sequence number that had
    * first been assigned to the message at its original point of submission.
    * @readonly
    */
   readonly enqueuedSequenceNumber?: number;
   /**
-   * @property The unique number assigned to a message by Service Bus.
+   * The unique number assigned to a message by Service Bus.
    * The sequence number is a unique 64-bit integer assigned to a message as it is accepted
    * and stored by the broker and functions as its true identifier. For partitioned entities,
    * the topmost 16 bits reflect the partition identifier. Sequence numbers monotonically increase.
@@ -423,7 +423,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
    */
   readonly sequenceNumber?: Long;
   /**
-   * @property The name of the queue or subscription that this message
+   * The name of the queue or subscription that this message
    * was enqueued on, before it was deadlettered. Only set in messages that have been dead-lettered
    * and subsequently auto-forwarded from the dead-letter sub-queue to another entity. Indicates the
    * entity in which the message was dead-lettered.
@@ -431,7 +431,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
    */
   readonly deadLetterSource?: string;
   /**
-   * @property The underlying raw amqp message.
+   * The underlying raw amqp message.
    * @readonly
    */
   readonly _rawAmqpMessage: AmqpAnnotatedMessage;
@@ -571,15 +571,15 @@ export function isServiceBusMessage(possible: any): possible is ServiceBusMessag
  */
 export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
   /**
-   * @property The message body that needs to be sent or is received.
+   * The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property The application specific properties.
+   * The application specific properties.
    */
   applicationProperties?: { [key: string]: any };
   /**
-   * @property The message identifier is an
+   * The message identifier is an
    * application-defined value that uniquely identifies the message and its payload. The identifier
    * is a free-form string and can reflect a GUID or an identifier derived from the application
    * context. If enabled, the
@@ -588,20 +588,20 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   messageId?: string | number | Buffer;
   /**
-   * @property The content type of the message. Optionally describes
+   * The content type of the message. Optionally describes
    * the payload of the message, with a descriptor following the format of RFC2045, Section 5, for
    * example "application/json".
    */
   contentType?: string;
   /**
-   * @property The correlation identifier that allows an
+   * The correlation identifier that allows an
    * application to specify a context for the message for the purposes of correlation, for example
    * reflecting the MessageId of a message that is being replied to.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   correlationId?: string | number | Buffer;
   /**
-   * @property The partition key for sending a message to a
+   * The partition key for sending a message to a
    * partitioned entity. Maximum length is 128 characters. For {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning partitioned entities},
    * setting this value enables assigning related messages to the same internal partition,
    * so that submission sequence order is correctly recorded. The partition is chosen by a hash
@@ -610,7 +610,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   partitionKey?: string;
   /**
-   * @property The partition key for sending a message into an entity
+   * The partition key for sending a message into an entity
    * via a partitioned transfer queue. Maximum length is 128 characters. If a message is sent via a
    * transfer queue in the scope of a transaction, this value selects the transfer queue partition:
    * This is functionally equivalent to `partitionKey` property and ensures that messages are kept
@@ -620,7 +620,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
   // Will be required later for implementing Transactions
   // viaPartitionKey?: string;
   /**
-   * @property The session identifier for a session-aware entity. Maximum
+   * The session identifier for a session-aware entity. Maximum
    * length is 128 characters. For session-aware entities, this application-defined value specifies
    * the session affiliation of the message. Messages with the same session identifier are subject
    * to summary locking and enable exact in-order processing and demultiplexing. For
@@ -629,14 +629,14 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   sessionId?: string;
   /**
-   * @property The session identifier augmenting the `replyTo` address.
+   * The session identifier augmenting the `replyTo` address.
    * Maximum length is 128 characters. This value augments the ReplyTo information and specifies
    * which SessionId should be set for the reply when sent to the reply entity.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   replyToSessionId?: string;
   /**
-   * @property The message’s time to live value. This value is the relative
+   * The message’s time to live value. This value is the relative
    * duration after which the message expires, starting from the instant the message has been
    * accepted and stored by the broker, as captured in `enqueuedTimeUtc`. When not set explicitly,
    * the assumed value is the DefaultTimeToLive for the respective queue or topic. A message-level
@@ -646,20 +646,20 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   timeToLive?: number;
   /**
-   * @property The application specific label. This property enables the
+   * The application specific label. This property enables the
    * application to indicate the purpose of the message to the receiver in a standardized. fashion,
    * similar to an email subject line. The mapped AMQP property is "subject".
    */
   subject?: string;
   /**
-   * @property The "to" address. This property is reserved for future use in routing
+   * The "to" address. This property is reserved for future use in routing
    * scenarios and presently ignored by the broker itself. Applications can use this value in
    * rule-driven {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding auto-forward chaining}
    * scenarios to indicate the intended logical destination of the message.
    */
   to?: string;
   /**
-   * @property The address of an entity to send replies to. This optional and
+   * The address of an entity to send replies to. This optional and
    * application-defined value is a standard way to express a reply path to the receiver of the
    * message. When a sender expects a reply, it sets the value to the absolute or relative path of
    * the queue or topic it expects the reply to be sent to. See
@@ -667,7 +667,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   replyTo?: string;
   /**
-   * @property The date and time in UTC at which the message will
+   * The date and time in UTC at which the message will
    * be enqueued. This property returns the time in UTC; when setting the property, the
    * supplied DateTime value must also be in UTC. This value is for delayed message sending.
    * It is utilized to delay messages sending to a specific time in the future. Message enqueuing
@@ -676,7 +676,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   scheduledEnqueueTimeUtc?: Date;
   /**
-   * @property The lock token is a reference to the lock that is being held by the broker in
+   * The lock token is a reference to the lock that is being held by the broker in
    * `peekLock` receive mode. Locks are used internally settle messages as explained in the
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
    * - Not applicable when the message is received in `receiveAndDelete` receive mode.
@@ -685,25 +685,25 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   readonly lockToken?: string;
   /**
-   * @property Number of deliveries that have been attempted for this message. The count is
+   * Number of deliveries that have been attempted for this message. The count is
    * incremented when a message lock expires, or the message is explicitly abandoned using the
    * `abandon()` method on the message.
    * @readonly
    */
   readonly deliveryCount?: number;
   /**
-   * @property The UTC instant at which the message has been accepted and stored in Service Bus.
+   * The UTC instant at which the message has been accepted and stored in Service Bus.
    * @readonly
    */
   readonly enqueuedTimeUtc?: Date;
   /**
-   * @property The UTC instant at which the message is marked for removal and no longer available for
+   * The UTC instant at which the message is marked for removal and no longer available for
    * retrieval from the entity due to expiration. This property is computed from 2 other properties
    * on the message: `enqueuedTimeUtc` + `timeToLive`.
    */
   readonly expiresAtUtc?: Date;
   /**
-   * @property The UTC instant until which the message is held locked in the queue/subscription.
+   * The UTC instant until which the message is held locked in the queue/subscription.
    * When the lock expires, the `deliveryCount` is incremented and the message is again available
    * for retrieval.
    * - Not applicable when the message is received in `receiveAndDelete` receive mode.
@@ -711,14 +711,14 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   lockedUntilUtc?: Date;
   /**
-   * @property The original sequence number of the message. For
+   * The original sequence number of the message. For
    * messages that have been auto-forwarded, this property reflects the sequence number that had
    * first been assigned to the message at its original point of submission.
    * @readonly
    */
   readonly enqueuedSequenceNumber?: number;
   /**
-   * @property The unique number assigned to a message by Service Bus.
+   * The unique number assigned to a message by Service Bus.
    * The sequence number is a unique 64-bit integer assigned to a message as it is accepted
    * and stored by the broker and functions as its true identifier. For partitioned entities,
    * the topmost 16 bits reflect the partition identifier. Sequence numbers monotonically increase.
@@ -727,7 +727,7 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   readonly sequenceNumber?: Long;
   /**
-   * @property The name of the queue or subscription that this message
+   * The name of the queue or subscription that this message
    * was enqueued on, before it was deadlettered. Only set in messages that have been dead-lettered
    * and subsequently auto-forwarded from the dead-letter sub-queue to another entity. Indicates the
    * entity in which the message was dead-lettered.
@@ -739,17 +739,17 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
    */
   readonly delivery: Delivery;
   /**
-   * @property {AmqpMessage} _rawAmqpMessage The underlying raw amqp annotated message.
+   * The underlying raw amqp annotated message.
    * @readonly
    */
   readonly _rawAmqpMessage: AmqpAnnotatedMessage;
   /**
-   * @property The reason for deadlettering the message.
+   * The reason for deadlettering the message.
    * @readonly
    */
   readonly deadLetterReason?: string;
   /**
-   * @property The error description for deadlettering the message.
+   * The error description for deadlettering the message.
    * @readonly
    */
   readonly deadLetterErrorDescription?: string;

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -566,8 +566,6 @@ export function isServiceBusMessage(possible: any): possible is ServiceBusMessag
  * Describes the message received from Service Bus.
  *
  * @internal
- * @class ServiceBusMessageImpl
- * @implements {ServiceBusReceivedMessage}
  */
 export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
   /**

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -104,11 +104,11 @@ export interface ServiceBusMessageBatch {
  */
 export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   /**
-   * @property Current size of the batch in bytes.
+   * Current size of the batch in bytes.
    */
   private _sizeInBytes: number;
   /**
-   * @property Encoded amqp messages.
+   * Encoded amqp messages.
    */
   private _encodedMessages: Buffer[] = [];
   /**
@@ -128,7 +128,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   }
 
   /**
-   * @property The maximum size of the batch, in bytes.
+   * The maximum size of the batch, in bytes.
    * @readonly
    */
   get maxSizeInBytes(): number {
@@ -136,7 +136,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   }
 
   /**
-   * @property Size of the `ServiceBusMessageBatch` instance after the messages added to it have been
+   * Size of the `ServiceBusMessageBatch` instance after the messages added to it have been
    * encoded into a single AMQP message.
    * @readonly
    */
@@ -145,7 +145,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   }
 
   /**
-   * @property Number of messages in the `ServiceBusMessageBatch` instance.
+   * Number of messages in the `ServiceBusMessageBatch` instance.
    * @readonly
    */
   get count(): number {
@@ -194,7 +194,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   }
 
   /**
-   * @property Represents the single AMQP message which is the result of encoding all the events
+   * Represents the single AMQP message which is the result of encoding all the events
    * added into the `ServiceBusMessageBatch` instance.
    *
    * This is not meant for the user to use directly.

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -42,7 +42,6 @@ const smallMessageMaxBytes = 255;
 /**
  * A batch of messages that you can create using the {@link createBatch} method.
  *
- * @export
  */
 export interface ServiceBusMessageBatch {
   /**
@@ -99,7 +98,6 @@ export interface ServiceBusMessageBatch {
 /**
  * An internal class representing a batch of messages which can be used to send messages to Service Bus.
  *
- * @class
  * @internal
  */
 export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
@@ -118,7 +116,6 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   /**
    * ServiceBusMessageBatch should not be constructed using `new ServiceBusMessageBatch()`
    * Use the `createBatch()` method on your `Sender` instead.
-   * @constructor
    * @internal
    * @hidden
    */
@@ -164,7 +161,6 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
   /**
    * Generates an AMQP message that contains the provided encoded messages and annotations.
    *
-   * @private
    * @param encodedMessages - The already encoded messages to include in the AMQP batch.
    * @param annotations - The message annotations to set on the batch.
    * @param applicationProperties - The application properties to set on the batch.

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -71,7 +71,7 @@ export interface ServiceBusMessageBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next event.
    *
-   * @param message  An individual service bus message.
+   * @param message - An individual service bus message.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
   tryAddMessage(message: ServiceBusMessage, options?: TryAddOptions): boolean;
@@ -236,7 +236,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next message.
    *
-   * @param message  An individual service bus message.
+   * @param message - An individual service bus message.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
   public tryAddMessage(message: ServiceBusMessage, options: TryAddOptions = {}): boolean {

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -166,9 +166,9 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    *
    * @private
    * @param encodedMessages The already encoded messages to include in the AMQP batch.
-   * @param [annotations] The message annotations to set on the batch.
-   * @param [applicationProperties] The application properties to set on the batch.
-   * @param [messageProperties] The message properties to set on the batch.
+   * @param annotations The message annotations to set on the batch.
+   * @param applicationProperties The application properties to set on the batch.
+   * @param messageProperties The message properties to set on the batch.
    * @returns {Buffer}
    */
   private _generateBatch(

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -170,7 +170,6 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * @param {{ [key: string]: any }} [applicationProperties] The application properties to set on the batch.
    * @param {{ [key: string]: string }} [messageProperties] The message properties to set on the batch.
    * @returns {Buffer}
-   * @memberof ServiceBusMessageBatchImpl
    */
   private _generateBatch(
     encodedMessages: Buffer[],

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -165,10 +165,10 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * Generates an AMQP message that contains the provided encoded messages and annotations.
    *
    * @private
-   * @param encodedMessages The already encoded messages to include in the AMQP batch.
-   * @param annotations The message annotations to set on the batch.
-   * @param applicationProperties The application properties to set on the batch.
-   * @param messageProperties The message properties to set on the batch.
+   * @param encodedMessages - The already encoded messages to include in the AMQP batch.
+   * @param annotations - The message annotations to set on the batch.
+   * @param applicationProperties - The application properties to set on the batch.
+   * @param messageProperties - The message properties to set on the batch.
    * @returns {Buffer}
    */
   private _generateBatch(

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -165,10 +165,10 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * Generates an AMQP message that contains the provided encoded messages and annotations.
    *
    * @private
-   * @param {Buffer[]} encodedMessages The already encoded messages to include in the AMQP batch.
-   * @param {MessageAnnotations} [annotations] The message annotations to set on the batch.
-   * @param {{ [key: string]: any }} [applicationProperties] The application properties to set on the batch.
-   * @param {{ [key: string]: string }} [messageProperties] The message properties to set on the batch.
+   * @param encodedMessages The already encoded messages to include in the AMQP batch.
+   * @param [annotations] The message annotations to set on the batch.
+   * @param [applicationProperties] The application properties to set on the batch.
+   * @param [messageProperties] The message properties to set on the batch.
    * @returns {Buffer}
    */
   private _generateBatch(

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -118,7 +118,7 @@ export class SharedAccessSignatureCredential extends SharedKeyCredential {
   /**
    * Retrieve a valid token for authenticaton.
    *
-   * @param _audience Not applicable in SharedAccessSignatureCredential as the token is not re-generated at every invocation of the method
+   * @param _audience - Not applicable in SharedAccessSignatureCredential as the token is not re-generated at every invocation of the method
    */
   getToken(_audience: string): AccessToken {
     return this._accessToken;

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -26,8 +26,8 @@ export class SharedKeyCredential {
   /**
    * Initializes a new instance of SharedKeyCredential
    * @constructor
-   * @param {string} keyName - The name of the EventHub/ServiceBus key.
-   * @param {string} key - The secret value associated with the above EventHub/ServiceBus key
+   * @param keyName - The name of the EventHub/ServiceBus key.
+   * @param key - The secret value associated with the above EventHub/ServiceBus key
    */
   constructor(keyName: string, key: string) {
     this.keyName = keyName;
@@ -36,7 +36,7 @@ export class SharedKeyCredential {
 
   /**
    * Gets the sas token for the specified audience
-   * @param {string} [audience] - The audience for which the token is desired.
+   * @param [audience] - The audience for which the token is desired.
    */
   getToken(audience: string): AccessToken {
     return this._createToken(Math.floor(Date.now() / 1000) + 3600, audience);
@@ -44,9 +44,9 @@ export class SharedKeyCredential {
 
   /**
    * Creates the sas token based on the provided information
-   * @param {string | number} expiry - The time period in unix time after which the token will expire.
-   * @param {string} [audience] - The audience for which the token is desired.
-   * @param {string | Buffer} [hashInput] The input to be provided to hmac to create the hash.
+   * @param expiry - The time period in unix time after which the token will expire.
+   * @param [audience] - The audience for which the token is desired.
+   * @param [hashInput] The input to be provided to hmac to create the hash.
    */
   protected _createToken(
     expiry: number,
@@ -76,7 +76,7 @@ export class SharedKeyCredential {
 
   /**
    * Creates a token provider from the EventHub/ServiceBus connection string;
-   * @param {string} connectionString - The EventHub/ServiceBus connection string
+   * @param connectionString - The EventHub/ServiceBus connection string
    */
   static fromConnectionString(connectionString: string): SharedKeyCredential {
     const parsed = parseConnectionString<{

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -8,7 +8,6 @@ import isBuffer from "is-buffer";
 import jssha from "jssha";
 
 /**
- * @class SharedKeyCredential
  * @internal
  * Defines the SharedKeyCredential.
  */
@@ -25,7 +24,6 @@ export class SharedKeyCredential {
 
   /**
    * Initializes a new instance of SharedKeyCredential
-   * @constructor
    * @param keyName - The name of the EventHub/ServiceBus key.
    * @param key - The secret value associated with the above EventHub/ServiceBus key
    */

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -103,7 +103,7 @@ export class SharedAccessSignatureCredential extends SharedKeyCredential {
   private _accessToken: AccessToken;
 
   /**
-   * @param sharedAccessSignature A shared access signature of the form
+   * @param sharedAccessSignature - A shared access signature of the form
    * `SharedAccessSignature sr=<resource>&sig=<signature>&se=<expiry>&skn=<keyname>`
    */
   constructor(sharedAccessSignature: string) {

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -46,7 +46,7 @@ export class SharedKeyCredential {
    * Creates the sas token based on the provided information
    * @param expiry - The time period in unix time after which the token will expire.
    * @param audience - The audience for which the token is desired.
-   * @param hashInput The input to be provided to hmac to create the hash.
+   * @param hashInput - The input to be provided to hmac to create the hash.
    */
   protected _createToken(
     expiry: number,

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -36,7 +36,7 @@ export class SharedKeyCredential {
 
   /**
    * Gets the sas token for the specified audience
-   * @param [audience] - The audience for which the token is desired.
+   * @param audience - The audience for which the token is desired.
    */
   getToken(audience: string): AccessToken {
     return this._createToken(Math.floor(Date.now() / 1000) + 3600, audience);
@@ -45,8 +45,8 @@ export class SharedKeyCredential {
   /**
    * Creates the sas token based on the provided information
    * @param expiry - The time period in unix time after which the token will expire.
-   * @param [audience] - The audience for which the token is desired.
-   * @param [hashInput] The input to be provided to hmac to create the hash.
+   * @param audience - The audience for which the token is desired.
+   * @param hashInput The input to be provided to hmac to create the hash.
    */
   protected _createToken(
     expiry: number,

--- a/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/src/servicebusSharedKeyCredential.ts
@@ -14,12 +14,12 @@ import jssha from "jssha";
  */
 export class SharedKeyCredential {
   /**
-   * @property {string} keyName - The name of the EventHub/ServiceBus key.
+   * The name of the EventHub/ServiceBus key.
    */
   keyName: string;
 
   /**
-   * @property {string} key - The secret value associated with the above EventHub/ServiceBus key.
+   * The secret value associated with the above EventHub/ServiceBus key.
    */
   key: string;
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -739,8 +739,8 @@ export class MessageSession extends LinkEntity<Receiver> {
    * Returns a batch of messages based on given count and timeout over an AMQP receiver link
    * from a Queue/Subscription.
    *
-   * @param maxMessageCount      The maximum number of messages to receive from Queue/Subscription.
-   * @param maxWaitTimeInMs The total wait time in milliseconds until which the receiver will attempt to receive specified number of messages.
+   * @param maxMessageCount - The maximum number of messages to receive from Queue/Subscription.
+   * @param maxWaitTimeInMs - The total wait time in milliseconds until which the receiver will attempt to receive specified number of messages.
    * If this time elapses before the `maxMessageCount` is reached, then messages collected till then will be returned to the user.
    * @returns Promise<ServiceBusMessage[]> A promise that resolves with an array of Message objects.
    */
@@ -765,9 +765,9 @@ export class MessageSession extends LinkEntity<Receiver> {
 
   /**
    * Settles the message with the specified disposition.
-   * @param message The ServiceBus Message that needs to be settled.
-   * @param operation The disposition type.
-   * @param options Optional parameters that can be provided while disposing the message.
+   * @param message - The ServiceBus Message that needs to be settled.
+   * @param operation - The disposition type.
+   * @param options - Optional parameters that can be provided while disposing the message.
    */
   async settleMessage(
     message: ServiceBusMessageImpl,
@@ -833,8 +833,8 @@ export class MessageSession extends LinkEntity<Receiver> {
 
   /**
    * Creates a new instance of the MessageSession based on the provided parameters.
-   * @param context The client entity context
-   * @param options Options that can be provided while creating the MessageSession.
+   * @param context - The client entity context
+   * @param options - Options that can be provided while creating the MessageSession.
    */
   static async create(
     context: ConnectionContext,

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -66,39 +66,39 @@ export type MessageSessionOptions = Pick<
  */
 export class MessageSession extends LinkEntity<Receiver> {
   /**
-   * @property {Date} [sessionLockedUntilUtc] Provides the duration until which the session is locked.
+   * Provides the duration until which the session is locked.
    */
   sessionLockedUntilUtc!: Date;
   /**
-   * @property {string} [sessionId] The sessionId for the message session. Empty string is valid sessionId.
+   * The sessionId for the message session. Empty string is valid sessionId.
    */
   sessionId!: string;
   /**
-   * @property {number} [maxConcurrentSessions] The maximum number of concurrent sessions that the
+   * The maximum number of concurrent sessions that the
    * client should initiate.
    * - **Default**: `1`.
    */
   maxConcurrentSessions?: number;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
+   * The maximum number of messages that should be
    * processed concurrently in a session while in streaming mode. Once this limit has been reached,
    * more messages will not be received until the user's message handler has completed processing current message.
    * - **Default**: `1` (message in a session at a time).
    */
   maxConcurrentCalls: number = 1;
   /**
-   * @property {number} [receiveMode] The mode in which messages should be received.
+   * The mode in which messages should be received.
    * Default: ReceiveMode.peekLock
    */
   receiveMode: ReceiveMode;
   /**
-   * @property {boolean} autoComplete Indicates whether `Message.complete()` should be called
+   * {boolean} autoComplete Indicates whether `Message.complete()` should be called
    * automatically after the message processing is complete while receiving messages with handlers.
    * Default: false.
    */
   autoComplete: boolean;
   /**
-   * @property {number} maxAutoRenewDurationInMs The maximum duration within which the
+   * {number} maxAutoRenewDurationInMs The maximum duration within which the
    * lock will be renewed automatically. This value should be greater than the longest message
    * lock duration; for example, the `lockDuration` property on the received message.
    *
@@ -106,7 +106,7 @@ export class MessageSession extends LinkEntity<Receiver> {
    */
   maxAutoRenewDurationInMs: number;
   /**
-   * @property {boolean} autoRenewLock Should lock renewal happen automatically.
+   * {boolean} autoRenewLock Should lock renewal happen automatically.
    */
   autoRenewLock: boolean;
   /**
@@ -120,7 +120,7 @@ export class MessageSession extends LinkEntity<Receiver> {
   private _isReceivingMessagesForSubscriber: boolean;
 
   /**
-   * @property {Map<number, Promise<any>>} _deliveryDispositionMap Maintains a map of deliveries that
+   * Maintains a map of deliveries that
    * are being actively disposed. It acts as a store for correlating the responses received for
    * active dispositions.
    */
@@ -129,47 +129,47 @@ export class MessageSession extends LinkEntity<Receiver> {
     DeferredPromiseAndTimer
   >();
   /**
-   * @property {OnMessage} _onMessage The message handler provided by the user that will
+   * The message handler provided by the user that will
    * be wrapped inside _onAmqpMessage.
    */
   private _onMessage!: OnMessage;
   /**
-   * @property {OnError} _onError The error handler provided by the user that will be wrapped
+   * The error handler provided by the user that will be wrapped
    * inside _onAmqpError.
    */
   private _onError?: OnError;
   /**
-   * @property {OnError} _notifyError If the user provided error handler is present then it will
+   * If the user provided error handler is present then it will
    * notify the user's error handler about the error.
    */
   private _notifyError: OnError;
   /**
-   * @property {OnAmqpEventAsPromise} _onAmqpClose The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_close" event.
    */
   private _onAmqpClose: OnAmqpEventAsPromise;
   /**
-   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_error" event.
    */
   private _onSessionError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEventAsPromise} _onSessionClose The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_close" event.
    */
   private _onSessionClose: OnAmqpEventAsPromise;
   /**
-   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_error" event.
    */
   private _onAmqpError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSettled The message handler that will be set as the handler on the
+   * The message handler that will be set as the handler on the
    * underlying rhea receiver for the "settled" event.
    */
   private _onSettled: OnAmqpEvent;
   /**
-   * @property {NodeJS.Timer} _sessionLockRenewalTimer The session lock renewal timer that keeps
+   * The session lock renewal timer that keeps
    * track of when the MessageSession is due for session lock renewal.
    */
   private _sessionLockRenewalTimer?: NodeJS.Timer;

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -347,7 +347,7 @@ export class MessageSession extends LinkEntity<Receiver> {
    * Constructs a MessageSession instance which lets you receive messages as batches
    * or via callbacks using subscribe.
    *
-   * @param _providedSessionId The sessionId provided by the user. This can be the
+   * @param _providedSessionId - The sessionId provided by the user. This can be the
    * name of a session ID to open (empty string is also valid) or it can be undefined,
    * to indicate we want the next unlocked non-empty session.
    */

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -114,9 +114,9 @@ export function sanitizeSerializableObject(resource: { [key: string]: any }) {
 /**
  * @internal
  * Serializes input information to construct the Atom XML request
- * @param resourceName Name of the resource to be serialized like `QueueDescription`
- * @param resource The entity details
- * @param allowedProperties The set of properties that are allowed by the service for the
+ * @param resourceName - Name of the resource to be serialized like `QueueDescription`
+ * @param resource - The entity details
+ * @param allowedProperties - The set of properties that are allowed by the service for the
  * associated operation(s);
  */
 export function serializeToAtomXmlRequest(resourceName: string, resource: any): object {
@@ -144,7 +144,7 @@ export function serializeToAtomXmlRequest(resourceName: string, resource: any): 
 /**
  * @internal
  * Transforms response to contain the parsed data.
- * @param nameProperties The set of 'name' properties to be constructed on the
+ * @param nameProperties - The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
  * @param response
  * @param shouldParseResponse
@@ -167,7 +167,7 @@ export async function deserializeAtomXmlResponse(
  * @internal
  * Utility to deserialize the given JSON content in response body based on
  * if it's a single `entry` or `feed` and updates the `response.parsedBody` to hold the evaluated output.
- * @param response Response containing the JSON value in `response.parsedBody`
+ * @param response - Response containing the JSON value in `response.parsedBody`
  * @nameProperties The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
  * */

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -99,7 +99,7 @@ export async function executeAtomXmlOperation(
  *
  * This method recursively removes the key-value pairs with undefined/null as the values from the request object that is to be serialized.
  *
- * @param {{ [key: string]: any }} resource
+ * @param resource
  */
 export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
@@ -307,7 +307,7 @@ function parseFeedResult(feed: any): object[] & { nextLink?: string } {
 
 /**
  * @internal
- * @param {number} statusCode
+ * @param statusCode
  * @returns {statusCode is keyof typeof Constants.HttpResponseCodes}
  */
 function isKnownResponseCode(

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -34,8 +34,8 @@ export interface AtomXmlSerializer {
 /**
  * @internal
  * Utility to execute Atom XML operations as HTTP requests
- * @param webResource
- * @param serializer
+ * @param webResource -
+ * @param serializer -
  */
 export async function executeAtomXmlOperation(
   serviceBusAtomManagementClient: ServiceClient,
@@ -99,7 +99,7 @@ export async function executeAtomXmlOperation(
  *
  * This method recursively removes the key-value pairs with undefined/null as the values from the request object that is to be serialized.
  *
- * @param resource
+ * @param resource -
  */
 export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
@@ -146,8 +146,8 @@ export function serializeToAtomXmlRequest(resourceName: string, resource: any): 
  * Transforms response to contain the parsed data.
  * @param nameProperties - The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
- * @param response
- * @param shouldParseResponse
+ * @param response -
+ * @param shouldParseResponse -
  */
 export async function deserializeAtomXmlResponse(
   nameProperties: string[],
@@ -214,7 +214,7 @@ function parseAtomResult(response: HttpOperationResponse, nameProperties: string
 /**
  * @internal
  * Utility to help parse given `entry` result
- * @param entry
+ * @param entry -
  */
 function parseEntryResult(entry: any): object | undefined {
   let result: any;
@@ -262,7 +262,7 @@ function parseEntryResult(entry: any): object | undefined {
 /**
  * @internal
  * Utility to help parse link info from the given `feed` result
- * @param feedLink
+ * @param feedLink -
  */
 function parseLinkInfo(
   feedLink: { [Constants.XML_METADATA_MARKER]: { rel: string; href: string } }[],
@@ -282,7 +282,7 @@ function parseLinkInfo(
 /**
  * @internal
  * Utility to help parse given `feed` result
- * @param feed
+ * @param feed -
  */
 function parseFeedResult(feed: any): object[] & { nextLink?: string } {
   const result: object[] & { nextLink?: string } = [];
@@ -307,7 +307,7 @@ function parseFeedResult(feed: any): object[] & { nextLink?: string } {
 
 /**
  * @internal
- * @param statusCode
+ * @param statusCode -
  * @returns {statusCode is keyof typeof Constants.HttpResponseCodes}
  */
 function isKnownResponseCode(
@@ -330,8 +330,8 @@ function isKnownResponseCode(
  *     - `<namespace-component>/<topic-name>/Subscriptions/<subscription-name>`
  *     - `<namespace-component>/<any-entity-name>`
  *
- * @param entry
- * @param nameProperties
+ * @param entry -
+ * @param nameProperties -
  */
 function setName(entry: any, nameProperties: any): any {
   if (entry[Constants.ATOM_METADATA_MARKER]) {
@@ -379,7 +379,7 @@ function setName(entry: any, nameProperties: any): any {
  * @internal
  * Utility to help construct the normalized `RestError` object based on given error
  * information and other data present in the received `response` object.
- * @param response
+ * @param response -
  */
 export function buildError(response: HttpOperationResponse): RestError {
   if (!isKnownResponseCode(response.status)) {
@@ -425,8 +425,8 @@ export function buildError(response: HttpOperationResponse): RestError {
  * @internal
  * Helper utility to construct user friendly error codes based on based on given error
  * information and other data present in the received `response` object.
- * @param response
- * @param errorMessage
+ * @param response -
+ * @param errorMessage -
  */
 function getErrorCode(response: HttpOperationResponse, errorMessage: string): string {
   if (response.status == 401) {

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -168,7 +168,7 @@ export async function deserializeAtomXmlResponse(
  * Utility to deserialize the given JSON content in response body based on
  * if it's a single `entry` or `feed` and updates the `response.parsedBody` to hold the evaluated output.
  * @param response - Response containing the JSON value in `response.parsedBody`
- * @nameProperties The set of 'name' properties to be constructed on the
+ * @param nameProperties - The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
  * */
 function parseAtomResult(response: HttpOperationResponse, nameProperties: string[]): void {

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -34,8 +34,6 @@ export interface AtomXmlSerializer {
 /**
  * @internal
  * Utility to execute Atom XML operations as HTTP requests
- * @param webResource -
- * @param serializer -
  */
 export async function executeAtomXmlOperation(
   serviceBusAtomManagementClient: ServiceClient,
@@ -99,7 +97,6 @@ export async function executeAtomXmlOperation(
  *
  * This method recursively removes the key-value pairs with undefined/null as the values from the request object that is to be serialized.
  *
- * @param resource -
  */
 export function sanitizeSerializableObject(resource: { [key: string]: any }) {
   Object.keys(resource).forEach(function(property) {
@@ -146,8 +143,6 @@ export function serializeToAtomXmlRequest(resourceName: string, resource: any): 
  * Transforms response to contain the parsed data.
  * @param nameProperties - The set of 'name' properties to be constructed on the
  * resultant object e.g., QueueName, TopicName, etc.
- * @param response -
- * @param shouldParseResponse -
  */
 export async function deserializeAtomXmlResponse(
   nameProperties: string[],
@@ -214,7 +209,6 @@ function parseAtomResult(response: HttpOperationResponse, nameProperties: string
 /**
  * @internal
  * Utility to help parse given `entry` result
- * @param entry -
  */
 function parseEntryResult(entry: any): object | undefined {
   let result: any;
@@ -262,7 +256,6 @@ function parseEntryResult(entry: any): object | undefined {
 /**
  * @internal
  * Utility to help parse link info from the given `feed` result
- * @param feedLink -
  */
 function parseLinkInfo(
   feedLink: { [Constants.XML_METADATA_MARKER]: { rel: string; href: string } }[],
@@ -282,7 +275,6 @@ function parseLinkInfo(
 /**
  * @internal
  * Utility to help parse given `feed` result
- * @param feed -
  */
 function parseFeedResult(feed: any): object[] & { nextLink?: string } {
   const result: object[] & { nextLink?: string } = [];
@@ -307,7 +299,6 @@ function parseFeedResult(feed: any): object[] & { nextLink?: string } {
 
 /**
  * @internal
- * @param statusCode -
  * @returns {statusCode is keyof typeof Constants.HttpResponseCodes}
  */
 function isKnownResponseCode(
@@ -330,8 +321,6 @@ function isKnownResponseCode(
  *     - `<namespace-component>/<topic-name>/Subscriptions/<subscription-name>`
  *     - `<namespace-component>/<any-entity-name>`
  *
- * @param entry -
- * @param nameProperties -
  */
 function setName(entry: any, nameProperties: any): any {
   if (entry[Constants.ATOM_METADATA_MARKER]) {
@@ -379,7 +368,6 @@ function setName(entry: any, nameProperties: any): any {
  * @internal
  * Utility to help construct the normalized `RestError` object based on given error
  * information and other data present in the received `response` object.
- * @param response -
  */
 export function buildError(response: HttpOperationResponse): RestError {
   if (!isKnownResponseCode(response.status)) {
@@ -425,8 +413,6 @@ export function buildError(response: HttpOperationResponse): RestError {
  * @internal
  * Helper utility to construct user friendly error codes based on based on given error
  * information and other data present in the received `response` object.
- * @param response -
- * @param errorMessage -
  */
 function getErrorCode(response: HttpOperationResponse, errorMessage: string): string {
   if (response.status == 401) {

--- a/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
+++ b/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
@@ -47,7 +47,7 @@ export interface ServiceBusConnectionStringProperties {
 /**
  * Parses given connection string into the different properties applicable to Azure Service Bus.
  * The properties are useful to then construct a ServiceBusClient.
- * @param connectionString The connection string associated with the Shared Access Policy created
+ * @param connectionString - The connection string associated with the Shared Access Policy created
  * for the Service Bus namespace, queue or topic.
  */
 export function parseServiceBusConnectionString(

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -42,7 +42,7 @@ function convertToUint8Array(value: string) {
 
 /**
  * Encodes a byte array in base64 format.
- * @param value the Uint8Aray to encode
+ * @param value - the Uint8Aray to encode
  * @internal
  * @param {Uint8Array} value
  * @returns {string}

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -6,8 +6,6 @@
 
 /**
  * @internal
- * @param secret -
- * @param stringToSign -
  * @returns {Promise<string>}
  */
 export async function generateKey(secret: string, stringToSign: string): Promise<string> {
@@ -30,7 +28,6 @@ export async function generateKey(secret: string, stringToSign: string): Promise
 
 /**
  * @internal
- * @param value -
  */
 function convertToUint8Array(value: string) {
   const arr = new Uint8Array(value.length);
@@ -44,7 +41,6 @@ function convertToUint8Array(value: string) {
  * Encodes a byte array in base64 format.
  * @param value - the Uint8Aray to encode
  * @internal
- * @param value -
  * @returns {string}
  */
 function encodeByteArray(value: Uint8Array): string {

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -6,8 +6,8 @@
 
 /**
  * @internal
- * @param {string} secret
- * @param {string} stringToSign
+ * @param secret
+ * @param stringToSign
  * @returns {Promise<string>}
  */
 export async function generateKey(secret: string, stringToSign: string): Promise<string> {
@@ -30,7 +30,7 @@ export async function generateKey(secret: string, stringToSign: string): Promise
 
 /**
  * @internal
- * @param {string} value
+ * @param value
  */
 function convertToUint8Array(value: string) {
   const arr = new Uint8Array(value.length);
@@ -44,7 +44,7 @@ function convertToUint8Array(value: string) {
  * Encodes a byte array in base64 format.
  * @param value - the Uint8Aray to encode
  * @internal
- * @param {Uint8Array} value
+ * @param value
  * @returns {string}
  */
 function encodeByteArray(value: Uint8Array): string {

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -6,8 +6,8 @@
 
 /**
  * @internal
- * @param secret
- * @param stringToSign
+ * @param secret -
+ * @param stringToSign -
  * @returns {Promise<string>}
  */
 export async function generateKey(secret: string, stringToSign: string): Promise<string> {
@@ -30,7 +30,7 @@ export async function generateKey(secret: string, stringToSign: string): Promise
 
 /**
  * @internal
- * @param value
+ * @param value -
  */
 function convertToUint8Array(value: string) {
   const arr = new Uint8Array(value.length);
@@ -44,7 +44,7 @@ function convertToUint8Array(value: string) {
  * Encodes a byte array in base64 format.
  * @param value - the Uint8Aray to encode
  * @internal
- * @param value
+ * @param value -
  * @returns {string}
  */
 function encodeByteArray(value: Uint8Array): string {

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -27,7 +27,7 @@ export const InvalidMaxMessageCountError = "'maxMessageCount' must be a number g
 /**
  * @internal
  * Logs and throws Error if the current AMQP connection is closed.
- * @param context The ConnectionContext associated with the current AMQP connection.
+ * @param context - The ConnectionContext associated with the current AMQP connection.
  */
 export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
   if (context && context.wasConnectionCloseCalled) {
@@ -41,7 +41,7 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
 /**
  * @internal
  * Gets the error message when a sender is used when its already closed
- * @param entityPath Value of the `entityPath` property on the client which denotes its name
+ * @param entityPath - Value of the `entityPath` property on the client which denotes its name
  */
 export function getSenderClosedErrorMsg(entityPath: string): string {
   return (
@@ -53,8 +53,8 @@ export function getSenderClosedErrorMsg(entityPath: string): string {
 /**
  * @internal
  * Gets the error message when a receiver is used when its already closed
- * @param entityPath Value of the `entityPath` property on the client which denotes its name
- * @param sessionId If using session receiver, then the id of the session
+ * @param entityPath - Value of the `entityPath` property on the client which denotes its name
+ * @param sessionId - If using session receiver, then the id of the session
  */
 export function getReceiverClosedErrorMsg(entityPath: string, sessionId?: string): string {
   if (sessionId == undefined) {
@@ -71,8 +71,8 @@ export function getReceiverClosedErrorMsg(entityPath: string, sessionId?: string
 
 /**
  * @internal
- * @param entityPath Value of the `entityPath` property on the client which denotes its name
- * @param sessionId If using session receiver, then the id of the session
+ * @param entityPath - Value of the `entityPath` property on the client which denotes its name
+ * @param sessionId - If using session receiver, then the id of the session
  */
 export function getAlreadyReceivingErrorMsg(entityPath: string, sessionId?: string): string {
   if (sessionId == undefined) {
@@ -84,9 +84,9 @@ export function getAlreadyReceivingErrorMsg(entityPath: string, sessionId?: stri
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is undefined or null
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param parameterName Name of the parameter to check
- * @param parameterValue Value of the parameter to check
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to check
+ * @param parameterValue - Value of the parameter to check
  */
 export function throwTypeErrorIfParameterMissing(
   connectionId: string,
@@ -103,10 +103,10 @@ export function throwTypeErrorIfParameterMissing(
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is not of expected type
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param parameterName Name of the parameter to type check
- * @param parameterValue Value of the parameter to type check
- * @param expectedType Expected type of the parameter
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to type check
+ * @param parameterValue - Value of the parameter to type check
+ * @param expectedType - Expected type of the parameter
  */
 
 export function throwTypeErrorIfParameterTypeMismatch(
@@ -127,9 +127,9 @@ export function throwTypeErrorIfParameterTypeMismatch(
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is not of type `Long` or an array of type `Long`
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param parameterName Name of the parameter to type check
- * @param parameterValue Value of the parameter to type check
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to type check
+ * @param parameterValue - Value of the parameter to type check
  */
 export function throwTypeErrorIfParameterNotLong(
   connectionId: string,
@@ -150,9 +150,9 @@ export function throwTypeErrorIfParameterNotLong(
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is not an array of type `Long`
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param parameterName Name of the parameter to type check
- * @param parameterValue Value of the parameter to type check
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to type check
+ * @param parameterValue - Value of the parameter to type check
  */
 export function throwTypeErrorIfParameterNotLongArray(
   connectionId: string,
@@ -170,9 +170,9 @@ export function throwTypeErrorIfParameterNotLongArray(
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is an empty string
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param parameterName Name of the parameter to type check
- * @param parameterValue Value of the parameter to type check
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to type check
+ * @param parameterValue - Value of the parameter to type check
  */
 export function throwTypeErrorIfParameterIsEmptyString(
   connectionId: string,
@@ -246,8 +246,8 @@ export const PartitionKeySessionIdMismatchError =
 /**
  * Throws error if the given object is not a valid ServiceBusMessage
  * @internal
- * @param msg The object that needs to be validated as a ServiceBusMessage
- * @param errorMessageForWrongType The error message to use when given object is not a ServiceBusMessage
+ * @param msg - The object that needs to be validated as a ServiceBusMessage
+ * @param errorMessageForWrongType - The error message to use when given object is not a ServiceBusMessage
  */
 export function throwIfNotValidServiceBusMessage(msg: any, errorMessageForWrongType: string): void {
   if (!isServiceBusMessage(msg)) {

--- a/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
@@ -6,7 +6,7 @@
 
 /**
  * @internal
- * @param {string} rawUrl
+ * @param rawUrl
  */
 export const parseURL = (rawUrl: string): any => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
@@ -6,7 +6,6 @@
 
 /**
  * @internal
- * @param rawUrl -
  */
 export const parseURL = (rawUrl: string): any => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.browser.ts
@@ -6,7 +6,7 @@
 
 /**
  * @internal
- * @param rawUrl
+ * @param rawUrl -
  */
 export const parseURL = (rawUrl: string): any => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/sdk/servicebus/service-bus/src/util/parseUrl.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.ts
@@ -11,7 +11,7 @@ const url = require("url");
 
 /**
  * @internal
- * @param {string} rawUrl
+ * @param rawUrl
  */
 export const parseURL = (rawUrl: string) => {
   return new url.URL(rawUrl);

--- a/sdk/servicebus/service-bus/src/util/parseUrl.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.ts
@@ -11,7 +11,6 @@ const url = require("url");
 
 /**
  * @internal
- * @param rawUrl -
  */
 export const parseURL = (rawUrl: string) => {
   return new url.URL(rawUrl);

--- a/sdk/servicebus/service-bus/src/util/parseUrl.ts
+++ b/sdk/servicebus/service-bus/src/util/parseUrl.ts
@@ -11,7 +11,7 @@ const url = require("url");
 
 /**
  * @internal
- * @param rawUrl
+ * @param rawUrl -
  */
 export const parseURL = (rawUrl: string) => {
   return new url.URL(rawUrl);

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -11,8 +11,6 @@ import { generateKey } from "./crypto";
 
 /**
  * @internal
- * @class SasServiceClientCredentials
- * @implements {ServiceClientCredentials}
  */
 export class SasServiceClientCredentials implements ServiceClientCredentials {
   keyName: string;

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -20,8 +20,8 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
    * Creates a new sasServiceClientCredentials object.
    *
    * @constructor
-   * @param sharedAccessKeyName The SAS key name to use.
-   * @param sharedAccessKey The SAS key value to use
+   * @param sharedAccessKeyName - The SAS key name to use.
+   * @param sharedAccessKey - The SAS key value to use
    */
   constructor(sharedAccessKeyName: string, sharedAccessKey: string) {
     this.keyName = sharedAccessKeyName;
@@ -38,7 +38,7 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param webResource The WebResource to be signed.
+   * @param webResource - The WebResource to be signed.
    * @returns {Promise<WebResource>} The signed request object.
    */
   async signRequest(webResource: WebResource): Promise<WebResource> {

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -22,8 +22,8 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
    * Creates a new sasServiceClientCredentials object.
    *
    * @constructor
-   * @param {string} sharedAccessKeyName The SAS key name to use.
-   * @param {string} sharedAccessKey The SAS key value to use
+   * @param sharedAccessKeyName The SAS key name to use.
+   * @param sharedAccessKey The SAS key value to use
    */
   constructor(sharedAccessKeyName: string, sharedAccessKey: string) {
     this.keyName = sharedAccessKeyName;
@@ -40,7 +40,7 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
+   * @param webResource The WebResource to be signed.
    * @returns {Promise<WebResource>} The signed request object.
    */
   async signRequest(webResource: WebResource): Promise<WebResource> {

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -19,7 +19,6 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
   /**
    * Creates a new sasServiceClientCredentials object.
    *
-   * @constructor
    * @param sharedAccessKeyName - The SAS key name to use.
    * @param sharedAccessKey - The SAS key value to use
    */

--- a/sdk/servicebus/service-bus/src/util/semaphore.ts
+++ b/sdk/servicebus/service-bus/src/util/semaphore.ts
@@ -4,7 +4,6 @@
 /**
  * @internal
  * A simple Semaphore
- * @class Semaphore
  */
 export class Semaphore {
   /**

--- a/sdk/servicebus/service-bus/src/util/semaphore.ts
+++ b/sdk/servicebus/service-bus/src/util/semaphore.ts
@@ -56,7 +56,7 @@ export class Semaphore {
   /**
    * Aquires a lock from the semaphore and then execute the fn. If the fn returns a Promise,
    * wait for that promise to settle and then release the lock back to the semaphore.
-   * @param fn The function that needs to be executed in the ciritical region.
+   * @param fn - The function that needs to be executed in the ciritical region.
    * @returns A Promise that will settle with the return value of fn.
    */
   use<T>(fn: () => T | PromiseLike<T>): Promise<T> {

--- a/sdk/servicebus/service-bus/src/util/tracing.ts
+++ b/sdk/servicebus/service-bus/src/util/tracing.ts
@@ -8,8 +8,8 @@ import { CanonicalCode, Span, SpanKind, SpanOptions as OTSpanOptions } from "@op
 /**
  * @internal
  * Creates a span using the global tracer.
- * @param name The name of the operation being performed.
- * @param operationOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param operationOptions - The options for the underlying http request.
  */
 export function createSpan(
   operationName: string,

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -646,7 +646,7 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
  * @internal
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
- * @param [prefix]
+ * @param prefix
  * @returns {string}
  */
 export function formatUserAgentPrefix(prefix?: string): string {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -171,7 +171,7 @@ export function toBuffer(input: any): Buffer {
  * @internal
  * Helper utility to retrieve `string` value from given string,
  * or throws error if undefined.
- * @param value
+ * @param value -
  */
 export function getString(value: any, nameOfProperty: string): string {
   const result = getStringOrUndefined(value);
@@ -187,7 +187,7 @@ export function getString(value: any, nameOfProperty: string): string {
  * @internal
  * Helper utility to retrieve `string` value from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function getStringOrUndefined(value: any): string | undefined {
   if (value == undefined) {
@@ -200,7 +200,7 @@ export function getStringOrUndefined(value: any): string | undefined {
  * @internal
  * Helper utility to retrieve `integer` value from given string,
  * or throws error if undefined.
- * @param value
+ * @param value -
  */
 export function getInteger(value: any, nameOfProperty: string): number {
   const result = getIntegerOrUndefined(value);
@@ -216,7 +216,7 @@ export function getInteger(value: any, nameOfProperty: string): number {
  * @internal
  * Helper utility to retrieve `integer` value from given string,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function getIntegerOrUndefined(value: any): number | undefined {
   if (value == undefined) {
@@ -229,7 +229,7 @@ export function getIntegerOrUndefined(value: any): number | undefined {
 /**
  * @internal
  * Helper utility to convert ISO-8601 time into Date type.
- * @param value
+ * @param value -
  */
 export function getDate(value: string, nameOfProperty: string): Date {
   return new Date(getString(value, nameOfProperty));
@@ -239,7 +239,7 @@ export function getDate(value: string, nameOfProperty: string): Date {
  * @internal
  * Helper utility to retrieve `boolean` value from given string,
  * or throws error if undefined.
- * @param value
+ * @param value -
  */
 export function getBoolean(value: any, nameOfProperty: string): boolean {
   const result = getBooleanOrUndefined(value);
@@ -255,7 +255,7 @@ export function getBoolean(value: any, nameOfProperty: string): boolean {
  * @internal
  * Helper utility to retrieve `boolean` value from given string,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function getBooleanOrUndefined(value: any): boolean | undefined {
   if (value == undefined) {
@@ -278,7 +278,7 @@ const EMPTY_JSON_OBJECT_CONSTRUCTOR = {}.constructor;
 /**
  * @internal
  * Returns `true` if given input is a JSON like object.
- * @param value
+ * @param value -
  */
 export function isJSONLikeObject(value: any): boolean {
   // `value.constructor === {}.constructor` differentiates among the "object"s,
@@ -299,7 +299,7 @@ export function isJSONLikeObject(value: any): boolean {
 /**
  * @internal
  * Helper utility to retrieve message count details from given input,
- * @param value
+ * @param value -
  */
 export function getMessageCountDetails(value: any): MessageCountDetails {
   const xmlnsPrefix = getXMLNSPrefix(value);
@@ -397,7 +397,7 @@ export interface AuthorizationRule {
  * @internal
  * Helper utility to retrieve array of `AuthorizationRule` from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function getAuthorizationRulesOrUndefined(value: any): AuthorizationRule[] | undefined {
   const authorizationRules: AuthorizationRule[] = [];
@@ -425,7 +425,7 @@ export function getAuthorizationRulesOrUndefined(value: any): AuthorizationRule[
 /**
  * @internal
  * Helper utility to build an instance of parsed authorization rule as `AuthorizationRule` from given input.
- * @param value
+ * @param value -
  */
 function buildAuthorizationRule(value: any): AuthorizationRule {
   let accessRights;
@@ -451,7 +451,7 @@ function buildAuthorizationRule(value: any): AuthorizationRule {
  * @internal
  * Helper utility to extract output containing array of `RawAuthorizationRule` instances from given input,
  * or undefined if not passed in.
- * @param value
+ * @param value -
  */
 export function getRawAuthorizationRules(authorizationRules: AuthorizationRule[] | undefined): any {
   if (authorizationRules == undefined) {
@@ -512,7 +512,7 @@ function buildRawAuthorizationRule(authorizationRule: AuthorizationRule): any {
 /**
  * @internal
  * Helper utility to check if given string is an absolute URL
- * @param url
+ * @param url -
  */
 export function isAbsoluteUrl(url: string) {
   const _url = url.toLowerCase();
@@ -646,7 +646,7 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
  * @internal
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
- * @param prefix
+ * @param prefix -
  * @returns {string}
  */
 export function formatUserAgentPrefix(prefix?: string): string {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -637,7 +637,7 @@ export function checkAndRegisterWithAbortSignal(
 
 /**
  * @internal
- * @property {string} libInfo The user agent prefix string for the ServiceBus client.
+ * The user agent prefix string for the ServiceBus client.
  * See guideline at https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
  */
 export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJsonInfo.version}`;

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -646,7 +646,7 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
  * @internal
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
- * @param {string} [prefix]
+ * @param [prefix]
  * @returns {string}
  */
 export function formatUserAgentPrefix(prefix?: string): string {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -29,7 +29,7 @@ declare const navigator: Navigator;
  * @internal
  * Provides a uniue name by appending a string guid to the given string in the following format:
  * `{name}-{uuid}`.
- * @param name The nme of the entity
+ * @param name - The nme of the entity
  */
 export function getUniqueName(name: string): string {
   return `${name}-${generate_uuid()}`;
@@ -41,7 +41,7 @@ export function getUniqueName(name: string): string {
  * flipped within the group, but the last two groups don't get flipped, so we end up with a
  * different byte order. This is the order of bytes needed to make Service Bus recognize the token.
  *
- * @param lockToken The lock token whose bytes need to be reorded.
+ * @param lockToken - The lock token whose bytes need to be reorded.
  * @returns Buffer - Buffer representing reordered bytes.
  */
 export function reorderLockToken(lockTokenBytes: Buffer): Buffer {
@@ -105,7 +105,7 @@ export function calculateRenewAfterDuration(lockedUntilUtc: Date): number {
  * - Ticks in DateTimeOffset is `1/10000000` second, while ticks in JS Date is `1/1000` second.
  *   - Thus, we `divide` the value by `10000` to convert it to JS Date ticks.
  *
- * @param buf Input as a Buffer
+ * @param buf - Input as a Buffer
  * @returns Date The JS Date object.
  */
 export function convertTicksToDate(buf: number[]): Date {
@@ -136,7 +136,7 @@ export function getProcessorCount(): number {
 /**
  * @internal
  * Converts any given input to a Buffer.
- * @param input The input that needs to be converted to a Buffer.
+ * @param input - The input that needs to be converted to a Buffer.
  */
 export function toBuffer(input: any): Buffer {
   let result: any;
@@ -478,7 +478,7 @@ export function getRawAuthorizationRules(authorizationRules: AuthorizationRule[]
 /**
  * @internal
  * Helper utility to build an instance of raw authorization rule as RawAuthorizationRule from given `AuthorizationRule` input.
- * @param authorizationRule parsed Authorization Rule instance
+ * @param authorizationRule - parsed Authorization Rule instance
  */
 function buildRawAuthorizationRule(authorizationRule: AuthorizationRule): any {
   if (!isJSONLikeObject(authorizationRule) || authorizationRule === null) {

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -171,7 +171,6 @@ export function toBuffer(input: any): Buffer {
  * @internal
  * Helper utility to retrieve `string` value from given string,
  * or throws error if undefined.
- * @param value -
  */
 export function getString(value: any, nameOfProperty: string): string {
   const result = getStringOrUndefined(value);
@@ -187,7 +186,6 @@ export function getString(value: any, nameOfProperty: string): string {
  * @internal
  * Helper utility to retrieve `string` value from given input,
  * or undefined if not passed in.
- * @param value -
  */
 export function getStringOrUndefined(value: any): string | undefined {
   if (value == undefined) {
@@ -200,7 +198,6 @@ export function getStringOrUndefined(value: any): string | undefined {
  * @internal
  * Helper utility to retrieve `integer` value from given string,
  * or throws error if undefined.
- * @param value -
  */
 export function getInteger(value: any, nameOfProperty: string): number {
   const result = getIntegerOrUndefined(value);
@@ -216,7 +213,6 @@ export function getInteger(value: any, nameOfProperty: string): number {
  * @internal
  * Helper utility to retrieve `integer` value from given string,
  * or undefined if not passed in.
- * @param value -
  */
 export function getIntegerOrUndefined(value: any): number | undefined {
   if (value == undefined) {
@@ -229,7 +225,6 @@ export function getIntegerOrUndefined(value: any): number | undefined {
 /**
  * @internal
  * Helper utility to convert ISO-8601 time into Date type.
- * @param value -
  */
 export function getDate(value: string, nameOfProperty: string): Date {
   return new Date(getString(value, nameOfProperty));
@@ -239,7 +234,6 @@ export function getDate(value: string, nameOfProperty: string): Date {
  * @internal
  * Helper utility to retrieve `boolean` value from given string,
  * or throws error if undefined.
- * @param value -
  */
 export function getBoolean(value: any, nameOfProperty: string): boolean {
   const result = getBooleanOrUndefined(value);
@@ -255,7 +249,6 @@ export function getBoolean(value: any, nameOfProperty: string): boolean {
  * @internal
  * Helper utility to retrieve `boolean` value from given string,
  * or undefined if not passed in.
- * @param value -
  */
 export function getBooleanOrUndefined(value: any): boolean | undefined {
   if (value == undefined) {
@@ -278,7 +271,6 @@ const EMPTY_JSON_OBJECT_CONSTRUCTOR = {}.constructor;
 /**
  * @internal
  * Returns `true` if given input is a JSON like object.
- * @param value -
  */
 export function isJSONLikeObject(value: any): boolean {
   // `value.constructor === {}.constructor` differentiates among the "object"s,
@@ -299,7 +291,6 @@ export function isJSONLikeObject(value: any): boolean {
 /**
  * @internal
  * Helper utility to retrieve message count details from given input,
- * @param value -
  */
 export function getMessageCountDetails(value: any): MessageCountDetails {
   const xmlnsPrefix = getXMLNSPrefix(value);
@@ -397,7 +388,6 @@ export interface AuthorizationRule {
  * @internal
  * Helper utility to retrieve array of `AuthorizationRule` from given input,
  * or undefined if not passed in.
- * @param value -
  */
 export function getAuthorizationRulesOrUndefined(value: any): AuthorizationRule[] | undefined {
   const authorizationRules: AuthorizationRule[] = [];
@@ -425,7 +415,6 @@ export function getAuthorizationRulesOrUndefined(value: any): AuthorizationRule[
 /**
  * @internal
  * Helper utility to build an instance of parsed authorization rule as `AuthorizationRule` from given input.
- * @param value -
  */
 function buildAuthorizationRule(value: any): AuthorizationRule {
   let accessRights;
@@ -451,7 +440,6 @@ function buildAuthorizationRule(value: any): AuthorizationRule {
  * @internal
  * Helper utility to extract output containing array of `RawAuthorizationRule` instances from given input,
  * or undefined if not passed in.
- * @param value -
  */
 export function getRawAuthorizationRules(authorizationRules: AuthorizationRule[] | undefined): any {
   if (authorizationRules == undefined) {
@@ -512,7 +500,6 @@ function buildRawAuthorizationRule(authorizationRule: AuthorizationRule): any {
 /**
  * @internal
  * Helper utility to check if given string is an absolute URL
- * @param url -
  */
 export function isAbsoluteUrl(url: string) {
   const _url = url.toLowerCase();
@@ -646,7 +633,6 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
  * @internal
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
  *
- * @param prefix -
  * @returns {string}
  */
 export function formatUserAgentPrefix(prefix?: string): string {

--- a/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
@@ -1,5 +1,5 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 // import chai from "chai";
 // const assert = chai.assert;

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -71,8 +71,8 @@ describe("Deferred Messages", () => {
 
   /**
    * Sends, defers, receives and then returns a test message
-   * @param testMessage Test message to send, defer, receive and then return
-   * @param passSequenceNumberInArray Boolean to indicate whether to pass the sequence number
+   * @param testMessage - Test message to send, defer, receive and then return
+   * @param passSequenceNumberInArray - Boolean to indicate whether to pass the sequence number
    * as is or in an array to ensure both get code coverage
    */
   async function deferMessage(

--- a/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/messageSession.spec.ts
@@ -358,7 +358,7 @@ describe("Message session unit tests", () => {
       try {
         let errorArgs: ProcessErrorArgs | undefined;
 
-        let eventContext = {
+        const eventContext = {
           delivery: {},
           message: {
             message_annotations: {

--- a/sdk/servicebus/service-bus/test/internal/serviceBusMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusMessage.spec.ts
@@ -56,7 +56,7 @@ describe("ServiceBusMessageImpl AmqpAnnotations unit tests", () => {
   const message_annotations: MessageAnnotations = {};
   message_annotations[Constants.enqueuedTime] = Date.now();
   message_annotations[Constants.partitionKey] = "dummy-partition-key";
-  //message_annotations[Constants.viaPartitionKey] = "dummy-via-partition-key";
+  // message_annotations[Constants.viaPartitionKey] = "dummy-via-partition-key";
   message_annotations["random-msg-annotation-key"] = "random-msg-annotation-value";
 
   const delivery_annotations: DeliveryAnnotations = {

--- a/sdk/servicebus/service-bus/test/internal/shared.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/shared.spec.ts
@@ -28,9 +28,9 @@ describe("shared", () => {
     });
 
     it(`basic translation`, () => {
-      let messagingError = new MessagingError("hello");
+      const messagingError = new MessagingError("hello");
       messagingError.code = "MessagingEntityNotFoundError";
-      let translatedError = translateServiceBusError(messagingError) as ServiceBusError;
+      const translatedError = translateServiceBusError(messagingError) as ServiceBusError;
 
       assert.deepEqual(
         {
@@ -57,9 +57,9 @@ describe("shared", () => {
     "GeneralError"
   ].forEach((unknownCode) => {
     it(`any unknown codes are marked with reason 'GeneralError': ${unknownCode}`, () => {
-      let messagingError = new MessagingError("hello");
+      const messagingError = new MessagingError("hello");
       messagingError.code = unknownCode;
-      let translatedError = translateServiceBusError(messagingError) as ServiceBusError;
+      const translatedError = translateServiceBusError(messagingError) as ServiceBusError;
       const expectedMessage = unknownCode ? `${unknownCode}: hello` : "hello";
 
       assert.deepEqual(

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
@@ -244,7 +244,7 @@ describe("StreamingReceiver unit tests", () => {
       try {
         let args: ProcessErrorArgs | undefined;
 
-        let eventContext = {
+        const eventContext = {
           delivery: {},
           message: {
             message_annotations: {
@@ -330,7 +330,7 @@ describe("StreamingReceiver unit tests", () => {
         }
       };
 
-      let errorsAfterRetryCycle: (Error | MessagingError | undefined)[] = [];
+      const errorsAfterRetryCycle: (Error | MessagingError | undefined)[] = [];
 
       await streamingReceiver.init({
         useNewName: false,

--- a/sdk/servicebus/service-bus/test/internal/tracing.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/tracing.spec.ts
@@ -259,7 +259,7 @@ describe("Tracing tests", () => {
   });
 
   function stubCreateProcessingSpan(receiver: any) {
-    let data: {
+    const data: {
       span?: TestSpan;
     } = {};
 

--- a/sdk/servicebus/service-bus/test/internal/unittestUtils.ts
+++ b/sdk/servicebus/service-bus/test/internal/unittestUtils.ts
@@ -27,7 +27,7 @@ export interface CreateConnectionContextForTestsOptions {
  *
  * Please feel free to expand this - every little bit helps the unit tests!
  *
- * @param options Makes it simple for you to modify the rhea
+ * @param options - Makes it simple for you to modify the rhea
  * receiver (via onCreateReceiverCalled) or get notified when a sender
  * is created (via onCreateAwaitableSenderCalled).
  *
@@ -113,7 +113,7 @@ export function createConnectionContextForTests(
  * Creates a test connection context that should work for testing ServiceBusSessionReceiverImpl
  * and MessageSession. By default it matches with an session ID of 'hello'.
  *
- * @param sessionId A session ID to use or the default ("hello")
+ * @param sessionId - A session ID to use or the default ("hello")
  */
 export function createConnectionContextForTestsWithSessionId(
   sessionId: string = "hello",

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -965,7 +965,7 @@ describe(testClientType + ": Streaming - disconnects", function(): void {
  * Creates a validator for processError that can handle the differences
  * between a browser and node.js when it comes to reported errors.
  *
- * @param receivedErrors Errors received while detaching
+ * @param receivedErrors - Errors received while detaching
  */
 export function createOnDetachedProcessErrorFake(): sinon.SinonSpy & {
   /**

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -257,9 +257,6 @@ export class SBStressTestsBase {
   }
 
   /**
-   * @param message -
-   * @param duration -
-   * @param completeMessageAfterDuration -
    */
   public renewMessageLockUntil(
     message: ServiceBusReceivedMessage,
@@ -319,7 +316,6 @@ export class SBStressTestsBase {
   }
 
   /**
-   * @param receiver -
    * @param duration Duration until which the lock is renewed
    */
   public renewSessionLockUntil(receiver: ServiceBusSessionReceiver, duration: number) {

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -257,9 +257,9 @@ export class SBStressTestsBase {
   }
 
   /**
-   * @param {ServiceBusReceivedMessageWithLock} message
-   * @param {number} duration
-   * @param {boolean} completeMessageAfterDuration
+   * @param message -
+   * @param duration -
+   * @param completeMessageAfterDuration -
    */
   public renewMessageLockUntil(
     message: ServiceBusReceivedMessage,
@@ -319,8 +319,8 @@ export class SBStressTestsBase {
   }
 
   /**
-   * @param {ServiceBusSessionReceiver<ServiceBusReceivedMessage>} receiver
-   * @param {number} duration Duration until which the lock is renewed
+   * @param receiver -
+   * @param duration Duration until which the lock is renewed
    */
   public renewSessionLockUntil(receiver: ServiceBusSessionReceiver, duration: number) {
     // TODO: pass in max number of lock renewals? and close the receiver at the end of max??

--- a/sdk/servicebus/service-bus/test/utils/envVarUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/envVarUtils.ts
@@ -16,7 +16,7 @@ export enum EnvVarNames {
 
 /**
  * Utility to retrieve the environment variable value with given name.
- * @param name
+ * @param name -
  */
 function getEnvVarValue(name: string): string | undefined {
   if (isNode) {

--- a/sdk/servicebus/service-bus/test/utils/envVarUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/envVarUtils.ts
@@ -16,7 +16,6 @@ export enum EnvVarNames {
 
 /**
  * Utility to retrieve the environment variable value with given name.
- * @param name -
  */
 function getEnvVarValue(name: string): string | undefined {
   if (isNode) {

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -31,7 +31,7 @@ async function getManagementClient() {
  * The retries will be preempted if given `breakConditionCallback` evaluates to `true` early on.
  * @param operationCallback -
  * @param breakConditionCallback -
- * @param operationDescription Text describing the operation. Used for logging purposes.
+ * @param operationDescription - Text describing the operation. Used for logging purposes.
  */
 async function retry(
   operationCallback: () => void,

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -188,7 +188,6 @@ export async function recreateSubscription(
 /**
  * Utility that verifies the message count of an entity.
  *
- * @export
  * @param expectedMessageCount -
  * @param queueName -
  * @param topicName -

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -29,8 +29,8 @@ async function getManagementClient() {
  * Utility to apply retries to a given `operationCallBack`.
  * Default policy is performing linear retries of up to `5` attempts that are `1000 milliseconds` apart.
  * The retries will be preempted if given `breakConditionCallback` evaluates to `true` early on.
- * @param operationCallback
- * @param breakConditionCallback
+ * @param operationCallback -
+ * @param breakConditionCallback -
  * @param operationDescription Text describing the operation. Used for logging purposes.
  */
 async function retry(
@@ -73,8 +73,8 @@ async function retry(
 
 /**
  * Utility that deletes and creates a queue using given parameters.
- * @param queueName
- * @param parameters
+ * @param queueName -
+ * @param parameters -
  */
 export async function recreateQueue(
   queueName: string,
@@ -111,8 +111,8 @@ export async function recreateQueue(
 
 /**
  * Utility that deletes and creates a topic using given parameters.
- * @param topicName
- * @param parameters
+ * @param topicName -
+ * @param parameters -
  */
 export async function recreateTopic(
   topicName: string,
@@ -149,9 +149,9 @@ export async function recreateTopic(
 
 /**
  * Utility that creates a subscription using given parameters.
- * @param topicName
- * @param subscriptionName
- * @param parameters
+ * @param topicName -
+ * @param subscriptionName -
+ * @param parameters -
  */
 export async function recreateSubscription(
   topicName: string,
@@ -214,7 +214,7 @@ export async function verifyMessageCount(
 
 /**
  * Utility function to get namespace string from given connection string
- * @param serviceBusConnectionString
+ * @param serviceBusConnectionString -
  */
 export function getNamespace(serviceBusConnectionString: string): string {
   return (serviceBusConnectionString.match("Endpoint=.*://(.*).servicebus.windows.net") || "")[1];

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -29,8 +29,6 @@ async function getManagementClient() {
  * Utility to apply retries to a given `operationCallBack`.
  * Default policy is performing linear retries of up to `5` attempts that are `1000 milliseconds` apart.
  * The retries will be preempted if given `breakConditionCallback` evaluates to `true` early on.
- * @param operationCallback -
- * @param breakConditionCallback -
  * @param operationDescription - Text describing the operation. Used for logging purposes.
  */
 async function retry(
@@ -73,8 +71,6 @@ async function retry(
 
 /**
  * Utility that deletes and creates a queue using given parameters.
- * @param queueName -
- * @param parameters -
  */
 export async function recreateQueue(
   queueName: string,
@@ -111,8 +107,6 @@ export async function recreateQueue(
 
 /**
  * Utility that deletes and creates a topic using given parameters.
- * @param topicName -
- * @param parameters -
  */
 export async function recreateTopic(
   topicName: string,
@@ -149,9 +143,6 @@ export async function recreateTopic(
 
 /**
  * Utility that creates a subscription using given parameters.
- * @param topicName -
- * @param subscriptionName -
- * @param parameters -
  */
 export async function recreateSubscription(
   topicName: string,
@@ -188,10 +179,6 @@ export async function recreateSubscription(
 /**
  * Utility that verifies the message count of an entity.
  *
- * @param expectedMessageCount -
- * @param queueName -
- * @param topicName -
- * @param subscriptionName -
  * @returns {Promise<void>}
  */
 export async function verifyMessageCount(
@@ -213,7 +200,6 @@ export async function verifyMessageCount(
 
 /**
  * Utility function to get namespace string from given connection string
- * @param serviceBusConnectionString -
  */
 export function getNamespace(serviceBusConnectionString: string): string {
   return (serviceBusConnectionString.match("Endpoint=.*://(.*).servicebus.windows.net") || "")[1];

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -189,10 +189,10 @@ export async function recreateSubscription(
  * Utility that verifies the message count of an entity.
  *
  * @export
- * @param {number} expectedMessageCount
- * @param {string} [queueName]
- * @param {string} [topicName]
- * @param {string} [subscriptionName]
+ * @param expectedMessageCount -
+ * @param queueName -
+ * @param topicName -
+ * @param subscriptionName -
  * @returns {Promise<void>}
  */
 export async function verifyMessageCount(

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -165,7 +165,7 @@ export async function checkWithTimeout(
 
 /**
  * Utility function to get namespace string from given connection string
- * @param serviceBusConnectionString
+ * @param serviceBusConnectionString -
  */
 export function getNamespace(serviceBusConnectionString: string): string {
   return (serviceBusConnectionString.match("Endpoint=.*://(.*).servicebus.windows.net") || "")[1];

--- a/sdk/servicebus/service-bus/test/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/testUtils.ts
@@ -165,7 +165,6 @@ export async function checkWithTimeout(
 
 /**
  * Utility function to get namespace string from given connection string
- * @param serviceBusConnectionString -
  */
 export function getNamespace(serviceBusConnectionString: string): string {
   return (serviceBusConnectionString.match("Endpoint=.*://(.*).servicebus.windows.net") || "")[1];

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -137,7 +137,7 @@ export async function drainAllMessages(receiver: ServiceBusReceiver) {
 
 /**
  * Returns a TestClientType for either a Queue or a Subscription
- * @param useSessions
+ * @param useSessions -
  */
 export function getRandomTestClientType(): TestClientType {
   const allTestClientTypes = [

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -137,7 +137,6 @@ export async function drainAllMessages(receiver: ServiceBusReceiver) {
 
 /**
  * Returns a TestClientType for either a Queue or a Subscription
- * @param useSessions -
  */
 export function getRandomTestClientType(): TestClientType {
   const allTestClientTypes = [


### PR DESCRIPTION
There were some mechanical transform fixes we could for linting (beyond errors that could be autofixed). There are still _quite_ a few more remaining but this is the easy set that's more or less just rote transformations.

There are no code changes to speak of - this entire change occurs in the comments.

Part of a series of changes for #10781