### PR TITLE
[Digital Twins] Run lint:fix and fix tsdoc lint errors

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -31,7 +31,7 @@
     "integration-test:node": "npm run build:test:node && nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 180000 --full-trace dist-esm/test/*.spec.js dist-esm/test/**/*.spec.js --harmony",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o search-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o digital-twins-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:node": "npm run clean && npm run build:test:node && npm run unit-test:node",

--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -89,9 +89,9 @@ export class DigitalTwinsClient {
    *   new DefaultAzureCredential();
    * );
    * ```
-   * @param endpointUrl The endpoint URL of the service.
-   * @param credential Used to authenticate requests to the service.
-   * @param options Used to configure the service client.
+   * @param endpointUrl - The endpoint URL of the service.
+   * @param credential - Used to authenticate requests to the service.
+   * @param options - Used to configure the service client.
    */
   constructor(
     endpointUrl: string,
@@ -133,8 +133,8 @@ export class DigitalTwinsClient {
   /**
    * Get a digital twin
    *
-   * @param digitalTwinId The Id of the digital twin.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param options - The operation options
    * @returns The application/json digital twin and the http response.
    */
   public getDigitalTwin(
@@ -158,9 +158,9 @@ export class DigitalTwinsClient {
   /**
    * Create or update a digital twin
    *
-   * @param digitalTwinId The Id of the digital twin to create or update.
-   * @param digitalTwinJson The application/json digital twin to create.
-   * @param options Extended operation options including
+   * @param digitalTwinId - The Id of the digital twin to create or update.
+   * @param digitalTwinJson - The application/json digital twin to create.
+   * @param options - Extended operation options including
    *  ifNoneMatch: Only perform the operation if the entity does not already exist.
    * @returns The created application/json digital twin and the http response.
    */
@@ -187,11 +187,11 @@ export class DigitalTwinsClient {
   /**
    * Update a digital twin using a json patch.
    *
-   * @param digitalTwinId The Id of the digital twin.
-   * @param jsonPatch An update specification described by JSON Patch. Updates to property values
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param jsonPatch - An update specification described by JSON Patch. Updates to property values
    * and $model elements may happen in the same request. Operations are limited to add, replace and
    * remove.
-   * @param options Extended operation options including
+   * @param options - Extended operation options including
    *   ifMatch: Only perform the operation if the entity's etag matches one of the etags provided or * is provided.
    * @returns The http response.
    */
@@ -217,8 +217,8 @@ export class DigitalTwinsClient {
   /**
    * Delete a digital twin
    *
-   * @param digitalTwinId The Id of the digital twin to delete.
-   * @param options Extended operation options including
+   * @param digitalTwinId - The Id of the digital twin to delete.
+   * @param options - Extended operation options including
    *   ifMatch: Only perform the operation if the entity's etag matches one of the etags provided or * is provided.
    * @returns The http response.
    */
@@ -243,9 +243,9 @@ export class DigitalTwinsClient {
   /**
    * Get a component on a digital twin.
    *
-   * @param digitalTwinId The Id of the digital twin.
-   * @param componentName The component being retrieved.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param componentName - The component being retrieved.
+   * @param options - The operation options
    * @returns Json string representation of the component corresponding to the provided componentName and the HTTP response.
    */
   public getComponent(
@@ -270,11 +270,11 @@ export class DigitalTwinsClient {
   /**
    * Update properties of a component on a digital twin using a JSON patch.
    *
-   * @param digitalTwinId The Id of the digital twin.
-   * @param componentName The component being updated.
-   * @param jsonPatch The application/json-patch+json operations to be performed on the specified digital twin's component.
-   * @param enableUpdate If true then update of an existing digital twin is enabled.
-   * @param options Extended operation options including
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param componentName - The component being updated.
+   * @param jsonPatch - The application/json-patch+json operations to be performed on the specified digital twin's component.
+   * @param enableUpdate - If true then update of an existing digital twin is enabled.
+   * @param options - Extended operation options including
    *   ifMatch: Only perform the operation if the entity's etag matches one of the etags provided or * is provided.
    * @returns The http response.
    */
@@ -306,9 +306,9 @@ export class DigitalTwinsClient {
   /**
    * Get a relationship on a digital twin.
    *
-   * @param digitalTwinId The Id of the source digital twin.
-   * @param relationshipId The Id of the relationship to retrieve.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the source digital twin.
+   * @param relationshipId - The Id of the relationship to retrieve.
+   * @param options - The operation options
    * @returns The pageable list of application/json relationships belonging to the specified digital twin and the http response.
    */
   public getRelationship(
@@ -337,10 +337,10 @@ export class DigitalTwinsClient {
   /**
    * Create or update a relationship on a digital twin.
    *
-   * @param digitalTwinId The Id of the source digital twin.
-   * @param relationshipId The Id of the relationship to create.
-   * @param relationship: The application/json relationship to be created.
-   * @param options Extended operation options including
+   * @param digitalTwinId - The Id of the source digital twin.
+   * @param relationshipId - The Id of the relationship to create.
+   * @param relationship - The application/json relationship to be created.
+   * @param options - Extended operation options including
    *  ifNoneMatch: Only perform the operation if the entity does not already exist.
    */
   public upsertRelationship(
@@ -371,10 +371,10 @@ export class DigitalTwinsClient {
   /**
    * Updates the properties of a relationship on a digital twin using a JSON patch.
    *
-   * @param digitalTwinId The Id of the digital twin to delete.
-   * @param relationshipId The Id of the relationship to be updated.
-   * @param jsonPatch The application/json-patch+json operations to be performed on the specified digital twin's relationship.
-   * @param options Extended operation options
+   * @param digitalTwinId - The Id of the digital twin to delete.
+   * @param relationshipId - The Id of the relationship to be updated.
+   * @param jsonPatch - The application/json-patch+json operations to be performed on the specified digital twin's relationship.
+   * @param options - Extended operation options
    *   ifMatch: Only perform the operation if the entity's etag matches one of the etags provided or * is provided.
    */
   public updateRelationship(
@@ -405,9 +405,9 @@ export class DigitalTwinsClient {
   /**
    * Delete a relationship on a digital twin.
    *
-   * @param digitalTwinId The Id of the source digital twin.
-   * @param relationshipId The Id of the relationship to delete.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the source digital twin.
+   * @param relationshipId - The Id of the relationship to delete.
+   * @param options - The operation options
    *   ifMatch: Only perform the operation if the entity's etag matches one of the etags provided or * is
    * @returns The http response.
    */
@@ -438,8 +438,9 @@ export class DigitalTwinsClient {
    * @internal
    * Deals with the pagination of {@link listRelationships}.
    *
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {DigitalTwinsListRelationshipsOptionalParams} [options] Common options for the iterative endpoints.
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param options - Common options for the iterative endpoints.
+   * @param continuationState - An object that indicates the position of the paginated request.
    *
    */
   private async *listRelationshipsPage(
@@ -473,7 +474,7 @@ export class DigitalTwinsClient {
   /**
    * @internal
    * Deals with the iteration of all the available results of {@link listRelationships}.
-   * @param {DigitalTwinsListRelationshipsOptionalParams} [options] Common options for the iterative endpoints.
+   * @param options - Common options for the iterative endpoints.
    */
   private async *listRelationshipsAll(
     digitalTwinId: string,
@@ -490,7 +491,7 @@ export class DigitalTwinsClient {
   /**
    * Retrieve relationships for a digital twin.
    *
-   * @param digitalTwinId The Id of the digital twin.
+   * @param digitalTwinId - The Id of the digital twin.
    */
   public listRelationships(
     digitalTwinId: string,
@@ -525,8 +526,9 @@ export class DigitalTwinsClient {
    * @internal
    * Deals with the pagination of {@link listIncomingRelationships}.
    *
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {OperationOptions} [options] Common options for the iterative endpoints.
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param options - Common options for the iterative endpoints.
+   * @param continuationState - An object that indicates the position of the paginated request.
    *
    */
   private async *listIncomingRelationshipsPage(
@@ -560,7 +562,8 @@ export class DigitalTwinsClient {
   /**
    * @internal
    * Deals with the iteration of all the available results of {@link listIncomingRelationships}.
-   * @param {OperationOptions} [options] Common options for the iterative endpoints.
+   * @param digitalTwinId - The Id of the digital twin.
+   * @param options - Common options for the iterative endpoints.
    */
   private async *listIncomingRelationshipsAll(
     digitalTwinId: string,
@@ -575,7 +578,7 @@ export class DigitalTwinsClient {
   /**
    * Retrieve all incoming relationships for a digital twin.
    *
-   * @param digitalTwinId The Id of the digital twin.
+   * @param digitalTwinId - The Id of the digital twin.
    */
   public listIncomingRelationships(
     digitalTwinId: string,
@@ -615,10 +618,10 @@ export class DigitalTwinsClient {
   /**
    * Publish telemetry from a digital twin, which is then consumed by one or many destination endpoints (subscribers) defined under.
    *
-   * @param digitalTwinId The Id of the digital twin to delete.
-   * @param payload The application/json telemetry payload to be sent.
-   * @param messageId The message Id.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the digital twin to delete.
+   * @param payload - The application/json telemetry payload to be sent.
+   * @param messageId - The message Id.
+   * @param options - The operation options
    * @returns The http response.
    */
   public publishTelemetry(
@@ -657,11 +660,11 @@ export class DigitalTwinsClient {
   /**
    * Publish telemetry from a digital twin's component, which is then consumed by one or many destination endpoints (subscribers) defined under.
    *
-   * @param digitalTwinId The Id of the digital twin to delete.
-   * @param componentName The name of the DTDL component.
-   * @param payload The application/json telemetry payload to be sent.
-   * @param messageId The message Id.
-   * @param options The operation options
+   * @param digitalTwinId - The Id of the digital twin to delete.
+   * @param componentName - The name of the DTDL component.
+   * @param payload - The application/json telemetry payload to be sent.
+   * @param messageId - The message Id.
+   * @param options - The operation options
    * @returns The http response.
    */
   public publishComponentTelemetry(
@@ -702,8 +705,8 @@ export class DigitalTwinsClient {
   /**
    * Get a model, including the model metadata and the model definition.
    *
-   * @param modelId The Id of the model.
-   * @param options Extended operation options including
+   * @param modelId - The Id of the model.
+   * @param options - Extended operation options including
    *  includeModelDefinition: When true the model definition will be returned as part of the result. Default value: false.
    * @returns The application/json model and the http response.
    */
@@ -735,8 +738,8 @@ export class DigitalTwinsClient {
    * @internal
    * Deals with the pagination of {@link list}.
    *
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {DigitalTwinModelsListOptionalParams} [options] Common options for the iterative endpoints.
+   * @param options - Common options for the iterative endpoints.
+   * @param continuationState - An object that indicates the position of the paginated request.
    *
    */
   private async *getModelsPage(
@@ -765,7 +768,7 @@ export class DigitalTwinsClient {
   /**
    * @internal
    * Deals with the iteration of all the available results of {@link list}.
-   * @param {DigitalTwinModelsListOptionalParams} [options] Common options for the iterative endpoints.
+   * @param options - Common options for the iterative endpoints.
    */
   private async *getModelsAll(
     options: DigitalTwinModelsListOptionalParams
@@ -783,9 +786,9 @@ export class DigitalTwinsClient {
   /**
    * Get the list of models
    *
-   * @param dependeciesFor The model Ids to have dependencies retrieved. If omitted, all models are retrieved.
-   * @param includeModelDefinition Whether to include the model definition in the result. If false, only the model metadata will be returned.
-   * @param resultsPerPage The maximum number of items to retrieve per request. The server may choose to return less than the requested max.
+   * @param dependeciesFor - The model Ids to have dependencies retrieved. If omitted, all models are retrieved.
+   * @param includeModelDefinition - Whether to include the model definition in the result. If false, only the model metadata will be returned.
+   * @param resultsPerPage - The maximum number of items to retrieve per request. The server may choose to return less than the requested max.
    * @returns A pageable set of application/json models and the http response.
    */
   public listModels(
@@ -794,7 +797,7 @@ export class DigitalTwinsClient {
     resultsPerPage?: number,
     options: OperationOptions & PageSettings = {}
   ): PagedAsyncIterableIterator<DigitalTwinsModelData, DigitalTwinModelsListResponse> {
-    var digitalTwinModelsListOptionalParams: DigitalTwinModelsListOptionalParams = options;
+    let digitalTwinModelsListOptionalParams: DigitalTwinModelsListOptionalParams = options;
     digitalTwinModelsListOptionalParams = {
       maxItemsPerPage: resultsPerPage,
       dependenciesFor: dependeciesFor,
@@ -831,8 +834,8 @@ export class DigitalTwinsClient {
   /**
    * Create one or many
    *
-   * @param models The set of models to create. Each string corresponds to exactly one model.
-   * @param options The operation options
+   * @param models - The set of models to create. Each string corresponds to exactly one model.
+   * @param options - The operation options
    * @returns The created application/json models and the http response.
    */
   public createModels(
@@ -860,14 +863,15 @@ export class DigitalTwinsClient {
 
   /**
    * Decommission a model using a json patch.
-   *
-   * @param modelId The Id of the model to decommission.
-   * property can be replaced.
-   * @param options The operation options
-   * @returns The http response.
-   * @summary When a model is decomissioned, new digital twins will no longer be able to be
+   * When a model is decomissioned, new digital twins will no longer be able to be
    * defined by this model. However, existing digital twins may continue to use this model.
    * Once a model is decomissioned, it may not be recommissioned.
+   *
+   * @param modelId - The Id of the model to decommission.
+   * property can be replaced.
+   * @param options - The operation options
+   * @returns The http response.
+   *
    */
   public decomissionModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
     const jsonPatch = [{ op: "replace", path: "/decommissioned", value: true }];
@@ -889,8 +893,8 @@ export class DigitalTwinsClient {
   /**
    * Delete a model.
    *
-   * @param modelId The Id of the model to delete.
-   * @param options The operation options
+   * @param modelId - The Id of the model to delete.
+   * @param options - The operation options
    * @returns The http response.
    */
   public deleteModel(modelId: string, options: OperationOptions = {}): Promise<RestResponse> {
@@ -911,8 +915,8 @@ export class DigitalTwinsClient {
   /**
    * Get an event route.
    *
-   * @param modelId The Id of the event route.
-   * @param options The operation options
+   * @param modelId - The Id of the event route.
+   * @param options - The operation options
    * @returns The application/json event route and the http response.
    */
   public getEventRoute(
@@ -937,8 +941,8 @@ export class DigitalTwinsClient {
    * @internal
    * Deals with the pagination of {@link list}.
    *
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {EventRoutesListOptionalParams} [options] Common options for the iterative endpoints.
+   * @param options - Common options for the iterative endpoints.
+   * @param continuationState - An object that indicates the position of the paginated request.
    *
    */
   private async *getEventRoutesPage(
@@ -967,7 +971,7 @@ export class DigitalTwinsClient {
   /**
    * @internal
    * Deals with the iteration of all the available results of {@link list}.
-   * @param {EventRoutesListOptionalParams} [options] Common options for the iterative endpoints.
+   * @param options - Common options for the iterative endpoints.
    */
   private async *getEventRoutesAll(
     options: EventRoutesListOptionalParams
@@ -984,7 +988,7 @@ export class DigitalTwinsClient {
   /**
    * List the event routes in a digital twins instance.
    *
-   * @param resultsPerPage The maximum number of items to retrieve per request. The server may choose to return less than
+   * @param resultsPerPage - The maximum number of items to retrieve per request. The server may choose to return less than
    * the requested max.
    * @returns The application/json event route and the http response.
    */
@@ -992,7 +996,7 @@ export class DigitalTwinsClient {
     resultsPerPage?: number,
     options: OperationOptions & PageSettings = {}
   ): PagedAsyncIterableIterator<EventRoute, EventRoutesListNextResponse> {
-    var eventRoutesListOptionalParams: EventRoutesListOptionalParams = options;
+    let eventRoutesListOptionalParams: EventRoutesListOptionalParams = options;
     eventRoutesListOptionalParams = {
       maxItemsPerPage: resultsPerPage
     };
@@ -1028,10 +1032,10 @@ export class DigitalTwinsClient {
   /**
    * Create or update an event route.
    *
-   * @param eventRouteId The Id of the event route to create or update.
-   * @param endpointId The id of the endpoint this event route is bound to.
-   * @param filter An expression which describes the events which are routed to the endpoint.
-   * @param options The operation options
+   * @param eventRouteId - The Id of the event route to create or update.
+   * @param endpointId - The id of the endpoint this event route is bound to.
+   * @param filter - An expression which describes the events which are routed to the endpoint.
+   * @param options - The operation options
    * @returns The http response.
    */
   public upsertEventRoute(
@@ -1066,8 +1070,8 @@ export class DigitalTwinsClient {
   /**
    * Delete an event route.
    *
-   * @param eventRouteId The Id of the eventRoute to delete.
-   * @param options The operation options
+   * @param eventRouteId - The Id of the eventRoute to delete.
+   * @param options - The operation options
    * @returns The http response.
    */
   public deleteEventRoute(
@@ -1092,8 +1096,9 @@ export class DigitalTwinsClient {
    * @internal
    * Deals with the pagination of {@link query}.
    *
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {OperationOptions} [options] Common options for the iterative endpoints.
+   * @param query - The query string, in SQL-like syntax.
+   * @param options - Common options for the iterative endpoints.
+   * @param continuationState - An object that indicates the position of the paginated request.
    *
    */
   private async *queryTwinsPage(
@@ -1125,7 +1130,8 @@ export class DigitalTwinsClient {
   /**
    * @internal
    * Deals with the iteration of all the available results of {@link query}.
-   * @param {OperationOptions} [options] Common options for the iterative endpoints.
+   * @param query - The query string, in SQL-like syntax.
+   * @param options - Common options for the iterative endpoints.
    */
   private async *queryTwinsAll(
     query: string,
@@ -1145,8 +1151,8 @@ export class DigitalTwinsClient {
   /**
    * Query for digital twins.
    *
-   * @param query The query string, in SQL-like syntax.
-   * @param resultsPerPage The maximum number of items to retrieve per request. The server may choose to return less than the requested max.
+   * @param query - The query string, in SQL-like syntax.
+   * @param resultsPerPage - The maximum number of items to retrieve per request. The server may choose to return less than the requested max.
    * @returns The pageable list of query results.
    */
   public queryTwins(
@@ -1154,7 +1160,7 @@ export class DigitalTwinsClient {
     resultsPerPage?: number,
     options: OperationOptions & PageSettings = {}
   ): PagedAsyncIterableIterator<any, QueryQueryTwinsResponse> {
-    var queryQueryTwinsOptionalParams: QueryQueryTwinsOptionalParams = options;
+    let queryQueryTwinsOptionalParams: QueryQueryTwinsOptionalParams = options;
     queryQueryTwinsOptionalParams = {
       maxItemsPerPage: resultsPerPage
     };

--- a/sdk/digitaltwins/digital-twins-core/src/logger.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/logger.ts
@@ -4,6 +4,6 @@
 import { createClientLogger } from "@azure/logger";
 
 /**
- * The @azure/logger configuration for this package.
+ * The \@azure/logger configuration for this package.
  */
 export const logger = createClientLogger("azure-digitaltwins-core");

--- a/sdk/digitaltwins/digital-twins-core/src/tracing.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @internal
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,

--- a/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
@@ -278,7 +278,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     ];
     try {
       const twin = await client.getDigitalTwin(DIGITAL_TWIN_ID);
-      let options: DigitalTwinsUpdateComponentOptionalParams = {
+      const options: DigitalTwinsUpdateComponentOptionalParams = {
         ifMatch: twin.etag
       };
       await client.updateComponent(DIGITAL_TWIN_ID, "Component1", patch, options);
@@ -303,7 +303,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
         value: "value2"
       }
     ];
-    let options: DigitalTwinsUpdateComponentOptionalParams = {
+    const options: DigitalTwinsUpdateComponentOptionalParams = {
       ifMatch: "etag-value"
     };
     let errorWasThrown = false;

--- a/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
@@ -191,7 +191,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       AverageTemperature: 68,
       TemperatureUnit: "Celsius"
     };
-    let options: DigitalTwinsAddOptionalParams = {
+    const options: DigitalTwinsAddOptionalParams = {
       ifNoneMatch: "*"
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin), options);
@@ -254,7 +254,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       );
       assert.notEqual(createdTwin.body.$etag, "", "No etag in result from upsertDigitalTwin().");
 
-      let newTemperature = 69;
+      const newTemperature = 69;
       buildingTwin.AverageTemperature = newTemperature;
       const updatedTwin = await client.upsertDigitalTwin(
         digitalTwinId,
@@ -303,7 +303,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       AverageTemperature: 68,
       TemperatureUnit: "Celsius"
     };
-    let options: DigitalTwinsAddOptionalParams = {
+    const options: DigitalTwinsAddOptionalParams = {
       ifNoneMatch: "XXX"
     };
     let errorWasThrown = false;
@@ -441,7 +441,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     };
     const createdTwin = await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
-    let options: DigitalTwinsDeleteOptionalParams = {
+    const options: DigitalTwinsDeleteOptionalParams = {
       ifMatch: createdTwin.etag
     };
     let errorWasThrown = false;
@@ -486,7 +486,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     };
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
-    let options: DigitalTwinsDeleteOptionalParams = {
+    const options: DigitalTwinsDeleteOptionalParams = {
       ifMatch: "XXX"
     };
     let errorWasThrown = false;
@@ -748,7 +748,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       }
     ];
     const createdTwin = await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
-    let options: DigitalTwinsUpdateOptionalParams = {
+    const options: DigitalTwinsUpdateOptionalParams = {
       ifMatch: createdTwin.etag
     };
     await client.updateDigitalTwin(digitalTwinId, patch, options);
@@ -796,7 +796,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     ];
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(buildingTwin));
 
-    let options: DigitalTwinsDeleteOptionalParams = {
+    const options: DigitalTwinsDeleteOptionalParams = {
       ifMatch: "XXX"
     };
     let errorWasThrown = false;

--- a/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
@@ -213,7 +213,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "FloorContainsRoom";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
@@ -241,7 +241,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "FloorContainsRoom";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: FLOOR_DIGITAL_TWIN_ID,
       $relationshipName: "contains",
@@ -332,7 +332,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -415,7 +415,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -522,7 +522,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -612,7 +612,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -696,7 +696,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -778,7 +778,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -870,7 +870,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -957,7 +957,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -1066,7 +1066,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -1182,7 +1182,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",
@@ -1241,7 +1241,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await setUpDigitalTwins();
 
     const relationshipId = "BuildingHasFloor";
-    let relationship = {
+    const relationship = {
       $relationshipId: relationshipId,
       $sourceId: BUILDING_DIGITAL_TWIN_ID,
       $relationshipName: "has",


### PR DESCRIPTION
This PR has the following changes
- Result from running the lint:fix script 
- Updates to fix the docs with the `@param` tag to follow the expected format
- Fix the file name for the lint report

This brings down the linting errors from over 220 to about 85, contributing to https://github.com/Azure/azure-sdk-for-js/issues/12729 and fixes https://github.com/Azure/azure-sdk-for-js/issues/12958

