### PR TITLE
Clean up after digital twins pkg rename

### DIFF
--- a/eng/pipelines/mgmt-ci.yml
+++ b/eng/pipelines/mgmt-ci.yml
@@ -24,7 +24,7 @@ trigger:
       - sdk/core/core-xml/
       - sdk/core/logger/
       - sdk/cosmosdb/cosmos/
-      - sdk/digitaltwins/digital-twins/
+      - sdk/digitaltwins/digital-twins-core/
       - sdk/eventgrid/eventgrid/
       - sdk/eventhub/event-hubs/
       - sdk/eventhub/event-processor-host/

--- a/eng/pipelines/mgmt-pr.yml
+++ b/eng/pipelines/mgmt-pr.yml
@@ -24,7 +24,7 @@ pr:
       - sdk/core/core-xml/
       - sdk/core/logger/
       - sdk/cosmosdb/cosmos/
-      - sdk/digitaltwins/digital-twins/
+      - sdk/digitaltwins/digital-twins-core/
       - sdk/eventgrid/eventgrid/
       - sdk/eventhub/event-hubs/
       - sdk/eventhub/event-processor-host/

--- a/sdk/digitaltwins/digital-twins/tsdoc.json
+++ b/sdk/digitaltwins/digital-twins/tsdoc.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
-  "extends": ["../../../tsdoc.json"]
-}


### PR DESCRIPTION
After the `digitaltwins` package was renamed to `digital-twins-core`, we had a few clean up items that were missed. Since #13251 which attempted to do the clean up is battling build errors, creating a separate PR and pulling out the safe changes.

https://github.com/Azure/azure-sdk-for-js/pull/13607 that took care of the tests.yml file is already merged
