### PR TITLE
[Event Hubs] Remove invalid tsdoc tags

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -76,7 +76,6 @@ export interface ConnectionContext extends ConnectionContextBase {
 /**
  * Describes the members on the ConnectionContext that are only
  * used by it internally.
- * @hidden
  * @internal
  */
 export interface ConnectionContextInternalMembers extends ConnectionContext {
@@ -432,7 +431,6 @@ export namespace ConnectionContext {
  * Helper method to create a ConnectionContext from the input passed to either
  * EventHubProducerClient or EventHubConsumerClient constructors
  *
- * @hidden
  * @internal
  */
 export function createConnectionContext(

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -16,8 +16,6 @@ export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
  * has already been instrumented.
  * @param eventData The `EventData` to instrument.
  * @param span The `Span` containing the context to propagate tracing information.
- * @hidden
- * @internal
  */
 export function instrumentEventData(eventData: EventData, span: Span): EventData {
   if (eventData.properties && eventData.properties[TRACEPARENT_PROPERTY]) {

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -63,7 +63,6 @@ export interface EventDataBatch {
    * set the partitionKey.
    * @readonly
    * @internal
-   * @hidden
    */
   readonly partitionKey?: string;
 
@@ -72,7 +71,6 @@ export interface EventDataBatch {
    * the `EventHubProducerClient` to set the partitionId.
    * @readonly
    * @internal
-   * @hidden
    */
   readonly partitionId?: string;
 
@@ -113,7 +111,6 @@ export interface EventDataBatch {
    * This is not meant for the user to use directly.
    *
    * @internal
-   * @hidden
    */
   _generateMessage(): Buffer;
 
@@ -121,7 +118,6 @@ export interface EventDataBatch {
    * Gets the "message" span contexts that were created when adding events to the batch.
    * Used internally by the `sendBatch()` method to set up the right spans in traces if tracing is enabled.
    * @internal
-   * @hidden
    */
   readonly _messageSpanContexts: SpanContext[];
 }
@@ -129,7 +125,6 @@ export interface EventDataBatch {
 /**
  * An internal class representing a batch of events which can be used to send events to Event Hub.
  *
- * @class
  * @internal
  */
 export class EventDataBatchImpl implements EventDataBatch {
@@ -179,9 +174,7 @@ export class EventDataBatchImpl implements EventDataBatch {
   /**
    * EventDataBatch should not be constructed using `new EventDataBatch()`
    * Use the `createBatch()` method on your `EventHubProducer` instead.
-   * @constructor
    * @internal
-   * @hidden
    */
   constructor(
     context: ConnectionContext,
@@ -243,7 +236,6 @@ export class EventDataBatchImpl implements EventDataBatch {
   /**
    * Gets the "message" span contexts that were created when adding events to the batch.
    * @internal
-   * @hidden
    */
   get _messageSpanContexts(): SpanContext[] {
     return this._spanContexts;

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -86,7 +86,6 @@ export type OnAbort = () => void;
 
 /**
  * Describes the EventHubReceiver that will receive event data from EventHub.
- * @class EventHubReceiver
  * @internal
  */
 export class EventHubReceiver extends LinkEntity {
@@ -193,7 +192,6 @@ export class EventHubReceiver extends LinkEntity {
    * Instantiates a receiver that can be used to receive events over an AMQP receiver link in
    * either batching or streaming mode.
    * @hidden
-   * @constructor
    * @param context        The connection context corresponding to the EventHubClient instance
    * @param consumerGroup  The consumer group from which the receiver should receive events from.
    * @param partitionId    The Partition ID from which to receive.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -35,7 +35,6 @@ import { defaultDataTransformer } from "./dataTransformer";
 
 /**
  * Describes the EventHubSender that will send event data to EventHub.
- * @class EventHubSender
  * @internal
  */
 export class EventHubSender extends LinkEntity {
@@ -75,7 +74,6 @@ export class EventHubSender extends LinkEntity {
   /**
    * Creates a new EventHubSender instance.
    * @hidden
-   * @constructor
    * @param context The connection context.
    * @param [partitionId] The EventHub partition id to which the sender
    * wants to send the event data.

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -107,7 +107,6 @@ export const latestEventPosition: EventPosition = {
 };
 
 /**
- * @hidden
  * @internal
  */
 export function validateEventPositions(
@@ -142,7 +141,6 @@ export function validateEventPositions(
  * Determines whether a position is an EventPosition.
  * Does not validate that the position is allowed.
  * @param position
- * @hidden
  * @internal
  */
 export function isEventPosition(position: unknown): position is EventPosition {

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -131,7 +131,6 @@ export interface FullEventProcessorOptions extends CommonEventProcessorOptions {
   /**
    * An optional pump manager to use, rather than instantiating one internally
    * @internal
-   * @hidden
    */
   pumpManager?: PumpManager;
   /**
@@ -172,7 +171,6 @@ export interface FullEventProcessorOptions extends CommonEventProcessorOptions {
  * For production, choose an implementation that will store checkpoints and partition ownership details to a durable store.
  * Implementations of `CheckpointStore` can be found on npm by searching for packages with the prefix &commat;azure/eventhub-checkpointstore-.
  *
- * @class EventProcessor
  * @internal
  */
 export class EventProcessor {

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -10,7 +10,6 @@ import { parseEndpoint } from "./util/parseEndpoint";
  * string. It also provides some convenience methods for getting the address and audience for
  * different entities.
  * @internal
- * @ignore
  */
 export interface EventHubConnectionConfig extends ConnectionConfig {
   /**
@@ -69,7 +68,6 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
  * string. It also provides some convenience methods for getting the address and audience for
  * different entities.
  * @internal
- * @ignore
  */
 export const EventHubConnectionConfig = {
   /**

--- a/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
@@ -8,7 +8,6 @@ import isBuffer from "is-buffer";
 import jssha from "jssha";
 
 /**
- * @class SharedKeyCredential
  * Defines the SharedKeyCredential .
  */
 export class SharedKeyCredential {
@@ -24,7 +23,6 @@ export class SharedKeyCredential {
 
   /**
    * Initializes a new instance of SharedKeyCredential
-   * @constructor
    * @param {string} keyName - The name of the EventHub/ServiceBus key.
    * @param {string} key - The secret value associated with the above EventHub/ServiceBus key
    */

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -15,7 +15,6 @@ import { throwTypeErrorIfParameterMissing } from "./util/error";
  * But in production, you should choose an implementation of the `CheckpointStore` interface that will
  * store the checkpoints and partition ownerships to a durable store instead.
  *
- * @class
  * @internal
  */
 export class InMemoryCheckpointStore implements CheckpointStore {

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -35,7 +35,6 @@ export interface LinkEntityOptions {
 /**
  * Describes the base class for entities like EventHub Sender, Receiver and Management link.
  * @internal
- * @class LinkEntity
  */
 export class LinkEntity {
   /**
@@ -96,7 +95,6 @@ export class LinkEntity {
   /**
    * Creates a new LinkEntity instance.
    * @hidden
-   * @constructor
    * @param context The connection context.
    * @param [options] Options that can be provided while creating the LinkEntity.
    */

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
@@ -59,7 +59,6 @@ interface EventProcessorCounts {
  * @param partitionOwnershipMap The existing PartitionOwnerships mapped by partition.
  * @param expirationIntervalInMs The length of time a PartitionOwnership claim is valid.
  * @hidden
- * @internal
  */
 function getActivePartitionOwnerships(
   partitionOwnershipMap: Map<string, PartitionOwnership>,
@@ -89,7 +88,6 @@ function getActivePartitionOwnerships(
  * and the number of EventProcessors that should have an extra partition assigned.
  * @param ownerToOwnershipMap The current ownerships for partitions.
  * @param partitionIds The full list of the Event Hub's partition ids.
- * @hidden
  * @internal
  */
 function calculateBalancedLoadCounts(
@@ -171,7 +169,6 @@ function getEventProcessorCounts(
  * @param requiredNumberOfOwnersWithExtraPartition The # of EventProcessors that process an additional partition, in addition to the required minimum.
  * @param totalExpectedProcessors The total # of EventProcessors we expect.
  * @param eventProcessorCounts EventProcessor counts, grouped by criteria.
- * @hidden
  * @internal
  */
 function isLoadBalanced(
@@ -192,7 +189,6 @@ function isLoadBalanced(
  * @param requiredNumberOfOwnersWithExtraPartition The current number of processors that should have an additional partition.
  * @param numPartitionsOwnedByUs The number of partitions we currently own.
  * @param eventProcessorCounts Processors, grouped by criteria.
- * @hidden
  * @internal
  */
 function getNumberOfPartitionsToClaim(

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -96,7 +96,6 @@ export interface ManagementClientOptions {
 }
 
 /**
- * @class ManagementClient
  * @internal
  * Descibes the EventHubs Management Client that talks
  * to the $management endpoint over AMQP connection.
@@ -119,7 +118,6 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Instantiates the management client.
-   * @constructor
    * @hidden
    * @param context The connection context.
    * @param [address] The address for the management endpoint. For IotHub it will be
@@ -137,7 +135,6 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Gets the security token for the management application properties.
-   * @hidden
    * @internal
    */
   async getSecurityToken(): Promise<AccessToken | null> {

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -11,7 +11,6 @@ import { LoadBalancingStrategy } from "../loadBalancerStrategies/loadBalancingSt
  * - `partitionId`  : The string identifier of the partition that the producer can be bound to.
  * - `retryOptions` : The retry options used to govern retry attempts when an issue is encountered while sending events.
  * A simple usage can be `{ "maxRetries": 4 }`.
- * @hidden
  * @internal
  */
 export interface EventHubProducerOptions {

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -17,7 +17,6 @@ import { ReceivedEventData } from "./eventData";
 import { ConnectionContext } from "./connectionContext";
 
 /**
- * @hidden
  * @internal
  */
 export class PartitionPump {
@@ -248,7 +247,6 @@ export function createProcessingSpan(
 }
 
 /**
- * @hidden
  * @internal
  */
 export async function trace(fn: () => Promise<void>, span: Span): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -14,7 +14,6 @@ import { ConnectionContext } from "./connectionContext";
  * The PumpManager handles the creation and removal of PartitionPumps.
  * It also starts a PartitionPump when it is created, and stops a
  * PartitionPump when it is removed.
- * @hidden
  * @internal
  */
 export interface PumpManager {
@@ -24,7 +23,6 @@ export interface PumpManager {
    * @param eventHubClient The EventHubClient to forward to the PartitionPump.
    * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
    * @param abortSignal Used to cancel pump creation.
-   * @hidden
    */
   createPump(
     startPosition: EventPosition,
@@ -36,15 +34,12 @@ export interface PumpManager {
   /**
    * Indicates whether the pump manager is actively receiving events from a given partition.
    * @param partitionId The partition to check.
-   * @hidden
-   * @internal
    */
   isReceivingFromPartition(partitionId: string): boolean;
 
   /**
    * Stops all PartitionPumps and removes them from the internal map.
    * @param reason The reason for removing the pump.
-   * @hidden
    */
   removeAllPumps(reason: CloseReason): Promise<void>;
 }
@@ -85,7 +80,6 @@ export class PumpManagerImpl implements PumpManager {
   /**
    * Indicates whether the pump manager is actively receiving events from a given partition.
    * @param partitionId
-   * @hidden
    * @internal
    */
   public isReceivingFromPartition(partitionId: string): boolean {

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -7,8 +7,6 @@ import { logErrorStackTrace, logger } from "./log";
 /**
  * Describes the receive handler object that is returned from the receive() method with handlers.
  * The ReceiveHandler is used to stop receiving more messages.
- * @class ReceiveHandler
- * @hidden
  * @internal
  */
 export class ReceiveHandler {
@@ -19,7 +17,6 @@ export class ReceiveHandler {
 
   /**
    * Creates an instance of the ReceiveHandler.
-   * @constructor
    * @internal
    * @param receiver The underlying EventHubReceiver.
    */

--- a/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
+++ b/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
@@ -90,7 +90,6 @@ export function parseEventHubConnectionString(
 
 /**
  * @internal
- * @ignore
  */
 function validateProperties(
   endpoint?: string,

--- a/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
+++ b/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
@@ -4,7 +4,6 @@
 /**
  * Parses the host, hostname, and port from an endpoint.
  * @param endpoint And endpoint to parse.
- * @hidden
  * @internal
  */
 export function parseEndpoint(endpoint: string): { host: string; hostname: string; port?: string } {

--- a/sdk/eventhub/event-hubs/src/util/runtimeInfo.browser.ts
+++ b/sdk/eventhub/event-hubs/src/util/runtimeInfo.browser.ts
@@ -13,7 +13,6 @@ interface Navigator {
 
 /**
  * Returns information about the platform this function is being run on.
- * @hidden
  * @internal
  */
 export function getRuntimeInfo(): string {

--- a/sdk/eventhub/event-hubs/src/util/runtimeInfo.ts
+++ b/sdk/eventhub/event-hubs/src/util/runtimeInfo.ts
@@ -5,7 +5,6 @@ import * as os from "os";
 
 /**
  * Returns information about the platform this function is being run on.
- * @hidden
  * @internal
  */
 export function getRuntimeInfo(): string {

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -13,9 +13,7 @@ import { generate_uuid } from "rhea-promise";
  * But in production, you should choose an implementation of the `CheckpointStore` interface that will
  * store the checkpoints and partition ownerships to a durable store instead.
  * Please note - this is only meant for use within the test and not in production code
- * @class
  * @internal
- * @ignore
  */
 export class TestInMemoryCheckpointStore implements CheckpointStore {
   private _partitionOwnershipMap: Map<string, PartitionOwnership> = new Map();


### PR DESCRIPTION
This PR removes the below invalid TSDoc tags fixing about 20 linting errors
- `@class`
- `@ignore`
- `@constructor`

Additionally, 
- it removes the `@hidden` tag if  `@internal` is already applied
- it removes the `@hidden` or `internal` tag on a interface/class member if the interface/class itself already has one of the two tags

Related to #12953
