### PR TITLE
[Event Hubs] Fix param and return tags to follow TSDoc

### DIFF
--- a/sdk/eventhub/event-hubs/samples/expressSample/src/asyncBatchingProducer.ts
+++ b/sdk/eventhub/event-hubs/samples/expressSample/src/asyncBatchingProducer.ts
@@ -37,7 +37,6 @@ export class AsyncBatchingProducer {
 
   /**
    * Queues up the eventData so it can be sent to Event Hubs.
-   * @param eventData
    */
   public send(eventData: EventData) {
     this._eventQueue.push(eventData);
@@ -124,8 +123,8 @@ export class AsyncBatchingProducer {
 /**
  * This function returns a promise that resolves after the specified amount of time.
  * It also supports cancellation via passing in an `abortSignal`.
- * @param timeInMs The amount of time in milliseconds the function should wait before resolving.
- * @param abortSignal Used to support rejecting the promise immediately.
+ * @param timeInMs - The amount of time in milliseconds the function should wait before resolving.
+ * @param abortSignal - Used to support rejecting the promise immediately.
  */
 function wait(timeInMs: number, abortSignal: AbortSignalLike): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -191,7 +190,6 @@ class AwaitableQueue<T> {
 
   /**
    * Appends new item to the queue.
-   * @param item
    */
   public push(item: T): void {
     if (!this._resolveNextItem(item)) {

--- a/sdk/eventhub/event-hubs/samples/typescript/src/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/iothubConnectionString.ts
@@ -29,7 +29,7 @@ dotenv.config();
 
 /**
  * Type guard for AmqpError.
- * @param err An unknown error.
+ * @param err - An unknown error.
  */
 function isAmqpError(err: any): err is AmqpError {
   return rheaIsAmqpError(err);
@@ -60,7 +60,7 @@ function generateSasToken(
 
 /**
  * Converts an IotHub Connection string into an Event Hubs-compatible connection string.
- * @param connectionString An IotHub connection string in the format:
+ * @param connectionString - An IotHub connection string in the format:
  * `"HostName=<your-iot-hub>.azure-devices.net;SharedAccessKeyName=<KeyName>;SharedAccessKey=<Key>"`
  * @returns An Event Hubs-compatible connection string in the format:
  * `"Endpoint=sb://<hostname>;EntityPath=<your-iot-hub>;SharedAccessKeyName=<KeyName>;SharedAccessKey=<Key>"`

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -18,7 +18,7 @@ export const defaultDataTransformer = {
    * and returns an encoded body (some form of AMQP type).
    *
    * @param body - The AMQP message body
-   * @return {DataSection} encodedBody - The encoded AMQP message body as an AMQP Data type
+   * @returns The encoded AMQP message body as an AMQP Data type
    * (data section in rhea terms). Section object with following properties:
    * - typecode: 117 (0x75)
    * - content: The given AMQP message body as a Buffer.
@@ -55,7 +55,7 @@ export const defaultDataTransformer = {
    * If it cannot decode the body then it returns the body
    * as-is.
    * @param body - The AMQP message body
-   * @return {*} decoded body or the given body as-is.
+   * @returns decoded body or the given body as-is.
    */
   decode(body: unknown): any {
     let processedBody: any = body;

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -17,7 +17,7 @@ export const defaultDataTransformer = {
    * A function that takes the body property from an EventData object
    * and returns an encoded body (some form of AMQP type).
    *
-   * @param {*} body The AMQP message body
+   * @param body - The AMQP message body
    * @return {DataSection} encodedBody - The encoded AMQP message body as an AMQP Data type
    * (data section in rhea terms). Section object with following properties:
    * - typecode: 117 (0x75)
@@ -54,7 +54,7 @@ export const defaultDataTransformer = {
    * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
    * If it cannot decode the body then it returns the body
    * as-is.
-   * @param {DataSection} body The AMQP message body
+   * @param body - The AMQP message body
    * @return {*} decoded body or the given body as-is.
    */
   decode(body: unknown): any {

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -14,8 +14,8 @@ export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
  * Populates the `EventData` with `SpanContext` info to support trace propagation.
  * Creates and returns a copy of the passed in `EventData` unless the `EventData`
  * has already been instrumented.
- * @param eventData The `EventData` to instrument.
- * @param span The `Span` containing the context to propagate tracing information.
+ * @param eventData - The `EventData` to instrument.
+ * @param span - The `Span` containing the context to propagate tracing information.
  */
 export function instrumentEventData(eventData: EventData, span: Span): EventData {
   if (eventData.properties && eventData.properties[TRACEPARENT_PROPERTY]) {
@@ -35,7 +35,7 @@ export function instrumentEventData(eventData: EventData, span: Span): EventData
 
 /**
  * Extracts the `SpanContext` from an `EventData` if the context exists.
- * @param eventData An individual `EventData` object.
+ * @param eventData - An individual `EventData` object.
  * @internal
  */
 export function extractSpanContextFromEventData(eventData: EventData): SpanContext | undefined {

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -129,7 +129,7 @@ const messagePropertiesMap = {
 
 /**
  * Converts the AMQP message to an EventData.
- * @param msg The AMQP message that needs to be converted to EventData.
+ * @param msg - The AMQP message that needs to be converted to EventData.
  * @hidden
  */
 export function fromRheaMessage(msg: RheaMessage): EventDataInternal {
@@ -190,8 +190,8 @@ export function fromRheaMessage(msg: RheaMessage): EventDataInternal {
 
 /**
  * Converts an EventData object to an AMQP message.
- * @param data The EventData object that needs to be converted to an AMQP message.
- * @param partitionKey An optional key to determine the partition that this event should land in.
+ * @param data - The EventData object that needs to be converted to an AMQP message.
+ * @param partitionKey - An optional key to determine the partition that this event should land in.
  * @hidden
  */
 export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessage {

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -26,7 +26,7 @@ const smallMessageMaxBytes = 255;
 
 /**
  * Checks if the provided eventDataBatch is an instance of `EventDataBatch`.
- * @param eventDataBatch The instance of `EventDataBatch` to verify.
+ * @param eventDataBatch - The instance of `EventDataBatch` to verify.
  * @internal
  */
 export function isEventDataBatch(eventDataBatch: unknown): eventDataBatch is EventDataBatch {
@@ -100,7 +100,7 @@ export interface EventDataBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next event.
    *
-   * @param eventData  An individual event data object.
+   * @param eventData -  An individual event data object.
    * @returns A boolean value indicating if the event data has been added to the batch or not.
    */
   tryAdd(eventData: EventData, options?: TryAddOptions): boolean;
@@ -243,8 +243,8 @@ export class EventDataBatchImpl implements EventDataBatch {
 
   /**
    * Generates an AMQP message that contains the provided encoded events and annotations.
-   * @param encodedEvents The already encoded events to include in the AMQP batch.
-   * @param annotations The message annotations to set on the batch.
+   * @param encodedEvents - The already encoded events to include in the AMQP batch.
+   * @param annotations - The message annotations to set on the batch.
    */
   private _generateBatch(encodedEvents: Buffer[], annotations?: MessageAnnotations): Buffer {
     const batchEnvelope: RheaMessage = {
@@ -275,7 +275,7 @@ export class EventDataBatchImpl implements EventDataBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next event.
    *
-   * @param eventData  An individual event data object.
+   * @param eventData -  An individual event data object.
    * @returns A boolean value indicating if the event data has been added to the batch or not.
    */
   public tryAdd(eventData: EventData, options: TryAddOptions = {}): boolean {

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -74,7 +74,6 @@ export class EventHubConsumerClient {
   private _subscriptions = new Set<Subscription>();
 
   /**
-   * @property
    * The name of the default consumer group in the Event Hubs service.
    */
   static defaultConsumerGroupName: string = Constants.defaultConsumerGroup;
@@ -88,7 +87,6 @@ export class EventHubConsumerClient {
   private readonly _loadBalancingOptions: Required<LoadBalancingOptions>;
 
   /**
-   * @property
    * @readonly
    * The name of the Event Hub instance for which this client is created.
    */
@@ -97,7 +95,6 @@ export class EventHubConsumerClient {
   }
 
   /**
-   * @property
    * @readonly
    * The fully qualified namespace of the Event Hub instance for which this client is created.
    * This is likely to be similar to <yournamespace>.servicebus.windows.net.

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -109,7 +109,7 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
    * It is expected that the shared key properties and the Event Hub path are contained in this connection string.
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;EntityPath=my-event-hub-name'.
@@ -127,11 +127,11 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
    * It is expected that the shared key properties and the Event Hub path are contained in this connection string.
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;EntityPath=my-event-hub-name'.
-   * @param checkpointStore A checkpoint store that is used by the client to read checkpoints to determine
+   * @param checkpointStore - A checkpoint store that is used by the client to read checkpoints to determine
    * the position from where it should resume receiving events when your application gets restarted.
    * It is also used by the client to load balance multiple instances of your application.
    * @param options - A set of options to apply when configuring the client.
@@ -149,7 +149,7 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
    * It is expected that the shared key properties are contained in this connection string, but not the Event Hub path,
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'.
@@ -169,12 +169,12 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
    * It is expected that the shared key properties are contained in this connection string, but not the Event Hub path,
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'.
    * @param eventHubName - The name of the specific Event Hub to connect the client to.
-   * @param checkpointStore A checkpoint store that is used by the client to read checkpoints to determine
+   * @param checkpointStore - A checkpoint store that is used by the client to read checkpoints to determine
    * the position from where it should resume receiving events when your application gets restarted.
    * It is also used by the client to load balance multiple instances of your application.
    * @param options - A set of options to apply when configuring the client.
@@ -193,7 +193,7 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    * @param eventHubName - The name of the specific Event Hub to connect the client to.
@@ -215,13 +215,13 @@ export class EventHubConsumerClient {
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
-   * @param consumerGroup The name of the consumer group from which you want to process events.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    * @param eventHubName - The name of the specific Event Hub to connect the client to.
    * @param credential - An credential object used by the client to get the token to authenticate the connection
    * with the Azure Event Hubs service. See &commat;azure/identity for creating the credentials.
-   * @param checkpointStore A checkpoint store that is used by the client to read checkpoints to determine
+   * @param checkpointStore - A checkpoint store that is used by the client to read checkpoints to determine
    * the position from where it should resume receiving events when your application gets restarted.
    * It is also used by the client to load balance multiple instances of your application.
    * @param options - A set of options to apply when configuring the client.
@@ -347,7 +347,7 @@ export class EventHubConsumerClient {
 
   /**
    * Provides the id for each partition associated with the Event Hub.
-   * @param options The set of options to apply to the operation call.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with an Array of strings representing the id for
    * each partition associated with the Event Hub.
    * @throws Error if the underlying connection has been closed, create a new EventHubConsumerClient.
@@ -366,8 +366,8 @@ export class EventHubConsumerClient {
 
   /**
    * Provides information about the state of the specified partition.
-   * @param partitionId The id of the partition for which information is required.
-   * @param options The set of options to apply to the operation call.
+   * @param partitionId - The id of the partition for which information is required.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with information about the state of the partition .
    * @throws Error if the underlying connection has been closed, create a new EventHubConsumerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
@@ -384,7 +384,7 @@ export class EventHubConsumerClient {
 
   /**
    * Provides the Event Hub runtime information.
-   * @param options The set of options to apply to the operation call.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with information about the Event Hub instance.
    * @throws Error if the underlying connection has been closed, create a new EventHubConsumerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
@@ -417,10 +417,10 @@ export class EventHubConsumerClient {
    * );
    * ```
    *
-   * @param handlers Handlers for the lifecycle of the subscription - subscription initialization
+   * @param handlers - Handlers for the lifecycle of the subscription - subscription initialization
    *                 per partition, receiving events, handling errors and the closing
    *                 of a subscription per partition.
-   * @param options Configures the way events are received.
+   * @param options - Configures the way events are received.
    * Most common are `maxBatchSize` and `maxWaitTimeInSeconds` that control the flow of
    * events to the handler provided to receive events as well as the start position. For example,
    * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }
@@ -443,11 +443,11 @@ export class EventHubConsumerClient {
    * );
    * ```
    *
-   * @param partitionId The id of the partition to subscribe to.
-   * @param handlers Handlers for the lifecycle of the subscription - subscription initialization
+   * @param partitionId - The id of the partition to subscribe to.
+   * @param handlers - Handlers for the lifecycle of the subscription - subscription initialization
    *                 of the partition, receiving events, handling errors and the closing
    *                 of a subscription to the partition.
-   * @param options Configures the way events are received.
+   * @param options - Configures the way events are received.
    * Most common are `maxBatchSize` and `maxWaitTimeInSeconds` that control the flow of
    * events to the handler provided to receive events as well as the start position. For example,
    * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -68,7 +68,7 @@ export interface PartitionContext {
    * A checkpoint is meant to represent the last successfully processed event by the user from a particular
    * partition of a consumer group in an Event Hub instance.
    *
-   * @param eventData The event that you want to update the checkpoint with.
+   * @param eventData - The event that you want to update the checkpoint with.
    * @return Promise<void>
    */
   updateCheckpoint(eventData: ReceivedEventData): Promise<void>;

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -69,7 +69,6 @@ export interface PartitionContext {
    * partition of a consumer group in an Event Hub instance.
    *
    * @param eventData - The event that you want to update the checkpoint with.
-   * @return Promise<void>
    */
   updateCheckpoint(eventData: ReceivedEventData): Promise<void>;
 }

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -181,7 +181,6 @@ export interface SubscribeOptions {
    */
   startPosition?: EventPosition | { [partitionId: string]: EventPosition };
   /**
-   * @property
    * Indicates whether or not the consumer should request information on the last enqueued event on its
    * associated partition, and track that information as events are received.
 

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -161,7 +161,7 @@ export class EventHubProducerClient {
    * }
    * ```
    *
-   * @param options  Configures the behavior of the batch.
+   * @param options -  Configures the behavior of the batch.
    * - `partitionKey`  : A value that is hashed and used by the Azure Event Hubs service to determine the partition to which
    * the events need to be sent.
    * - `partitionId`   : Id of the partition to which the batch of events need to be sent.
@@ -218,8 +218,8 @@ export class EventHubProducerClient {
    * await client.sendBatch(messages);
    * ```
    *
-   * @param batch An array of {@link EventData}.
-   * @param options A set of options that can be specified to influence the way in which
+   * @param batch - An array of {@link EventData}.
+   * @param options - A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.
    * - `abortSignal`  : A signal the request to cancel the send operation.
    * - `partitionId`  : The partition this batch will be sent to. If set, `partitionKey` can not be set.
@@ -251,8 +251,8 @@ export class EventHubProducerClient {
    *   }
    * }
    * ```
-   * @param batch A batch of events that you can create using the {@link createBatch} method.
-   * @param options A set of options that can be specified to influence the way in which
+   * @param batch - A batch of events that you can create using the {@link createBatch} method.
+   * @param options - A set of options that can be specified to influence the way in which
    * events are sent to the associated Event Hub.
    * - `abortSignal`  : A signal the request to cancel the send operation.
    *
@@ -378,7 +378,7 @@ export class EventHubProducerClient {
 
   /**
    * Provides the Event Hub runtime information.
-   * @param options The set of options to apply to the operation call.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with information about the Event Hub instance.
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
@@ -392,7 +392,7 @@ export class EventHubProducerClient {
 
   /**
    * Provides the id for each partition associated with the Event Hub.
-   * @param options The set of options to apply to the operation call.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with an Array of strings representing the id for
    * each partition associated with the Event Hub.
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
@@ -411,8 +411,8 @@ export class EventHubProducerClient {
 
   /**
    * Provides information about the state of the specified partition.
-   * @param partitionId The id of the partition for which information is required.
-   * @param options The set of options to apply to the operation call.
+   * @param partitionId - The id of the partition for which information is required.
+   * @param options - The set of options to apply to the operation call.
    * @returns A promise that resolves with information about the state of the partition .
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -51,7 +51,6 @@ export class EventHubProducerClient {
    */
   private _sendersMap: Map<string, EventHubSender>;
   /**
-   * @property
    * @readonly
    * The name of the Event Hub instance for which this client is created.
    */
@@ -60,7 +59,6 @@ export class EventHubProducerClient {
   }
 
   /**
-   * @property
    * @readonly
    * The fully qualified namespace of the Event Hub instance for which this client is created.
    * This is likely to be similar to <yournamespace>.servicebus.windows.net.

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -192,11 +192,11 @@ export class EventHubReceiver extends LinkEntity {
    * Instantiates a receiver that can be used to receive events over an AMQP receiver link in
    * either batching or streaming mode.
    * @hidden
-   * @param context        The connection context corresponding to the EventHubClient instance
-   * @param consumerGroup  The consumer group from which the receiver should receive events from.
-   * @param partitionId    The Partition ID from which to receive.
-   * @param eventPosition  The position in the stream from where to start receiving events.
-   * @param [options]      Receiver options.
+   * @param context -        The connection context corresponding to the EventHubClient instance
+   * @param consumerGroup -  The consumer group from which the receiver should receive events from.
+   * @param partitionId -    The Partition ID from which to receive.
+   * @param eventPosition -  The position in the stream from where to start receiving events.
+   * @param options -      Receiver options.
    */
   constructor(
     context: ConnectionContext,
@@ -652,10 +652,10 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Returns a promise that resolves to an array of events received from the service.
    *
-   * @param maxMessageCount The maximum number of messages to receive.
-   * @param maxWaitTimeInSeconds The maximum amount of time to wait to build up the requested message count;
+   * @param maxMessageCount - The maximum number of messages to receive.
+   * @param maxWaitTimeInSeconds - The maximum amount of time to wait to build up the requested message count;
    * If not provided, it defaults to 60 seconds.
-   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * @param abortSignal - An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @returns Promise<ReceivedEventData[]>.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -288,7 +288,6 @@ export class EventHubSender extends LinkEntity {
    * @hidden
    * @param events -  An array of EventData objects to be sent in a Batch message.
    * @param options - Options to control the way the events are batched along with request options
-   * @return Promise<void>
    */
   async send(
     events: EventData[] | EventDataBatch,

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -74,8 +74,8 @@ export class EventHubSender extends LinkEntity {
   /**
    * Creates a new EventHubSender instance.
    * @hidden
-   * @param context The connection context.
-   * @param [partitionId] The EventHub partition id to which the sender
+   * @param context - The connection context.
+   * @param partitionId - The EventHub partition id to which the sender
    * wants to send the event data.
    */
   constructor(context: ConnectionContext, partitionId?: string) {
@@ -206,7 +206,7 @@ export class EventHubSender extends LinkEntity {
   }
   /**
    * Returns maximum message size on the AMQP sender link.
-   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * @param abortSignal - An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    * @returns Promise<number>
    * @throws AbortError if the operation is cancelled via the abortSignal.
@@ -286,8 +286,8 @@ export class EventHubSender extends LinkEntity {
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
    * @hidden
-   * @param events  An array of EventData objects to be sent in a Batch message.
-   * @param options Options to control the way the events are batched along with request options
+   * @param events -  An array of EventData objects to be sent in a Batch message.
+   * @param options - Options to control the way the events are batched along with request options
    * @return Promise<void>
    */
   async send(
@@ -388,7 +388,7 @@ export class EventHubSender extends LinkEntity {
    * We have implemented a synchronous send over here in the sense that we shall be waiting
    * for the message to be accepted or rejected and accordingly resolve or reject the promise.
    * @hidden
-   * @param rheaMessage The message to be sent to EventHub.
+   * @param rheaMessage - The message to be sent to EventHub.
    * @returns Promise<void>
    */
   private _trySendBatch(
@@ -600,7 +600,7 @@ export class EventHubSender extends LinkEntity {
    * not present in the context or returns the one present in the context.
    * @hidden
    * @static
-   * @param [partitionId] Partition ID to which it will send event data.
+   * @param partitionId - Partition ID to which it will send event data.
    */
   static create(context: ConnectionContext, partitionId?: string): EventHubSender {
     const ehSender: EventHubSender = new EventHubSender(context, partitionId);

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -140,7 +140,6 @@ export function validateEventPositions(
 /**
  * Determines whether a position is an EventPosition.
  * Does not validate that the position is allowed.
- * @param position
  * @internal
  */
 export function isEventPosition(position: unknown): position is EventPosition {

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -46,7 +46,7 @@ export interface EventPosition {
 /**
  * @internal
  * Gets the expression to be set as the filter clause when creating the receiver
- * @return {string} filterExpression
+ * @returns filterExpression
  */
 export function getEventPositionFilter(eventPosition: EventPosition): string {
   let result;

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -73,7 +73,7 @@ export interface CheckpointStore {
    * <yournamespace>.servicebus.windows.net.
    * @param eventHubName - The event hub name.
    * @param consumerGroup - The consumer group name.
-   * @returnsA list of partition ownership details of all the partitions that have/had an owner.
+   * @returns A list of partition ownership details of all the partitions that have/had an owner.
    */
   listOwnership(
     fullyQualifiedNamespace: string,
@@ -85,7 +85,7 @@ export interface CheckpointStore {
    * successfully.
    *
    * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
-   * @returnsA list of partitions this instance successfully claimed ownership.
+   * @returns A list of partitions this instance successfully claimed ownership.
    */
   claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]>;
 

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -73,7 +73,7 @@ export interface CheckpointStore {
    * <yournamespace>.servicebus.windows.net.
    * @param eventHubName - The event hub name.
    * @param consumerGroup - The consumer group name.
-   * @return A list of partition ownership details of all the partitions that have/had an owner.
+   * @returnsA list of partition ownership details of all the partitions that have/had an owner.
    */
   listOwnership(
     fullyQualifiedNamespace: string,
@@ -85,7 +85,7 @@ export interface CheckpointStore {
    * successfully.
    *
    * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
-   * @return A list of partitions this instance successfully claimed ownership.
+   * @returnsA list of partitions this instance successfully claimed ownership.
    */
   claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]>;
 
@@ -234,8 +234,6 @@ export class EventProcessor {
 
   /**
    * The unique identifier for the EventProcessor.
-   *
-   * @return {string}
    */
   get id(): string {
     return this._id;
@@ -542,7 +540,6 @@ export class EventProcessor {
    * Subsequent calls to start will be ignored if this event processor is already running.
    * Calling `start()` after `stop()` is called will restart this event processor.
    *
-   * @return {void}
    */
   start(): void {
     if (this._isRunning) {

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -69,10 +69,10 @@ export interface CheckpointStore {
    * Called to get the list of all existing partition ownership from the underlying data store. Could return empty
    * results if there are is no existing ownership information.
    *
-   * @param fullyQualifiedNamespace The fully qualified Event Hubs namespace. This is likely to be similar to
+   * @param fullyQualifiedNamespace - The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net.
-   * @param eventHubName The event hub name.
-   * @param consumerGroup The consumer group name.
+   * @param eventHubName - The event hub name.
+   * @param consumerGroup - The consumer group name.
    * @return A list of partition ownership details of all the partitions that have/had an owner.
    */
   listOwnership(
@@ -84,7 +84,7 @@ export interface CheckpointStore {
    * Called to claim ownership of a list of partitions. This will return the list of partitions that were owned
    * successfully.
    *
-   * @param partitionOwnership The list of partition ownership this instance is claiming to own.
+   * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
    * @return A list of partitions this instance successfully claimed ownership.
    */
   claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]>;
@@ -92,17 +92,17 @@ export interface CheckpointStore {
   /**
    * Updates the checkpoint in the data store for a partition.
    *
-   * @param checkpoint The checkpoint.
+   * @param checkpoint - The checkpoint.
    */
   updateCheckpoint(checkpoint: Checkpoint): Promise<void>;
 
   /**
    * Lists all the checkpoints in a data store for a given namespace, eventhub and consumer group.
    *
-   * @param fullyQualifiedNamespace The fully qualified Event Hubs namespace. This is likely to be similar to
+   * @param fullyQualifiedNamespace - The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net.
-   * @param eventHubName The event hub name.
-   * @param consumerGroup The consumer group name.
+   * @param eventHubName - The event hub name.
+   * @param consumerGroup - The consumer group name.
    */
   listCheckpoints(
     fullyQualifiedNamespace: string,
@@ -196,13 +196,13 @@ export class EventProcessor {
   private _fullyQualifiedNamespace: string;
 
   /**
-   * @param consumerGroup The name of the consumer group from which you want to process events.
-   * @param eventHubClient An instance of `EventHubClient` that was created for the Event Hub instance.
-   * @param PartitionProcessorClass A user-provided class that extends the `PartitionProcessor` class.
+   * @param consumerGroup - The name of the consumer group from which you want to process events.
+   * @param eventHubClient - An instance of `EventHubClient` that was created for the Event Hub instance.
+   * @param PartitionProcessorClass - A user-provided class that extends the `PartitionProcessor` class.
    * This class will be responsible for processing and checkpointing events.
-   * @param checkpointStore An instance of `CheckpointStore`. See &commat;azure/eventhubs-checkpointstore-blob for an implementation.
+   * @param checkpointStore - An instance of `CheckpointStore`. See &commat;azure/eventhubs-checkpointstore-blob for an implementation.
    * For production, choose an implementation that will store checkpoints and partition ownership details to a durable store.
-   * @param options A set of options to configure the Event Processor
+   * @param options - A set of options to configure the Event Processor
    * - `maxBatchSize`         : The max size of the batch of events passed each time to user code for processing.
    * - `maxWaitTimeInSeconds` : The maximum amount of time to wait to build up the requested message count before
    * passing the data to user code for processing. If not provided, it defaults to 60 seconds.

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -22,7 +22,7 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
    * - `"<hubName>"`
    * - `"<hubName>/Partitions/<partitionId>"`
    *
-   * @param partitionId The partitionId in the EventHub to which messages will be sent.
+   * @param partitionId - The partitionId in the EventHub to which messages will be sent.
    */
   getSenderAddress(partitionId?: string | number): string;
   /**
@@ -30,15 +30,15 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
    * - `"sb://<yournamespace>.servicebus.windows.net/<hubName>"`
    * - `"sb://<yournamespace>.servicebus.windows.net/<hubName>/Partitions/<partitionId>"`
    *
-   * @param partitionId The partitionId in the EventHub to which messages will be sent.
+   * @param partitionId - The partitionId in the EventHub to which messages will be sent.
    */
   getSenderAudience(partitionId?: string | number): string;
   /**
    * Provides the EventHub Receiver address:
    * - `"<hub-name>/ConsumerGroups/<consumer-group-name>/Partitions/<partition-id>"`
    *
-   * @param partitionId The partitionId in the EventHub from which messages will be received.
-   * @param consumergroup The consumergoup in the EventHub from which the messages will
+   * @param partitionId - The partitionId in the EventHub from which messages will be received.
+   * @param consumergroup - The consumergoup in the EventHub from which the messages will
    * be received. Default: `$default`.
    */
   getReceiverAddress(partitionId: string | number, consumergroup?: string): string;
@@ -46,8 +46,8 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
    * Provides the EventHub Receiver audience.
    * - `"sb://<your-namespace>.servicebus.windows.net/<hub-name>/ConsumerGroups/<consumer-group-name>/Partitions/<partition-id>"`
    *
-   * @param partitionId The partitionId in the EventHub from which messages will be received.
-   * @param consumergroup The consumergoup in the EventHub from which the messages will
+   * @param partitionId - The partitionId in the EventHub from which messages will be received.
+   * @param consumergroup - The consumergoup in the EventHub from which the messages will
    * be received. Default: `$default`.
    */
   getReceiverAudience(partitionId: string | number, consumergroup?: string): string;
@@ -72,9 +72,9 @@ export interface EventHubConnectionConfig extends ConnectionConfig {
 export const EventHubConnectionConfig = {
   /**
    * Creates the connection config.
-   * @param {string} connectionString - The connection string for a given service like
+   * @param connectionString - The connection string for a given service like
    * EventHub/ServiceBus.
-   * @param {string} [path]           - The name/path of the entity (hub name) to which the
+   * @param path - The name/path of the entity (hub name) to which the
    * connection needs to happen. This will override the EntityPath in the connectionString
    * if present.
    * @returns {EventHubConnectionConfig} EventHubConnectionConfig
@@ -92,7 +92,7 @@ export const EventHubConnectionConfig = {
 
   /**
    * Creates an EventHubConnectionConfig from the provided base ConnectionConfig.
-   * @param config The base connection config from which the EventHubConnectionConfig needs to be
+   * @param config - The base connection config from which the EventHubConnectionConfig needs to be
    * created.
    * @returns EventHubConnectionConfig
    */
@@ -145,8 +145,8 @@ export const EventHubConnectionConfig = {
 
   /**
    * Updates the provided EventHubConnectionConfig to use the custom endpoint address.
-   * @param config An existing connection configuration to be updated.
-   * @param customEndpointAddress The custom endpoint address to use.
+   * @param config - An existing connection configuration to be updated.
+   * @param customEndpointAddress - The custom endpoint address to use.
    */
   setCustomEndpointAddress(config: EventHubConnectionConfig, customEndpointAddress: string): void {
     // The amqpHostname should match the host prior to using the custom endpoint.
@@ -161,7 +161,7 @@ export const EventHubConnectionConfig = {
 
   /**
    * Validates the properties of connection config.
-   * @param {ConnectionConfig} config The connection config to be validated.
+   * @param config - The connection config to be validated.
    * @returns {void} void
    */
   validate(config: EventHubConnectionConfig): void {

--- a/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubConnectionConfig.ts
@@ -77,7 +77,7 @@ export const EventHubConnectionConfig = {
    * @param path - The name/path of the entity (hub name) to which the
    * connection needs to happen. This will override the EntityPath in the connectionString
    * if present.
-   * @returns {EventHubConnectionConfig} EventHubConnectionConfig
+   * @returns EventHubConnectionConfig
    */
   create(connectionString: string, path?: string): EventHubConnectionConfig {
     const config = ConnectionConfig.create(connectionString, path);
@@ -162,7 +162,7 @@ export const EventHubConnectionConfig = {
   /**
    * Validates the properties of connection config.
    * @param config - The connection config to be validated.
-   * @returns {void} void
+   * @returns void
    */
   validate(config: EventHubConnectionConfig): void {
     return ConnectionConfig.validate(config, { isEntityPathRequired: true });

--- a/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
+++ b/sdk/eventhub/event-hubs/src/eventhubSharedKeyCredential.ts
@@ -23,8 +23,8 @@ export class SharedKeyCredential {
 
   /**
    * Initializes a new instance of SharedKeyCredential
-   * @param {string} keyName - The name of the EventHub/ServiceBus key.
-   * @param {string} key - The secret value associated with the above EventHub/ServiceBus key
+   * @param keyName - The name of the EventHub/ServiceBus key.
+   * @param key - The secret value associated with the above EventHub/ServiceBus key
    */
   constructor(keyName: string, key: string) {
     this.keyName = keyName;
@@ -33,7 +33,7 @@ export class SharedKeyCredential {
 
   /**
    * Gets the sas token for the specified audience
-   * @param {string} [audience] - The audience for which the token is desired.
+   * @param audience - The audience for which the token is desired.
    */
   getToken(audience: string): AccessToken {
     return this._createToken(Math.floor(Date.now() / 1000) + 3600, audience);
@@ -41,9 +41,9 @@ export class SharedKeyCredential {
 
   /**
    * Creates the sas token based on the provided information
-   * @param {string | number} expiry - The time period in unix time after which the token will expire.
-   * @param {string} [audience] - The audience for which the token is desired.
-   * @param {string | Buffer} [hashInput] The input to be provided to hmac to create the hash.
+   * @param expiry - The time period in unix time after which the token will expire.
+   * @param audience - The audience for which the token is desired.
+   * @param hashInput - The input to be provided to hmac to create the hash.
    */
   protected _createToken(
     expiry: number,
@@ -73,7 +73,7 @@ export class SharedKeyCredential {
 
   /**
    * Creates a token provider from the EventHub/ServiceBus connection string;
-   * @param {string} connectionString - The EventHub/ServiceBus connection string
+   * @param connectionString - The EventHub/ServiceBus connection string
    */
   static fromConnectionString(connectionString: string): SharedKeyCredential {
     const parsed = parseEventHubConnectionString(connectionString);
@@ -96,7 +96,7 @@ export class SharedAccessSignatureCredential extends SharedKeyCredential {
   private _accessToken: AccessToken;
 
   /**
-   * @param sharedAccessSignature A shared access signature of the form
+   * @param sharedAccessSignature - A shared access signature of the form
    * `SharedAccessSignature sr=<resource>&sig=<signature>&se=<expiry>&skn=<keyname>`
    */
   constructor(sharedAccessSignature: string) {
@@ -111,7 +111,7 @@ export class SharedAccessSignatureCredential extends SharedKeyCredential {
   /**
    * Retrieve a valid token for authenticaton.
    *
-   * @param _audience Not applicable in SharedAccessSignatureCredential as the token is not re-generated at every invocation of the method
+   * @param _audience - Not applicable in SharedAccessSignatureCredential as the token is not re-generated at every invocation of the method
    */
   getToken(_audience: string): AccessToken {
     return this._accessToken;

--- a/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
+++ b/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
@@ -18,7 +18,7 @@ export class PartitionGate {
    * Adds a partition, throwing an Error if there is a conflict with partitions (including "all")
    * that are already added.
    *
-   * @param partitionId A partition ID or the constant "all"
+   * @param partitionId - A partition ID or the constant "all"
    */
   add(partitionId: string | "all"): void {
     if (
@@ -35,7 +35,7 @@ export class PartitionGate {
   /**
    * Removes a partition
    *
-   * @param partitionId A partition ID or the constant "all"
+   * @param partitionId - A partition ID or the constant "all"
    */
   remove(partitionId: string | "all"): void {
     this._partitions.delete(partitionId);

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -25,10 +25,10 @@ export class InMemoryCheckpointStore implements CheckpointStore {
    * Get the list of all existing partition ownership from the underlying data store. Could return empty
    * results if there are is no existing ownership information.
    *
-   * @param fullyQualifiedNamespace The fully qualified Event Hubs namespace. This is likely to be similar to
+   * @param fullyQualifiedNamespace - The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net.
-   * @param eventHubName The event hub name.
-   * @param consumerGroup The consumer group name.
+   * @param eventHubName - The event hub name.
+   * @param consumerGroup - The consumer group name.
    * @return Partition ownership details of all the partitions that have/had an owner..
    */
   async listOwnership(
@@ -49,7 +49,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
    * Claim ownership of a list of partitions. This will return the list of partitions that were owned
    * successfully.
    *
-   * @param partitionOwnership The list of partition ownership this instance is claiming to own.
+   * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
    * @return A list partitions this instance successfully claimed ownership.
    */
   async claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]> {
@@ -78,7 +78,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
   /**
    * Updates the checkpoint in the data store for a partition.
    *
-   * @param checkpoint The checkpoint.
+   * @param checkpoint - The checkpoint.
    */
   async updateCheckpoint(checkpoint: Checkpoint): Promise<void> {
     throwTypeErrorIfParameterMissing(

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -29,7 +29,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
    * <yournamespace>.servicebus.windows.net.
    * @param eventHubName - The event hub name.
    * @param consumerGroup - The consumer group name.
-   * @return Partition ownership details of all the partitions that have/had an owner..
+   * @returns Partition ownership details of all the partitions that have/had an owner..
    */
   async listOwnership(
     _fullyQualifiedNamespace: string,
@@ -50,7 +50,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
    * successfully.
    *
    * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
-   * @return A list partitions this instance successfully claimed ownership.
+   * @returns A list partitions this instance successfully claimed ownership.
    */
   async claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]> {
     const claimedOwnerships = [];

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -95,8 +95,8 @@ export class LinkEntity {
   /**
    * Creates a new LinkEntity instance.
    * @hidden
-   * @param context The connection context.
-   * @param [options] Options that can be provided while creating the LinkEntity.
+   * @param context - The connection context.
+   * @param options - Options that can be provided while creating the LinkEntity.
    */
   constructor(context: ConnectionContext, options?: LinkEntityOptions) {
     if (!options) options = {};
@@ -110,7 +110,7 @@ export class LinkEntity {
   /**
    * Negotiates cbs claim for the LinkEntity.
    * @hidden
-   * @param [setTokenRenewal] Set the token renewal timer. Default false.
+   * @param setTokenRenewal - Set the token renewal timer. Default false.
    * @returns Promise<void>
    */
   protected async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {
@@ -225,7 +225,7 @@ export class LinkEntity {
    * Closes the Sender|Receiver link and it's underlying session and also removes it from the
    * internal map.
    * @hidden
-   * @param [link] The Sender or Receiver link that needs to be closed and
+   * @param link - The Sender or Receiver link that needs to be closed and
    * removed.
    */
   protected async _closeLink(link?: AwaitableSender | Receiver): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/balancedStrategy.ts
@@ -17,16 +17,16 @@ export class BalancedLoadBalancingStrategy implements LoadBalancingStrategy {
   /**
    * Creates an instance of BalancedLoadBalancingStrategy.
    *
-   * @param _partitionOwnershipExpirationIntervalInMs The length of time a partition claim is valid.
+   * @param _partitionOwnershipExpirationIntervalInMs - The length of time a partition claim is valid.
    */
   constructor(private readonly _partitionOwnershipExpirationIntervalInMs: number) {}
 
   /**
    * Implements load balancing by taking into account current ownership and
    * the full set of partitions in the Event Hub.
-   * @param ourOwnerId The id we should assume is _our_ id when checking for ownership.
-   * @param claimedPartitionOwnershipMap The current claimed ownerships for partitions.
-   * @param partitionIds Partitions to assign owners to.
+   * @param ourOwnerId - The id we should assume is _our_ id when checking for ownership.
+   * @param claimedPartitionOwnershipMap - The current claimed ownerships for partitions.
+   * @param partitionIds - Partitions to assign owners to.
    * @returns Partition ids to claim.
    */
   public getPartitionsToCliam(

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/greedyStrategy.ts
@@ -11,16 +11,16 @@ export class GreedyLoadBalancingStrategy implements LoadBalancingStrategy {
   /**
    * Creates an instance of GreedyLoadBalancingStrategy.
    *
-   * @param _partitionOwnershipExpirationIntervalInMs The length of time a partition claim is valid.
+   * @param _partitionOwnershipExpirationIntervalInMs - The length of time a partition claim is valid.
    */
   constructor(private readonly _partitionOwnershipExpirationIntervalInMs: number) {}
 
   /**
    * Implements load balancing by taking into account current ownership and
    * the new set of partitions to add.
-   * @param ourOwnerId The id we should assume is _our_ id when checking for ownership.
-   * @param claimedPartitionOwnershipMap The current claimed ownerships for partitions.
-   * @param partitionIds Partitions to assign owners to.
+   * @param ourOwnerId - The id we should assume is _our_ id when checking for ownership.
+   * @param claimedPartitionOwnershipMap - The current claimed ownerships for partitions.
+   * @param partitionIds - Partitions to assign owners to.
    * @returns Partition ids to claim.
    */
   public getPartitionsToCliam(

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
@@ -12,9 +12,9 @@ export interface LoadBalancingStrategy {
   /**
    * Implements load balancing by taking into account current ownership and
    * the full set of partitions in the Event Hub.
-   * @param ourOwnerId The id we should assume is _our_ id when checking for ownership.
-   * @param claimedPartitionOwnershipMap The current claimed ownerships for partitions.
-   * @param partitionIds Partitions to assign owners to.
+   * @param ourOwnerId - The id we should assume is _our_ id when checking for ownership.
+   * @param claimedPartitionOwnershipMap - The current claimed ownerships for partitions.
+   * @param partitionIds - Partitions to assign owners to.
    * @returns Partition ids to claim.
    */
   getPartitionsToCliam(
@@ -56,8 +56,8 @@ interface EventProcessorCounts {
  * inactivity time limit are assumed to be owned by dead event processors.
  * These will not be included in the map returned by this method.
  *
- * @param partitionOwnershipMap The existing PartitionOwnerships mapped by partition.
- * @param expirationIntervalInMs The length of time a PartitionOwnership claim is valid.
+ * @param partitionOwnershipMap - The existing PartitionOwnerships mapped by partition.
+ * @param expirationIntervalInMs - The length of time a PartitionOwnership claim is valid.
  * @hidden
  */
 function getActivePartitionOwnerships(
@@ -86,8 +86,8 @@ function getActivePartitionOwnerships(
 /**
  * Calculates the minimum number of partitions each EventProcessor should own,
  * and the number of EventProcessors that should have an extra partition assigned.
- * @param ownerToOwnershipMap The current ownerships for partitions.
- * @param partitionIds The full list of the Event Hub's partition ids.
+ * @param ownerToOwnershipMap - The current ownerships for partitions.
+ * @param partitionIds - The full list of the Event Hub's partition ids.
  * @internal
  */
 function calculateBalancedLoadCounts(
@@ -124,8 +124,8 @@ function calculateBalancedLoadCounts(
  * shouldOwnMorePartitions(), both of which depend on knowing if our current list
  * of EventProcessors is actually in the proper state.
  *
- * @param minPartitionsPerOwner The number of required partitions per EventProcessor.
- * @param ownerToOwnershipMap The current ownerships for partitions.
+ * @param minPartitionsPerOwner - The number of required partitions per EventProcessor.
+ * @param ownerToOwnershipMap - The current ownerships for partitions.
  * @internal
  */
 function getEventProcessorCounts(
@@ -166,9 +166,9 @@ function getEventProcessorCounts(
  * minimum required number of partitions (and additional partitions, if the # of partitions
  * is not evenly divisible by the # of EventProcessors).
  *
- * @param requiredNumberOfOwnersWithExtraPartition The # of EventProcessors that process an additional partition, in addition to the required minimum.
- * @param totalExpectedProcessors The total # of EventProcessors we expect.
- * @param eventProcessorCounts EventProcessor counts, grouped by criteria.
+ * @param requiredNumberOfOwnersWithExtraPartition - The # of EventProcessors that process an additional partition, in addition to the required minimum.
+ * @param totalExpectedProcessors - The total # of EventProcessors we expect.
+ * @param eventProcessorCounts - EventProcessor counts, grouped by criteria.
  * @internal
  */
 function isLoadBalanced(
@@ -185,10 +185,10 @@ function isLoadBalanced(
 /**
  * Determines the number of new partitions to claim for this particular processor.
  *
- * @param minRequired The minimum required number of partitions.
- * @param requiredNumberOfOwnersWithExtraPartition The current number of processors that should have an additional partition.
- * @param numPartitionsOwnedByUs The number of partitions we currently own.
- * @param eventProcessorCounts Processors, grouped by criteria.
+ * @param minRequired - The minimum required number of partitions.
+ * @param requiredNumberOfOwnersWithExtraPartition - The current number of processors that should have an additional partition.
+ * @param numPartitionsOwnedByUs - The number of partitions we currently own.
+ * @param eventProcessorCounts - Processors, grouped by criteria.
  * @internal
  */
 function getNumberOfPartitionsToClaim(
@@ -216,11 +216,11 @@ function getNumberOfPartitionsToClaim(
 /**
  * Determines which partitions can be stolen from other owners while maintaining
  * a balanced state.
- * @param numberOfPartitionsToClaim The number of partitions the owner needs to claim to reach a balanced state.
- * @param minPartitionsPerOwner The minimum number of partitions each owner needs for the partition load to be balanced.
- * @param requiredNumberOfOwnersWithExtraPartition The number of owners that should have 1 extra partition.
- * @param ourOwnerId The id of _our_ owner.
- * @param ownerToOwnershipMap The current ownerships for partitions.
+ * @param numberOfPartitionsToClaim - The number of partitions the owner needs to claim to reach a balanced state.
+ * @param minPartitionsPerOwner - The minimum number of partitions each owner needs for the partition load to be balanced.
+ * @param requiredNumberOfOwnersWithExtraPartition - The number of owners that should have 1 extra partition.
+ * @param ourOwnerId - The id of _our_ owner.
+ * @param ownerToOwnershipMap - The current ownerships for partitions.
  * @internal
  */
 function findPartitionsToSteal(
@@ -277,10 +277,10 @@ function findPartitionsToSteal(
 /**
  * Identifies all of the partitions that can be claimed by the specified owner for
  * that owner to reach a balanced state.
- * @param OwnerId The id we should assume is _our_ id when checking for ownership.
- * @param claimedPartitionOwnershipMap The current claimed ownerships for partitions.
- * @param partitionIds Partitions to assign owners to.
- * @param expirationIntervalInMs The length of time a partition claim is valid.
+ * @param OwnerId - The id we should assume is _our_ id when checking for ownership.
+ * @param claimedPartitionOwnershipMap - The current claimed ownerships for partitions.
+ * @param partitionIds - Partitions to assign owners to.
+ * @param expirationIntervalInMs - The length of time a partition claim is valid.
  * @returns Partition ids that may be claimed.
  * @internal
  */

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/unbalancedStrategy.ts
@@ -14,9 +14,9 @@ export class UnbalancedLoadBalancingStrategy implements LoadBalancingStrategy {
   /**
    * Implements load balancing by taking into account current ownership and
    * the full set of partitions in the Event Hub.
-   * @param _ourOwnerId The id we should assume is _our_ id when checking for ownership.
-   * @param _claimedPartitionOwnershipMap The current claimed ownerships for partitions.
-   * @param partitionIds Partitions to assign owners to.
+   * @param _ourOwnerId - The id we should assume is _our_ id when checking for ownership.
+   * @param _claimedPartitionOwnershipMap - The current claimed ownerships for partitions.
+   * @param partitionIds - Partitions to assign owners to.
    * @returns Partition ids to claim.
    */
   public getPartitionsToCliam(

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -12,7 +12,7 @@ export const logger = createClientLogger("event-hubs");
 
 /**
  * Logs the error's stack trace to "verbose" if a stack trace is available.
- * @param error Error containing a stack trace.
+ * @param error - Error containing a stack trace.
  * @hidden
  */
 export function logErrorStackTrace(error: unknown): void {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -119,8 +119,8 @@ export class ManagementClient extends LinkEntity {
   /**
    * Instantiates the management client.
    * @hidden
-   * @param context The connection context.
-   * @param [address] The address for the management endpoint. For IotHub it will be
+   * @param context - The connection context.
+   * @param address - The address for the management endpoint. For IotHub it will be
    * `/messages/events/$management`.
    */
   constructor(context: ConnectionContext, options?: ManagementClientOptions) {
@@ -211,7 +211,7 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides information about the specified partition.
    * @hidden
-   * @param partitionId Partition ID for which partition information is required.
+   * @param partitionId - Partition ID for which partition information is required.
    */
   async getPartitionProperties(
     partitionId: string,
@@ -374,8 +374,8 @@ export class ManagementClient extends LinkEntity {
 
   /**
    * Helper method to make the management request
-   * @param request The AMQP message to send
-   * @param options The options to use when sending a request over a $management link
+   * @param request - The AMQP message to send
+   * @param options - The options to use when sending a request over a $management link
    */
   private async _makeManagementRequest(
     request: Message,

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -15,14 +15,12 @@ import { LoadBalancingStrategy } from "../loadBalancerStrategies/loadBalancingSt
  */
 export interface EventHubProducerOptions {
   /**
-   * @property
    * The identifier of the partition that the producer will be bound to.
    * If a value is provided, all events sent using the producer will reach the same partition.
    * If no value is provided, the service will determine the partition to which the event will be sent.
    */
   partitionId?: string;
   /**
-   * @property
    * The retry options used to govern retry attempts when an issue is encountered while sending events.
    * If no value is provided here, the retry options set when creating the `EventHubClient` is used.
    */
@@ -92,7 +90,6 @@ export interface CommonEventProcessorOptions
  */
 export interface EventHubConsumerOptions {
   /**
-   * @property
    * The owner level associated with an exclusive consumer.
    *
    * When provided, the owner level indicates that a consumer is intended to be the exclusive receiver of events for the
@@ -102,13 +99,11 @@ export interface EventHubConsumerOptions {
    */
   ownerLevel?: number;
   /**
-   * @property
    * The retry options used to govern retry attempts when an issue is encountered while receiving events.
    * If no value is provided here, the retry options set when creating the `EventHubClient` is used.
    */
   retryOptions?: RetryOptions;
   /**
-   * @property
    * Indicates whether or not the consumer should request information on the last enqueued event on its
    * associated partition, and track that information as events are received.
 

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -64,7 +64,6 @@ export interface SendBatchOptions extends OperationOptions {
  */
 export interface SendOptions extends OperationOptions {
   /**
-   * @property
    * A value that is hashed to produce a partition assignment.
    * It guarantees that messages with the same partitionKey end up in the same partition.
    * Specifying this will throw an error if the producer was created using a `paritionId`.
@@ -240,7 +239,6 @@ export interface CreateBatchOptions extends OperationOptions {
    */
   partitionId?: string;
   /**
-   * @property
    * The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    */
   maxSizeInBytes?: number;

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -133,8 +133,6 @@ export class PartitionProcessor implements PartitionContext {
   /**
    * This method is called when the `EventProcessor` takes ownership of a new partition and before any
    * events are received.
-   *
-   * @return {Promise<EventPosition>}
    */
   async initialize(): Promise<void> {
     if (this._eventHandlers.processInitialize) {
@@ -146,7 +144,6 @@ export class PartitionProcessor implements PartitionContext {
    * This method is called before the partition processor is closed by the EventProcessor.
    *
    * @param reason - The reason for closing this partition processor.
-   * @return {Promise<void>}
    */
   async close(reason: CloseReason): Promise<void> {
     if (this._eventHandlers.processClose) {
@@ -160,7 +157,6 @@ export class PartitionProcessor implements PartitionContext {
    * This is also a good place to update checkpoints as appropriate.
    *
    * @param event - The received events to be processed.
-   * @return {Promise<void>}
    */
   async processEvents(events: ReceivedEventData[]): Promise<void> {
     await this._eventHandlers.processEvents(events, this);
@@ -170,7 +166,6 @@ export class PartitionProcessor implements PartitionContext {
    * This method is called when an error occurs while receiving events from Event Hubs.
    *
    * @param error - The error to be processed.
-   * @return {Promise<void>}
    */
   async processError(error: Error): Promise<void> {
     if (this._eventHandlers.processError) {
@@ -189,7 +184,6 @@ export class PartitionProcessor implements PartitionContext {
    * partition of a consumer group in an Event Hub instance.
    *
    * @param eventData - The event that you want to update the checkpoint with.
-   * @return Promise<void>
    */
   public async updateCheckpoint(eventData: ReceivedEventData): Promise<void> {
     const checkpoint: Checkpoint = {

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -145,7 +145,7 @@ export class PartitionProcessor implements PartitionContext {
   /**
    * This method is called before the partition processor is closed by the EventProcessor.
    *
-   * @param reason The reason for closing this partition processor.
+   * @param reason - The reason for closing this partition processor.
    * @return {Promise<void>}
    */
   async close(reason: CloseReason): Promise<void> {
@@ -159,7 +159,7 @@ export class PartitionProcessor implements PartitionContext {
    *
    * This is also a good place to update checkpoints as appropriate.
    *
-   * @param event The received events to be processed.
+   * @param event - The received events to be processed.
    * @return {Promise<void>}
    */
   async processEvents(events: ReceivedEventData[]): Promise<void> {
@@ -169,7 +169,7 @@ export class PartitionProcessor implements PartitionContext {
   /**
    * This method is called when an error occurs while receiving events from Event Hubs.
    *
-   * @param error The error to be processed.
+   * @param error - The error to be processed.
    * @return {Promise<void>}
    */
   async processError(error: Error): Promise<void> {
@@ -188,7 +188,7 @@ export class PartitionProcessor implements PartitionContext {
    * A checkpoint is meant to represent the last successfully processed event by the user from a particular
    * partition of a consumer group in an Event Hub instance.
    *
-   * @param eventData The event that you want to update the checkpoint with.
+   * @param eventData - The event that you want to update the checkpoint with.
    * @return Promise<void>
    */
   public async updateCheckpoint(eventData: ReceivedEventData): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -60,8 +60,8 @@ export class PartitionPump {
 
   /**
    * Creates a new `EventHubReceiver` and replaces any existing receiver.
-   * @param partitionId The partition the receiver should read messages from.
-   * @param lastSeenSequenceNumber The sequence number to begin receiving messages from (exclusive).
+   * @param partitionId - The partition the receiver should read messages from.
+   * @param lastSeenSequenceNumber - The sequence number to begin receiving messages from (exclusive).
    * If `-1`, then the PartitionPump's startPosition will be used instead.
    */
   private _setOrReplaceReceiver(

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -19,10 +19,10 @@ import { ConnectionContext } from "./connectionContext";
 export interface PumpManager {
   /**
    * Creates and starts a PartitionPump.
-   * @param startPosition The position in the partition to start reading from.
-   * @param eventHubClient The EventHubClient to forward to the PartitionPump.
-   * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
-   * @param abortSignal Used to cancel pump creation.
+   * @param startPosition - The position in the partition to start reading from.
+   * @param eventHubClient - The EventHubClient to forward to the PartitionPump.
+   * @param partitionProcessor - The PartitionProcessor to forward to the PartitionPump.
+   * @param abortSignal - Used to cancel pump creation.
    */
   createPump(
     startPosition: EventPosition,
@@ -33,13 +33,13 @@ export interface PumpManager {
 
   /**
    * Indicates whether the pump manager is actively receiving events from a given partition.
-   * @param partitionId The partition to check.
+   * @param partitionId - The partition to check.
    */
   isReceivingFromPartition(partitionId: string): boolean;
 
   /**
    * Stops all PartitionPumps and removes them from the internal map.
-   * @param reason The reason for removing the pump.
+   * @param reason - The reason for removing the pump.
    */
   removeAllPumps(reason: CloseReason): Promise<void>;
 }
@@ -79,7 +79,6 @@ export class PumpManagerImpl implements PumpManager {
 
   /**
    * Indicates whether the pump manager is actively receiving events from a given partition.
-   * @param partitionId
    * @internal
    */
   public isReceivingFromPartition(partitionId: string): boolean {
@@ -89,9 +88,9 @@ export class PumpManagerImpl implements PumpManager {
 
   /**
    * Creates and starts a PartitionPump.
-   * @param startPosition The position in the partition to start reading from.
-   * @param connectionContext The ConnectionContext to forward to the PartitionPump.
-   * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
+   * @param startPosition - The position in the partition to start reading from.
+   * @param connectionContext - The ConnectionContext to forward to the PartitionPump.
+   * @param partitionProcessor - The PartitionProcessor to forward to the PartitionPump.
    * @hidden
    */
   public async createPump(
@@ -146,8 +145,8 @@ export class PumpManagerImpl implements PumpManager {
 
   /**
    * Stop a PartitionPump and removes it from the internal map.
-   * @param partitionId The partitionId to remove the associated PartitionPump from.
-   * @param reason The reason for removing the pump.
+   * @param partitionId - The partitionId to remove the associated PartitionPump from.
+   * @param reason - The reason for removing the pump.
    * @hidden
    */
   public async removePump(partitionId: string, reason: CloseReason): Promise<void> {
@@ -172,7 +171,7 @@ export class PumpManagerImpl implements PumpManager {
 
   /**
    * Stops all PartitionPumps and removes them from the internal map.
-   * @param reason The reason for removing the pump.
+   * @param reason - The reason for removing the pump.
    * @hidden
    */
   public async removeAllPumps(reason: CloseReason): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -18,7 +18,7 @@ export class ReceiveHandler {
   /**
    * Creates an instance of the ReceiveHandler.
    * @internal
-   * @param receiver The underlying EventHubReceiver.
+   * @param receiver - The underlying EventHubReceiver.
    */
   constructor(receiver: EventHubReceiver) {
     this._receiver = receiver;

--- a/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
+++ b/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
@@ -46,7 +46,7 @@ export interface EventHubConnectionStringProperties {
 /**
  * Parses given connection string into the different properties applicable to Azure Event Hubs.
  * The properties are useful to then construct an EventHub{Producer|Consumer}Client.
- * @param connectionString The connection string associated with the Shared Access Policy created
+ * @param connectionString - The connection string associated with the Shared Access Policy created
  * for the Event Hubs namespace.
  */
 export function parseEventHubConnectionString(

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -5,8 +5,8 @@ import { delay } from "@azure/core-amqp";
 import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
- * @param delayInMs The number of milliseconds to be delayed.
- * @param abortSignal The abortSignal associated with the containing operation.
+ * @param delayInMs - The number of milliseconds to be delayed.
+ * @param abortSignal - The abortSignal associated with the containing operation.
  * @internal
  */
 export async function delayWithoutThrow(

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -8,7 +8,7 @@ import { isDefined } from "./typeGuards";
 /**
  * @internal
  * Logs and throws Error if the current AMQP connection is closed.
- * @param context The ConnectionContext associated with the current AMQP connection.
+ * @param context - The ConnectionContext associated with the current AMQP connection.
  */
 export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
   if (context && context.wasConnectionCloseCalled) {
@@ -23,10 +23,10 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
 /**
  * @internal
  * Logs and Throws TypeError if given parameter is undefined or null
- * @param connectionId Id of the underlying AMQP connection used for logging
- * @param methodName Name of the method that was passed the parameter
- * @param parameterName Name of the parameter to check
- * @param parameterValue Value of the parameter to check
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param methodName - Name of the method that was passed the parameter
+ * @param parameterName - Name of the parameter to check
+ * @param parameterValue - Value of the parameter to check
  */
 export function throwTypeErrorIfParameterMissing(
   connectionId: string,

--- a/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
+++ b/sdk/eventhub/event-hubs/src/util/parseEndpoint.ts
@@ -3,7 +3,7 @@
 
 /**
  * Parses the host, hostname, and port from an endpoint.
- * @param endpoint And endpoint to parse.
+ * @param endpoint - And endpoint to parse.
  * @internal
  */
 export function parseEndpoint(endpoint: string): { host: string; hostname: string; port?: string } {

--- a/sdk/eventhub/event-hubs/src/util/typeGuards.ts
+++ b/sdk/eventhub/event-hubs/src/util/typeGuards.ts
@@ -3,7 +3,7 @@
 
 /**
  * Helper TypeGuard that checks if something is defined or not.
- * @param thing Anything
+ * @param thing - Anything
  * @internal
  */
 export function isDefined<T>(thing: T | undefined | null): thing is T {

--- a/sdk/eventhub/event-hubs/test/public/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/receivedMessagesTester.ts
@@ -28,9 +28,9 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
   /**
    * Creates a ReceivedMessagesTester
    *
-   * @param expectedPartitions The only partitions we expect to see messages from.
-   * @param expectedMessageBodies The message bodies we expect to get at least once.
-   * @param multipleConsumers If you're running a test that involves multiple consumers there
+   * @param expectedPartitions - The only partitions we expect to see messages from.
+   * @param expectedMessageBodies - The message bodies we expect to get at least once.
+   * @param multipleConsumers - If you're running a test that involves multiple consumers there
    *                      will be errors as they balance. Set this to true to be less picky
    *                      about errors that occur and concentrate on making sure all expected
    *                      messages are received at least once.

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -27,7 +27,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * <yournamespace>.servicebus.windows.net.
    * @param eventHubName - The event hub name.
    * @param consumerGroup - The consumer group name.
-   * @return Partition ownership details of all the partitions that have/had an owner..
+   * @returnsPartition ownership details of all the partitions that have/had an owner..
    */
   async listOwnership(
     _fullyQualifiedNamespace: string,
@@ -48,7 +48,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * successfully.
    *
    * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
-   * @return A list partitions this instance successfully claimed ownership.
+   * @returnsA list partitions this instance successfully claimed ownership.
    */
   async claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]> {
     const claimedOwnerships = [];

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -23,10 +23,10 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * Get the list of all existing partition ownership from the underlying data store. Could return empty
    * results if there are is no existing ownership information.
    *
-   * @param fullyQualifiedNamespace The fully qualified Event Hubs namespace. This is likely to be similar to
+   * @param fullyQualifiedNamespace - The fully qualified Event Hubs namespace. This is likely to be similar to
    * <yournamespace>.servicebus.windows.net.
-   * @param eventHubName The event hub name.
-   * @param consumerGroup The consumer group name.
+   * @param eventHubName - The event hub name.
+   * @param consumerGroup - The consumer group name.
    * @return Partition ownership details of all the partitions that have/had an owner..
    */
   async listOwnership(
@@ -47,7 +47,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * Claim ownership of a list of partitions. This will return the list of partitions that were owned
    * successfully.
    *
-   * @param partitionOwnership The list of partition ownership this instance is claiming to own.
+   * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
    * @return A list partitions this instance successfully claimed ownership.
    */
   async claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]> {
@@ -76,7 +76,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
   /**
    * Updates the checkpoint in the data store for a partition.
    *
-   * @param checkpoint The checkpoint.
+   * @param checkpoint - The checkpoint.
    */
   async updateCheckpoint(checkpoint: Checkpoint): Promise<void> {
     checkpoint = { ...checkpoint };

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -27,7 +27,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * <yournamespace>.servicebus.windows.net.
    * @param eventHubName - The event hub name.
    * @param consumerGroup - The consumer group name.
-   * @returnsPartition ownership details of all the partitions that have/had an owner..
+   * @returns Partition ownership details of all the partitions that have/had an owner..
    */
   async listOwnership(
     _fullyQualifiedNamespace: string,
@@ -48,7 +48,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
    * successfully.
    *
    * @param partitionOwnership - The list of partition ownership this instance is claiming to own.
-   * @returnsA list partitions this instance successfully claimed ownership.
+   * @returns A list partitions this instance successfully claimed ownership.
    */
   async claimOwnership(partitionOwnership: PartitionOwnership[]): Promise<PartitionOwnership[]> {
     const claimedOwnerships = [];


### PR DESCRIPTION
This PR 
- updates all the `@param` tags to follow TSDoc fixing 97 linting errors. The ones that had no description were removed altogether
- updates all the `@returns` /`@return` tags to follow TSDoc fixing about 35 linting errors
- removes `@property` tags that were missed in a previous PR fixing about 10 more linting errors

Related to #12953
