### PR TITLE
[event-hubs] clean up afterEach for client close tests

### DIFF
--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -79,8 +79,6 @@ describe("EventHubConsumerClient", () => {
 
       await Promise.all(clients.map((client) => client.close()));
       clients = [];
-
-      return producerClient.close();
     });
 
     describe("#close()", function(): void {

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -56,22 +56,15 @@ describe("EventHubConsumerClient", () => {
     partitionIds = await producerClient.getPartitionIds({});
   });
 
-  afterEach("Closing the clients", async () => {
-    await producerClient.close();
-    await consumerClient.close();
+  afterEach("Closing the clients", () => {
+    return Promise.all([producerClient.close(), consumerClient.close()]);
   });
 
   describe("functional tests", () => {
     let clients: EventHubConsumerClient[];
-    let producerClient: EventHubProducerClient;
-    let partitionIds: string[];
     let subscriptions: Subscription[];
 
-    beforeEach(async () => {
-      producerClient = new EventHubProducerClient(service.connectionString!, service.path!, {});
-
-      partitionIds = await producerClient.getPartitionIds();
-
+    beforeEach(() => {
       // ensure we have at least 2 partitions
       partitionIds.length.should.gte(2);
 
@@ -84,12 +77,10 @@ describe("EventHubConsumerClient", () => {
         await subscription.close();
       }
 
-      for (const client of clients) {
-        await client.close();
-      }
-
+      await Promise.all(clients.map((client) => client.close()));
       clients = [];
-      await producerClient.close();
+
+      return producerClient.close();
     });
 
     describe("#close()", function(): void {


### PR DESCRIPTION
Noticed there were some redundant `close()` calls so checking if cleaning those up reduces the `afterEach` failures we sometimes see in test runs.