### PR TITLE
[Synapse] Use mysynapse instead of personal resource name

### DIFF
--- a/sdk/synapse/synapse-access-control/README.md
+++ b/sdk/synapse/synapse-access-control/README.md
@@ -28,7 +28,7 @@ export async function main(): Promise<void> {
 
   let client = new AccessControlClient(
     credential,
-    "https://joturnersynapsetest.dev.azuresynapse.net"
+    "https://mysynapse.dev.azuresynapse.net"
   );
   let list = await client.listRoleDefinitions();
   for await (let item of list) {


### PR DESCRIPTION
Fixes #12998