### PR TITLE
[Event Hubs] Remove use of @property tag in docs

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -30,30 +30,30 @@ import { SharedKeyCredential } from "./eventhubSharedKeyCredential";
  */
 export interface ConnectionContext extends ConnectionContextBase {
   /**
-   * @property config The EventHub connection config that is created after
+   * The EventHub connection config that is created after
    * parsing the connection string.
    */
   readonly config: EventHubConnectionConfig;
   /**
-   * @property {SharedKeyCredential | TokenCredential} [tokenCredential] The credential to be used for Authentication.
+   * The credential to be used for Authentication.
    * Default value: SharedKeyCredentials.
    */
   tokenCredential: SharedKeyCredential | TokenCredential;
   /**
-   * @property wasConnectionCloseCalled Indicates whether the close() method was
+   * Indicates whether the close() method was
    * called on theconnection object.
    */
   wasConnectionCloseCalled: boolean;
   /**
-   * @property receivers A dictionary of the EventHub Receivers associated with this client.
+   * A dictionary of the EventHub Receivers associated with this client.
    */
   receivers: Dictionary<EventHubReceiver>;
   /**
-   * @property senders A dictionary of the EventHub Senders associated with this client.
+   * A dictionary of the EventHub Senders associated with this client.
    */
   senders: Dictionary<EventHubSender>;
   /**
-   * @property managementSession A reference to the management session ($management endpoint) on
+   * A reference to the management session ($management endpoint) on
    * the underlying amqp connection for the EventHub Client.
    */
   managementSession?: ManagementClient;
@@ -131,7 +131,7 @@ type ConnectionContextMethods = Omit<
  */
 export namespace ConnectionContext {
   /**
-   * @property userAgent The user agent string for the EventHubs client.
+   * The user agent string for the EventHubs client.
    * See guideline at https://github.com/Azure/azure-sdk/blob/master/docs/design/Telemetry.mdk
    */
   const userAgent: string = `azsdk-js-azureeventhubs/${

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -50,7 +50,7 @@ export const defaultDataTransformer = {
   },
 
   /**
-   * @property {Function} [decode] A function that takes the body property from an AMQP message
+   * A function that takes the body property from an AMQP message
    * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
    * If it cannot decode the body then it returns the body
    * as-is.

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -11,23 +11,23 @@ import { isDefined } from "./util/typeGuards";
  */
 export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
   /**
-   * @property [last_enqueued_offset] The offset of the last event.
+   * The offset of the last event.
    */
   last_enqueued_offset?: string;
   /**
-   * @property [last_enqueued_sequence_number] The sequence number of the last event.
+   * The sequence number of the last event.
    */
   last_enqueued_sequence_number?: number;
   /**
-   * @property [last_enqueued_time_utc] The enqueued time of the last event.
+   * The enqueued time of the last event.
    */
   last_enqueued_time_utc?: number;
   /**
-   * @property [runtime_info_retrieval_time_utc] The retrieval time of the last event.
+   * The retrieval time of the last event.
    */
   runtime_info_retrieval_time_utc?: number;
   /**
-   * @property Any unknown delivery annotations.
+   * Any unknown delivery annotations.
    */
   [x: string]: any;
 }
@@ -38,23 +38,23 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
  */
 export interface EventHubMessageAnnotations extends MessageAnnotations {
   /**
-   * @property [x-opt-partition-key] Annotation for the partition key set for the event.
+   * Annotation for the partition key set for the event.
    */
   "x-opt-partition-key"?: string | null;
   /**
-   * @property [x-opt-sequence-number] Annontation for the sequence number of the event.
+   * Annontation for the sequence number of the event.
    */
   "x-opt-sequence-number"?: number;
   /**
-   * @property [x-opt-enqueued-time] Annotation for the enqueued time of the event.
+   * Annotation for the enqueued time of the event.
    */
   "x-opt-enqueued-time"?: number;
   /**
-   * @property [x-opt-offset] Annotation for the offset of the event.
+   * Annotation for the offset of the event.
    */
   "x-opt-offset"?: string;
   /**
-   * @property Any other annotation that can be added to the message.
+   * Any other annotation that can be added to the message.
    */
   [x: string]: any;
 }
@@ -65,48 +65,48 @@ export interface EventHubMessageAnnotations extends MessageAnnotations {
  */
 export interface EventDataInternal {
   /**
-   * @property body - The message body that needs to be sent or is received.
+   * The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property [enqueuedTimeUtc] The enqueued time of the event.
+   * The enqueued time of the event.
    */
   enqueuedTimeUtc?: Date;
   /**
-   * @property [partitionKey] If specified EventHub will hash this to a partitionId.
+   * If specified EventHub will hash this to a partitionId.
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   partitionKey?: string | null;
   /**
-   * @property [offset] The offset of the event.
+   * The offset of the event.
    */
   offset?: number;
   /**
-   * @property [sequenceNumber] The sequence number of the event.
+   * The sequence number of the event.
    */
   sequenceNumber?: number;
   /**
-   * @property [properties] The application specific properties.
+   * The application specific properties.
    */
   properties?: { [property: string]: any };
   /**
-   * @property [lastSequenceNumber] The last sequence number of the event within the partition stream of the Event Hub.
+   * The last sequence number of the event within the partition stream of the Event Hub.
    */
   lastSequenceNumber?: number;
   /**
-   * @property [lastEnqueuedOffset] The offset of the last enqueued event.
+   * The offset of the last enqueued event.
    */
   lastEnqueuedOffset?: string;
   /**
-   * @property [lastEnqueuedTime] The enqueued UTC time of the last event.
+   * The enqueued UTC time of the last event.
    */
   lastEnqueuedTime?: Date;
   /**
-   * @property [retrievalTime] The time when the runtime info was retrieved
+   * The time when the runtime info was retrieved
    */
   retrievalTime?: Date;
   /**
-   * @property [systemProperties] The properties set by the service.
+   * The properties set by the service.
    */
   systemProperties?: { [property: string]: any };
 }
@@ -229,14 +229,14 @@ export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessa
  */
 export interface EventData {
   /**
-   * @property The message body that needs to be sent.
+   * The message body that needs to be sent.
    * If the application reading the events is not using this SDK,
    * convert your body payload to a byte array or Buffer for better
    * cross-language compatibility.
    */
   body: any;
   /**
-   * @property Set of key value pairs that can be used to set properties specific to user application.
+   * Set of key value pairs that can be used to set properties specific to user application.
    */
   properties?: {
     [key: string]: any;
@@ -250,34 +250,34 @@ export interface EventData {
  */
 export interface ReceivedEventData {
   /**
-   * @property The message body that needs to be sent or is received.
+   * The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property The application specific properties.
+   * The application specific properties.
    */
   properties?: {
     [key: string]: any;
   };
   /**
-   * @property The enqueued time of the event.
+   * The enqueued time of the event.
    */
   enqueuedTimeUtc: Date;
   /**
-   * @property When specified Event Hub will hash this to a partitionId.
+   * When specified Event Hub will hash this to a partitionId.
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   partitionKey: string | null;
   /**
-   * @property The offset of the event.
+   * The offset of the event.
    */
   offset: number;
   /**
-   * @property The sequence number of the event.
+   * The sequence number of the event.
    */
   sequenceNumber: number;
   /**
-   * @property The properties set by the service.
+   * The properties set by the service.
    */
   systemProperties?: {
     [key: string]: any;

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -134,34 +134,34 @@ export interface EventDataBatch {
  */
 export class EventDataBatchImpl implements EventDataBatch {
   /**
-   * @property Describes the amqp connection context for the Client.
+   * Describes the amqp connection context for the Client.
    */
   private _context: ConnectionContext;
   /**
-   * @property The Id of the partition to which the batch is expected to be sent to.
+   * The Id of the partition to which the batch is expected to be sent to.
    * Specifying this will throw an error if the batch was created using a `paritionKey`.
    */
   private _partitionId?: string;
   /**
-   * @property A value that is hashed to produce a partition assignment.
+   * A value that is hashed to produce a partition assignment.
    * It guarantees that messages with the same partitionKey end up in the same partition.
    * Specifying this will throw an error if the batch was created using a `paritionId`.
    */
   private _partitionKey?: string;
   /**
-   * @property The maximum size allowed for the batch.
+   * The maximum size allowed for the batch.
    */
   private _maxSizeInBytes: number;
   /**
-   * @property Current size of the batch in bytes.
+   * Current size of the batch in bytes.
    */
   private _sizeInBytes: number;
   /**
-   * @property Encoded amqp messages.
+   * Encoded amqp messages.
    */
   private _encodedMessages: Buffer[] = [];
   /**
-   * @property Number of events in the batch.
+   * Number of events in the batch.
    */
   private _count: number;
   /**
@@ -198,7 +198,7 @@ export class EventDataBatchImpl implements EventDataBatch {
   }
 
   /**
-   * @property The maximum size of the batch, in bytes.
+   * The maximum size of the batch, in bytes.
    * @readonly
    */
   get maxSizeInBytes(): number {
@@ -206,7 +206,7 @@ export class EventDataBatchImpl implements EventDataBatch {
   }
 
   /**
-   * @property The partitionKey set during `EventDataBatch` creation. This value is hashed to
+   * The partitionKey set during `EventDataBatch` creation. This value is hashed to
    * produce a partition assignment when the producer is created without a `partitionId`
    * @readonly
    */
@@ -224,7 +224,7 @@ export class EventDataBatchImpl implements EventDataBatch {
   }
 
   /**
-   * @property Size of the `EventDataBatch` instance after the events added to it have been
+   * Size of the `EventDataBatch` instance after the events added to it have been
    * encoded into a single AMQP message.
    * @readonly
    */
@@ -233,7 +233,7 @@ export class EventDataBatchImpl implements EventDataBatch {
   }
 
   /**
-   * @property Number of events in the `EventDataBatch` instance.
+   * Number of events in the `EventDataBatch` instance.
    * @readonly
    */
   get count(): number {

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -13,20 +13,20 @@ import { MessagingError } from "@azure/core-amqp";
  */
 export interface BasicPartitionProperties {
   /**
-   * @property The fully qualified Event Hubs namespace. This is likely to be similar to
+   * The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    */
   fullyQualifiedNamespace: string;
   /**
-   * @property The event hub name.
+   * The event hub name.
    */
   eventHubName: string;
   /**
-   * @property The consumer group name.
+   * The consumer group name.
    */
   consumerGroup: string;
   /**
-   * @property The identifier of the Event Hub partition.
+   * The identifier of the Event Hub partition.
    */
   partitionId: string;
 }
@@ -39,20 +39,20 @@ export interface BasicPartitionProperties {
  */
 export interface PartitionContext {
   /**
-   * @property The fully qualified Event Hubs namespace. This is likely to be similar to
+   * The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    */
   readonly fullyQualifiedNamespace: string;
   /**
-   * @property The event hub name.
+   * The event hub name.
    */
   readonly eventHubName: string;
   /**
-   * @property The consumer group name.
+   * The consumer group name.
    */
   readonly consumerGroup: string;
   /**
-   * @property The identifier of the Event Hub partition.
+   * The identifier of the Event Hub partition.
    */
   readonly partitionId: string;
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -46,22 +46,22 @@ interface CreateReceiverOptions {
  */
 export interface LastEnqueuedEventProperties {
   /**
-   * @property The sequence number of the event that was last enqueued into the Event Hub partition from which
+   * The sequence number of the event that was last enqueued into the Event Hub partition from which
    * this event was received.
    */
   sequenceNumber?: number;
   /**
-   * @property The date and time, in UTC, that the last event was enqueued into the Event Hub partition from
+   * The date and time, in UTC, that the last event was enqueued into the Event Hub partition from
    * which this event was received.
    */
   enqueuedOn?: Date;
   /**
-   * @property The offset of the event that was last enqueued into the Event Hub partition from which
+   * The offset of the event that was last enqueued into the Event Hub partition from which
    * this event was received.
    */
   offset?: string;
   /**
-   * @property The date and time, in UTC, that the last event was retrieved from the Event Hub partition.
+   * The date and time, in UTC, that the last event was retrieved from the Event Hub partition.
    */
   retrievedOn?: Date;
 }
@@ -91,73 +91,73 @@ export type OnAbort = () => void;
  */
 export class EventHubReceiver extends LinkEntity {
   /**
-   * @property consumerGroup The EventHub consumer group from which the receiver will
+   * The EventHub consumer group from which the receiver will
    * receive messages. (Default: "default").
    */
   consumerGroup: string;
   /**
-   * @property runtimeInfo The receiver runtime info.
+   * The receiver runtime info.
    */
   runtimeInfo: LastEnqueuedEventProperties;
   /**
-   * @property [ownerLevel] The Receiver ownerLevel.
+   * The Receiver ownerLevel.
    */
   ownerLevel?: number;
   /**
-   * @property eventPosition The event position in the partition at which to start receiving messages.
+   * The event position in the partition at which to start receiving messages.
    */
   eventPosition: EventPosition;
   /**
-   * @property [options] Optional properties that can be set while creating
+   * Optional properties that can be set while creating
    * the EventHubConsumer.
    */
   options: EventHubConsumerOptions;
   /**
-   * @property [_receiver] The RHEA AMQP-based receiver link.
+   * The RHEA AMQP-based receiver link.
    */
   private _receiver?: Receiver;
   /**
-   * @property _onMessage The message handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
+   * The message handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
    */
   private _onMessage?: OnMessage;
   /**
-   * @property _OnError The error handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
+   * The error handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
    */
   private _onError?: OnError;
   /**
-   * @property _onAbort The abort handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
+   * The abort handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
    */
   private _onAbort?: OnAbort;
   /**
-   * @property _abortSignal An implementation of the `AbortSignalLike` interface to signal cancelling a receiver operation.
+   * An implementation of the `AbortSignalLike` interface to signal cancelling a receiver operation.
    */
   private _abortSignal?: AbortSignalLike;
   /**
-   * @property _checkpoint The sequence number of the most recently received AMQP message.
+   * The sequence number of the most recently received AMQP message.
    */
   private _checkpoint: number = -1;
   /**
-   * @property _internalQueue A queue of events that were received from the AMQP link but not consumed externally by `EventHubConsumer`
+   * A queue of events that were received from the AMQP link but not consumed externally by `EventHubConsumer`
    */
   private _internalQueue: ReceivedEventData[] = [];
   /**
-   * @property _usingInternalQueue Indicates that events in the internal queue are being processed to be consumed by `EventHubConsumer`
+   * Indicates that events in the internal queue are being processed to be consumed by `EventHubConsumer`
    */
   private _usingInternalQueue: boolean = false;
   /**
-   * @property _isReceivingMessages Indicates if messages are being received from this receiver.
+   * Indicates if messages are being received from this receiver.
    */
   private _isReceivingMessages: boolean = false;
   /**
-   * @property _isStreaming Indicated if messages are being received in streaming mode.
+   * Indicated if messages are being received in streaming mode.
    */
   private _isStreaming: boolean = false;
   /**
-   * @property Denotes if close() was called on this receiver
+   * Denotes if close() was called on this receiver
    */
   private _isClosed: boolean = false;
   /**
-   * @property Returns sequenceNumber of the last event received from the service. This will not match the
+   * Returns sequenceNumber of the last event received from the service. This will not match the
    * last event received by `EventHubConsumer` when the `_internalQueue` is not empty
    * @readonly
    */
@@ -166,7 +166,7 @@ export class EventHubReceiver extends LinkEntity {
   }
 
   /**
-   * @property Indicates if messages are being received from this receiver.
+   * Indicates if messages are being received from this receiver.
    * @readonly
    */
   get isReceivingMessages(): boolean {
@@ -181,7 +181,7 @@ export class EventHubReceiver extends LinkEntity {
   }
 
   /**
-   * @property The last enqueued event information. This property will only
+   * The last enqueued event information. This property will only
    * be enabled when `trackLastEnqueuedEventProperties` option is set to true
    * @readonly
    */

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -40,35 +40,35 @@ import { defaultDataTransformer } from "./dataTransformer";
  */
 export class EventHubSender extends LinkEntity {
   /**
-   * @property senderLock The unique lock name per connection that is used to acquire the
+   * The unique lock name per connection that is used to acquire the
    * lock for establishing a sender link by an entity on that connection.
    * @readonly
    */
   readonly senderLock: string = `sender-${uuid()}`;
   /**
-   * @property _onAmqpError The handler function to handle errors that happen on the
+   * The handler function to handle errors that happen on the
    * underlying sender.
    * @readonly
    */
   private readonly _onAmqpError: OnAmqpEvent;
   /**
-   * @property _onAmqpClose The handler function to handle "sender_close" event
+   * The handler function to handle "sender_close" event
    * that happens on the underlying sender.
    * @readonly
    */
   private readonly _onAmqpClose: OnAmqpEvent;
   /**
-   * @property _onSessionError The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_error" event.
    */
   private _onSessionError: OnAmqpEvent;
   /**
-   * @property _onSessionClose The message handler that will be set as the handler on
+   * The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_close" event.
    */
   private _onSessionClose: OnAmqpEvent;
   /**
-   * @property [_sender] The AMQP sender link.
+   * The AMQP sender link.
    */
   private _sender?: AwaitableSender;
 

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -14,7 +14,7 @@ import { isDefined, objectHasProperty } from "./util/typeGuards";
  */
 export interface EventPosition {
   /**
-   * @property The offset of the event identified by this position.
+   * The offset of the event identified by this position.
    * Expected to be undefined if the position is just created from a sequence number or an enqueued time.
    *
    * The offset is the relative position for an event in the context of the partition.
@@ -24,20 +24,20 @@ export interface EventPosition {
    */
   offset?: number | "@latest";
   /**
-   * @property Indicates if the specified offset is inclusive of the event which it identifies.
+   * Indicates if the specified offset is inclusive of the event which it identifies.
    * This information is only relevent if the event position was identified by an offset or sequence number.
    * Default value: `false`.
    */
   isInclusive?: boolean;
   /**
-   * @property The enqueued time in UTC of the event identified by this position.
+   * The enqueued time in UTC of the event identified by this position.
    * When provided as a number this value is the number of milliseconds since the Unix Epoch.
    * Expected to be undefined if the position is just created from a sequence number or an offset.
    */
   enqueuedOn?: Date | number;
 
   /**
-   * @property The sequence number of the event identified by this position.
+   * The sequence number of the event identified by this position.
    * Expected to be undefined if the position is just created from an offset or enqueued time.
    */
   sequenceNumber?: number;

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -22,32 +22,32 @@ import { LoadBalancingStrategy } from "./loadBalancerStrategies/loadBalancingStr
  */
 export interface PartitionOwnership {
   /**
-   * @property The fully qualified Event Hubs namespace. This is likely to be similar to
+   * The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    */
   fullyQualifiedNamespace: string;
   /**
-   * @property The event hub name
+   * The event hub name
    */
   eventHubName: string;
   /**
-   * @property The consumer group name
+   * The consumer group name
    */
   consumerGroup: string;
   /**
-   * @property The identifier of the Event Hub partition.
+   * The identifier of the Event Hub partition.
    */
   partitionId: string;
   /**
-   * @property The unique identifier of the event processor.
+   * The unique identifier of the event processor.
    */
   ownerId: string;
   /**
-   * @property The last modified time.
+   * The last modified time.
    */
   lastModifiedTimeInMs?: number;
   /**
-   * @property The unique identifier for the operation.
+   * The unique identifier for the operation.
    */
   etag?: string;
 }

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -14,7 +14,7 @@ import { parseEndpoint } from "./util/parseEndpoint";
  */
 export interface EventHubConnectionConfig extends ConnectionConfig {
   /**
-   * @property {string} entityPath - The name/path of the entity (event hub name) to which the
+   * The name/path of the entity (event hub name) to which the
    * connection needs to happen.
    */
   entityPath: string;

--- a/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
@@ -13,12 +13,12 @@ import jssha from "jssha";
  */
 export class SharedKeyCredential {
   /**
-   * @property {string} keyName - The name of the EventHub/ServiceBus key.
+   * The name of the EventHub/ServiceBus key.
    */
   keyName: string;
 
   /**
-   * @property {string} key - The secret value associated with the above EventHub/ServiceBus key.
+   * The secret value associated with the above EventHub/ServiceBus key.
    */
   key: string;
 

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -14,20 +14,20 @@ import { SharedKeyCredential } from "../src/eventhubSharedKeyCredential";
  */
 export interface LinkEntityOptions {
   /**
-   * @property [name] The unique name for the entity. If not provided then a guid will be
+   * The unique name for the entity. If not provided then a guid will be
    * assigned.
    */
   name?: string;
   /**
-   * @property [partitionId] The partitionId associated with the link entity.
+   * The partitionId associated with the link entity.
    */
   partitionId?: string;
   /**
-   * @property address The link entity address in one of the following forms:
+   * The link entity address in one of the following forms:
    */
   address?: string;
   /**
-   * @property audience The link entity token audience in one of the following forms:
+   * The link entity token audience in one of the following forms:
    */
   audience?: string;
 }
@@ -39,11 +39,11 @@ export interface LinkEntityOptions {
  */
 export class LinkEntity {
   /**
-   * @property [name] The unique name for the entity (mostly a guid).
+   * The unique name for the entity (mostly a guid).
    */
   name: string;
   /**
-   * @property address The link entity address in one of the following forms:
+   * The link entity address in one of the following forms:
    *
    * **Sender**
    * - `"<hubName>"`
@@ -57,7 +57,7 @@ export class LinkEntity {
    */
   address: string;
   /**
-   * @property audience The link entity token audience in one of the following forms:
+   * The link entity token audience in one of the following forms:
    *
    * **Sender**
    * - `"sb://<yournamespace>.servicebus.windows.net/<hubName>"`
@@ -71,26 +71,26 @@ export class LinkEntity {
    */
   audience: string;
   /**
-   * @property [partitionId] The partitionId associated with the link entity.
+   * The partitionId associated with the link entity.
    */
   partitionId?: string;
   /**
-   * @property isConnecting Indicates whether the link is in the process of connecting
+   * Indicates whether the link is in the process of connecting
    * (establishing) itself. Default value: `false`.
    */
   isConnecting: boolean = false;
   /**
-   * @property _context Provides relevant information about the amqp connection,
+   * Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
    */
   protected _context: ConnectionContext;
   /**
-   * @property _tokenRenewalTimer The token renewal timer that keeps track of when
+   * The token renewal timer that keeps track of when
    * the Link Entity is due for token renewal.
    */
   protected _tokenRenewalTimer?: NodeJS.Timer;
   /**
-   * @property _tokenTimeout Indicates token timeout in milliseconds
+   * Indicates token timeout in milliseconds
    */
   protected _tokenTimeoutInMs?: number;
   /**

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -40,15 +40,15 @@ import { SharedKeyCredential } from "../src/eventhubSharedKeyCredential";
  */
 export interface EventHubProperties {
   /**
-   * @property The name of the event hub.
+   * The name of the event hub.
    */
   name: string;
   /**
-   * @property The date and time the hub was created in UTC.
+   * The date and time the hub was created in UTC.
    */
   createdOn: Date;
   /**
-   * @property The slice of string partition identifiers.
+   * The slice of string partition identifiers.
    */
   partitionIds: string[];
 }
@@ -58,31 +58,31 @@ export interface EventHubProperties {
  */
 export interface PartitionProperties {
   /**
-   * @property The name of the Event Hub.
+   * The name of the Event Hub.
    */
   eventHubName: string;
   /**
-   * @property Identifier of the partition within the Event Hub.
+   * Identifier of the partition within the Event Hub.
    */
   partitionId: string;
   /**
-   * @property The starting sequence number of the partition's message log.
+   * The starting sequence number of the partition's message log.
    */
   beginningSequenceNumber: number;
   /**
-   * @property The last sequence number of the partition's message log.
+   * The last sequence number of the partition's message log.
    */
   lastEnqueuedSequenceNumber: number;
   /**
-   * @property The offset of the last enqueued message in the partition's message log.
+   * The offset of the last enqueued message in the partition's message log.
    */
   lastEnqueuedOffset: number;
   /**
-   * @property The time of the last enqueued message in the partition's message log in UTC.
+   * The time of the last enqueued message in the partition's message log in UTC.
    */
   lastEnqueuedOnUtc: Date;
   /**
-   * @property Indicates whether the partition is empty.
+   * Indicates whether the partition is empty.
    */
   isEmpty: boolean;
 }
@@ -104,12 +104,12 @@ export interface ManagementClientOptions {
 export class ManagementClient extends LinkEntity {
   readonly managementLock: string = `${Constants.managementRequestKey}-${uuid()}`;
   /**
-   * @property entityPath - The name/path of the entity (hub name) for which the management
+   * The name/path of the entity (hub name) for which the management
    * request needs to be made.
    */
   entityPath: string;
   /**
-   * @property replyTo The reply to Guid for the management client.
+   * The reply to Guid for the management client.
    */
   replyTo: string = uuid();
   /**

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -25,28 +25,28 @@ import { logger } from "./log";
  **/
 export interface Checkpoint {
   /**
-   * @property The fully qualified Event Hubs namespace. This is likely to be similar to
+   * The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    */
   fullyQualifiedNamespace: string;
   /**
-   * @property The event hub name
+   * The event hub name
    */
   eventHubName: string;
   /**
-   * @property The consumer group name
+   * The consumer group name
    */
   consumerGroup: string;
   /**
-   * @property The identifier of the Event Hub partition
+   * The identifier of the Event Hub partition
    */
   partitionId: string;
   /**
-   * @property The sequence number of the event
+   * The sequence number of the event
    */
   sequenceNumber: number;
   /**
-   * @property The offset of the event.
+   * The offset of the event.
    */
   offset: number;
 }
@@ -73,7 +73,7 @@ export class PartitionProcessor implements PartitionContext {
   ) {}
 
   /**
-   * @property Information on the last enqueued event in the partition that is being processed.
+   * Information on the last enqueued event in the partition that is being processed.
    * This property is updated by the `EventProcessor` if the `trackLastEnqueuedEventProperties` option is set to true
    * when creating an instance of EventProcessor
    * @readonly
@@ -83,7 +83,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property Information on the last enqueued event in the partition that is being processed.
+   * Information on the last enqueued event in the partition that is being processed.
    * This property is updated by the `EventProcessor` if the `trackLastEnqueuedEventProperties` option is set to true
    * when creating an instance of EventProcessor
    */
@@ -92,7 +92,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property The fully qualified namespace from where the current partition is being processed. It is set by the `EventProcessor`
+   * The fully qualified namespace from where the current partition is being processed. It is set by the `EventProcessor`
    * @readonly
    */
   public get fullyQualifiedNamespace(): string {
@@ -100,7 +100,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property The name of the consumer group from where the current partition is being processed. It is set by the `EventProcessor`
+   * The name of the consumer group from where the current partition is being processed. It is set by the `EventProcessor`
    * @readonly
    */
   public get consumerGroup(): string {
@@ -108,7 +108,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property The name of the event hub to which the current partition belongs. It is set by the `EventProcessor`
+   * The name of the event hub to which the current partition belongs. It is set by the `EventProcessor`
    * @readonly
    */
   public get eventHubName(): string {
@@ -116,7 +116,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property The identifier of the Event Hub partition that is being processed. It is set by the `EventProcessor`
+   * The identifier of the Event Hub partition that is being processed. It is set by the `EventProcessor`
    * @readonly
    */
   public get partitionId(): string {
@@ -124,7 +124,7 @@ export class PartitionProcessor implements PartitionContext {
   }
 
   /**
-   * @property The unique identifier of the `EventProcessor` that has spawned the current instance of `PartitionProcessor`. This is set by the `EventProcessor`
+   * The unique identifier of the `EventProcessor` that has spawned the current instance of `PartitionProcessor`. This is set by the `EventProcessor`
    */
   public get eventProcessorId(): string {
     return this._context.eventProcessorId;

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -13,7 +13,7 @@ import { logErrorStackTrace, logger } from "./log";
  */
 export class ReceiveHandler {
   /**
-   * @property _receiver  The underlying EventHubReceiver.
+   * The underlying EventHubReceiver.
    */
   private _receiver: EventHubReceiver;
 
@@ -28,7 +28,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property The partitionId from which the handler is receiving events.
+   * The partitionId from which the handler is receiving events.
    * @readonly
    */
   get partitionId(): string | undefined {
@@ -36,7 +36,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property The consumer group from which the handler is receiving events.
+   * The consumer group from which the handler is receiving events.
    * @readonly
    */
   get consumerGroup(): string | undefined {
@@ -44,7 +44,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property Indicates whether the receiver is connected/open.
+   * Indicates whether the receiver is connected/open.
    * `true` - is open; `false` otherwise.
    * @readonly
    */


### PR DESCRIPTION
This PR resolves about 150 linter errors around the use of `@property` tag which is not allowed in TSDoc

Related to #12953