### PR TITLE
[service-bus] Add in long-running stress/perf test

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/package.json
+++ b/sdk/servicebus/service-bus/test/stress/package.json
@@ -18,6 +18,7 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
+    "@types/minimist": "^1.2.1",
     "@types/node": "^14.14.22",
     "@types/uuid": "^8.3.0",
     "typescript": "^4.1.3"

--- a/sdk/servicebus/service-bus/test/stress/runContainer.js
+++ b/sdk/servicebus/service-bus/test/stress/runContainer.js
@@ -6,7 +6,7 @@ const { spawnSync } = require("child_process");
 
 dotenv.config();
 
-// these should match what we have in your .env file (you can use sample.env 
+// these should match what we have in your .env file (you can use sample.env
 // as the template for your own file)
 const serviceBusConnectionString = process.env.SERVICEBUS_CONNECTION_STRING;
 const appInsightsInstrumentationKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY;
@@ -45,7 +45,9 @@ const containerInstanceName = `${resourceGroup}-sb-stressperf-${testFileNameWith
 
 const expectedJsFile = path.join(`dist`, `${testFileNameWithoutExtension}.js`);
 if (!fs.existsSync(expectedJsFile)) {
-  console.error(`No file named ${expectedJsFile}. Need a valid JS file when creating your container group.`);
+  console.error(
+    `No file named ${expectedJsFile}. Need a valid JS file when creating your container group.`
+  );
   process.exit(1);
 }
 
@@ -56,7 +58,9 @@ console.log(`Pushing image (will fail if you have not yet run \`docker login ${r
 spawn(`docker push "${imageName}"`);
 
 console.log(`Deleting Azure Container Instance (if exists)`);
-spawn(`az container delete --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
+spawn(
+  `az container delete --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
+);
 
 console.log(`Creating Azure Container Instance for stress/perf that runs ${options.testToRun}`);
 spawn(

--- a/sdk/servicebus/service-bus/test/stress/runContainer.js
+++ b/sdk/servicebus/service-bus/test/stress/runContainer.js
@@ -6,8 +6,11 @@ const { spawnSync } = require("child_process");
 
 dotenv.config();
 
+// these should match what we have in your .env file (you can use sample.env 
+// as the template for your own file)
 const serviceBusConnectionString = process.env.SERVICEBUS_CONNECTION_STRING;
 const appInsightsInstrumentationKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY;
+const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID;
 const resourceGroup = process.env.RESOURCE_GROUP;
 const registryUserName = process.env.REGISTRY_USERNAME;
 const registryPassword = process.env.REGISTRY_PASSWORD;
@@ -53,17 +56,17 @@ console.log(`Pushing image (will fail if you have not yet run \`docker login ${r
 spawn(`docker push "${imageName}"`);
 
 console.log(`Deleting Azure Container Instance (if exists)`);
-spawn(`az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
+spawn(`az container delete --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}"`);
 
 console.log(`Creating Azure Container Instance for stress/perf that runs ${options.testToRun}`);
 spawn(
-  `az container create --resource-group "${resourceGroup}" --name "${containerInstanceName}" ` +
+  `az container create --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}" ` +
     `--image ${imageName}  ` +
     "--cpu 1 --memory 0.7 " +
     "--restart-policy Never " +
     `--registry-username ${registryUserName} ` +
     `--registry-password "${registryPassword}" ` +
-    `--command-line "node /src/${options.testToRun}" ` +
+    `--command-line "node /src/${path.basename(expectedJsFile)}" ` +
     `--secure-environment-variables "SERVICEBUS_CONNECTION_STRING=${serviceBusConnectionString}" "APPINSIGHTS_INSTRUMENTATIONKEY=${appInsightsInstrumentationKey}"`
 );
 
@@ -73,11 +76,11 @@ console.log(
 
 console.log(`Some other commands you might find useful to manage your container:\n`);
 console.log(
-  `az container stop --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
+  `az container stop --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
 );
 console.log(
-  `az container delete --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
+  `az container delete --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}"`
 );
 console.log(
-  `az container logs --resource-group "${resourceGroup}" --name "${containerInstanceName}" --follow`
+  `az container logs --subscription "${subscriptionId}" --resource-group "${resourceGroup}" --name "${containerInstanceName}" --follow`
 );

--- a/sdk/servicebus/service-bus/test/stress/runContainer.js
+++ b/sdk/servicebus/service-bus/test/stress/runContainer.js
@@ -29,16 +29,22 @@ const options = minimist(process.argv, {
   string: ["testToRun"]
 });
 
-if (!options.testToRun || !fs.existsSync(path.join("dist", options.testToRun))) {
-  console.error("Usage: runcontainer.js --testToRun <name of file in `dist`>");
+if (!options.testToRun) {
+  console.error("Usage: runcontainer.js --testToRun <name of a stress test file`>");
   process.exit(1);
 }
+
+console.log(`Running \`npm run build\``);
+spawn(`npm run build`);
 
 const { name: testFileNameWithoutExtension } = path.parse(options.testToRun);
 const containerInstanceName = `${resourceGroup}-sb-stressperf-${testFileNameWithoutExtension.toLowerCase()}`;
 
-console.log(`Running \`npm run build\``);
-spawn(`npm run build`);
+const expectedJsFile = path.join(`dist`, `${testFileNameWithoutExtension}.js`);
+if (!fs.existsSync(expectedJsFile)) {
+  console.error(`No file named ${expectedJsFile}. Need a valid JS file when creating your container group.`);
+  process.exit(1);
+}
 
 console.log(`Building container image: ${imageName}...`);
 spawn(`docker build -t "${imageName}" --no-cache .`);

--- a/sdk/servicebus/service-bus/test/stress/sample.env
+++ b/sdk/servicebus/service-bus/test/stress/sample.env
@@ -1,15 +1,20 @@
-APPINSIGHTS_INSTRUMENTATIONKEY=
-SERVICEBUS_CONNECTION_STRING=
-
-# Where your Azure Container Registry and Azure Container Instance will be deployed
+AZURE_SUBSCRIPTION_ID=
 RESOURCE_GROUP=
 
+# CLI:
+# az monitor app-insights component show --subscription AZURE_SUBSCRIPTION_ID --resource-group RESOURCE_GROUP --app APPINSIGHTS NAME
+APPINSIGHTS_INSTRUMENTATIONKEY=
+
+# CLI:
+# az servicebus namespace authorization-rule keys list --subscription AZURE_SUBSCRIPTION_ID --namespace-name SERVICEBUS_NAMESPACE_NAME --resource-group RESOURCE_GROUP --name RootManageSharedAccessKey
+SERVICEBUS_CONNECTION_STRING=
+
 # You'll need to create an Azure Container Registry to host your container images
-# az acr create --resource-group RESOURCE_GROUP --admin-enabled --sku Basic --name REGISTRY_NAME
+# az acr create --subscription AZURE_SUBSCRIPTION_ID --resource-group RESOURCE_GROUP --admin-enabled --sku Basic --name REGISTRY_NAME
 #
 # To get the credentials after you've created the registry:
-# az acr credential show --resource-group RESOURCE_GROUP --name REGISTRY_NAME
+# az acr credential show --subscription AZURE_SUBSCRIPTION_ID --resource-group RESOURCE_GROUP --name REGISTRY_NAME
 REGISTRY_USERNAME=
 REGISTRY_PASSWORD=
 # FQDN of your Azure Container Registry (ie: something.azurecr.io)
-REGISTRY_NAME=.azurecr.io
+REGISTRY_NAME=

--- a/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioBatchReceive.ts
@@ -45,7 +45,7 @@ function sanitizeOptions(args: string[]): Required<ScenarioReceiveBatchOptions> 
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 1,
     delayBetweenSendsInMs: options.delayBetweenSendsInMs || 0,
     totalNumberOfMessagesToSend: options.totalNumberOfMessagesToSend || Infinity,
-    sendAllMessagesBeforeReceiveStarts: options.sendAllMessagesBeforeReceiveStarts,
+    sendAllMessagesBeforeReceiveStarts: !!options.sendAllMessagesBeforeReceiveStarts,
     maxAutoLockRenewalDurationInMs: options.maxAutoLockRenewalDurationInMs || 0, // 0 = disabled
     settleMessageOnReceive: options.settleMessageOnReceive,
     numberOfParallelSends: options.numberOfParallelSends || 5
@@ -97,7 +97,7 @@ export async function scenarioReceiveBatch() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     while (
       elapsedTime < testDurationForSendInMs &&
-      stressBase.messagesSent.length < totalNumberOfMessagesToSend
+      stressBase.numMessagesSent() < totalNumberOfMessagesToSend
     ) {
       await stressBase.sendMessages(
         new Array(numberOfParallelSends).fill(sender),

--- a/sdk/servicebus/service-bus/test/stress/scenarioCloseOpen.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioCloseOpen.ts
@@ -30,7 +30,7 @@ function sanitizeOptions(args: string[]): Required<ScenarioCloseOptions> {
     receiveBatchMaxWaitTimeInMs: options.receiveBatchMaxWaitTimeInMs || 10000,
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 1,
     delayBeforeCallingCloseInMs: options.delayBeforeCallingCloseInMs || 100,
-    shouldCreateNewClientEachTime: options.shouldCreateNewClientEachTime
+    shouldCreateNewClientEachTime: !!options.shouldCreateNewClientEachTime
   };
 }
 

--- a/sdk/servicebus/service-bus/test/stress/scenarioLongRunning.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioLongRunning.ts
@@ -1,0 +1,105 @@
+import {hostname} from "os";
+import { captureConsoleOutputToAppInsights, defaultClient, SBStressTestsBase } from "./stressTestsBase";
+import { AbortController, AbortSignalLike } from "@azure/abort-controller";
+import { ServiceBusClient, ServiceBusSender } from "@azure/service-bus";
+import { v4 as uuidv4 } from "uuid";
+
+captureConsoleOutputToAppInsights();
+
+const stressTest = new SBStressTestsBase({
+    testName: "longRunning",
+    snapshotFocus: [
+        "send-info",
+        "receive-info"
+    ]
+});
+
+async function looper(fn: () => Promise<void>, delay: number, abortSignal: AbortSignalLike) {
+    const timeout = () => new Promise((resolve) => setTimeout(() => resolve(true), delay));
+
+    while (!abortSignal.aborted && await timeout()) {
+        await fn();
+    }
+}
+
+async function sendMessagesForever(clientForSender: ServiceBusClient, abortSignal: AbortSignalLike) {
+    console.log(`Started message sending`);
+
+    let sender: ServiceBusSender|undefined;
+
+    return looper(async () => {
+        if (abortSignal.aborted) {
+            console.log(`Aborting sending because of abortSignal`);
+            return;
+        }
+
+        try {
+            if (sender == null) {
+                sender = clientForSender.createSender(stressTest.queueName);
+            }
+            
+            const messagesToSend = [{
+                messageId: uuidv4(),
+                body: `Message: ${Date.now()}`
+            }];
+
+            stressTest.trackSentMessages(messagesToSend);
+            await sender.sendMessages(messagesToSend);
+        } catch (err) {
+            console.log(`Sending message failed: `, err);
+            stressTest.trackError("send", err);
+            sender = undefined;
+        }
+    }, 1000, abortSignal);
+}
+
+async function main() {
+    const abortController = new AbortController();
+    const abortSignal = abortController.signal;
+
+    await stressTest.init();
+
+    console.log(`Starting with hostname ${hostname}`);
+
+    defaultClient.trackEvent({
+        name: "ApplicationStart"
+    });
+
+    const clientForReceiver = stressTest.createServiceBusClient();
+
+    const receiver = clientForReceiver.createReceiver(stressTest.queueName, {
+        receiveMode: "peekLock"
+    });
+
+    console.log(`Subscribing...`);
+
+    const subscription = receiver.subscribe({
+        processMessage: async (msg) => {
+            stressTest.addReceivedMessage([msg]);            
+            await stressTest.completeMessage(receiver, msg);
+        },
+        processError: async (args) => {
+            console.log(`subscribe error:`, args);
+            stressTest.trackError("receive", args.error);
+        }
+    }, {
+        autoCompleteMessages: false,
+        maxConcurrentCalls: 10
+    });
+
+    const clientForSender = stressTest.createServiceBusClient();
+
+    await sendMessagesForever(clientForSender, abortSignal);
+    defaultClient.flush();
+
+    await subscription.close();
+    await clientForReceiver.close();
+    await clientForSender.close();
+
+    await stressTest.end();
+}
+
+main().catch((err) => { 
+    console.error(err);
+    process.exit(1);
+});

--- a/sdk/servicebus/service-bus/test/stress/scenarioLongRunning.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioLongRunning.ts
@@ -25,7 +25,7 @@ async function looper(fn: () => Promise<void>, delay: number, abortSignal: Abort
 async function sendMessagesForever(clientForSender: ServiceBusClient, abortSignal: AbortSignalLike) {
     console.log(`Started message sending`);
 
-    let sender: ServiceBusSender|undefined;
+    let sender: ServiceBusSender | undefined;
 
     return looper(async () => {
         if (abortSignal.aborted) {

--- a/sdk/servicebus/service-bus/test/stress/scenarioPeekMessages.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioPeekMessages.ts
@@ -1,4 +1,4 @@
-import { ServiceBusClient, ServiceBusReceiver } from "@azure/service-bus";
+import { ServiceBusClient, ServiceBusReceivedMessage, ServiceBusReceiver } from "@azure/service-bus";
 import { SBStressTestsBase } from "./stressTestsBase";
 import { delay } from "rhea-promise";
 import parsedArgs from "minimist";
@@ -56,6 +56,7 @@ export async function scenarioPeekMessages() {
   const sbClient = new ServiceBusClient(connectionString);
 
   await stressBase.init(undefined, undefined, testOptions);
+  
   const sender = sbClient.createSender(stressBase.queueName);
   let receiver: ServiceBusReceiver;
 
@@ -66,7 +67,7 @@ export async function scenarioPeekMessages() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     while (
       elapsedTime < testDurationForSendInMs &&
-      stressBase.messagesSent.length < totalNumberOfMessagesToSend
+      stressBase.numMessagesSent() < totalNumberOfMessagesToSend
     ) {
       await stressBase.sendMessages([sender], numberOfMessagesPerSend);
       elapsedTime = new Date().valueOf() - startedAt.valueOf();
@@ -78,7 +79,7 @@ export async function scenarioPeekMessages() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     let fromSequenceNumber = undefined;
     while (elapsedTime < testDurationInMs) {
-      const peekedMessages = await stressBase.peekMessages(
+      const peekedMessages: ServiceBusReceivedMessage[] = await stressBase.peekMessages(
         receiver,
         peekMaxMessageCount,
         fromSequenceNumber

--- a/sdk/servicebus/service-bus/test/stress/scenarioRenewMessageLock.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioRenewMessageLock.ts
@@ -33,7 +33,7 @@ function sanitizeOptions(args: string[]): Required<ScenarioRenewMessageLockOptio
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 1,
     delayBetweenSendsInMs: options.delayBetweenSendsInMs || 0,
     totalNumberOfMessagesToSend: options.totalNumberOfMessagesToSend || Infinity,
-    completeMessageAfterDuration: options.completeMessageAfterDuration
+    completeMessageAfterDuration: !!options.completeMessageAfterDuration
   };
 }
 
@@ -71,7 +71,7 @@ export async function main() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     while (
       elapsedTime < testDurationForSendInMs &&
-      stressBase.messagesSent.length < totalNumberOfMessagesToSend
+      stressBase.numMessagesSent() < totalNumberOfMessagesToSend
     ) {
       await stressBase.sendMessages([sender], numberOfMessagesPerSend);
       elapsedTime = new Date().valueOf() - startedAt.valueOf();

--- a/sdk/servicebus/service-bus/test/stress/scenarioRenewSessionLock.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioRenewSessionLock.ts
@@ -42,8 +42,8 @@ function sanitizeOptions(args: string[]): Required<ScenarioRenewSessionLockOptio
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 100,
     delayBetweenSendsInMs: options.delayBetweenSendsInMs || 0,
     totalNumberOfMessagesToSend: options.totalNumberOfMessagesToSend || Infinity,
-    autoLockRenewal: options.autoLockRenewal,
-    settleMessageOnReceive: options.settleMessageOnReceive
+    autoLockRenewal: !!options.autoLockRenewal,
+    settleMessageOnReceive: !!options.settleMessageOnReceive
   };
 }
 
@@ -85,7 +85,7 @@ export async function scenarioRenewSessionLock() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     while (
       elapsedTime < testDurationForSendInMs &&
-      stressBase.messagesSent.length < totalNumberOfMessagesToSend
+      stressBase.numMessagesSent() < totalNumberOfMessagesToSend
     ) {
       await stressBase.sendMessages(
         [sender],

--- a/sdk/servicebus/service-bus/test/stress/scenarioSend.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioSend.ts
@@ -28,7 +28,7 @@ function sanitizeOptions(args: string[]): Required<ScenarioSimpleSendOptions> {
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 1,
     delayBetweenSendsInMs: options.delayBetweenSendsInMs || 0,
     totalNumberOfMessagesToSend: options.totalNumberOfMessagesToSend || Infinity,
-    useScheduleApi: options.useScheduleApi
+    useScheduleApi: !!options.useScheduleApi
   };
 }
 
@@ -52,7 +52,7 @@ async function main() {
   let elapsedTime = 0;
   while (
     elapsedTime < testDurationInMs &&
-    stressBase.messagesSent.length < totalNumberOfMessagesToSend
+    stressBase.numMessagesSent() < totalNumberOfMessagesToSend
   ) {
     await stressBase.sendMessages([sender], numberOfMessagesPerSend, false, useScheduleApi);
     elapsedTime = new Date().valueOf() - startedAt.valueOf();

--- a/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
+++ b/sdk/servicebus/service-bus/test/stress/scenarioStreamingReceive.ts
@@ -46,15 +46,15 @@ function sanitizeOptions(args: string[]): Required<ScenarioStreamingReceiveOptio
   return {
     testDurationInMs: options.testDurationInMs || 60 * 60 * 1000, // Default = 60 minutes
     receiveMode: options.receiveMode || "peekLock",
-    autoComplete: options.autoComplete,
+    autoComplete: !!options.autoComplete,
     maxConcurrentCalls: options.maxConcurrentCalls || 100,
     maxAutoRenewLockDurationInMs: options.maxAutoRenewLockDurationInMs || 0,
     manualLockRenewal: options.manualLockRenewal,
     numberOfMessagesPerSend: options.numberOfMessagesPerSend || 1,
     delayBetweenSendsInMs: options.delayBetweenSendsInMs || 0,
     totalNumberOfMessagesToSend: options.totalNumberOfMessagesToSend || Infinity,
-    completeMessageAfterDuration: options.completeMessageAfterDuration,
-    settleMessageOnReceive: options.settleMessageOnReceive
+    completeMessageAfterDuration: !!options.completeMessageAfterDuration,
+    settleMessageOnReceive: !!options.settleMessageOnReceive
   };
 }
 
@@ -101,7 +101,7 @@ export async function scenarioStreamingReceive() {
     let elapsedTime = new Date().valueOf() - startedAt.valueOf();
     while (
       elapsedTime < testDurationForSendInMs &&
-      stressBase.messagesSent.length < totalNumberOfMessagesToSend
+      stressBase.numMessagesSent() < totalNumberOfMessagesToSend
     ) {
       await stressBase.sendMessages([sender], numberOfMessagesPerSend);
       elapsedTime = new Date().valueOf() - startedAt.valueOf();

--- a/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
+++ b/sdk/servicebus/service-bus/test/stress/stressTestsBase.ts
@@ -112,7 +112,7 @@ export class SBStressTestsBase {
 
   public async init(
     queueNamePrefix?: string,
-    options?: CreateQueueOptions | undefined,
+    options?: CreateQueueOptions,
     testOptions?: Record<string, string | number | boolean>
   ) {
     try {

--- a/sdk/servicebus/service-bus/test/stress/tsconfig.json
+++ b/sdk/servicebus/service-bus/test/stress/tsconfig.json
@@ -5,7 +5,13 @@
     "esModuleInterop": true,
     "lib": ["ESNext.AsyncIterable"],
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "strict": true,
+    "alwaysStrict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["./*.ts"],
   "exclude": ["node_modules"]

--- a/sdk/servicebus/service-bus/test/stress/utils.ts
+++ b/sdk/servicebus/service-bus/test/stress/utils.ts
@@ -1,11 +1,8 @@
 import { v4 as uuidv4 } from "uuid";
-import util from "util";
-import fs from "fs";
 
 export interface OperationInfo {
   numberOfSuccesses: number;
   numberOfFailures: number;
-  errors: any[];
 }
 
 export interface LockRenewalOperationInfo extends OperationInfo {
@@ -39,7 +36,6 @@ export interface TrackedMessageIdsInfo {
     sentCount: number;
     receivedCount: number;
     settledCount: number;
-    errors: any[];
   };
 }
 
@@ -47,7 +43,6 @@ export function initializeOperationInfo(): OperationInfo {
   return {
     numberOfSuccesses: 0,
     numberOfFailures: 0,
-    errors: []
   };
 }
 
@@ -67,12 +62,13 @@ export async function saveDiscrepanciesFromTrackedMessages(
   trackedMessageIds: TrackedMessageIdsInfo
 ) {
   const output = {
-    messages_sent_but_never_received: [],
-    messages_not_sent_but_received: [],
-    messages_sent_multiple_times: [],
-    messages_sent_once_but_received_multiple_times: [],
-    messages_sent_once_and_received_once: []
+    messages_sent_but_never_received: [] as string[],
+    messages_not_sent_but_received: [] as string[],
+    messages_sent_multiple_times: [] as string[],
+    messages_sent_once_but_received_multiple_times: [] as string[],
+    messages_sent_once_and_received_once: [] as string[],
   };
+
   for (const id in trackedMessageIds) {
     if (trackedMessageIds[id].sentCount <= 0) {
       // Message was not sent but received


### PR DESCRIPTION
Added in the "long running test" that I had previously written, now ported to @HarshaNalluru's much nicer stress framework. This test is intended to run for long periods of time, sending messages every second (and receiving the entire time). This should complement some of the other tests we have that test more stressful/high perf conditions by allowing us to see how our code handles running long-term.

Also, some other changes for quality of life and others:
* Make tsconfig.json more strict to catch more errors and other "risky" constructs in the stress tests.
* Fix aforementioned risky and erroneous constructs (mostly just using before initialization, assuming falsy, etc..)
* Refactored stressTestBase (not too drastically) to allow for tracking statistics generated from outside of the stressBase. This lets you take advantage of the snapshotting and reporting but still be able to write all your own logic. More refactoring possible, but left as an exercise to a future reader (probably me later).