### PR TITLE
add ms-cv to list of visible headers

### DIFF
--- a/sdk/core/core-http/src/util/sanitizer.ts
+++ b/sdk/core/core-http/src/util/sanitizer.ts
@@ -28,6 +28,7 @@ const defaultAllowedHeaderNames = [
   "x-ms-correlation-request-id",
   "x-ms-request-id",
   "client-request-id",
+  "ms-cv",
   "return-client-request-id",
   "traceparent",
 

--- a/sdk/core/core-https/src/util/sanitizer.ts
+++ b/sdk/core/core-https/src/util/sanitizer.ts
@@ -36,6 +36,7 @@ const defaultAllowedHeaderNames = [
   "x-ms-correlation-request-id",
   "x-ms-request-id",
   "client-request-id",
+  "ms-cv",
   "return-client-request-id",
   "traceparent",
 


### PR DESCRIPTION
To add ms-cv to list of headers that can be enabled by default for customer logging options so that they can share these for debugging and reporting.