### PR TITLE
Add a createOctKey convenience method and relevant options.

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a constructor overload to `CryptographyClient` that takes a `JsonWebKey` and allows for local-only subset of operations.
 - Added `KeyId` to the public API of CryptographyClient.
 - Removed `parseKeyVaultKeysId` from the public API and made `KeyOptionsOptions.additionalAuthenticatedData` a readonly property.
+- Added a `createOctKey` convenience method to create a key of type `oct` or `oct-HSM` as appropriate.
 
 ## 4.2.0-beta.2 (2020-10-06)
 

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations/recording_can_create_an_oct_key_with_options.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations/recording_can_create_an_oct_key_with_options.json
@@ -1,0 +1,146 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "query": {
+    "api-version": "7.1"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "2e445fd8-64ef-11eb-8854-0242ac12000b",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Tue, 02 Feb 2021 00:39:59 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11444.12 - NCUS ProdSlices",
+    "x-ms-request-id": "599892fb-32d8-4b74-8211-f87a6deaaf00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "query": {
+    "api-version": "7.1"
+   },
+   "requestBody": "{\"kty\":\"oct-HSM\",\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1612226400,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1612226400},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/86b28bf6c92e012781fb30a70306963d\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "379",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "2e75adea-64ef-11eb-8854-0242ac12000b",
+    "x-ms-server-latency": "213"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.1"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1612226400,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1612226400},\"deletedDate\":1612226400,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/86b28bf6c92e012781fb30a70306963d\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1620002400}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "565",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "2eaf3916-64ef-11eb-8854-0242ac12000b",
+    "x-ms-server-latency": "136"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.1"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1612226400,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1612226400},\"deletedDate\":1612226400,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/86b28bf6c92e012781fb30a70306963d\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1620002400}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "565",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210128-1-4c3070d1-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "2edd61d8-64ef-11eb-8854-0242ac12000b",
+    "x-ms-server-latency": "59"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.1"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "2efee5ba-64ef-11eb-8854-0242ac12000b",
+    "x-ms-server-latency": "144"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "d11dbdb04de555b87c098999a70cc618"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations/recording_can_create_an_oct_key_with_options.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations/recording_can_create_an_oct_key_with_options.js
@@ -1,0 +1,178 @@
+let nock = require('nock');
+
+module.exports.hash = "b2df495aea09d11d6586c5d0cdc3d49e";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '2a1cd098-64ef-11eb-91de-0242ac120003',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '91607e6f-71dd-4259-a759-d8eae447b800',
+  'x-ms-ests-server',
+  '2.1.11444.12 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=ApHPgK2Vz_1PlUa33MNOo45dWxHLAQAAAFiWqtcOAAAA; expires=Thu, 04-Mar-2021 00:39:53 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 02 Feb 2021 00:39:52 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create', {"kty":"oct-HSM","attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1612226393,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1612226393},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/6e832436767e04932b3327fefc4fc9e5","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '379',
+  'x-ms-request-id',
+  '2a4efc3a-64ef-11eb-91de-0242ac120003',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '218',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(200, {"attributes":{"created":1612226393,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1612226393},"deletedDate":1612226393,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/6e832436767e04932b3327fefc4fc9e5","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1620002393}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '565',
+  'x-ms-request-id',
+  '2a8bd312-64ef-11eb-91de-0242ac120003',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '138',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(200, {"attributes":{"created":1612226393,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1612226393},"deletedDate":1612226393,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/6e832436767e04932b3327fefc4fc9e5","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1620002393}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '2aba8edc-64ef-11eb-91de-0242ac120003',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '565',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210128-1-4c3070d1-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '37'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '2ad97f90-64ef-11eb-91de-0242ac120003',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '139',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -43,6 +43,11 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
 }
 
 // @public
+export interface CreateOctKeyOptions extends CreateKeyOptions {
+    hsm?: boolean;
+}
+
+// @public
 export interface CreateRsaKeyOptions extends CreateKeyOptions {
     hsm?: boolean;
     keySize?: number;
@@ -163,6 +168,7 @@ export class KeyClient {
     beginRecoverDeletedKey(name: string, options?: BeginRecoverDeletedKeyOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey>;
     createKey(name: string, keyType: KeyType, options?: CreateKeyOptions): Promise<KeyVaultKey>;
+    createOctKey(name: string, options?: CreateOctKeyOptions): Promise<KeyVaultKey>;
     createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     getDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<DeletedKey>;
     getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -436,7 +436,12 @@ export class KeyClient {
 
       return getKeyFromKeyBundle(response);
     } else {
-      const response = await this.client.createKey(this.vaultUrl, name, "OCT", options);
+      const response = await this.client.createKey(
+        this.vaultUrl,
+        name,
+        KnownJsonWebKeyType.Oct,
+        options
+      );
       return getKeyFromKeyBundle(response);
     }
   }

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -29,7 +29,8 @@ import {
   KeyItem,
   KeyVaultClientGetKeysOptionalParams,
   KeyVaultClientRestoreKeyResponse,
-  KeyVaultClientUpdateKeyResponse
+  KeyVaultClientUpdateKeyResponse,
+  KnownJsonWebKeyType
 } from "./generated/models";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import { SDK_VERSION } from "./constants";
@@ -70,7 +71,8 @@ import {
   UpdateKeyPropertiesOptions,
   KeyClientOptions,
   CryptographyClientOptions,
-  LATEST_API_VERSION
+  LATEST_API_VERSION,
+  CreateOctKeyOptions
 } from "./keysModels";
 
 import { CryptographyClient } from "./cryptographyClient";
@@ -110,6 +112,7 @@ export {
   CreateEcKeyOptions,
   CreateKeyOptions,
   CreateRsaKeyOptions,
+  CreateOctKeyOptions,
   CryptographyClient,
   CryptographyOptions,
   DecryptOptions,
@@ -386,6 +389,54 @@ export class KeyClient {
       return getKeyFromKeyBundle(response);
     } else {
       const response = await this.client.createKey(this.vaultUrl, name, "RSA", options);
+      return getKeyFromKeyBundle(response);
+    }
+  }
+
+  /**
+   * The createOctKey method creates a new OCT key in Azure Key Vault. If the named key
+   * already exists, Azure Key Vault creates a new version of the key. It requires the keys/create
+   * permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeyClient(url, credentials);
+   * let result = await client.createOctKey("MyKey", { hsm: true });
+   * ```
+   * Creates a new key, stores it, then returns key parameters and properties to the client.
+   * @param name - The name of the key.
+   * @param options - The optional parameters.
+   */
+  public async createOctKey(name: string, options?: CreateOctKeyOptions): Promise<KeyVaultKey> {
+    if (options) {
+      const requestOptions = operationOptionsToRequestOptionsBase(options);
+      const { enabled, notBefore, expiresOn: expires, hsm, ...remainingOptions } = requestOptions;
+      const unflattenedOptions = {
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
+      };
+
+      const span = createSpan("createOctKey", unflattenedOptions);
+
+      let response: KeyVaultClientCreateKeyResponse;
+      try {
+        response = await this.client.createKey(
+          this.vaultUrl,
+          name,
+          hsm ? KnownJsonWebKeyType.OctHSM : KnownJsonWebKeyType.Oct,
+          setParentSpan(span, unflattenedOptions)
+        );
+      } finally {
+        span.end();
+      }
+
+      return getKeyFromKeyBundle(response);
+    } else {
+      const response = await this.client.createKey(this.vaultUrl, name, "OCT", options);
       return getKeyFromKeyBundle(response);
     }
   }

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -360,6 +360,17 @@ export interface CreateRsaKeyOptions extends CreateKeyOptions {
 
 /**
  * An interface representing the optional parameters that can be
+ * passed to {@link createOctKey}
+ */
+export interface CreateOctKeyOptions extends CreateKeyOptions {
+  /**
+   * Whether to create a hardware-protected key in a hardware security module (HSM).
+   */
+  hsm?: boolean;
+}
+
+/**
+ * An interface representing the optional parameters that can be
  * passed to {@link importKey}
  */
 export interface ImportKeyOptions extends coreHttp.OperationOptions {

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -166,10 +166,10 @@ describe("Keys client - create, read, update and delete operations", () => {
       this.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    let options: CreateOctKeyOptions = {
+    const options: CreateOctKeyOptions = {
       hsm: true
     };
-    let result = await client.createOctKey(keyName, options);
+    const result = await client.createOctKey(keyName, options);
     assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     assert.equal(result.keyType, "oct-HSM");
     await testClient.flushKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import { RestError } from "@azure/core-http";
 import { AbortController } from "@azure/abort-controller";
-import { env, Recorder } from "@azure/test-utils-recorder";
+import { env, isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 
 import {
   KeyClient,
@@ -16,6 +16,7 @@ import { assertThrowsAbortError } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { CreateOctKeyOptions } from "../../src/keysModels";
 
 describe("Keys client - create, read, update and delete operations", () => {
   const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
@@ -157,6 +158,21 @@ describe("Keys client - create, read, update and delete operations", () => {
         }
       });
     });
+  });
+
+  it("can create an OCT key with options", async function() {
+    if (!isPlaybackMode()) {
+      // oct key types are only supported in HSM instances, so avoid running this in a live setting until KeyVault supports them as well.
+      this.skip();
+    }
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    let options: CreateOctKeyOptions = {
+      hsm: true
+    };
+    let result = await client.createOctKey(keyName, options);
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
+    assert.equal(result.keyType, "oct-HSM");
+    await testClient.flushKey(keyName);
   });
 
   it("can create a disabled key", async function() {


### PR DESCRIPTION
## What

- Add `createOctKey` method to support creating keys of type `oct` and `oct-HSM`
- Add `createOctKeyOptions` supporting `hsm` (keySize is already supported at the `createKeyOptions` interface)

## Why

- This adds the same convenience layer we have for createEcKey, createRsaKey, etc....

## Callouts

- Decided to use `hsm` to be compatible with the APIs we already shipped. Feel free to let me know if you want this to be hardwareProtected at the cost of being inconsistent with our other create<Type>KeyOptions.

resolves #12457