### PR TITLE
Use the right pkg name in tests.yml

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/tests.yml
+++ b/sdk/digitaltwins/digital-twins-core/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 extends:
   template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
   parameters:
-    PackageName: "@azure/digitaltwins"
+    PackageName: "@azure/digital-twins-core"
     ResourceServiceDirectory: digitaltwins
     TestBrowser: true
     TestSamples: false


### PR DESCRIPTION
The nightly tests have not been running for the `@azure/digital-twins-core` package as the right package name was not updated in tests.yml file. We had the below error in the build stage:

![image](https://user-images.githubusercontent.com/16890566/106970437-affaa780-6701-11eb-90b6-79c8b7b53adb.png)

This PR fixes the build error, but the tests are now failing which needs to be looked at by the Digital Twins team

cc @deyaaeldeen @zolvarga 