### PR TITLE
Revert "[Service Bus] Revert core-amqp to 2.0.0 (#13401)"

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -47,9 +47,6 @@
     // "@azure/storage-blob": ["^12.3.0"],
 
     "@azure/ms-rest-js": ["^2.0.0"],
-    // The following is required for service-bus 7.0.3 release,
-    // To be reverted once the 7.0.3 is released
-    "@azure/core-amqp": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^2.0.0",
+    "@azure/core-amqp": "^2.1.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.9",


### PR DESCRIPTION
This reverts commit ba6bbbab05fc132f3dd6d7c06bb4fa020b38b754.

Since the service-bus 7.0.3 is released, we can move to the latest core-amqp.