### PR TITLE
[KeyVault] - Include missing properties when reading SecretBundle

### DIFF
--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -23,7 +23,7 @@ const banner = [
   " * license information.",
   " * ",
   ` * Azure KeyVault Secrets SDK for JavaScript - ${version}`,
-  " */"
+  " */",
 ].join("\n");
 
 const depNames = Object.keys(pkg.dependencies);
@@ -40,7 +40,7 @@ export function nodeConfig(test = false) {
       format: "cjs",
       name: "azurekeyvaultsecrets",
       sourcemap: true,
-      banner: banner
+      banner: banner,
     },
     plugins: [
       sourcemaps(),
@@ -48,12 +48,12 @@ export function nodeConfig(test = false) {
         delimiters: ["", ""],
         // replace dynamic checks with if (true) since this is for node only.
         // Allows rollup's dead code elimination to be more aggressive.
-        "if (isNode)": "if (true)"
+        "if (isNode)": "if (true)",
       }),
       nodeResolve({ preferBuiltins: true }),
       json(),
-      cjs()
-    ]
+      cjs(),
+    ],
   };
 
   if (test) {
@@ -64,7 +64,7 @@ export function nodeConfig(test = false) {
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";
 
-    baseConfig.external.push("assert", "fs", "path");
+    baseConfig.external.push("assert", "fs", "path", "chai");
 
     baseConfig.context = "null";
 
@@ -88,9 +88,9 @@ export function browserConfig(test = false) {
       format: "umd",
       name: "azurekeyvaultsecrets",
       globals: {
-        "@azure/core-http": "Azure.Core.HTTP"
+        "@azure/core-http": "Azure.Core.HTTP",
       },
-      sourcemap: true
+      sourcemap: true,
     },
     preserveSymlinks: false,
     plugins: [
@@ -100,7 +100,7 @@ export function browserConfig(test = false) {
         // replace dynamic checks with if (false) since this is for
         // browser only. Rollup's dead code elimination will remove
         // any code guarded by if (isNode) { ... }
-        "if (isNode)": "if (false)"
+        "if (isNode)": "if (false)",
       }),
       // os is not used by the browser bundle, so just shim it
       shim({
@@ -108,20 +108,21 @@ export function browserConfig(test = false) {
         os: `
           export const type = 1;
           export const release = 1;
-        `
+        `,
       }),
       nodeResolve({
         mainFields: ["module", "browser"],
-        preferBuiltins: false
+        preferBuiltins: false,
       }),
       json(),
       cjs({
         namedExports: {
-          assert: ["ok", "equal", "strictEqual", "deepEqual"],
-          "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"]
-        }
-      })
-    ]
+          chai: ["assert"],
+          assert: ["ok", "equal", "strictEqual", "deepEqual", "exists"],
+          "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"],
+        },
+      }),
+    ],
   };
 
   if (test) {

--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -23,7 +23,7 @@ const banner = [
   " * license information.",
   " * ",
   ` * Azure KeyVault Secrets SDK for JavaScript - ${version}`,
-  " */",
+  " */"
 ].join("\n");
 
 const depNames = Object.keys(pkg.dependencies);
@@ -40,7 +40,7 @@ export function nodeConfig(test = false) {
       format: "cjs",
       name: "azurekeyvaultsecrets",
       sourcemap: true,
-      banner: banner,
+      banner: banner
     },
     plugins: [
       sourcemaps(),
@@ -48,12 +48,12 @@ export function nodeConfig(test = false) {
         delimiters: ["", ""],
         // replace dynamic checks with if (true) since this is for node only.
         // Allows rollup's dead code elimination to be more aggressive.
-        "if (isNode)": "if (true)",
+        "if (isNode)": "if (true)"
       }),
       nodeResolve({ preferBuiltins: true }),
       json(),
-      cjs(),
-    ],
+      cjs()
+    ]
   };
 
   if (test) {
@@ -88,9 +88,9 @@ export function browserConfig(test = false) {
       format: "umd",
       name: "azurekeyvaultsecrets",
       globals: {
-        "@azure/core-http": "Azure.Core.HTTP",
+        "@azure/core-http": "Azure.Core.HTTP"
       },
-      sourcemap: true,
+      sourcemap: true
     },
     preserveSymlinks: false,
     plugins: [
@@ -100,7 +100,7 @@ export function browserConfig(test = false) {
         // replace dynamic checks with if (false) since this is for
         // browser only. Rollup's dead code elimination will remove
         // any code guarded by if (isNode) { ... }
-        "if (isNode)": "if (false)",
+        "if (isNode)": "if (false)"
       }),
       // os is not used by the browser bundle, so just shim it
       shim({
@@ -108,21 +108,21 @@ export function browserConfig(test = false) {
         os: `
           export const type = 1;
           export const release = 1;
-        `,
+        `
       }),
       nodeResolve({
         mainFields: ["module", "browser"],
-        preferBuiltins: false,
+        preferBuiltins: false
       }),
       json(),
       cjs({
         namedExports: {
           chai: ["assert"],
           assert: ["ok", "equal", "strictEqual", "deepEqual", "exists"],
-          "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"],
-        },
-      }),
-    ],
+          "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"]
+        }
+      })
+    ]
   };
 
   if (test) {

--- a/sdk/keyvault/keyvault-secrets/src/transformations.ts
+++ b/sdk/keyvault/keyvault-secrets/src/transformations.ts
@@ -23,9 +23,13 @@ export function getSecretFromSecretBundle(
     value: secretBundle.value,
     name: parsedId.name,
     properties: {
-      expiresOn: (attributes as any).expires,
-      createdOn: (attributes as any).created,
-      updatedOn: (attributes as any).updated,
+      expiresOn: attributes?.expires,
+      createdOn: attributes?.created,
+      updatedOn: attributes?.updated,
+      enabled: attributes?.enabled,
+      notBefore: attributes?.notBefore,
+      recoverableDays: attributes?.recoverableDays,
+      recoveryLevel: attributes?.recoveryLevel,
 
       id: secretBundle.id,
       contentType: secretBundle.contentType,

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { DeletedSecret, KeyVaultSecret } from "../../src";
+import { DeletedSecretBundle, SecretBundle } from "../../src/generated";
+import { getSecretFromSecretBundle } from "../../src/transformations";
+
+describe.only("Transformations", () => {
+  it("correctly assigns all properties for a secret", () => {
+    const date = new Date();
+    const bundle: SecretBundle = {
+      attributes: {
+        created: date,
+        enabled: true,
+        expires: date,
+        notBefore: date,
+        recoverableDays: 7,
+        recoveryLevel: "Purgable",
+        updated: date
+      },
+      contentType: "content_type",
+      id: "https://azure_keyvault.vault.azure.net/keys/abc123/1",
+      kid: "test_kid",
+      managed: true,
+      tags: {
+        tag1: "value1",
+        tag2: "value2"
+      },
+      value: "my secret value"
+    };
+
+    const secret: KeyVaultSecret = getSecretFromSecretBundle(bundle);
+    assert.equal(secret.value, bundle.value);
+    assert.equal("abc123", secret.name);
+    assert.equal(secret.properties.expiresOn, date);
+    assert.equal(secret.properties.createdOn, date);
+    assert.equal(secret.properties.updatedOn, date);
+    assert.isTrue(secret.properties.enabled);
+    assert.equal(secret.properties.notBefore, date);
+    assert.equal(secret.properties.recoverableDays, 7);
+    assert.equal(secret.properties.recoveryLevel, "Purgable");
+    assert.equal(secret.properties.updatedOn, date);
+    assert.equal(secret.properties.id, bundle.id);
+    assert.equal(secret.properties.contentType, "content_type");
+    assert.deepEqual(secret.properties.tags, bundle.tags);
+    assert.isTrue(secret.properties.managed);
+    assert.equal("https://azure_keyvault.vault.azure.net", secret.properties.vaultUrl);
+    assert.equal("1", secret.properties.version);
+    assert.exists(secret.properties.name);
+  });
+
+  it("correctly assigns all properties for a deleted secret", () => {
+    const date = new Date();
+    const bundle: DeletedSecretBundle = {
+      id: "https://azure_keyvault.vault.azure.net/keys/abc123/1",
+      recoveryId: "recovery_id",
+      scheduledPurgeDate: date,
+      deletedDate: date
+    };
+
+    const secret: DeletedSecret = getSecretFromSecretBundle(bundle);
+    assert.equal(secret.properties.recoveryId, "recovery_id");
+    assert.equal(secret.properties.deletedOn, date);
+    assert.equal(secret.properties.scheduledPurgeDate, date);
+  });
+});

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -6,7 +6,7 @@ import { DeletedSecret, KeyVaultSecret } from "../../src";
 import { DeletedSecretBundle, SecretBundle } from "../../src/generated";
 import { getSecretFromSecretBundle } from "../../src/transformations";
 
-describe.only("Transformations", () => {
+describe("Transformations", () => {
   it("correctly assigns all properties for a secret", () => {
     const date = new Date();
     const bundle: SecretBundle = {

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -30,24 +30,32 @@ describe("Transformations", () => {
       value: "my secret value"
     };
 
+    const expectedResult: KeyVaultSecret = {
+      value: bundle.value,
+      name: "abc123",
+      properties: {
+        expiresOn: date,
+        createdOn: date,
+        updatedOn: date,
+        enabled: true,
+        notBefore: date,
+        recoverableDays: 7,
+        recoveryLevel: "Purgable",
+        id: "https://azure_keyvault.vault.azure.net/keys/abc123/1",
+        contentType: "content_type",
+        tags: {
+          tag1: "value1",
+          tag2: "value2"
+        },
+        managed: true,
+        vaultUrl: "https://azure_keyvault.vault.azure.net",
+        version: "1",
+        name: "abc123"
+      }
+    };
+
     const secret: KeyVaultSecret = getSecretFromSecretBundle(bundle);
-    assert.equal(secret.value, bundle.value);
-    assert.equal("abc123", secret.name);
-    assert.equal(secret.properties.expiresOn, date);
-    assert.equal(secret.properties.createdOn, date);
-    assert.equal(secret.properties.updatedOn, date);
-    assert.isTrue(secret.properties.enabled);
-    assert.equal(secret.properties.notBefore, date);
-    assert.equal(secret.properties.recoverableDays, 7);
-    assert.equal(secret.properties.recoveryLevel, "Purgable");
-    assert.equal(secret.properties.updatedOn, date);
-    assert.equal(secret.properties.id, bundle.id);
-    assert.equal(secret.properties.contentType, "content_type");
-    assert.deepEqual(secret.properties.tags, bundle.tags);
-    assert.isTrue(secret.properties.managed);
-    assert.equal("https://azure_keyvault.vault.azure.net", secret.properties.vaultUrl);
-    assert.equal("1", secret.properties.version);
-    assert.exists(secret.properties.name);
+    assert.deepEqual(secret, expectedResult);
   });
 
   it("correctly assigns all properties for a deleted secret", () => {


### PR DESCRIPTION
## What

- Fix a bug where not all properties were correctly assigned when reading a secret's properties.
- Add a test as a sort of change detector that ensures we don't accidentally miss currently available properties

## Why

- @jeremymeng noticed that listing secrets sample wasn't listing anything. This is because `enabled`
wasn't being correctly set. 
