### PR TITLE
[KeyVault] - Address KeyVault feedback

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
 - Updated the Key Vault Certificates Long Running Operation Pollers to follow a more compact and meaningful approach moving forward.
 - Bug fix: The logging of HTTP requests wasn't properly working - now it has been fixed and tests have been written that verify the fix.
+- Removed `parseKeyVaultCertificatesIdentifier` from the public API.
 
 ## 4.2.0-beta.1 (2020-09-11)
 

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -421,9 +421,6 @@ export const logger: import("@azure/logger").AzureLogger;
 // @public
 export type MergeCertificateOptions = coreHttp.OperationOptions;
 
-// @public
-export function parseKeyVaultCertificateId(id: string): KeyVaultCertificateId;
-
 export { PipelineOptions }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/identifier.ts
+++ b/sdk/keyvault/keyvault-certificates/src/identifier.ts
@@ -46,6 +46,7 @@ export interface KeyVaultCertificateId {
  *   }
  *```
  * @param id - The Id of the Key Vault Certificate.
+ * @internal
  */
 export function parseKeyVaultCertificateId(id: string): KeyVaultCertificateId {
   const urlParts = id.split("/");

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -141,7 +141,7 @@ import { DeleteCertificateState } from "./lro/delete/operation";
 import { CreateCertificateState } from "./lro/create/operation";
 import { RecoverDeletedCertificateState } from "./lro/recover/operation";
 import { parseCertificateBytes } from "./utils";
-import { parseKeyVaultCertificateId, KeyVaultCertificateId } from "./identifier";
+import { KeyVaultCertificateId } from "./identifier";
 import {
   coreContactsToCertificateContacts,
   getCertificateFromCertificateBundle,
@@ -168,7 +168,6 @@ export {
   BeginRecoverDeletedCertificateOptions,
   KeyVaultCertificate,
   KeyVaultCertificateWithPolicy,
-  parseKeyVaultCertificateId,
   BackupCertificateOptions,
   CertificateContentType,
   CertificateProperties,

--- a/sdk/keyvault/keyvault-certificates/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/identifier.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultCertificateId } from "../../src";
+import { parseKeyVaultCertificateId } from "../../src/identifier";
 import * as assert from "assert";
 
 describe("Key Vault Certificates Identifier", () => {

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -5,8 +5,9 @@
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
 - Updated the Key Vault Keys Long Running Operation Pollers to follow a more compact and meaningful approach moving forward.
 - Bug fix: The logging of HTTP requests wasn't properly working - now it has been fixed and tests have been written that verify the fix.
-- Add a constructor overload to `CryptographyClient` that takes a `JsonWebKey` and allows for local-only subset of operations.
-- Add `KeyId` to the public API of CryptographyClient.
+- Added a constructor overload to `CryptographyClient` that takes a `JsonWebKey` and allows for local-only subset of operations.
+- Added `KeyId` to the public API of CryptographyClient.
+- Removed `parseKeyVaultKeysId` from the public API and made `KeyOptionsOptions.additionalAuthenticatedData` a readonly property.
 
 ## 4.2.0-beta.2 (2020-10-06)
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -189,7 +189,7 @@ export type KeyOperation = string;
 
 // @public
 export interface KeyOperationsOptions extends CryptographyOptions {
-    additionalAuthenticatedData?: Uint8Array;
+    readonly additionalAuthenticatedData?: Uint8Array;
     iv?: Uint8Array;
     tag?: Uint8Array;
 }
@@ -339,9 +339,6 @@ export const logger: import("@azure/logger").AzureLogger;
 export { PagedAsyncIterableIterator }
 
 export { PageSettings }
-
-// @public
-export function parseKeyVaultKeyId(id: string): KeyVaultKeyId;
 
 export { PipelineOptions }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -147,7 +147,7 @@ export interface KeyOperationsOptions extends CryptographyOptions {
    * Additional data to authenticate but not encrypt/decrypt when using authenticated crypto
    * algorithms.
    */
-  additionalAuthenticatedData?: Uint8Array;
+  readonly additionalAuthenticatedData?: Uint8Array;
   /**
    * The tag to authenticate when performing decryption with an authenticated algorithm.
    */

--- a/sdk/keyvault/keyvault-keys/src/identifier.ts
+++ b/sdk/keyvault/keyvault-keys/src/identifier.ts
@@ -47,6 +47,7 @@ export interface KeyVaultKeyId {
  *```
  
  * @param id - The Id of the Key Vault Key.
+ * @internal
  */
 export function parseKeyVaultKeyId(id: string): KeyVaultKeyId {
   const urlParts = id.split("/");

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -132,7 +132,6 @@ export {
   KeyType,
   KnownKeyTypes,
   KeyPollerOptions,
-  parseKeyVaultKeyId,
   BeginDeleteKeyOptions,
   BeginRecoverDeletedKeyOptions,
   KeyProperties,

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -92,9 +92,6 @@ export { PagedAsyncIterableIterator }
 
 export { PageSettings }
 
-// @public
-export function parseKeyVaultSecretId(id: string): KeyVaultSecretId;
-
 export { PipelineOptions }
 
 export { PollerLike }

--- a/sdk/keyvault/keyvault-secrets/src/identifier.ts
+++ b/sdk/keyvault/keyvault-secrets/src/identifier.ts
@@ -46,6 +46,7 @@ export interface KeyVaultSecretId {
  *   }
  *```
  * @param id - The Id of the Key Vault Secret.
+ * @internal
  */
 export function parseKeyVaultSecretId(id: string): KeyVaultSecretId {
   const urlParts = id.split("/");

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -61,7 +61,7 @@ import {
   SecretClientOptions,
   LATEST_API_VERSION
 } from "./secretsModels";
-import { parseKeyVaultSecretId, KeyVaultSecretId } from "./identifier";
+import { KeyVaultSecretId } from "./identifier";
 import { getSecretFromSecretBundle } from "./transformations";
 
 export {
@@ -84,7 +84,6 @@ export {
   PollerLike,
   PollOperationState,
   KeyVaultSecret,
-  parseKeyVaultSecretId,
   SecretProperties,
   SecretPollerOptions,
   BeginDeleteSecretOptions,

--- a/sdk/keyvault/keyvault-secrets/test/public/identifier.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/identifier.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultSecretId } from "../../src";
+import { parseKeyVaultSecretId } from "../../src/identifier";
 import * as assert from "assert";
 
 describe("Key Vault Secrets Identifier", () => {


### PR DESCRIPTION
## What

- Hide various parse identifier methods
- Make additionalAuthenticatedData readonly

## Why

These came out of the recent KV architecture review. I spoke to @sadasant and 
made sure that the other tasks are not applicable to us

## Callouts

The only thing I wasn't sure about is renaming EncryptOptions to EncryptParameters since I
think we already GA'd with EncryptOptions - should I add a new EncryptParameters where iv and aad 
are set?

Partially resolves #13237