### PR TITLE
[Text Analytics] Integrating action failures and successes into one array

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -2,7 +2,7 @@
 
 [Azure TextAnalytics](https://azure.microsoft.com/services/cognitive-services/text-analytics/) is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:
 
-**Note:** This SDK targets Azure Text Analytics service API version 3.1.0-preview.2.
+**Note:** This SDK targets Azure Text Analytics service API version 3.1.0-preview.3.
 
 - Language Detection
 - Sentiment Analysis
@@ -449,42 +449,48 @@ async function main() {
   const resultPages = await poller.pollUntilDone();
 
   for await (const page of resultPages) {
-    const keyPhrasesResults = page.extractKeyPhrasesResults[0];
-    for (const doc of keyPhrasesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
 
-    const entitiesResults = page.recognizeEntitiesResults[0];
-    for (const doc of entitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
 
-    const piiEntitiesResults = page.recognizePiiEntitiesResults[0];
-    for (const doc of piiEntitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -447,49 +447,49 @@ async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
-  const page = (await resultPages.next()).value;
-
-  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-  if (!keyPhrasesAction.error) {
-    for (const doc of keyPhrasesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+  for (const page of resultPages) {
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const entitiesAction = page.recognizeEntitiesResults[0];
-  if (!entitiesAction.error) {
-    for (const doc of entitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-  if (!piiEntitiesAction.error) {
-    for (const doc of piiEntitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -447,50 +447,49 @@ async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
+  const page = (await resultPages.next()).value;
 
-  for await (const page of resultPages) {
-    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-    if (!keyPhrasesAction.error) {
-      for (const doc of keyPhrasesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tKey phrases:");
-          for (const phrase of doc.keyPhrases) {
-            console.log(`\t- ${phrase}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+  if (!keyPhrasesAction.error) {
+    for (const doc of keyPhrasesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tKey phrases:");
+        for (const phrase of doc.keyPhrases) {
+          console.log(`\t- ${phrase}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const entitiesAction = page.recognizeEntitiesResults[0];
-    if (!entitiesAction.error) {
-      for (const doc of entitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tEntities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const entitiesAction = page.recognizeEntitiesResults[0];
+  if (!entitiesAction.error) {
+    for (const doc of entitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tEntities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-    if (!piiEntitiesAction.error) {
-      for (const doc of piiEntitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tPii Entities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+  if (!piiEntitiesAction.error) {
+    for (const doc of piiEntitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tPii Entities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Text Analytics service.",
-  "version": "5.1.0-beta.3",
+  "version": "5.1.0-beta.4",
   "keywords": [
     "node",
     "azure",

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_action_failures_are_returned.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_action_failures_are_returned.json
@@ -1,0 +1,1314 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:15 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11459.15 - EUS ProdSlices",
+    "x-ms-request-id": "54462bdb-e08e-48cc-9bd5-96b45d9d3a00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze",
+   "query": {},
+   "requestBody": "{\"tasks\":{\"entityRecognitionPiiTasks\":[{\"parameters\":{\"model-version\":\"bad\",\"stringIndexType\":\"Utf16CodeUnit\"}},{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}},{\"parameters\":{\"model-version\":\"bad\",\"stringIndexType\":\"TextElements_v8\"}}]},\"analysisInput\":{\"documents\":[{\"id\":\"1\",\"text\":\"I will go to the park.\"}]}}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "apim-request-id": "48c813de-5985-4bd5-8a28-02d0e7c47f1a",
+    "date": "Fri, 05 Feb 2021 17:49:14 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "27"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:15Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:15Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "responseHeaders": {
+    "apim-request-id": "7ee7af52-8eb2-44b2-a596-fa4c598c54ce",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:14 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "10"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:15Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:15Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "responseHeaders": {
+    "apim-request-id": "1886ace7-1278-4008-bff6-6d1f2581af56",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:15 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "10"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "5f40f6d2-1730-4515-8fce-3a2eec0b8d30",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:17 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "65"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "e0b82b0f-a7e1-4f5e-87a8-0f01bff0216f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "342"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "89a56af0-07bb-4278-b7e2-3fe3e8a6e73f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:22 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "65"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "ff83619e-c3bf-4d45-841b-31ea05fbe5c2",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:24 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "45"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "dc65256e-c27b-4798-8e08-ab4a0808c6af",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:26 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "7641cd07-ab15-4bef-8f34-daafa01917ec",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:28 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "38"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "82c2dc4f-55c9-4503-a948-b112790e6b64",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:30 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "152"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "b3205fc3-89e8-4003-b052-6680281fbfc9",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:32 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "35"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "de98250e-9080-4480-a363-acff263bff33",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:34 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "63"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "a908c452-93fc-4547-864a-ed5fdc8ff0b5",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:36 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "94"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "6ab733c3-4f67-46ec-93d2-9b3b9e77bf2e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:38 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "95"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "4e443a08-9e4c-4f4b-9108-96ed667f4e29",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:40 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "42"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "af232524-c070-49a5-8718-228fcbd59b9b",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "33"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:45 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11459.15 - NCUS ProdSlices",
+    "x-ms-request-id": "794b70c3-c877-48f5-8452-efea5f824600"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "34ac207a-932c-4241-8c1b-5678f748482e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "e1adc10a-64a3-4b50-99c2-dd1db3a97637",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:47 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "36"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "637cb685-6e82-4ec1-8f97-8e32146a1f61",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:49 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "67"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "b82eb736-1e06-418f-811f-8e29c4c0351f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:51 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "71"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "307bc4dd-dd99-407a-9dda-95f9bdf2e486",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:53 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "39"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "97841bd3-d4f4-4e0f-b7e7-000cb85d4ffe",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:55 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "27"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "78139eda-3216-4ffa-82fc-10e58fbb7499",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:57 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "35"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "215211aa-6599-472a-92fc-b9b3387ae723",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:49:59 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "60"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "04c76c33-81a8-4649-92ad-e6fa24f25c52",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:01 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "ec4ce268-1dd3-4ce4-b97c-3ce291791f7c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:04 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "89"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "f25c679e-f917-4455-8976-985c7b250355",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:06 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "73"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "49df99f8-97f1-4be9-98f5-9159895ceb86",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:09 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "38"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "a74b07e6-f3d4-4b29-960e-da4b1255fc35",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:11 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "31"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "476e7d89-e422-4aad-ad21-db0c4170c37c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:13 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "33"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "b8db6fc0-031a-4ab9-9eba-dde86f2e3099",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:15 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "62"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:17 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11459.15 - SCUS ProdSlices",
+    "x-ms-request-id": "59d3a2a4-12d4-41ae-bf2e-4e9d1f434300"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "47929dcd-e92d-42a7-8243-5133777354ba",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:17 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "64"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "44db86a3-8e87-4b3c-8fac-25c07eb7d554",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "ddc11099-d5ad-452c-855d-f2ec98fbc806",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:21 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "64"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "3b084f2c-1537-441a-af9d-38707695b889",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "68"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "de06dace-d5ba-4bf7-846f-6adc54602f9f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:25 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "68"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "43407ab5-45ee-4e4a-b007-de6232da37f5",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:28 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "68"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "64ab1d6b-8257-45dc-9cb0-5505c311fb83",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:30 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "957ac23b-e8aa-4d33-94f4-832a1ff4844a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:32 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "28a561b9-0000-4711-ac86-36075fe189b4",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:34 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "29"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "3eaacda4-085b-47e2-bb7c-541ced477c24",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:36 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "71"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "33ceab56-9f21-43bb-b6b5-eff5fa118425",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:38 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "1dd7ad03-0595-49a2-88eb-b200712b0806",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:40 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "67"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "59bf9b1f-422e-4da4-97f4-b41d84399785",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "58"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "606aac7c-4f3c-4161-bb4c-c6b8a1cc9504",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "34"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "3fea3a3a-3f75-41f3-aac0-82104ca830d9",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:46 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "80"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:48 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11459.15 - WUS2 ProdSlices",
+    "x-ms-request-id": "9d598c72-dbfd-4682-b730-9b9d8c7abe00"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "267ca8a4-e90a-4678-b27f-ce25930dba9a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:49 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "95"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "5bbd3e40-a733-46db-9f69-1b9ac615f38f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:51 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "41"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "1840b4d1-45ea-4989-a21c-5df083ad2194",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:53 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "437239da-1e4b-4f61-b541-c147420394fc",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:55 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "33"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "0fcac061-c9be-4e1d-9b5b-68642ec64367",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:57 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "73"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "2b97aa16-6850-47d5-8fb2-a318df8ed4fd",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:50:59 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "37"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "1bf3900a-0a88-42f6-ab2f-f5dbb422e489",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:01 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "43"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "05d57e62-d4e6-4390-a814-9d7473b98316",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:03 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "42"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "f3eb6663-20d6-4cb1-b7dd-a51c8575f67a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:06 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "31"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "6a0cf071-ec85-4a52-a763-46b7228d94bd",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:08 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "c396fda6-fac9-423f-b681-b920e237d1fe",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:10 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "75"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "33c7b103-12f5-423b-bbfe-cd1246f57516",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:12 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "111"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "dca9cd95-3735-4b4f-b1ab-286130660518",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:14 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "102"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "af06b016-8b84-4715-8be2-e61b41fa8b88",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:16 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "64"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"running\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":0,\"failed\":2,\"inProgress\":1,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "9afb24b0-76ca-452f-bac8-fabab3188a3a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:18 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "34"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:20 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11459.15 - NCUS ProdSlices",
+    "x-ms-request-id": "794b70c3-c877-48f5-8452-efea6c9c4600"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"partiallySucceeded\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":1,\"failed\":2,\"inProgress\":0,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[{\"redactedText\":\"I will go to the park.\",\"id\":\"1\",\"entities\":[],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2020-07-01\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "94f8e485-f8ad-40ec-87ac-cfec714530db",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:20 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "57"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/29417026-efce-4738-94b1-26c51192e6b3_637480800000000000",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"29417026-efce-4738-94b1-26c51192e6b3_637480800000000000\",\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\",\"createdDateTime\":\"2021-02-05T17:49:15Z\",\"expirationDateTime\":\"2021-02-06T17:49:15Z\",\"status\":\"partiallySucceeded\",\"errors\":[{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/0\"},{\"code\":\"InvalidRequest\",\"message\":\"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.\",\"target\":\"#/tasks/entityRecognitionPiiTasks/2\"}],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-05T17:49:17Z\"},\"completed\":1,\"failed\":2,\"inProgress\":0,\"total\":3,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[{\"redactedText\":\"I will go to the park.\",\"id\":\"1\",\"entities\":[],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2020-07-01\"}},{\"lastUpdateDateTime\":\"2021-02-05T17:49:17.2452646Z\",\"results\":{\"documents\":[],\"errors\":[],\"modelVersion\":\"\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "1b5cf991-58b5-4bdd-8e6d-93ebe9555a7c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Feb 2021 17:51:20 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "65"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "ee30b2a17de653550448efc5151f1eb5"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_action_failures_are_returned.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_action_failures_are_returned.js
@@ -1,0 +1,823 @@
+let nock = require('nock');
+
+module.exports.hash = "0c1d176f079a7f3a55008c6d6c081cb2";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '43720175-c77c-4660-af72-fe69dc0f4800',
+  'x-ms-ests-server',
+  '2.1.11459.15 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AnHJHRxqM71KmcExfVMzal9z_bg1AQAAAM97r9cOAAAA; expires=Sun, 07-Mar-2021 17:47:59 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 05 Feb 2021 17:47:59 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.1-preview.3/analyze', {"tasks":{"entityRecognitionPiiTasks":[{"parameters":{"model-version":"bad","stringIndexType":"Utf16CodeUnit"}},{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}},{"parameters":{"model-version":"bad","stringIndexType":"TextElements_v8"}}]},"analysisInput":{"documents":[{"id":"1","text":"I will go to the park."}]}})
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'operation-location',
+  'https://endpoint/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000',
+  'x-envoy-upstream-service-time',
+  '231',
+  'apim-request-id',
+  'b3d7ef4d-c29f-4ae7-b6b2-ecb497adbb85',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:01 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:01Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:01Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '12',
+  'apim-request-id',
+  '05641a7c-5d9f-4faf-a5ab-992588b45f43',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:01 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:01Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:01Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '12',
+  'apim-request-id',
+  '04461ffc-0e3a-4a1c-bdc1-47c82164bee5',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:01 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:01Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:01Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '10',
+  'apim-request-id',
+  '035bc6dc-b943-49db-805c-5ccbeb8cea45',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:03 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '41',
+  'apim-request-id',
+  '7c26f02d-0715-4a41-a166-f1ec25c7703d',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:05 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '41',
+  'apim-request-id',
+  '8eedd429-0c9f-4cf3-8076-b0e5e1ee842c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:07 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  'e7793937-4d7a-4303-82ca-16ff0d99f8cc',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:09 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '38',
+  'apim-request-id',
+  '5186557b-1507-4eae-9d04-edbb29356441',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:11 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '85',
+  'apim-request-id',
+  '5ea8dab5-77b5-4fcf-8174-8226028e00d1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:14 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '35',
+  'apim-request-id',
+  'd772e632-b2ad-45fc-a06f-4f2260372d54',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:16 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '31',
+  'apim-request-id',
+  '77f88bf3-c872-43fc-8349-1e46b02b198d',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:18 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '62',
+  'apim-request-id',
+  'eccd472f-6978-4265-baab-a350d76eb222',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:20 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '35',
+  'apim-request-id',
+  '7af38478-dc0f-4800-822f-d4ee5b8df3be',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:22 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '34',
+  'apim-request-id',
+  'e89866fd-9d9c-4dae-8878-f5bf1afc3f14',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:24 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '44',
+  'apim-request-id',
+  'e79fafc8-7ab1-45ab-8ac2-d2c8476a527c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:26 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '32',
+  'apim-request-id',
+  '493e4b0d-0771-4074-9b8b-75bb2e93bfd3',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:28 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '34',
+  'apim-request-id',
+  'c6ba9633-5a9a-4b5d-b49a-301fb0b3f165',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:31 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7e974386-ef2e-479c-9830-e1360be43c00',
+  'x-ms-ests-server',
+  '2.1.11459.15 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AnHJHRxqM71KmcExfVMzal9z_bg1AgAAAM97r9cOAAAA; expires=Sun, 07-Mar-2021 17:48:31 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:30 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '75',
+  'apim-request-id',
+  '1e60d27e-9653-4924-835f-5675b4698b63',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:33 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '35',
+  'apim-request-id',
+  '5a52d5e4-db9c-438a-8727-7d4c09c44462',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:35 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '35',
+  'apim-request-id',
+  '889799bf-bc27-4ec7-be7c-fa66437cfeda',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:37 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '67',
+  'apim-request-id',
+  'f48ab878-01c3-467a-ba9a-efc2d19f9fc3',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:39 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  '376f9f2b-0d86-4d65-b075-bfc58b1fb90e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:41 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  'f44c06a1-1861-491a-ac8c-49faf1dea373',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:44 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '70',
+  'apim-request-id',
+  'ccf832c9-5d0f-4143-8995-5b979ad94223',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:46 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '37',
+  'apim-request-id',
+  '4fbaf6fa-8b7b-486b-a79d-0aa5b0e4c23a',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:48 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '64',
+  'apim-request-id',
+  '08733046-daa4-4e66-ae03-85524a558bfb',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:50 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '40',
+  'apim-request-id',
+  'd487af3b-4200-423c-94c9-4cfe7cc31b98',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:52 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '38',
+  'apim-request-id',
+  '82f8fb9d-7c81-42f4-a70a-53394952f489',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:54 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '678',
+  'apim-request-id',
+  '6695cfb6-c865-4259-94ff-e0c38aede434',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:56 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '66',
+  'apim-request-id',
+  'c1c78026-8ace-4fa5-8f5e-21525a414867',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:48:58 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '3b0d0b20-ad92-4115-8d5e-a6ade3254600',
+  'x-ms-ests-server',
+  '2.1.11459.15 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AnHJHRxqM71KmcExfVMzal9z_bg1AwAAAM97r9cOAAAA; expires=Sun, 07-Mar-2021 17:49:01 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:01 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '574',
+  'apim-request-id',
+  '5044fb58-5a78-413e-a69c-b9ae693ebaa3',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:02 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '68',
+  'apim-request-id',
+  'd12b0a70-7570-4fb3-aec2-322c02a96ba9',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:04 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '97',
+  'apim-request-id',
+  'a62edbcb-a284-47a0-a86c-cd0e60907569',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:06 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"running","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":0,"failed":2,"inProgress":1,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '71',
+  'apim-request-id',
+  'b65e0993-4251-42f0-b2cd-86655a6655c3',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:08 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"partiallySucceeded","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":1,"failed":2,"inProgress":0,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[{"redactedText":"I will go to the park.","id":"1","entities":[],"warnings":[]}],"errors":[],"modelVersion":"2020-07-01"}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '141',
+  'apim-request-id',
+  '336aba27-244d-4ff9-a5c4-1bba003371c1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:10 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.3/analyze/jobs/69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000')
+  .query(true)
+  .reply(200, {"jobId":"69431a24-225f-47f0-8276-9ebaaafe0362_637480800000000000","lastUpdateDateTime":"2021-02-05T17:48:04Z","createdDateTime":"2021-02-05T17:48:01Z","expirationDateTime":"2021-02-06T17:48:01Z","status":"partiallySucceeded","errors":[{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/0"},{"code":"InvalidRequest","message":"Job task parameter value bad is not supported for model-version parameter for job task type PersonallyIdentifiableInformation. Supported values latest,2020-07-01.","target":"#/tasks/entityRecognitionPiiTasks/2"}],"tasks":{"details":{"lastUpdateDateTime":"2021-02-05T17:48:04Z"},"completed":1,"failed":2,"inProgress":0,"total":3,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[{"redactedText":"I will go to the park.","id":"1","entities":[],"warnings":[]}],"errors":[],"modelVersion":"2020-07-01"}},{"lastUpdateDateTime":"2021-02-05T17:48:04.3600788Z","results":{"documents":[],"errors":[],"modelVersion":""}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '86',
+  'apim-request-id',
+  'cbd5904b-1b97-4a5f-a507-270310a7a45c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Feb 2021 17:49:10 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -34,9 +34,12 @@ export type AnalyzeBatchActionsPollerLike = PollerLike<AnalyzeBatchActionsOperat
 
 // @public
 export interface AnalyzeBatchActionsResult {
-    extractKeyPhrasesResults: ExtractKeyPhrasesResultArray[];
-    recognizeEntitiesResults: RecognizeCategorizedEntitiesResultArray[];
-    recognizePiiEntitiesResults: RecognizePiiEntitiesResultArray[];
+    // Warning: (ae-forgotten-export) The symbol "ExtractKeyPhrasesActionResult" needs to be exported by the entry point index.d.ts
+    extractKeyPhrasesResults: ExtractKeyPhrasesActionResult[];
+    // Warning: (ae-forgotten-export) The symbol "RecognizeCategorizedEntitiesActionResult" needs to be exported by the entry point index.d.ts
+    recognizeEntitiesResults: RecognizeCategorizedEntitiesActionResult[];
+    // Warning: (ae-forgotten-export) The symbol "RecognizePiiEntitiesActionResult" needs to be exported by the entry point index.d.ts
+    recognizePiiEntitiesResults: RecognizePiiEntitiesActionResult[];
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -34,11 +34,8 @@ export type AnalyzeBatchActionsPollerLike = PollerLike<AnalyzeBatchActionsOperat
 
 // @public
 export interface AnalyzeBatchActionsResult {
-    // Warning: (ae-forgotten-export) The symbol "ExtractKeyPhrasesActionResult" needs to be exported by the entry point index.d.ts
     extractKeyPhrasesResults: ExtractKeyPhrasesActionResult[];
-    // Warning: (ae-forgotten-export) The symbol "RecognizeCategorizedEntitiesActionResult" needs to be exported by the entry point index.d.ts
     recognizeEntitiesResults: RecognizeCategorizedEntitiesActionResult[];
-    // Warning: (ae-forgotten-export) The symbol "RecognizePiiEntitiesActionResult" needs to be exported by the entry point index.d.ts
     recognizePiiEntitiesResults: RecognizePiiEntitiesActionResult[];
 }
 
@@ -194,6 +191,17 @@ export interface ExtractKeyPhrasesAction {
 }
 
 // @public
+export type ExtractKeyPhrasesActionErrorResult = TextAnalyticsActionErrorResult;
+
+// @public
+export type ExtractKeyPhrasesActionResult = ExtractKeyPhrasesActionSuccessResult | ExtractKeyPhrasesActionErrorResult;
+
+// @public
+export interface ExtractKeyPhrasesActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: ExtractKeyPhrasesResultArray;
+}
+
+// @public
 export type ExtractKeyPhrasesErrorResult = TextAnalyticsErrorResult;
 
 // @public
@@ -327,6 +335,17 @@ export type RecognizeCategorizedEntitiesAction = {
 };
 
 // @public
+export type RecognizeCategorizedEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+
+// @public
+export type RecognizeCategorizedEntitiesActionResult = RecognizeCategorizedEntitiesActionSuccessResult | RecognizeCategorizedEntitiesActionErrorResult;
+
+// @public
+export interface RecognizeCategorizedEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: RecognizeCategorizedEntitiesResultArray;
+}
+
+// @public
 export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;
 
 // @public
@@ -376,6 +395,17 @@ export type RecognizePiiEntitiesAction = {
     modelVersion?: string;
     stringIndexType?: StringIndexType;
 };
+
+// @public
+export type RecognizePiiEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+
+// @public
+export type RecognizePiiEntitiesActionResult = RecognizePiiEntitiesActionSuccessResult | RecognizePiiEntitiesActionErrorResult;
+
+// @public
+export interface RecognizePiiEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
+    results: RecognizePiiEntitiesResultArray;
+}
 
 // @public
 export type RecognizePiiEntitiesErrorResult = TextAnalyticsErrorResult;
@@ -438,10 +468,21 @@ export interface SentimentConfidenceScores {
 export type StringIndexType = "TextElements_v8" | "UnicodeCodePoint" | "Utf16CodeUnit";
 
 // @public
+export interface TextAnalyticsActionErrorResult {
+    readonly error: TextAnalyticsError;
+}
+
+// @public
 export interface TextAnalyticsActions {
     extractKeyPhrasesActions?: ExtractKeyPhrasesAction[];
     recognizeEntitiesActions?: RecognizeCategorizedEntitiesAction[];
     recognizePiiEntitiesActions?: RecognizePiiEntitiesAction[];
+}
+
+// @public
+export interface TextAnalyticsActionSuccessState {
+    readonly completedOn: Date;
+    readonly error?: undefined;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -37,42 +37,48 @@ async function main() {
   const resultPages = await poller.pollUntilDone();
 
   for await (const page of resultPages) {
-    const keyPhrasesResults = page.extractKeyPhrasesResults[0];
-    for (const doc of keyPhrasesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
 
-    const entitiesResults = page.recognizeEntitiesResults[0];
-    for (const doc of entitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
 
-    const piiEntitiesResults = page.recognizePiiEntitiesResults[0];
-    for (const doc of piiEntitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -35,49 +35,49 @@ async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
-  const page = (await resultPages.next()).value;
-
-  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-  if (!keyPhrasesAction.error) {
-    for (const doc of keyPhrasesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+  for (const page of resultPages) {
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const entitiesAction = page.recognizeEntitiesResults[0];
-  if (!entitiesAction.error) {
-    for (const doc of entitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-  if (!piiEntitiesAction.error) {
-    for (const doc of piiEntitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -35,50 +35,49 @@ async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
+  const page = (await resultPages.next()).value;
 
-  for await (const page of resultPages) {
-    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-    if (!keyPhrasesAction.error) {
-      for (const doc of keyPhrasesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tKey phrases:");
-          for (const phrase of doc.keyPhrases) {
-            console.log(`\t- ${phrase}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+  if (!keyPhrasesAction.error) {
+    for (const doc of keyPhrasesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tKey phrases:");
+        for (const phrase of doc.keyPhrases) {
+          console.log(`\t- ${phrase}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const entitiesAction = page.recognizeEntitiesResults[0];
-    if (!entitiesAction.error) {
-      for (const doc of entitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tEntities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const entitiesAction = page.recognizeEntitiesResults[0];
+  if (!entitiesAction.error) {
+    for (const doc of entitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tEntities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-    if (!piiEntitiesAction.error) {
-      for (const doc of piiEntitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tPii Entities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+  if (!piiEntitiesAction.error) {
+    for (const doc of piiEntitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tPii Entities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -35,7 +35,7 @@ async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
-  for (const page of resultPages) {
+  for await (const page of resultPages) {
     const keyPhrasesAction = page.extractKeyPhrasesResults[0];
     if (!keyPhrasesAction.error) {
       for (const doc of keyPhrasesAction.results) {

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
@@ -35,7 +35,6 @@ export async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
-  const page = (await resultPages.next()).value;
   console.log(
     `The analyze batch actions operation created on ${
       poller.getOperationState().createdOn
@@ -47,47 +46,49 @@ export async function main() {
     }`
   );
 
-  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-  if (!keyPhrasesAction.error) {
-    for (const doc of keyPhrasesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+  for (const page of resultPages) {
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const entitiesAction = page.recognizeEntitiesResults[0];
-  if (!entitiesAction.error) {
-    for (const doc of entitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
-  }
 
-  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-  if (!piiEntitiesAction.error) {
-    for (const doc of piiEntitiesAction.results) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
@@ -46,7 +46,7 @@ export async function main() {
     }`
   );
 
-  for (const page of resultPages) {
+  for await (const page of resultPages) {
     const keyPhrasesAction = page.extractKeyPhrasesResults[0];
     if (!keyPhrasesAction.error) {
       for (const doc of keyPhrasesAction.results) {

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
@@ -47,42 +47,48 @@ export async function main() {
   );
 
   for await (const page of resultPages) {
-    const keyPhrasesResults = page.extractKeyPhrasesResults![0];
-    for (const doc of keyPhrasesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tKey phrases:");
-        for (const phrase of doc.keyPhrases) {
-          console.log(`\t- ${phrase}`);
+    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+    if (!keyPhrasesAction.error) {
+      for (const doc of keyPhrasesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tKey phrases:");
+          for (const phrase of doc.keyPhrases) {
+            console.log(`\t- ${phrase}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
 
-    const entitiesResults = page.recognizeEntitiesResults![0];
-    for (const doc of entitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tEntities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const entitiesAction = page.recognizeEntitiesResults[0];
+    if (!entitiesAction.error) {
+      for (const doc of entitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tEntities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("  Error:", doc.error);
       }
     }
 
-    const piiEntitiesResults = page.recognizePiiEntitiesResults![0];
-    for (const doc of piiEntitiesResults) {
-      console.log(`- Document ${doc.id}`);
-      if (!doc.error) {
-        console.log("\tPii Entities:");
-        for (const entity of doc.entities) {
-          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+    if (!piiEntitiesAction.error) {
+      for (const doc of piiEntitiesAction.results) {
+        console.log(`- Document ${doc.id}`);
+        if (!doc.error) {
+          console.log("\tPii Entities:");
+          for (const entity of doc.entities) {
+            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
+          }
+        } else {
+          console.error("\tError:", doc.error);
         }
-      } else {
-        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
@@ -35,6 +35,7 @@ export async function main() {
   };
   const poller = await client.beginAnalyzeBatchActions(documents, actions);
   const resultPages = await poller.pollUntilDone();
+  const page = (await resultPages.next()).value;
   console.log(
     `The analyze batch actions operation created on ${
       poller.getOperationState().createdOn
@@ -46,49 +47,47 @@ export async function main() {
     }`
   );
 
-  for await (const page of resultPages) {
-    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-    if (!keyPhrasesAction.error) {
-      for (const doc of keyPhrasesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tKey phrases:");
-          for (const phrase of doc.keyPhrases) {
-            console.log(`\t- ${phrase}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const keyPhrasesAction = page.extractKeyPhrasesResults[0];
+  if (!keyPhrasesAction.error) {
+    for (const doc of keyPhrasesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tKey phrases:");
+        for (const phrase of doc.keyPhrases) {
+          console.log(`\t- ${phrase}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const entitiesAction = page.recognizeEntitiesResults[0];
-    if (!entitiesAction.error) {
-      for (const doc of entitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tEntities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const entitiesAction = page.recognizeEntitiesResults[0];
+  if (!entitiesAction.error) {
+    for (const doc of entitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tEntities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
+  }
 
-    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-    if (!piiEntitiesAction.error) {
-      for (const doc of piiEntitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tPii Entities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
+  const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
+  if (!piiEntitiesAction.error) {
+    for (const doc of piiEntitiesAction.results) {
+      console.log(`- Document ${doc.id}`);
+      if (!doc.error) {
+        console.log("\tPii Entities:");
+        for (const entity of doc.entities) {
+          console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
         }
+      } else {
+        console.error("\tError:", doc.error);
       }
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -218,9 +218,11 @@ function convertTaskTypeToActionType(taskType: string): TextAnalyticsActionType 
  * @returns an action error with an action type and index
  * @internal
  */
-function parseActionError(erredActions: TextAnalyticsError): TextAnalyticsActionError {
+export function parseActionError(erredActions: TextAnalyticsError): TextAnalyticsActionError {
   if (erredActions.target) {
-    const regex = new RegExp(/#\/tasks\/(\s+)\/(\d+)/);
+    const regex = new RegExp(
+      /#\/tasks\/(entityRecognitionTasks|entityRecognitionPiiTasks|keyPhraseExtractionTasks)\/(\d+)/
+    );
     const res = regex.exec(erredActions.target);
     if (res !== null) {
       return {
@@ -287,9 +289,8 @@ export function combineSucceededAndErredActions<TSuccess extends TextAnalyticsAc
   erredActions: TextAnalyticsActionError[]
 ): (TSuccess | TextAnalyticsActionErrorResult)[] {
   const actions: (TSuccess | TextAnalyticsActionErrorResult)[] = [];
-  let errorIndex = 0;
   for (
-    let actionIndex = 0;
+    let actionIndex = 0, errorIndex = 0;
     actionIndex < succeededActions.length + erredActions.length;
     ++actionIndex
   ) {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -49,7 +49,7 @@ export interface TextAnalyticsActionSuccessState {
   /**
    * When was the last time this action was updated by the service.
    */
-  readonly lastUpdatedOn: Date;
+  readonly completedOn: Date;
   /**
    * Discriminant to determine if that this is an error result.
    */
@@ -200,7 +200,7 @@ export class ActionsResultBuilder {
             actionResults?.modelVersion,
             actionResults?.statistics
           );
-          return { results: recognizeEntitiesResults, lastUpdatedOn: lastUpdateDateTime };
+          return { results: recognizeEntitiesResults, completedOn: lastUpdateDateTime };
         }
       }
     );
@@ -226,7 +226,7 @@ export class ActionsResultBuilder {
             this.documents,
             actionResults
           );
-          return { results: recognizePiiEntitiesResults, lastUpdatedOn: lastUpdateDateTime };
+          return { results: recognizePiiEntitiesResults, completedOn: lastUpdateDateTime };
         }
       }
     );
@@ -255,7 +255,7 @@ export class ActionsResultBuilder {
             actionResults?.modelVersion,
             actionResults?.statistics
           );
-          return { results: extractKeyPhrasesResults, lastUpdatedOn: lastUpdateDateTime };
+          return { results: extractKeyPhrasesResults, completedOn: lastUpdateDateTime };
         }
       }
     );

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -61,7 +61,7 @@ export interface TextAnalyticsActionSuccessState {
  */
 export interface TextAnalyticsActionErrorResult {
   /**
-   * The Error for this document result.
+   * The Error for this action result.
    */
   readonly error: TextAnalyticsError;
 }
@@ -282,12 +282,13 @@ function categorizeActionErrors(
  * @returns a list of succeeded and erred actions
  * @internal
  */
-function combineSucceededAndErredActions<TSuccess extends TextAnalyticsActionSuccessState>(
+export function combineSucceededAndErredActions<TSuccess extends TextAnalyticsActionSuccessState>(
   succeededActions: TSuccess[],
   erredActions: TextAnalyticsActionError[]
 ): (TSuccess | TextAnalyticsActionErrorResult)[] {
   const actions: (TSuccess | TextAnalyticsActionErrorResult)[] = [];
-  for (let actionIndex = 0, errorIndex = 0; actionIndex < succeededActions.length; ++actionIndex) {
+  let errorIndex = 0;
+  for (let actionIndex = 0; actionIndex < succeededActions.length; ++actionIndex) {
     if (errorIndex < erredActions.length) {
       const error = erredActions[errorIndex];
       if (error.index === actionIndex) {
@@ -298,6 +299,15 @@ function combineSucceededAndErredActions<TSuccess extends TextAnalyticsActionSuc
       }
     }
     actions.push(succeededActions[actionIndex]);
+  }
+  if (errorIndex < erredActions.length) {
+    actions.push(
+      ...erredActions.slice(errorIndex).map(
+        (obj: TextAnalyticsActionError): TextAnalyticsActionErrorResult => ({
+          error: intoTextAnalyticsError(obj)
+        })
+      )
+    );
   }
   return actions;
 }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -25,7 +25,7 @@ import {
 import { ErrorCode, intoTextAnalyticsError, TextAnalyticsError } from "./textAnalyticsResult";
 
 /**
- * The results of a succeeded analyze batch actions operation.
+ * The results of an analyze batch actions operation.
  */
 export interface AnalyzeBatchActionsResult {
   /**
@@ -409,7 +409,7 @@ function makeExtractKeyPhrasesActionResult(
   ): ExtractKeyPhrasesActionSuccessResult[] {
     const { results: actionResults, lastUpdateDateTime } = task;
     if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
-      const recognizeEntitiesResults = makeExtractKeyPhrasesResultArray(
+      const extractKeyPhrasesResults = makeExtractKeyPhrasesResultArray(
         documents,
         actionResults?.documents,
         actionResults?.errors,
@@ -419,7 +419,7 @@ function makeExtractKeyPhrasesActionResult(
       return [
         ...actions,
         {
-          results: recognizeEntitiesResults,
+          results: extractKeyPhrasesResults,
           completedOn: lastUpdateDateTime
         }
       ];

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -223,13 +223,13 @@ export function parseActionError(erredActions: TextAnalyticsError): TextAnalytic
     const regex = new RegExp(
       /#\/tasks\/(entityRecognitionTasks|entityRecognitionPiiTasks|keyPhraseExtractionTasks)\/(\d+)/
     );
-    const res = regex.exec(erredActions.target);
-    if (res !== null) {
+    const result = regex.exec(erredActions.target);
+    if (result !== null) {
       return {
         code: erredActions.code,
         message: erredActions.message,
-        index: parseInt(res[2]),
-        type: convertTaskTypeToActionType(res[1])
+        index: parseInt(result[2]),
+        type: convertTaskTypeToActionType(result[1])
       };
     } else {
       throw new Error(`Pointer "${erredActions.target}" is not a valid action pointer`);

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -25,7 +25,7 @@ import {
 import { ErrorCode, intoTextAnalyticsError, TextAnalyticsError } from "./textAnalyticsResult";
 
 /**
- * The results of a successful analyze batch actions operation.
+ * The results of a succeeded analyze batch actions operation.
  */
 export interface AnalyzeBatchActionsResult {
   /**
@@ -43,11 +43,11 @@ export interface AnalyzeBatchActionsResult {
 }
 
 /**
- * The state of a successful action.
+ * The state of a succeeded action.
  */
 export interface TextAnalyticsActionSuccessState {
   /**
-   * When was the last time this action was updated by the service.
+   * When this action was completed by the service.
    */
   readonly completedOn: Date;
   /**
@@ -72,7 +72,7 @@ export interface TextAnalyticsActionErrorResult {
 export type RecognizeCategorizedEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
- * The results of a successful recognize categorized entities action.
+ * The results of a succeeded recognize categorized entities action.
  */
 export interface RecognizeCategorizedEntitiesActionSuccessResult
   extends TextAnalyticsActionSuccessState {
@@ -95,7 +95,7 @@ export type RecognizeCategorizedEntitiesActionResult =
 export type RecognizePiiEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
- * The results of a successful recognize pii entities action.
+ * The results of a succeeded recognize pii entities action.
  */
 export interface RecognizePiiEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
   /**
@@ -117,7 +117,7 @@ export type RecognizePiiEntitiesActionResult =
 export type ExtractKeyPhrasesActionErrorResult = TextAnalyticsActionErrorResult;
 
 /**
- * The results of a successful extract key phrases action.
+ * The results of a succeeded extract key phrases action.
  */
 export interface ExtractKeyPhrasesActionSuccessResult extends TextAnalyticsActionSuccessState {
   /**
@@ -305,7 +305,7 @@ function combineSucceededAndErredActions<TSuccess extends TextAnalyticsActionSuc
 /**
  * Creates a list of results for recognize categorized entities actions.
  * @param documents - list of input documents
- * @param succeededTasks - list of successful action results
+ * @param succeededTasks - list of succeeded action results
  * @param erredActions - list of erred actions
  * @internal
  */
@@ -319,7 +319,7 @@ function makeRecognizeCategorizedEntitiesActionResult(
     task: TasksStateTasksEntityRecognitionTasksItem
   ): RecognizeCategorizedEntitiesActionSuccessResult[] {
     const { results: actionResults, lastUpdateDateTime } = task;
-    if (actionResults.documents.length !== 0) {
+    if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
       const recognizeEntitiesResults = makeRecognizeCategorizedEntitiesResultArray(
         documents,
         actionResults?.documents,
@@ -346,7 +346,7 @@ function makeRecognizeCategorizedEntitiesActionResult(
 /**
  * Creates a list of results for recognize pii entities actions.
  * @param documents - list of input documents
- * @param succeededTasks - list of successful action results
+ * @param succeededTasks - list of succeeded action results
  * @param erredActions - list of erred actions
  * @internal
  */
@@ -360,7 +360,7 @@ function makeRecognizePiiEntitiesActionResult(
     task: TasksStateTasksEntityRecognitionPiiTasksItem
   ): RecognizePiiEntitiesActionSuccessResult[] {
     const { results: actionResults, lastUpdateDateTime } = task;
-    if (actionResults.documents.length !== 0) {
+    if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
       const recognizeEntitiesResults = makeRecognizePiiEntitiesResultArray(
         documents,
         actionResults
@@ -384,7 +384,7 @@ function makeRecognizePiiEntitiesActionResult(
 /**
  * Creates a list of results for extract key phrases actions.
  * @param documents - list of input documents
- * @param succeededTasks - list of successful action results
+ * @param succeededTasks - list of succeeded action results
  * @param erredActions - list of erred actions
  * @internal
  */
@@ -398,7 +398,7 @@ function makeExtractKeyPhrasesActionResult(
     task: TasksStateTasksKeyPhraseExtractionTasksItem
   ): ExtractKeyPhrasesActionSuccessResult[] {
     const { results: actionResults, lastUpdateDateTime } = task;
-    if (actionResults.documents.length !== 0) {
+    if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
       const recognizeEntitiesResults = makeExtractKeyPhrasesResultArray(
         documents,
         actionResults?.documents,

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -288,26 +288,19 @@ export function combineSucceededAndErredActions<TSuccess extends TextAnalyticsAc
 ): (TSuccess | TextAnalyticsActionErrorResult)[] {
   const actions: (TSuccess | TextAnalyticsActionErrorResult)[] = [];
   let errorIndex = 0;
-  for (let actionIndex = 0; actionIndex < succeededActions.length; ++actionIndex) {
-    if (errorIndex < erredActions.length) {
-      const error = erredActions[errorIndex];
-      if (error.index === actionIndex) {
-        actions.push({
-          error: intoTextAnalyticsError(error)
-        });
-        ++errorIndex;
-      }
+  for (
+    let actionIndex = 0;
+    actionIndex < succeededActions.length + erredActions.length;
+    ++actionIndex
+  ) {
+    if (errorIndex < erredActions.length && erredActions[errorIndex].index === actionIndex) {
+      actions.push({
+        error: intoTextAnalyticsError(erredActions[errorIndex])
+      });
+      ++errorIndex;
+    } else {
+      actions.push(succeededActions[actionIndex - errorIndex]);
     }
-    actions.push(succeededActions[actionIndex]);
-  }
-  if (errorIndex < erredActions.length) {
-    actions.push(
-      ...erredActions.slice(errorIndex).map(
-        (obj: TextAnalyticsActionError): TextAnalyticsActionErrorResult => ({
-          error: intoTextAnalyticsError(obj)
-        })
-      )
-    );
   }
   return actions;
 }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -2,10 +2,27 @@
 // Licensed under the MIT license.
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
-import { ExtractKeyPhrasesResultArray } from "./extractKeyPhrasesResultArray";
-import { TextDocumentBatchStatistics } from "./generated/models";
-import { RecognizeCategorizedEntitiesResultArray } from "./recognizeCategorizedEntitiesResultArray";
-import { RecognizePiiEntitiesResultArray } from "./recognizePiiEntitiesResultArray";
+import {
+  ExtractKeyPhrasesResultArray,
+  makeExtractKeyPhrasesResultArray
+} from "./extractKeyPhrasesResultArray";
+import {
+  AnalyzeJobState as GeneratedResponse,
+  TasksStateTasksEntityRecognitionPiiTasksItem,
+  TasksStateTasksEntityRecognitionTasksItem,
+  TasksStateTasksKeyPhraseExtractionTasksItem,
+  TextDocumentBatchStatistics,
+  TextDocumentInput
+} from "./generated/models";
+import {
+  makeRecognizeCategorizedEntitiesResultArray,
+  RecognizeCategorizedEntitiesResultArray
+} from "./recognizeCategorizedEntitiesResultArray";
+import {
+  makeRecognizePiiEntitiesResultArray,
+  RecognizePiiEntitiesResultArray
+} from "./recognizePiiEntitiesResultArray";
+import { intoTextAnalyticsError, TextAnalyticsError } from "./textAnalyticsResult";
 
 /**
  * The results of a successful analyze batch actions operation.
@@ -14,16 +31,107 @@ export interface AnalyzeBatchActionsResult {
   /**
    * Array of the results for each categorized entities recognition action.
    */
-  recognizeEntitiesResults: RecognizeCategorizedEntitiesResultArray[];
+  recognizeEntitiesResults: RecognizeCategorizedEntitiesActionResult[];
   /**
    * Array of the results for each Pii entities recognition action.
    */
-  recognizePiiEntitiesResults: RecognizePiiEntitiesResultArray[];
+  recognizePiiEntitiesResults: RecognizePiiEntitiesActionResult[];
   /**
    * Array of the results for each key phrases extraction action.
    */
-  extractKeyPhrasesResults: ExtractKeyPhrasesResultArray[];
+  extractKeyPhrasesResults: ExtractKeyPhrasesActionResult[];
 }
+
+/**
+ * The state of a successful action.
+ */
+export interface TextAnalyticsActionSuccessState {
+  /**
+   * When was the last time this action was updated by the service.
+   */
+  readonly lastUpdatedOn: Date;
+  /**
+   * Discriminant to determine if that this is an error result.
+   */
+  readonly error?: undefined;
+}
+
+/**
+ * The error of an analyze batch action.
+ */
+export interface TextAnalyticsActionErrorResult {
+  /**
+   * The Error for this document result.
+   */
+  readonly error: TextAnalyticsError;
+}
+
+/**
+ * The error of a recognize categorized entities action.
+ */
+export type RecognizeCategorizedEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+
+/**
+ * The results of a successful recognize categorized entities action.
+ */
+export interface RecognizeCategorizedEntitiesActionSuccessResult
+  extends TextAnalyticsActionSuccessState {
+  /**
+   * Array of the results for each categorized entities recognition action.
+   */
+  results: RecognizeCategorizedEntitiesResultArray;
+}
+
+/**
+ * The result of a recognize categorized entities action.
+ */
+export type RecognizeCategorizedEntitiesActionResult =
+  | RecognizeCategorizedEntitiesActionSuccessResult
+  | RecognizeCategorizedEntitiesActionErrorResult;
+
+/**
+ * The error of a recognize pii entities action.
+ */
+export type RecognizePiiEntitiesActionErrorResult = TextAnalyticsActionErrorResult;
+
+/**
+ * The results of a successful recognize pii entities action.
+ */
+export interface RecognizePiiEntitiesActionSuccessResult extends TextAnalyticsActionSuccessState {
+  /**
+   * Array of the results for each pii entities recognition action.
+   */
+  results: RecognizePiiEntitiesResultArray;
+}
+
+/**
+ * The result of a recognize pii entities action.
+ */
+export type RecognizePiiEntitiesActionResult =
+  | RecognizePiiEntitiesActionSuccessResult
+  | RecognizePiiEntitiesActionErrorResult;
+
+/**
+ * The error of a extract key phrases action.
+ */
+export type ExtractKeyPhrasesActionErrorResult = TextAnalyticsActionErrorResult;
+
+/**
+ * The results of a successful extract key phrases action.
+ */
+export interface ExtractKeyPhrasesActionSuccessResult extends TextAnalyticsActionSuccessState {
+  /**
+   * Array of the results for each extract key phrases action.
+   */
+  results: ExtractKeyPhrasesResultArray;
+}
+
+/**
+ * The result of a extract key phrases action.
+ */
+export type ExtractKeyPhrasesActionResult =
+  | ExtractKeyPhrasesActionSuccessResult
+  | ExtractKeyPhrasesActionErrorResult;
 
 /**
  * The results of an analyze batch actions operation represented as a paged iterator that
@@ -46,4 +154,110 @@ export interface PagedAnalyzeBatchActionsResult
    * in the client call.
    */
   statistics?: TextDocumentBatchStatistics;
+}
+
+export class ActionsResultBuilder {
+  private readonly documents: TextDocumentInput[];
+  private readonly errors: TextAnalyticsError[];
+  private readonly recognizeEntitiesActionsResults: TasksStateTasksEntityRecognitionTasksItem[];
+  private readonly recognizePiiEntitiesActionsResults: TasksStateTasksEntityRecognitionPiiTasksItem[];
+  private readonly extractKeyPhrasesActionsResults: TasksStateTasksKeyPhraseExtractionTasksItem[];
+  constructor(response: GeneratedResponse, documents: TextDocumentInput[]) {
+    this.errors = response?.errors ?? [];
+    this.recognizeEntitiesActionsResults = response.tasks.entityRecognitionTasks ?? [];
+    this.recognizePiiEntitiesActionsResults = response.tasks.entityRecognitionPiiTasks ?? [];
+    this.extractKeyPhrasesActionsResults = response.tasks.keyPhraseExtractionTasks ?? [];
+    this.documents = documents;
+  }
+
+  private *getAnError() {
+    yield* this.errors;
+  }
+
+  public makeRecognizeCategorizedEntitiesActionResult(): RecognizeCategorizedEntitiesActionResult[] {
+    return this.recognizeEntitiesActionsResults.map(
+      ({
+        results: actionResults,
+        lastUpdateDateTime
+      }): RecognizeCategorizedEntitiesActionResult => {
+        // this indicates that the action failed
+        if (actionResults.documents.length === 0 && actionResults.modelVersion === "") {
+          const error = this.getAnError().next().value;
+          if (error != undefined) {
+            return {
+              error: intoTextAnalyticsError(error)
+            };
+          } else {
+            throw new Error(
+              "Expected the service to have an error for this action but did not find any"
+            );
+          }
+        } else {
+          const recognizeEntitiesResults = makeRecognizeCategorizedEntitiesResultArray(
+            this.documents,
+            actionResults?.documents,
+            actionResults?.errors,
+            actionResults?.modelVersion,
+            actionResults?.statistics
+          );
+          return { results: recognizeEntitiesResults, lastUpdatedOn: lastUpdateDateTime };
+        }
+      }
+    );
+  }
+
+  public makeRecognizePiiEntitiesActionResult(): RecognizePiiEntitiesActionResult[] {
+    return this.recognizePiiEntitiesActionsResults.map(
+      ({ results: actionResults, lastUpdateDateTime }): RecognizePiiEntitiesActionResult => {
+        // this indicates that the action failed
+        if (actionResults.documents.length === 0 && actionResults.modelVersion === "") {
+          const error = this.getAnError().next().value;
+          if (error != undefined) {
+            return {
+              error: intoTextAnalyticsError(error)
+            };
+          } else {
+            throw new Error(
+              "Expected the service to have an error for this action but did not find any"
+            );
+          }
+        } else {
+          const recognizePiiEntitiesResults = makeRecognizePiiEntitiesResultArray(
+            this.documents,
+            actionResults
+          );
+          return { results: recognizePiiEntitiesResults, lastUpdatedOn: lastUpdateDateTime };
+        }
+      }
+    );
+  }
+
+  public makeExtractKeyPhrasesActionResult(): ExtractKeyPhrasesActionResult[] {
+    return this.extractKeyPhrasesActionsResults.map(
+      ({ results: actionResults, lastUpdateDateTime }): ExtractKeyPhrasesActionResult => {
+        // this indicates that the action failed
+        if (actionResults.documents.length === 0 && actionResults.modelVersion === "") {
+          const error = this.getAnError().next().value;
+          if (error != undefined) {
+            return {
+              error: intoTextAnalyticsError(error)
+            };
+          } else {
+            throw new Error(
+              "Expected the service to have an error for this action but did not find any"
+            );
+          }
+        } else {
+          const extractKeyPhrasesResults = makeExtractKeyPhrasesResultArray(
+            this.documents,
+            actionResults?.documents,
+            actionResults?.errors,
+            actionResults?.modelVersion,
+            actionResults?.statistics
+          );
+          return { results: extractKeyPhrasesResults, lastUpdatedOn: lastUpdateDateTime };
+        }
+      }
+    );
+  }
 }

--- a/sdk/textanalytics/ai-text-analytics/src/constants.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "5.1.0-beta.3";
+export const SDK_VERSION: string = "5.1.0-beta.4";

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { GeneratedClientOptionalParams } from "./models";
 
 const packageName = "@azure/ai-text-analytics";
-const packageVersion = "5.1.0-beta.3";
+const packageVersion = "5.1.0-beta.4";
 
 /** @hidden */
 export class GeneratedClientContext extends coreHttp.ServiceClient {

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -89,7 +89,18 @@ export {
 export {
   PagedAnalyzeBatchActionsResult,
   PagedAsyncIterableAnalyzeBatchActionsResult,
-  AnalyzeBatchActionsResult
+  AnalyzeBatchActionsResult,
+  RecognizeCategorizedEntitiesActionResult,
+  RecognizePiiEntitiesActionResult,
+  ExtractKeyPhrasesActionResult,
+  TextAnalyticsActionSuccessState,
+  TextAnalyticsActionErrorResult,
+  RecognizeCategorizedEntitiesActionErrorResult,
+  RecognizeCategorizedEntitiesActionSuccessResult,
+  RecognizePiiEntitiesActionErrorResult,
+  RecognizePiiEntitiesActionSuccessResult,
+  ExtractKeyPhrasesActionErrorResult,
+  ExtractKeyPhrasesActionSuccessResult
 } from "./analyzeBatchActionsResult";
 export {
   TextAnalyticsResult,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
@@ -129,7 +129,7 @@ export interface TextAnalyticsResponse<T1 extends TextAnalyticsSuccessResult> {
  * Helper function for converting nested service error into
  * the unified TextAnalyticsError
  */
-function intoTextAnalyticsError(
+export function intoTextAnalyticsError(
   errorModel: GeneratedTextAnalyticsErrorModel | InnerError
 ): TextAnalyticsError {
   // Return the deepest error. This will always be at most

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -14,7 +14,7 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/25616b92ccaec6c8bd3dd51f1312243bca88fe2d/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.3/TextAnalytics.json
 add-credentials: false
-package-version: 5.1.0-beta.3
+package-version: 5.1.0-beta.4
 v3: true
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.2"

--- a/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
@@ -10,6 +10,7 @@ import { makeRecognizeLinkedEntitiesResultArray } from "../../src/recognizeLinke
 import { makeRecognizeCategorizedEntitiesResultArray } from "../../src/recognizeCategorizedEntitiesResultArray";
 import { DetectLanguageInput, TextDocumentInput } from "../../src";
 import { makeRecognizePiiEntitiesResultArray } from "../../src/recognizePiiEntitiesResultArray";
+import { combineSucceededAndErredActions } from "../../src/analyzeBatchActionsResult";
 
 describe("SentimentResultArray", () => {
   it("merges items in order", () => {
@@ -381,6 +382,92 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
       const inputOrder = input.map((item) => item.id);
       const outputOrder = result.map((item) => item.id);
       assert.deepEqual(inputOrder, outputOrder);
+    });
+  });
+
+  describe("combineSucceededAndErredActions", () => {
+    it("merges items in order", () => {
+      const succeededAction = {
+        completedOn: new Date()
+      };
+      const result = combineSucceededAndErredActions(
+        [succeededAction],
+        [
+          {
+            code: "",
+            index: 0,
+            message: "0",
+            type: "ExtractKeyPhrases"
+          },
+          {
+            code: "",
+            index: 2,
+            message: "2",
+            type: "ExtractKeyPhrases"
+          }
+        ]
+      );
+      assert.deepEqual(result, [
+        {
+          error: {
+            code: "",
+            message: "0",
+            target: undefined
+          }
+        },
+        succeededAction,
+        {
+          error: {
+            code: "",
+            message: "2",
+            target: undefined
+          }
+        }
+      ]);
+    });
+
+    it("correctly handles empty succeeded actions list", () => {
+      const result = combineSucceededAndErredActions(
+        [],
+        [
+          {
+            code: "",
+            index: 0,
+            message: "0",
+            type: "ExtractKeyPhrases"
+          },
+          {
+            code: "",
+            index: 2,
+            message: "2",
+            type: "ExtractKeyPhrases"
+          }
+        ]
+      );
+      assert.deepEqual(result, [
+        {
+          error: {
+            code: "",
+            message: "0",
+            target: undefined
+          }
+        },
+        {
+          error: {
+            code: "",
+            message: "2",
+            target: undefined
+          }
+        }
+      ]);
+    });
+
+    it("correctly handles empty erred actions list", () => {
+      const succeededAction = {
+        completedOn: new Date()
+      };
+      const result = combineSucceededAndErredActions([succeededAction], []);
+      assert.deepEqual(result, [succeededAction]);
     });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
@@ -391,7 +391,7 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
         completedOn: new Date()
       };
       const result = combineSucceededAndErredActions(
-        [succeededAction],
+        [succeededAction, succeededAction],
         [
           {
             code: "",
@@ -422,7 +422,8 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
             message: "2",
             target: undefined
           }
-        }
+        },
+        succeededAction
       ]);
     });
 
@@ -438,8 +439,8 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
           },
           {
             code: "",
-            index: 2,
-            message: "2",
+            index: 1,
+            message: "1",
             type: "ExtractKeyPhrases"
           }
         ]
@@ -455,7 +456,7 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
         {
           error: {
             code: "",
-            message: "2",
+            message: "1",
             target: undefined
           }
         }
@@ -466,8 +467,89 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
       const succeededAction = {
         completedOn: new Date()
       };
-      const result = combineSucceededAndErredActions([succeededAction], []);
-      assert.deepEqual(result, [succeededAction]);
+      const result = combineSucceededAndErredActions([succeededAction, succeededAction], []);
+      assert.deepEqual(result, [succeededAction, succeededAction]);
+    });
+
+    it("correctly handles a prefix of erred actions", () => {
+      const succeededAction = {
+        completedOn: new Date()
+      };
+      const result = combineSucceededAndErredActions(
+        [succeededAction],
+        [
+          {
+            code: "",
+            index: 0,
+            message: "0",
+            type: "ExtractKeyPhrases"
+          },
+          {
+            code: "",
+            index: 1,
+            message: "1",
+            type: "ExtractKeyPhrases"
+          }
+        ]
+      );
+      assert.deepEqual(result, [
+        {
+          error: {
+            code: "",
+            message: "0",
+            target: undefined
+          }
+        },
+        {
+          error: {
+            code: "",
+            message: "1",
+            target: undefined
+          }
+        },
+        succeededAction
+      ]);
+    });
+
+    it("correctly handles a prefix of succeeded actions", () => {
+      const succeededAction = {
+        completedOn: new Date()
+      };
+      const result = combineSucceededAndErredActions(
+        [succeededAction, succeededAction],
+        [
+          {
+            code: "",
+            index: 2,
+            message: "2",
+            type: "ExtractKeyPhrases"
+          },
+          {
+            code: "",
+            index: 3,
+            message: "3",
+            type: "ExtractKeyPhrases"
+          }
+        ]
+      );
+      assert.deepEqual(result, [
+        succeededAction,
+        succeededAction,
+        {
+          error: {
+            code: "",
+            message: "2",
+            target: undefined
+          }
+        },
+        {
+          error: {
+            code: "",
+            message: "3",
+            target: undefined
+          }
+        }
+      ]);
     });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/internal/util.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/internal/util.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
+import { parseActionError } from "../../src/analyzeBatchActionsResult";
 import { sortResponseIdObjects, nextLinkToTopAndSkip } from "../../src/util";
 
 describe("util.sortByPreviousOrder", () => {
@@ -19,5 +20,30 @@ describe("util.nextLinkToTopAndSkip", () => {
       "https://somehost/text/analytics/v3.2-preview.1/entities/health/jobs/1ef2876d-a815-4927-9fc9-e6d5fbc6ce95?$skip=10&$top=5";
     const result = nextLinkToTopAndSkip(nextLink);
     assert.deepEqual(result, { skip: 10, top: 5 });
+  });
+});
+
+describe("analyzeBatchActionsResult.parseActionError", () => {
+  it("parses entityRecognitionTasks pointer", () => {
+    const pointer = "#/tasks/entityRecognitionTasks/2";
+    const result = parseActionError({ message: "", target: pointer, code: "" });
+    assert.deepEqual(result, {
+      code: "",
+      message: "",
+      type: "RecognizeCategorizedEntities",
+      index: 2
+    });
+  });
+
+  it("parses entityRecognitionPiiTasks pointer", () => {
+    const pointer = "#/tasks/entityRecognitionPiiTasks/2";
+    const result = parseActionError({ message: "", target: pointer, code: "" });
+    assert.deepEqual(result, { code: "", message: "", type: "RecognizePiiEntities", index: 2 });
+  });
+
+  it("parses keyPhraseExtractionTasks pointer", () => {
+    const pointer = "#/tasks/keyPhraseExtractionTasks/2";
+    const result = parseActionError({ message: "", target: pointer, code: "" });
+    assert.deepEqual(result, { code: "", message: "", type: "ExtractKeyPhrases", index: 2 });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1739,6 +1739,32 @@ describe("[AAD] TextAnalyticsClient", function() {
           }
         }
       });
+
+      it("action failures are returned", async function() {
+        const docs = [{ id: "1", text: "I will go to the park." }];
+
+        const poller = await client.beginAnalyzeBatchActions(
+          docs,
+          {
+            recognizePiiEntitiesActions: [
+              { modelVersion: "bad" },
+              { modelVersion: "latest" },
+              { modelVersion: "bad", stringIndexType: "TextElements_v8" }
+            ]
+          },
+          {
+            updateIntervalInMs: pollingInterval
+          }
+        );
+        const result = await poller.pollUntilDone();
+        for await (const page of result) {
+          const piiEntitiesResult = page.recognizePiiEntitiesResults;
+          assert.equal(piiEntitiesResult.length, 3);
+          assert.isDefined(piiEntitiesResult[0].error);
+          assert.isUndefined(piiEntitiesResult[1].error);
+          assert.isDefined(piiEntitiesResult[2].error);
+        }
+      });
     });
   });
 });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -891,12 +891,14 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const action = entitiesResult[0];
-            for (const result of action) {
-              if (!result.error) {
-                assert.ok(result.id);
-                assert.ok(result.entities);
-              } else {
-                assert.fail("did not expect document errors but got one.");
+            if (!action.error) {
+              for (const result of action.results) {
+                if (!result.error) {
+                  assert.ok(result.id);
+                  assert.ok(result.entities);
+                } else {
+                  assert.fail("did not expect document errors but got one.");
+                }
               }
             }
           } else {
@@ -925,13 +927,15 @@ describe("[AAD] TextAnalyticsClient", function() {
           const keyPhrasesResult = page.extractKeyPhrasesResults;
           if (keyPhrasesResult.length === 1) {
             const action = keyPhrasesResult[0];
-            assert.equal(action.length, 2);
-            for (const result of action) {
-              if (!result.error) {
-                assert.include(result.keyPhrases, "Paul Allen");
-                assert.include(result.keyPhrases, "Bill Gates");
-                assert.include(result.keyPhrases, "Microsoft");
-                assert.ok(result.id);
+            if (!action.error) {
+              assert.equal(action.results.length, 2);
+              for (const result of action.results) {
+                if (!result.error) {
+                  assert.include(result.keyPhrases, "Paul Allen");
+                  assert.include(result.keyPhrases, "Bill Gates");
+                  assert.include(result.keyPhrases, "Microsoft");
+                  assert.ok(result.id);
+                }
               }
             }
           } else {
@@ -973,15 +977,17 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const action = entitiesResult[0];
-            assert.equal(action.length, 3);
-            for (const doc of action) {
-              if (!doc.error) {
-                assert.equal(doc.entities.length, 4);
-                for (const entity of doc.entities) {
-                  assert.isDefined(entity.text);
-                  assert.isDefined(entity.category);
-                  assert.isDefined(entity.offset);
-                  assert.isDefined(entity.confidenceScore);
+            if (!action.error) {
+              assert.equal(action.results.length, 3);
+              for (const doc of action.results) {
+                if (!doc.error) {
+                  assert.equal(doc.entities.length, 4);
+                  for (const entity of doc.entities) {
+                    assert.isDefined(entity.text);
+                    assert.isDefined(entity.category);
+                    assert.isDefined(entity.offset);
+                    assert.isDefined(entity.confidenceScore);
+                  }
                 }
               }
             }
@@ -1016,29 +1022,32 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizePiiEntitiesResults;
           if (entitiesResult.length === 1) {
             const action = entitiesResult[0];
-            assert.equal(action.length, 3);
-            const doc1 = action[0];
-            const doc2 = action[1];
-            const doc3 = action[2];
-            if (!doc1.error) {
-              assert.equal(doc1.entities[0].text, "859-98-0987");
-              assert.equal(doc1.entities[0].category, "U.S. Social Security Number (SSN)");
-            }
-            if (!doc2.error) {
-              assert.equal(doc2.entities[0].text, "111000025");
-              // assert.equal(doc2.entities[0].category, "ABA Routing Number")  # Service is currently returning PhoneNumber here
-            }
-            if (!doc3.error) {
-              assert.equal(doc3.entities[0].text, "998.214.865-68");
-              assert.equal(doc3.entities[0].category, "Brazil CPF Number");
-            }
-            for (const doc of action) {
-              if (!doc.error) {
-                for (const entity of doc.entities) {
-                  assert.isDefined(entity.text);
-                  assert.isDefined(entity.category);
-                  assert.isDefined(entity.offset);
-                  assert.isDefined(entity.confidenceScore);
+            if (!action.error) {
+              const actionResults = action.results;
+              assert.equal(actionResults.length, 3);
+              const doc1 = actionResults[0];
+              const doc2 = actionResults[1];
+              const doc3 = actionResults[2];
+              if (!doc1.error) {
+                assert.equal(doc1.entities[0].text, "859-98-0987");
+                assert.equal(doc1.entities[0].category, "U.S. Social Security Number (SSN)");
+              }
+              if (!doc2.error) {
+                assert.equal(doc2.entities[0].text, "111000025");
+                // assert.equal(doc2.entities[0].category, "ABA Routing Number")  # Service is currently returning PhoneNumber here
+              }
+              if (!doc3.error) {
+                assert.equal(doc3.entities[0].text, "998.214.865-68");
+                assert.equal(doc3.entities[0].category, "Brazil CPF Number");
+              }
+              for (const doc of actionResults) {
+                if (!doc.error) {
+                  for (const entity of doc.entities) {
+                    assert.isDefined(entity.text);
+                    assert.isDefined(entity.category);
+                    assert.isDefined(entity.offset);
+                    assert.isDefined(entity.confidenceScore);
+                  }
                 }
               }
             }
@@ -1101,10 +1110,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
-            assert.equal(entitiesDocs.length, 3);
-            assert.isDefined(entitiesDocs[0].error);
-            assert.isDefined(entitiesDocs[1].error);
-            assert.isUndefined(entitiesDocs[2].error);
+            if (!entitiesDocs.error) {
+              const entitiesDocsResults = entitiesDocs.results;
+              assert.equal(entitiesDocsResults.length, 3);
+              assert.isDefined(entitiesDocsResults[0].error);
+              assert.isDefined(entitiesDocsResults[1].error);
+              assert.isUndefined(entitiesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of entities results but did not get one.");
           }
@@ -1112,10 +1124,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const piiEntitiesResult = page.recognizePiiEntitiesResults;
           if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
-            assert.equal(piiEntitiesDocs.length, 3);
-            assert.isDefined(piiEntitiesDocs[0].error);
-            assert.isDefined(piiEntitiesDocs[1].error);
-            assert.isUndefined(piiEntitiesDocs[2].error);
+            if (!piiEntitiesDocs.error) {
+              const piiEntitiesDocsResults = piiEntitiesDocs.results;
+              assert.equal(piiEntitiesDocsResults.length, 3);
+              assert.isDefined(piiEntitiesDocsResults[0].error);
+              assert.isDefined(piiEntitiesDocsResults[1].error);
+              assert.isUndefined(piiEntitiesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of pii entities results but did not get one.");
           }
@@ -1123,10 +1138,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const keyPhrasesResult = page.extractKeyPhrasesResults;
           if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
-            assert.equal(keyPhrasesDocs.length, 3);
-            assert.isDefined(keyPhrasesDocs[0].error);
-            assert.isDefined(keyPhrasesDocs[1].error);
-            assert.isUndefined(keyPhrasesDocs[2].error);
+            if (!keyPhrasesDocs.error) {
+              const keyPhrasesDocsResults = keyPhrasesDocs.results;
+              assert.equal(keyPhrasesDocsResults.length, 3);
+              assert.isDefined(keyPhrasesDocsResults[0].error);
+              assert.isDefined(keyPhrasesDocsResults[1].error);
+              assert.isUndefined(keyPhrasesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of key phrases results but did not get one.");
           }
@@ -1167,10 +1185,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
-            assert.equal(entitiesDocs.length, 3);
-            assert.isDefined(entitiesDocs[0].error);
-            assert.isDefined(entitiesDocs[1].error);
-            assert.isDefined(entitiesDocs[2].error);
+            if (!entitiesDocs.error) {
+              const entitiesDocsResults = entitiesDocs.results;
+              assert.equal(entitiesDocsResults.length, 3);
+              assert.isDefined(entitiesDocsResults[0].error);
+              assert.isDefined(entitiesDocsResults[1].error);
+              assert.isDefined(entitiesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of entities results but did not get one.");
           }
@@ -1178,10 +1199,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const piiEntitiesResult = page.recognizePiiEntitiesResults;
           if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
-            assert.equal(piiEntitiesDocs.length, 3);
-            assert.isDefined(piiEntitiesDocs[0].error);
-            assert.isDefined(piiEntitiesDocs[1].error);
-            assert.isDefined(piiEntitiesDocs[2].error);
+            if (!piiEntitiesDocs.error) {
+              const piiEntitiesDocsResults = piiEntitiesDocs.results;
+              assert.equal(piiEntitiesDocsResults.length, 3);
+              assert.isDefined(piiEntitiesDocsResults[0].error);
+              assert.isDefined(piiEntitiesDocsResults[1].error);
+              assert.isDefined(piiEntitiesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of pii entities results but did not get one.");
           }
@@ -1189,10 +1213,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const keyPhrasesResult = page.extractKeyPhrasesResults;
           if (keyPhrasesResult && keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
-            assert.equal(keyPhrasesDocs.length, 3);
-            assert.isDefined(keyPhrasesDocs[0].error);
-            assert.isDefined(keyPhrasesDocs[1].error);
-            assert.isDefined(keyPhrasesDocs[2].error);
+            if (!keyPhrasesDocs.error) {
+              const keyPhrasesDocsResults = keyPhrasesDocs.results;
+              assert.equal(keyPhrasesDocsResults.length, 3);
+              assert.isDefined(keyPhrasesDocsResults[0].error);
+              assert.isDefined(keyPhrasesDocsResults[1].error);
+              assert.isDefined(keyPhrasesDocsResults[2].error);
+            }
           } else {
             assert.fail("expected an array of key phrases results but did not get one.");
           }
@@ -1224,10 +1251,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
-            assert.equal(entitiesDocs.length, 5);
-            let i = 1;
-            for (const doc of entitiesDocs) {
-              assert.equal(parseInt(doc.id), i++);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 5);
+              let i = 1;
+              for (const doc of entitiesDocs.results) {
+                assert.equal(parseInt(doc.id), i++);
+              }
             }
           } else {
             assert.fail("expected an array of entities results but did not get one.");
@@ -1236,10 +1265,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const piiEntitiesResult = page.recognizePiiEntitiesResults;
           if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
-            assert.equal(piiEntitiesDocs.length, 5);
-            let i = 1;
-            for (const doc of piiEntitiesDocs) {
-              assert.equal(parseInt(doc.id), i++);
+            if (!piiEntitiesDocs.error) {
+              assert.equal(piiEntitiesDocs.results.length, 5);
+              let i = 1;
+              for (const doc of piiEntitiesDocs.results) {
+                assert.equal(parseInt(doc.id), i++);
+              }
             }
           } else {
             assert.fail("expected an array of pii entities results but did not get one.");
@@ -1248,10 +1279,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const keyPhrasesResult = page.extractKeyPhrasesResults;
           if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
-            assert.equal(keyPhrasesDocs.length, 5);
-            let i = 1;
-            for (const doc of keyPhrasesDocs) {
-              assert.equal(parseInt(doc.id), i++);
+            if (!keyPhrasesDocs.error) {
+              assert.equal(keyPhrasesDocs.results.length, 5);
+              let i = 1;
+              for (const doc of keyPhrasesDocs.results) {
+                assert.equal(parseInt(doc.id), i++);
+              }
             }
           } else {
             assert.fail("expected an array of key phrases results but did not get one.");
@@ -1285,10 +1318,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           if (entitiesResult.length === 1) {
             const entitiesDocs = entitiesResult[0];
-            assert.equal(entitiesDocs.length, 5);
-            let i = 0;
-            for (const doc of entitiesDocs) {
-              assert.equal(doc.id, in_order[i++]);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 5);
+              let i = 0;
+              for (const doc of entitiesDocs.results) {
+                assert.equal(doc.id, in_order[i++]);
+              }
             }
           } else {
             assert.fail("expected an array of entities results but did not get one.");
@@ -1297,10 +1332,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const piiEntitiesResult = page.recognizePiiEntitiesResults;
           if (piiEntitiesResult.length === 1) {
             const piiEntitiesDocs = piiEntitiesResult[0];
-            assert.equal(piiEntitiesDocs.length, 5);
-            let i = 0;
-            for (const doc of piiEntitiesDocs) {
-              assert.equal(doc.id, in_order[i++]);
+            if (!piiEntitiesDocs.error) {
+              assert.equal(piiEntitiesDocs.results.length, 5);
+              let i = 0;
+              for (const doc of piiEntitiesDocs.results) {
+                assert.equal(doc.id, in_order[i++]);
+              }
             }
           } else {
             assert.fail("expected an array of pii entities results but did not get one.");
@@ -1309,10 +1346,12 @@ describe("[AAD] TextAnalyticsClient", function() {
           const keyPhrasesResult = page.extractKeyPhrasesResults;
           if (keyPhrasesResult.length === 1) {
             const keyPhrasesDocs = keyPhrasesResult[0];
-            assert.equal(keyPhrasesDocs.length, 5);
-            let i = 0;
-            for (const doc of keyPhrasesDocs) {
-              assert.equal(doc.id, in_order[i++]);
+            if (!keyPhrasesDocs.error) {
+              assert.equal(keyPhrasesDocs.results.length, 5);
+              let i = 0;
+              for (const doc of keyPhrasesDocs.results) {
+                assert.equal(doc.id, in_order[i++]);
+              }
             }
           } else {
             assert.fail("expected an array of key phrases results but did not get one.");
@@ -1375,9 +1414,11 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
-            assert.equal(entitiesDocs.length, 3);
-            for (const doc of entitiesDocs) {
-              assert.isUndefined(doc.error);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 3);
+              for (const doc of entitiesDocs.results) {
+                assert.isUndefined(doc.error);
+              }
             }
           }
         }
@@ -1407,9 +1448,11 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
-            assert.equal(entitiesDocs.length, 3);
-            for (const doc of entitiesDocs) {
-              assert.isUndefined(doc.error);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 3);
+              for (const doc of entitiesDocs.results) {
+                assert.isUndefined(doc.error);
+              }
             }
           }
         }
@@ -1438,9 +1481,11 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
-            assert.equal(entitiesDocs.length, 3);
-            for (const doc of entitiesDocs) {
-              assert.isUndefined(doc.error);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 3);
+              for (const doc of entitiesDocs.results) {
+                assert.isUndefined(doc.error);
+              }
             }
           }
         }
@@ -1469,9 +1514,11 @@ describe("[AAD] TextAnalyticsClient", function() {
           const entitiesResult = page.recognizeEntitiesResults;
           assert.equal(entitiesResult.length, 1);
           for (const entitiesDocs of entitiesResult) {
-            assert.equal(entitiesDocs.length, 3);
-            for (const doc of entitiesDocs) {
-              assert.isUndefined(doc.error);
+            if (!entitiesDocs.error) {
+              assert.equal(entitiesDocs.results.length, 3);
+              for (const doc of entitiesDocs.results) {
+                assert.isUndefined(doc.error);
+              }
             }
           }
         }
@@ -1495,16 +1542,22 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
         const entitiesTaskDocs = firstResult?.recognizeEntitiesResults[0];
-        for (const doc of entitiesTaskDocs) {
-          assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+        if (!entitiesTaskDocs.error) {
+          for (const doc of entitiesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+          }
         }
         const piiEntitiesTaskDocs = firstResult?.recognizePiiEntitiesResults[0];
-        for (const doc of piiEntitiesTaskDocs) {
-          assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+        if (!piiEntitiesTaskDocs.error) {
+          for (const doc of piiEntitiesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+          }
         }
         const keyPhrasesTaskDocs = firstResult?.extractKeyPhrasesResults[0];
-        for (const doc of keyPhrasesTaskDocs) {
-          assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+        if (!keyPhrasesTaskDocs.error) {
+          for (const doc of keyPhrasesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnsupportedLanguageCode");
+          }
         }
       });
 
@@ -1531,16 +1584,22 @@ describe("[AAD] TextAnalyticsClient", function() {
         const result = await poller.pollUntilDone();
         const firstResult = (await result.next()).value;
         const entitiesTaskDocs = firstResult?.recognizeEntitiesResults[0];
-        for (const doc of entitiesTaskDocs) {
-          assert.equal(doc.error?.code, "UnknownError");
+        if (!entitiesTaskDocs.error) {
+          for (const doc of entitiesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnknownError");
+          }
         }
         const piiEntitiesTaskDocs = firstResult?.recognizePiiEntitiesResults[0];
-        for (const doc of piiEntitiesTaskDocs) {
-          assert.equal(doc.error?.code, "UnknownError");
+        if (!piiEntitiesTaskDocs.error) {
+          for (const doc of piiEntitiesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnknownError");
+          }
         }
         const keyPhrasesTaskDocs = firstResult?.extractKeyPhrasesResults[0];
-        for (const doc of keyPhrasesTaskDocs) {
-          assert.equal(doc.error?.code, "UnknownError");
+        if (!keyPhrasesTaskDocs.error) {
+          for (const doc of keyPhrasesTaskDocs.results) {
+            assert.equal(doc.error?.code, "UnknownError");
+          }
         }
       });
 
@@ -1566,14 +1625,16 @@ describe("[AAD] TextAnalyticsClient", function() {
         for await (const page of result.byPage({ maxPageSize: pageSize })) {
           const entitiesTaskDocs = page.recognizeEntitiesResults[0];
           ++pageCount;
-          for (const doc of entitiesTaskDocs) {
-            assert.isUndefined(doc.error);
-            ++docCount;
-            if (!doc.error) {
-              if (docCount === totalDocs) {
-                assert.equal(doc.entities.length, 3);
-              } else {
-                assert.equal(doc.entities.length, 0);
+          if (!entitiesTaskDocs.error) {
+            for (const doc of entitiesTaskDocs.results) {
+              assert.isUndefined(doc.error);
+              ++docCount;
+              if (!doc.error) {
+                if (docCount === totalDocs) {
+                  assert.equal(doc.entities.length, 3);
+                } else {
+                  assert.equal(doc.entities.length, 0);
+                }
               }
             }
           }
@@ -1603,11 +1664,13 @@ describe("[AAD] TextAnalyticsClient", function() {
           const piiEntitiesResult = page.recognizePiiEntitiesResults;
           assert.equal(piiEntitiesResult.length, 1);
           for (const piiEntitiesDocs of piiEntitiesResult) {
-            assert.equal(piiEntitiesDocs.length, 3);
-            for (const doc of piiEntitiesDocs) {
-              assert.isUndefined(doc.error);
-              if (!doc.error) {
-                assert.isNotEmpty(doc.redactedText);
+            if (!piiEntitiesDocs.error) {
+              assert.equal(piiEntitiesDocs.results.length, 3);
+              for (const doc of piiEntitiesDocs.results) {
+                assert.isUndefined(doc.error);
+                if (!doc.error) {
+                  assert.isNotEmpty(doc.redactedText);
+                }
               }
             }
           }
@@ -1666,11 +1729,14 @@ describe("[AAD] TextAnalyticsClient", function() {
         );
         const pollerResult = await poller.pollUntilDone();
         const firstResult = (await pollerResult.next()).value;
-        const result = firstResult.recognizePiiEntitiesResults![0]![0];
-        if (!result.error) {
-          assert.equal(result.entities[0].offset, 17); // 25 with UTF16
-          assert.equal(result.entities[0].length, 11);
-          assert.equal(result.entities[0].text.length, result.entities[0].length);
+        const actionResult = firstResult.recognizePiiEntitiesResults[0];
+        if (!actionResult.error) {
+          const docResult = actionResult.results[0];
+          if (!docResult.error) {
+            assert.equal(docResult.entities[0].offset, 17); // 25 with UTF16
+            assert.equal(docResult.entities[0].length, 11);
+            assert.equal(docResult.entities[0].text.length, docResult.entities[0].length);
+          }
         }
       });
     });


### PR DESCRIPTION
The text analytics crew recently agreed on treating action errors in a slightly different way and this PR implements this change. The `beginAnalyzeBatchActions` takes a list of actions (previously known as tasks) as input and apply all of them at once to the input documents and return the results. The results could be a mix of action errors and succeeded action results but the response keeps them separate. This PR combines both types of results into one list of action results (similar to how results on the document level are presented).

Things to note:
- If the service returns failed as a the job status, we used to create an exception out of all errors in the top-level errors list and throw it. Instead, in this PR, I no longer throw an exception and just return those errors as items in the action results list. This approach has the advantage of not confusing the user by using two different ways to show the same type of errors (exceptions and the result list). It also makes it easier for the user to inspect the errors by having them as individual items in a list rather than being one big string in an exception. 
- The list of action results is sorted with respect to the input list of actions.
- I commented all new functions and types so hopefully that will make it easier to review.
- I also bumped the package version.
- ~I will add new tests in another PR.~ I added unit test cases and one client test case.
- Code complete is February 5th so I would really appreciate your review before end of the day.