### PR TITLE
[App Config] Simple linting error fixes

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -245,36 +245,32 @@ export class AppConfigurationClient {
     options: GetConfigurationSettingOptions = {}
   ): Promise<GetConfigurationSettingResponse> {
     const requestOptions = operationOptionsToRequestOptionsBase(options);
-    return await this.spanner.trace(
-      "getConfigurationSetting",
-      requestOptions,
-      async (newOptions) => {
-        const originalResponse = await this.client.getKeyValue(id.key, {
-          ...newOptions,
-          label: id.label,
-          select: formatFieldsForSelect(options.fields),
-          ...formatAcceptDateTime(options),
-          ...checkAndFormatIfAndIfNoneMatch(id, options)
-        });
+    return this.spanner.trace("getConfigurationSetting", requestOptions, async (newOptions) => {
+      const originalResponse = await this.client.getKeyValue(id.key, {
+        ...newOptions,
+        label: id.label,
+        select: formatFieldsForSelect(options.fields),
+        ...formatAcceptDateTime(options),
+        ...checkAndFormatIfAndIfNoneMatch(id, options)
+      });
 
-        const response: GetConfigurationSettingResponse = transformKeyValueResponseWithStatusCode(
-          originalResponse
-        );
+      const response: GetConfigurationSettingResponse = transformKeyValueResponseWithStatusCode(
+        originalResponse
+      );
 
-        // 304 only comes back if the user has passed a conditional option in their
-        // request _and_ the remote object has the same etag as what the user passed.
-        if (response.statusCode === 304) {
-          // this is one of our few 'required' fields so we'll make sure it does get initialized
-          // with a value
-          response.key = id.key;
+      // 304 only comes back if the user has passed a conditional option in their
+      // request _and_ the remote object has the same etag as what the user passed.
+      if (response.statusCode === 304) {
+        // this is one of our few 'required' fields so we'll make sure it does get initialized
+        // with a value
+        response.key = id.key;
 
-          // and now we'll undefine all the other properties that are not HTTP related
-          makeConfigurationSettingEmpty(response);
-        }
-
-        return response;
+        // and now we'll undefine all the other properties that are not HTTP related
+        makeConfigurationSettingEmpty(response);
       }
-    );
+
+      return response;
+    });
   }
 
   /**
@@ -472,20 +468,16 @@ export class AppConfigurationClient {
   ): Promise<SetConfigurationSettingResponse> {
     const requestOptions = operationOptionsToRequestOptionsBase(options);
 
-    return await this.spanner.trace(
-      "setConfigurationSetting",
-      requestOptions,
-      async (newOptions) => {
-        const response = await this.client.putKeyValue(configurationSetting.key, {
-          ...newOptions,
-          label: configurationSetting.label,
-          entity: configurationSetting,
-          ...checkAndFormatIfAndIfNoneMatch(configurationSetting, options)
-        });
+    return this.spanner.trace("setConfigurationSetting", requestOptions, async (newOptions) => {
+      const response = await this.client.putKeyValue(configurationSetting.key, {
+        ...newOptions,
+        label: configurationSetting.label,
+        entity: configurationSetting,
+        ...checkAndFormatIfAndIfNoneMatch(configurationSetting, options)
+      });
 
-        return transformKeyValueResponse(response);
-      }
-    );
+      return transformKeyValueResponse(response);
+    });
   }
 
   /**

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -110,7 +110,7 @@ export function formatAcceptDateTime(newOptions: {
  * to get the next page of results.
  * @internal
  */
-export function extractAfterTokenFromNextLink(nextLink: string) {
+export function extractAfterTokenFromNextLink(nextLink: string): string {
   const parsedLink = URLBuilder.parse(nextLink);
   const afterToken = parsedLink.getQueryParameterValue("after");
 
@@ -130,7 +130,7 @@ export function extractAfterTokenFromNextLink(nextLink: string) {
  */
 export function makeConfigurationSettingEmpty(
   configurationSetting: Partial<Record<Exclude<keyof ConfigurationSetting, "key">, any>>
-) {
+): void {
   const names: Exclude<keyof ConfigurationSetting, "key">[] = [
     "contentType",
     "etag",
@@ -204,7 +204,7 @@ function normalizeResponse<T extends HttpResponseField<any> & { eTag?: string }>
  * Translates user-facing field names into their `select` equivalents (these can be
  * seen in the `KnownEnum5`)
  *
- * @param fieldNames fieldNames from users.
+ * @param fieldNames - fieldNames from users.
  * @returns The field names translated into the `select` field equivalents.
  *
  * @internal

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -64,8 +64,6 @@ class SyncTokenPolicy extends BaseRequestPolicy {
 export class SyncTokens {
   private _currentSyncTokens = new Map<string, SyncToken>();
 
-  constructor() {}
-
   /**
    * Takes the value from the header named after the constant `SyncTokenHeaderName`
    * and adds it to our list of accumulated sync tokens.
@@ -75,7 +73,7 @@ export class SyncTokens {
    *
    * @param syncTokenHeaderValue - The full value of the sync token header.
    */
-  addSyncTokenFromHeaderValue(syncTokenHeaderValue: string | undefined) {
+  addSyncTokenFromHeaderValue(syncTokenHeaderValue: string | undefined): void {
     if (syncTokenHeaderValue == null || syncTokenHeaderValue === "") {
       // eventually everything gets synced up and we don't have to track
       // these headers anymore

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -64,7 +64,7 @@ export class Spanner<TClient> {
     return { span, newOptions };
   }
 
-  static getCanonicalCode(err: Error) {
+  static getCanonicalCode(err: Error): CanonicalCode {
     if (Spanner.isRestError(err)) {
       switch (err.statusCode) {
         case 401:

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -130,6 +130,35 @@ describe("helper methods", () => {
     });
   });
 
+  const fakeHttp204Response: HttpResponseField<any> = {
+    _response: {
+      request: {
+        url: "unused",
+        abortSignal: {
+          aborted: true,
+          addEventListener: () => {},
+          removeEventListener: () => {}
+        },
+        method: "GET",
+        withCredentials: false,
+        headers: new HttpHeaders(),
+        timeout: 0,
+        requestId: "",
+        clone: function() {
+          return this;
+        },
+        validateRequestProperties: () => {},
+        prepare: function() {
+          return this;
+        }
+      },
+      status: 204,
+      headers: new HttpHeaders(),
+      bodyAsText: "",
+      parsedHeaders: {}
+    }
+  };
+
   it("makeConfigurationSettingEmpty", () => {
     const response: ConfigurationSetting & HttpResponseField<any> & HttpResponseFields = {
       key: "mykey",
@@ -269,37 +298,8 @@ describe("helper methods", () => {
     keyof ConfigurationSetting,
     "key"
   >[] {
-    let keys = getAllConfigurationSettingFields().filter((key) => key !== "key");
+    const keys = getAllConfigurationSettingFields().filter((key) => key !== "key");
 
     return keys as Exclude<keyof ConfigurationSetting, "key">[];
   }
-
-  const fakeHttp204Response: HttpResponseField<any> = {
-    _response: {
-      request: {
-        url: "unused",
-        abortSignal: {
-          aborted: true,
-          addEventListener: () => {},
-          removeEventListener: () => {}
-        },
-        method: "GET",
-        withCredentials: false,
-        headers: new HttpHeaders(),
-        timeout: 0,
-        requestId: "",
-        clone: function() {
-          return this;
-        },
-        validateRequestProperties: () => {},
-        prepare: function() {
-          return this;
-        }
-      },
-      status: 204,
-      headers: new HttpHeaders(),
-      bodyAsText: "",
-      parsedHeaders: {}
-    }
-  };
 });

--- a/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/http.spec.ts
@@ -50,7 +50,7 @@ describe("http request related tests", function() {
         chai.assert.match(
           prefix,
           new RegExp(
-            `^MyCustomUserAgent azsdk-js-app-configuration\/${packageVersion}+ core-http\/[^ ]+.+$`
+            `^MyCustomUserAgent azsdk-js-app-configuration/${packageVersion}+ core-http/[^ ]+.+$`
           ),
           `Using a custom user agent`
         );
@@ -61,7 +61,7 @@ describe("http request related tests", function() {
 
         chai.assert.match(
           prefix,
-          new RegExp(`^azsdk-js-app-configuration\/${packageVersion}+ core-http\/[^ ]+.+$`),
+          new RegExp(`^azsdk-js-app-configuration/${packageVersion}+ core-http/[^ ]+.+$`),
           `Using the default user agent`
         );
       });
@@ -194,7 +194,7 @@ describe("http request related tests", function() {
 
       await assertThrowsRestError(
         async () =>
-          await client.getConfigurationSetting({
+          client.getConfigurationSetting({
             key: "doesntmatter"
           }),
         418


### PR DESCRIPTION
This PR fixes about 20 linting errors for the App Config package
- redundant use of await
- empty constructors
- no return types
- variables used before being declared

Related to #10774