### PR TITLE
Revert "[Metrics Advisor] Create functions modified to return id with…

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -232,10 +232,8 @@ async function createDataFeed(adminClient, sqlServerConnectionString, sqlServerQ
     accessMode: "Private",
     adminEmails: ["xyz@example.com"]
   };
-  const created = await adminClient.createDataFeed(dataFeed);
-  /* To get the full datafeed object, you can call the get method and pass the id of the created datafeed
-   */
-  const result = await adminClient.getDataFeed(created.id);
+  const result = await adminClient.createDataFeed(dataFeed);
+
   return result;
 }
 ```
@@ -319,12 +317,7 @@ async function configureAnomalyDetectionConfiguration(adminClient, metricId) {
     },
     description: "Detection configuration description"
   };
-  const created = await adminClient.createDetectionConfig(anomalyConfig);
-
-  /* To get the full detection config object, you can call the get method and pass the id of the created detection config
-   */
-  const result = await adminClient.getDetectionConfig(created.id);
-  return result;
+  return await adminClient.createDetectionConfig(anomalyConfig);
 }
 ```
 
@@ -365,11 +358,7 @@ async function createWebhookHook(adminClient) {
     }
   };
 
-  const created = await adminClient.createHook(hook);
-  /* To get the full hook object, you can call the get method and pass the id of the created hook
-   */
-  const result = await adminClient.getHook(created.id);
-  return result;
+  return await adminClient.createHook(hook);
 }
 ```
 
@@ -421,11 +410,7 @@ async function configureAlertConfiguration(adminClient, detectionConfigId, hookI
     hookIds,
     description: "Alerting config description"
   };
-  const created = await adminClient.createAlertConfig(anomalyAlertConfig);
-  /* To get the full alert config object, you can call the get method and pass the id of the created alert config
-   */
-  const result = await adminClient.getAlertConfig(created.id);
-  return result;
+  return await adminClient.createAlertConfig(anomalyAlertConfig);
 }
 ```
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -192,67 +192,7 @@ export type ChangeThresholdConditionUnion = {
 };
 
 // @public
-export type CreateAnomalyAlertConfigurationResponse = CreatedAnomalyAlertConfiguration & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: any;
-    };
-};
-
-// @public
-export type CreateAnomalyDetectionConfigurationResponse = CreatedAnomalyDetectionConfiguration & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: any;
-    };
-};
-
-// @public
-export interface CreatedAnomalyAlertConfiguration {
-    id: string;
-}
-
-// @public
-export type CreatedAnomalyDetectionConfiguration = {
-    id: string;
-};
-
-// @public
 export type CreateDataFeedOptions = DataFeedOptions & OperationOptions;
-
-// @public
-export type CreateDataFeedResponse = CreatedDataFeed & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: any;
-    };
-};
-
-// @public
-export type CreatedDataFeed = {
-    id: string;
-};
-
-// @public
-export type CreatedNotificationHook = {
-    id: string;
-};
-
-// @public
-export type CreateFeedbackResponse = CreateMetricFeedback & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: any;
-    };
-};
-
-// @public
-export type CreateHookResponse = CreatedNotificationHook & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: any;
-    };
-};
-
-// @public
-export type CreateMetricFeedback = {
-    id: string;
-};
 
 // @public
 export type DataFeed = {
@@ -983,10 +923,10 @@ export type MetricPeriodFeedback = {
 // @public
 export class MetricsAdvisorAdministrationClient {
     constructor(endpointUrl: string, credential: TokenCredential | MetricsAdvisorKeyCredential, options?: MetricsAdvisorAdministrationClientOptions);
-    createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<CreateAnomalyAlertConfigurationResponse>;
-    createDataFeed(feed: DataFeedDescriptor, operationOptions?: OperationOptions): Promise<CreateDataFeedResponse>;
-    createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<CreateAnomalyDetectionConfigurationResponse>;
-    createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<CreateHookResponse>;
+    createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    createDataFeed(feed: DataFeedDescriptor, operationOptions?: OperationOptions): Promise<GetDataFeedResponse>;
+    createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<GetHookResponse>;
     deleteAlertConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDataFeed(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDetectionConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
@@ -1016,7 +956,7 @@ export interface MetricsAdvisorAdministrationClientOptions extends PipelineOptio
 // @public
 export class MetricsAdvisorClient {
     constructor(endpointUrl: string, credential: TokenCredential | MetricsAdvisorKeyCredential, options?: MetricsAdvisorClientOptions);
-    createFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<CreateFeedbackResponse>;
+    createFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
     readonly endpointUrl: string;
     getFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/metricFeedback.js
@@ -50,8 +50,7 @@ async function providePeriodFeedback(client, metricId) {
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  const created = await client.createFeedback(periodFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client, metricId) {
@@ -63,8 +62,7 @@ async function provideChangePointFeedback(client, metricId) {
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  const created = await client.createFeedback(changePointFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client, metricId) {
@@ -75,8 +73,7 @@ async function provideCommentFeedback(client, metricId) {
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  const created = await client.createFeedback(commendFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(commendFeedback);
 }
 
 async function getFeedback(client, feedbackId) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/javascript/quickstart.js
@@ -31,8 +31,7 @@ async function main() {
   const created = await createDataFeed(adminClient, sqlServerConnectionString, sqlServerQuery);
   console.log(`Data feed created: ${created.id}`);
   console.log("  metrics: ");
-  const datafeed = await adminClient.getDataFeed(created.id);
-  console.log(datafeed.schema.metrics);
+  console.log(created.schema.metrics);
 
   console.log("Waiting for a minute before checking ingestion status...");
   await delay(60 * 1000);
@@ -45,7 +44,7 @@ async function main() {
       new Date(Date.UTC(2020, 8, 12))
     );
 
-    const metricId = datafeed.schema.metrics[0].id;
+    const metricId = created.schema.metrics[0].id;
     const detectionConfig = await configureAnomalyDetectionConfiguration(adminClient, metricId);
     console.log(`Detection configuration created: ${detectionConfig.id}`);
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/dataFeed.ts
@@ -10,7 +10,7 @@ dotenv.config();
 import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
-  CreateDataFeedResponse,
+  GetDataFeedResponse,
   DataFeedPatch,
   DataFeedDescriptor
 } from "@azure/ai-metrics-advisor";
@@ -70,7 +70,7 @@ async function listDataFeeds(client: MetricsAdvisorAdministrationClient) {
 
 async function createDataFeed(
   client: MetricsAdvisorAdministrationClient
-): Promise<CreateDataFeedResponse> {
+): Promise<GetDataFeedResponse> {
   console.log("Creating Datafeed...");
   const feed: DataFeedDescriptor = {
     name: "test-datafeed-" + new Date().getTime().toString(),
@@ -127,7 +127,8 @@ async function createDataFeed(
     accessMode: "Private"
   };
   const result = await client.createDataFeed(feed);
-  console.log(result.id);
+
+  console.dir(result);
   return result;
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/metricFeedback.ts
@@ -58,9 +58,7 @@ async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: str
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-
-  const created = await client.createFeedback(periodFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -72,8 +70,7 @@ async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  const created = await client.createFeedback(changePointFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -84,8 +81,7 @@ async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: st
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  const created = await client.createFeedback(commendFeedback);
-  return await client.getFeedback(created.id);
+  return await client.createFeedback(commendFeedback);
 }
 
 async function getFeedback(client: MetricsAdvisorClient, feedbackId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/typescript/src/quickstart.ts
@@ -12,7 +12,7 @@ import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
   AnomalyAlert,
-  CreateDataFeedResponse,
+  GetDataFeedResponse,
   MetricsAdvisorClient,
   WebNotificationHook,
   DataFeedDescriptor,
@@ -38,9 +38,8 @@ export async function main() {
 
   const created = await createDataFeed(adminClient, sqlServerConnectionString, sqlServerQuery);
   console.log(`Data feed created: ${created.id}`);
-  const datafeed = await adminClient.getDataFeed(created.id);
   console.log("  metrics: ");
-  console.log(datafeed.schema.metrics);
+  console.log(created.schema.metrics);
 
   console.log("Waiting for a minute before checking ingestion status...");
   await delay(60 * 1000);
@@ -53,7 +52,7 @@ export async function main() {
       new Date(Date.UTC(2020, 8, 12))
     );
 
-    const metricId = datafeed.schema.metrics[0].id!;
+    const metricId = created.schema.metrics[0].id!;
     const detectionConfig = await configureAnomalyDetectionConfiguration(adminClient, metricId);
     console.log(`Detection configuration created: ${detectionConfig.id!}`);
 
@@ -89,7 +88,7 @@ async function createDataFeed(
   adminClient: MetricsAdvisorAdministrationClient,
   sqlServerConnectionString: string,
   sqlServerQuery: string
-): Promise<CreateDataFeedResponse> {
+): Promise<GetDataFeedResponse> {
   console.log("Creating Datafeed...");
   const dataFeed: DataFeedDescriptor = {
     name: "test_datafeed_" + new Date().getTime().toString(),

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -178,7 +178,7 @@ export class MetricsAdvisorAdministrationClient {
    * Adds a new data feed for a specific data source and provided settings
    * @param feed - the data feed object to create
    * @param options - The options parameter.
-   * @returns - An async response with Datafeed object
+   * @returns Response with Datafeed object
    */
 
   public async createDataFeed(
@@ -548,7 +548,7 @@ export class MetricsAdvisorAdministrationClient {
    * Creates an anomaly detection configuration for a given metric
    * @param config - The detection configuration object to create
    * @param options - The options parameter
-   * @returns - An async response with Detection Config object
+   * @returns Response with Detection Config object
    */
   public async createDetectionConfig(
     config: Omit<AnomalyDetectionConfiguration, "id">,
@@ -679,7 +679,7 @@ export class MetricsAdvisorAdministrationClient {
   /**
    * Creates anomaly alerting configuration for a given metric
    * @param config - The alert configuration object to create
-   * @returns - An async response with Alert object
+   * @returns Response with Alert object
    */
   public async createAlertConfig(
     config: Omit<AnomalyAlertConfiguration, "id">,
@@ -933,7 +933,7 @@ export class MetricsAdvisorAdministrationClient {
    * Adds a new hook
    * @param hookInfo - Information for the new hook consists of the hook type, name, description, external link and hook parameter
    * @param options - The options parameter.
-   * @returns - An async response with Hook object
+   * @returns  Response with Hook object
    */
   public async createHook(
     hookInfo: EmailNotificationHook | WebNotificationHook,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -31,7 +31,6 @@ import {
   WebNotificationHookPatch,
   EmailNotificationHookPatch,
   AnomalyDetectionConfiguration,
-  CreateDataFeedResponse,
   GetDataFeedResponse,
   GetAnomalyDetectionConfigurationResponse,
   GetAnomalyAlertConfigurationResponse,
@@ -45,10 +44,7 @@ import {
   HooksPageResponse,
   DataFeedStatus,
   GetIngestionProgressResponse,
-  AnomalyAlertConfiguration,
-  CreateAnomalyDetectionConfigurationResponse,
-  CreateAnomalyAlertConfigurationResponse,
-  CreateHookResponse
+  AnomalyAlertConfiguration
 } from "./models";
 import { DataSourceType, HookInfoUnion, NeedRollupEnum } from "./generated/models";
 import {
@@ -187,7 +183,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createDataFeed(
     feed: DataFeedDescriptor,
     operationOptions: OperationOptions = {}
-  ): Promise<CreateDataFeedResponse> {
+  ): Promise<GetDataFeedResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createDataFeed",
       operationOptions
@@ -264,8 +260,8 @@ export class MetricsAdvisorAdministrationClient {
         throw new Error("Expected a valid location to retrieve the created configuration");
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
-      const id = result.location.substring(lastSlashIndex + 1);
-      return { id, _response: result._response };
+      const feedId = result.location.substring(lastSlashIndex + 1);
+      return this.getDataFeed(feedId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -555,7 +551,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createDetectionConfig(
     config: Omit<AnomalyDetectionConfiguration, "id">,
     options: OperationOptions = {}
-  ): Promise<CreateAnomalyDetectionConfigurationResponse> {
+  ): Promise<GetAnomalyDetectionConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createDetectionConfig",
       options
@@ -572,7 +568,7 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      return { id: configId, _response: result._response };
+      return this.getDetectionConfig(configId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -685,7 +681,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createAlertConfig(
     config: Omit<AnomalyAlertConfiguration, "id">,
     options: OperationOptions = {}
-  ): Promise<CreateAnomalyAlertConfigurationResponse> {
+  ): Promise<GetAnomalyAlertConfigurationResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createAlertConfig",
       options
@@ -702,7 +698,7 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      return { id: configId, _response: result._response };
+      return this.getAlertConfig(configId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -938,7 +934,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createHook(
     hookInfo: EmailNotificationHook | WebNotificationHook,
     options: OperationOptions = {}
-  ): Promise<CreateHookResponse> {
+  ): Promise<GetHookResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createHook",
       options
@@ -962,7 +958,7 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const hookId = result.location.substring(lastSlashIndex + 1);
-      return { id: hookId, _response: result._response };
+      return this.getHook(hookId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -178,6 +178,7 @@ export class MetricsAdvisorAdministrationClient {
    * Adds a new data feed for a specific data source and provided settings
    * @param feed - the data feed object to create
    * @param options - The options parameter.
+   * @returns - An async response with Datafeed object
    */
 
   public async createDataFeed(
@@ -261,9 +262,6 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedId = result.location.substring(lastSlashIndex + 1);
-      /**
-       * @returns - An async response with Datafeed object
-       */
       return this.getDataFeed(feedId);
     } catch (e) {
       span.setStatus({
@@ -550,6 +548,7 @@ export class MetricsAdvisorAdministrationClient {
    * Creates an anomaly detection configuration for a given metric
    * @param config - The detection configuration object to create
    * @param options - The options parameter
+   * @returns - An async response with Detection Config object
    */
   public async createDetectionConfig(
     config: Omit<AnomalyDetectionConfiguration, "id">,
@@ -571,9 +570,6 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      /**
-       * @returns - An async response with Detection Config object
-       */
       return this.getDetectionConfig(configId);
     } catch (e) {
       span.setStatus({
@@ -683,6 +679,7 @@ export class MetricsAdvisorAdministrationClient {
   /**
    * Creates anomaly alerting configuration for a given metric
    * @param config - The alert configuration object to create
+   * @returns - An async response with Alert object
    */
   public async createAlertConfig(
     config: Omit<AnomalyAlertConfiguration, "id">,
@@ -704,9 +701,6 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
-      /**
-       * @returns - An async response with Alert object
-       */
       return this.getAlertConfig(configId);
     } catch (e) {
       span.setStatus({
@@ -939,6 +933,7 @@ export class MetricsAdvisorAdministrationClient {
    * Adds a new hook
    * @param hookInfo - Information for the new hook consists of the hook type, name, description, external link and hook parameter
    * @param options - The options parameter.
+   * @returns - An async response with Hook object
    */
   public async createHook(
     hookInfo: EmailNotificationHook | WebNotificationHook,
@@ -967,9 +962,6 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const hookId = result.location.substring(lastSlashIndex + 1);
-      /**
-       * @returns - An async response with Hook object
-       */
       return this.getHook(hookId);
     } catch (e) {
       span.setStatus({

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -261,6 +261,9 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedId = result.location.substring(lastSlashIndex + 1);
+      /**
+       * @returns - An async response with Datafeed object
+       */
       return this.getDataFeed(feedId);
     } catch (e) {
       span.setStatus({
@@ -568,6 +571,9 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
+      /**
+       * @returns - An async response with Detection Config object
+       */
       return this.getDetectionConfig(configId);
     } catch (e) {
       span.setStatus({
@@ -698,6 +704,9 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const configId = result.location.substring(lastSlashIndex + 1);
+      /**
+       * @returns - An async response with Alert object
+       */
       return this.getAlertConfig(configId);
     } catch (e) {
       span.setStatus({
@@ -958,6 +967,9 @@ export class MetricsAdvisorAdministrationClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const hookId = result.location.substring(lastSlashIndex + 1);
+      /**
+       * @returns - An async response with Hook object
+       */
       return this.getHook(hookId);
     } catch (e) {
       span.setStatus({

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -1577,6 +1577,7 @@ export class MetricsAdvisorClient {
    *
    * @param feedback - Content of the feedback
    * @param options - The options parameter
+   * @returns - An async response with Feedback object
    */
   public async createFeedback(
     feedback: MetricFeedbackUnion,
@@ -1596,9 +1597,6 @@ export class MetricsAdvisorClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedbackId = result.location.substring(lastSlashIndex + 1);
-      /**
-       * @returns - An async response with Feedback object
-       */
       return this.getFeedback(feedbackId);
     } catch (e) {
       span.setStatus({

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -1577,7 +1577,7 @@ export class MetricsAdvisorClient {
    *
    * @param feedback - Content of the feedback
    * @param options - The options parameter
-   * @returns - An async response with Feedback object
+   * @returns Response with Feedback object
    */
   public async createFeedback(
     feedback: MetricFeedbackUnion,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -1596,6 +1596,9 @@ export class MetricsAdvisorClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedbackId = result.location.substring(lastSlashIndex + 1);
+      /**
+       * @returns - An async response with Feedback object
+       */
       return this.getFeedback(feedbackId);
     } catch (e) {
       span.setStatus({

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -35,8 +35,7 @@ import {
   EnrichmentStatus,
   GetMetricSeriesDataResponse,
   MetricFeedbackPageResponse,
-  AlertQueryTimeMode,
-  CreateFeedbackResponse
+  AlertQueryTimeMode
 } from "./models";
 import { SeverityFilterCondition, FeedbackType, FeedbackQueryTimeMode } from "./generated/models";
 import { toServiceMetricFeedbackUnion, fromServiceMetricFeedbackUnion } from "./transforms";
@@ -1582,7 +1581,7 @@ export class MetricsAdvisorClient {
   public async createFeedback(
     feedback: MetricFeedbackUnion,
     options: OperationOptions = {}
-  ): Promise<CreateFeedbackResponse> {
+  ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createFeedback",
       options
@@ -1597,7 +1596,7 @@ export class MetricsAdvisorClient {
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const feedbackId = result.location.substring(lastSlashIndex + 1);
-      return { id: feedbackId, _response: result._response };
+      return this.getFeedback(feedbackId);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -272,16 +272,6 @@ export type DataFeedGranularity =
 export type DataFeedStatus = "Paused" | "Active" | string;
 
 /**
- * Represents newly created Metrics Advisor data feed.
- */
-export type CreatedDataFeed = {
-  /**
-   * Unique id of the data feed.
-   */
-  id: string;
-};
-
-/**
  * Represents a Metrics Advisor data feed.
  */
 export type DataFeed = {
@@ -647,15 +637,6 @@ export type ChangeThresholdConditionUnion =
     };
 
 /**
- * Represents newly created Metric Feedback
- */
-export type CreateMetricFeedback = {
-  /**
-   * feedback unique id
-   */
-  id: string;
-};
-/**
  * A union type of all metric feedback types.
  */
 export type MetricFeedbackUnion =
@@ -829,16 +810,6 @@ export type WebNotificationHook = {
  * A union type of all supported hooks
  */
 export type NotificationHookUnion = EmailNotificationHook | WebNotificationHook;
-
-/**
- * A union type of all supported created hooks
- */
-export type CreatedNotificationHook = {
-  /**
-   * Hook unique id
-   */
-  id: string;
-};
 
 /**
  * Represents properties common to the patch input to the Update Hook operation.
@@ -1134,16 +1105,6 @@ export interface MetricAlertConfiguration {
 }
 
 /**
- * Represents created anomaly alert configuration.
- */
-export interface CreatedAnomalyAlertConfiguration {
-  /**
-   * anomaly alerting configuration unique id
-   */
-  id: string;
-}
-
-/**
  * Represents an anomaly alert configuration.
  */
 export interface AnomalyAlertConfiguration {
@@ -1207,16 +1168,6 @@ export interface AnomalyDetectionConfiguration {
    */
   seriesDetectionConditions?: MetricSingleSeriesDetectionCondition[];
 }
-
-/**
- * Represents newly created metric anomaly detection configuration.
- */
-export type CreatedAnomalyDetectionConfiguration = {
-  /**
-   * Anomaly detection configuration unique id
-   */
-  id: string;
-};
 
 /**
  * Represents the root cause of an incident.
@@ -1331,35 +1282,7 @@ export type GetDataFeedResponse = DataFeed & {
     parsedBody: any;
   };
 };
-/**
- * Contains response data for the createDataFeed operation.
- */
-export type CreateDataFeedResponse = CreatedDataFeed & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
-    parsedHeaders: any;
-  };
-};
 
-/**
- * Contains response data for the createAnomalyDetectionConfiguration operation.
- */
-export type CreateAnomalyDetectionConfigurationResponse = CreatedAnomalyDetectionConfiguration & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedHeaders: any;
-  };
-};
 /**
  * Contains response data for the getAnomalyDetectionConfiguration operation.
  */
@@ -1381,21 +1304,6 @@ export type GetAnomalyDetectionConfigurationResponse = AnomalyDetectionConfigura
 };
 
 /**
- * Contains response data for the createAnomalyAlertConfiguration operation.
- */
-export type CreateAnomalyAlertConfigurationResponse = CreatedAnomalyAlertConfiguration & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedHeaders: any;
-  };
-};
-
-/**
  * Contains response data for the getAnomalyAlertConfiguration operation.
  */
 export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
@@ -1412,21 +1320,6 @@ export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
      * The response body as parsed JSON or XML
      */
     parsedBody: any;
-  };
-};
-
-/**
- * Contains response data for the createHook operation.
- */
-export type CreateHookResponse = CreatedNotificationHook & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedHeaders: any;
   };
 };
 
@@ -1488,21 +1381,6 @@ export type GetIncidentRootCauseResponse = {
      * The response body as parsed JSON or XML
      */
     parsedBody: any;
-  };
-};
-
-/**
- * Contains response data for the createFeedback operation.
- */
-export type CreateFeedbackResponse = CreateMetricFeedback & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedHeaders: any;
   };
 };
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
@@ -137,10 +137,11 @@ matrix([[true, false]] as const, async (useAad) => {
             seriesDetectionConditions: []
           };
 
-          const created = await client.createDetectionConfig(expected);
-          const actual = await client.getDetectionConfig(created.id);
+          const actual = await client.createDetectionConfig(expected);
+
           assert.ok(actual.id, "Expecting valid detection config");
           createdDetectionConfigId = actual.id!;
+
           assert.equal(actual.name, expected.name);
           assert.strictEqual(actual.description, expected.description);
           assert.equal(actual.metricId, expected.metricId);
@@ -279,8 +280,8 @@ matrix([[true, false]] as const, async (useAad) => {
             hookIds: []
           };
 
-          const created = await client.createAlertConfig(expectedAlertConfig);
-          const actual = await client.getAlertConfig(created.id);
+          const actual = await client.createAlertConfig(expectedAlertConfig);
+
           assert.ok(actual.id, "Expecting valid alert config");
           createdAlertConfigId = actual.id;
           assert.equal(actual.name, expectedAlertConfig.name);

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -525,8 +525,8 @@ matrix([[true, false]] as const, async (useAad) => {
             value: "NotAnomaly",
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const created = await client.createFeedback(anomalyFeedback);
-          const actual = await client.getFeedback(created.id);
+          const actual = await client.createFeedback(anomalyFeedback);
+
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
           assert.equal(actual.feedbackType, "Anomaly");
@@ -543,8 +543,8 @@ matrix([[true, false]] as const, async (useAad) => {
             value: "ChangePoint",
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const created = await client.createFeedback(changePointFeedback);
-          const actual = await client.getFeedback(created.id);
+          const actual = await client.createFeedback(changePointFeedback);
+
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
           assert.equal(actual.feedbackType, "ChangePoint");
@@ -561,8 +561,8 @@ matrix([[true, false]] as const, async (useAad) => {
             periodValue: 4,
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const created = await client.createFeedback(periodFeedback);
-          const actual = await client.getFeedback(created.id);
+          const actual = await client.createFeedback(periodFeedback);
+
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
           assert.equal(actual.feedbackType, "Period");
@@ -579,8 +579,9 @@ matrix([[true, false]] as const, async (useAad) => {
             dimensionKey: { city: "Cairo", category: "Home & Garden" },
             comment: "This is a comment"
           };
-          const created = await client.createFeedback(expectedCommentFeedback);
-          const actual = await client.getFeedback(created.id);
+
+          const actual = await client.createFeedback(expectedCommentFeedback);
+
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
           assert.equal(actual.feedbackType, "Comment");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -147,8 +147,7 @@ matrix([[true, false]] as const, async (useAad) => {
               blobTemplate: testEnv.METRICS_ADVISOR_AZURE_BLOB_TEMPLATE
             }
           };
-
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: feedName,
             source: expectedSource,
             granularity,
@@ -156,7 +155,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdAzureBlobDataFeedId = actual.id;
 
@@ -342,7 +341,7 @@ matrix([[true, false]] as const, async (useAad) => {
                 "let gran=60m; let starttime=datetime(@StartTime); let endtime=starttime + gran; requests | where timestamp >= starttime and timestamp < endtime | summarize request_count = count(), duration_avg_ms = avg(duration), duration_95th_ms = percentile(duration, 95), duration_max_ms = max(duration) by resultCode"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: appInsightsFeedName,
             source: expectedSource,
             granularity,
@@ -350,7 +349,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdAppFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "AzureApplicationInsights");
@@ -379,7 +378,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "select * from adsample2 where Timestamp = @StartTime"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: sqlServerFeedName,
             source: expectedSource,
             granularity,
@@ -387,7 +386,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdSqlServerFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "SqlServer");
@@ -451,7 +450,7 @@ matrix([[true, false]] as const, async (useAad) => {
               collectionId: "sample"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: cosmosFeedName,
             source: expectedSource,
             granularity,
@@ -460,7 +459,6 @@ matrix([[true, false]] as const, async (useAad) => {
             ...options
           });
 
-          const actual = await client.getDataFeed(created.id);
           assert.ok(actual.id, "Expecting valid data feed id");
           createdCosmosFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "AzureCosmosDB");
@@ -490,7 +488,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "let starttime=datetime(@StartTime); let endtime=starttime"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: dataExplorerFeedName,
             source: expectedSource,
             granularity,
@@ -498,7 +496,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdAzureDataExplorerFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "AzureDataExplorer");
@@ -527,7 +525,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "partition-key eq @start-time"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: azureTableFeedName,
             source: expectedSource,
             granularity,
@@ -536,7 +534,6 @@ matrix([[true, false]] as const, async (useAad) => {
             ...options
           });
 
-          const actual = await client.getDataFeed(created.id);
           assert.ok(actual.id, "Expecting valid data feed id");
           createdAzureTableFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "AzureTable");
@@ -564,7 +561,7 @@ matrix([[true, false]] as const, async (useAad) => {
               payload: "{start-time: @start-time}"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: httpRequestFeedName,
             source: expectedSource,
             granularity,
@@ -572,7 +569,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdHttpRequestFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "HttpRequest");
@@ -599,7 +596,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "partition-key eq @start-time"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: influxDbFeedName,
             source: expectedSource,
             granularity,
@@ -608,7 +605,6 @@ matrix([[true, false]] as const, async (useAad) => {
             ...options
           });
 
-          const actual = await client.getDataFeed(created.id);
           assert.ok(actual.id, "Expecting valid data feed id");
           createdInfluxFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "InfluxDB");
@@ -637,7 +633,7 @@ matrix([[true, false]] as const, async (useAad) => {
               command: "{ find: mongodb,filter: { Time: @StartTime },batch: 200 }"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: mongoDbFeedName,
             source: expectedSource,
             granularity,
@@ -645,7 +641,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdMongoDbFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "MongoDB");
@@ -674,7 +670,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "{ find: mongodb,filter: { Time: @StartTime },batch: 200 }"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: mySqlFeedName,
             source: expectedSource,
             granularity,
@@ -682,7 +678,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdMySqlFeedId = actual.id;
           assert.equal(actual.source.dataSourceType, "MySql");
@@ -710,7 +706,7 @@ matrix([[true, false]] as const, async (useAad) => {
               query: "{ find: postgresql,filter: { Time: @StartTime },batch: 200 }"
             }
           };
-          const created = await client.createDataFeed({
+          const actual = await client.createDataFeed({
             name: postgreSqlFeedName,
             source: expectedSource,
             granularity,
@@ -718,7 +714,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ingestionSettings: dataFeedIngestion,
             ...options
           });
-          const actual = await client.getDataFeed(created.id);
+
           assert.ok(actual.id, "Expecting valid data feed id");
           createdPostGreSqlId = actual.id;
           assert.equal(actual.source.dataSourceType, "PostgreSql");


### PR DESCRIPTION
Revert "[Metrics Advisor] Create functions modified to return id with response instead of complete objects (#13254)"

This reverts commit b56d19efbfae570e9ef64c9c823083253088d39d.

We are reverting this commit to align with Java and Python's decision on returning complete objects instead of just the id. Python follows the rule:
=> If there is no created item from response, instead the response returns for location header -> call an extra GET to translate the location header to an object and return the object to the user. Also location header gives information about etags, in case we need to use in future
