### PR TITLE
[core-https] Fix decoding of gzip responses

### DIFF
--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -184,7 +184,6 @@ export interface PipelineRequestOptions {
     onUploadProgress?: (progress: TransferProgressEvent) => void;
     proxySettings?: ProxySettings;
     requestId?: string;
-    skipDecompressResponse?: boolean;
     spanOptions?: SpanOptions;
     streamResponseStatusCodes?: Set<number>;
     timeout?: number;

--- a/sdk/core/core-https/src/constants.ts
+++ b/sdk/core/core-https/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0-preview.1";
+export const SDK_VERSION: string = "1.0.0-beta.1";

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -127,7 +127,7 @@ export class NodeHttpsClient implements HttpsClient {
             request
           };
 
-          let responseStream = getResponseStream(res, headers, shouldDecompress);
+          let responseStream = shouldDecompress ? getDecodedResponseStream(res, headers) : res;
 
           const onDownloadProgress = request.onDownloadProgress;
           if (onDownloadProgress) {
@@ -249,15 +249,10 @@ function getResponseHeaders(res: IncomingMessage): HttpHeaders {
   return headers;
 }
 
-function getResponseStream(
+function getDecodedResponseStream(
   stream: IncomingMessage,
-  headers: HttpHeaders,
-  skipDecompressResponse = false
+  headers: HttpHeaders
 ): NodeJS.ReadableStream {
-  if (skipDecompressResponse) {
-    return stream;
-  }
-
   const contentEncoding = headers.get("Content-Encoding");
   if (contentEncoding === "gzip") {
     const unzip = zlib.createGunzip();

--- a/sdk/core/core-https/src/pipelineRequest.ts
+++ b/sdk/core/core-https/src/pipelineRequest.ts
@@ -79,11 +79,6 @@ export interface PipelineRequestOptions {
   keepAlive?: boolean;
 
   /**
-   * Disable automatic decompression based on Accept-Encoding header (Node only)
-   */
-  skipDecompressResponse?: boolean;
-
-  /**
    * Used to abort the request later.
    */
   abortSignal?: AbortSignalLike;
@@ -113,7 +108,6 @@ class PipelineRequestImpl implements PipelineRequest {
   public streamResponseStatusCodes?: Set<number>;
   public proxySettings?: ProxySettings;
   public keepAlive: boolean;
-  public skipDecompressResponse: boolean;
   public abortSignal?: AbortSignalLike;
   public requestId: string;
   public spanOptions?: SpanOptions;
@@ -129,7 +123,6 @@ class PipelineRequestImpl implements PipelineRequest {
     this.formData = options.formData;
     this.keepAlive = options.keepAlive ?? true;
     this.proxySettings = options.proxySettings;
-    this.skipDecompressResponse = options.skipDecompressResponse ?? false;
     this.streamResponseStatusCodes = options.streamResponseStatusCodes;
     this.withCredentials = options.withCredentials ?? false;
     this.abortSignal = options.abortSignal;


### PR DESCRIPTION
#13266 accidentally flipped a boolean, causing gzip responses to not be properly decoded. This PR fixes the issue and changes the code to make it less convoluted.

Also fixes the version string used by the User-Agent policy and finishes removing some old API surface that #13266 forgot to clean up.