### PR TITLE
[Form Recognizer] hidden tag not needed when internal is present

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -205,7 +205,6 @@ export class FormRecognizerClient {
 
   /**
    * @internal
-   * @hidden
    * A reference to the auto-generated FormRecognizer HTTP client.
    */
   private readonly client: GeneratedClient;
@@ -361,7 +360,6 @@ export class FormRecognizerClient {
   /**
    * Retrieves result of content recognition operation.
    * @internal
-   * @hidden
    */
   private async getRecognizedContent(
     resultId: string,

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -177,19 +177,16 @@ export class FormTrainingClient {
 
   /**
    * @internal
-   * @hidden
    */
   private readonly credential: TokenCredential | KeyCredential;
 
   /**
    * @internal
-   * @hidden
    */
   private readonly clientOptions: FormRecognizerClientOptions;
 
   /**
    * @internal
-   * @hidden
    * A reference to the auto-generated FormRecognizer HTTP client.
    */
   private readonly client: GeneratedClient;


### PR DESCRIPTION
Now that our docs pipeline respects the `@internal` tag, we don't need to add `@hidden` additionally