### PR TITLE
[Communication] Update @param tag usage to follow tsdoc

### DIFF
--- a/sdk/communication/communication-administration/src/common/tracing.ts
+++ b/sdk/communication/communication-administration/src/common/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @ignore
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,

--- a/sdk/communication/communication-administration/src/phoneNumber/generated/src/operations/phoneNumberAdministration.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/generated/src/operations/phoneNumberAdministration.ts
@@ -61,7 +61,7 @@ export class PhoneNumberAdministration {
 
   /**
    * Initialize a new instance of the class PhoneNumberAdministration class.
-   * @param client Reference to the service client
+   * @param client - Reference to the service client
    */
   constructor(client: PhoneNumberRestClient) {
     this.client = client;
@@ -69,7 +69,7 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets the list of the acquired phone numbers.
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getAllPhoneNumbers(
     options?: PhoneNumberAdministrationGetAllPhoneNumbersOptionalParams
@@ -85,11 +85,11 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of the supported area codes
-   * @param locationType The type of location information required by the plan.
-   * @param countryCode The ISO 3166-2 country code
-   * @param phonePlanId The plan id from which to search area codes.
-   * @param body Location options for when location type is selection.
-   * @param options The options parameters.
+   * @param locationType - The type of location information required by the plan.
+   * @param countryCode - The ISO 3166-2 country code
+   * @param phonePlanId - The plan id from which to search area codes.
+   * @param body - Location options for when location type is selection.
+   * @param options - The options parameters.
    */
   getAllAreaCodes(
     locationType: string,
@@ -116,7 +116,7 @@ export class PhoneNumberAdministration {
   /**
    * Get capabilities by capabilities update id.
    * @param capabilitiesUpdateId
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getCapabilitiesUpdate(
     capabilitiesUpdateId: string,
@@ -133,8 +133,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Adds or removes phone number capabilities
-   * @param body Represents a numbers capabilities update request
-   * @param options The options parameters.
+   * @param body - Represents a numbers capabilities update request
+   * @param options - The options parameters.
    */
   updateCapabilities(
     body: UpdateNumberCapabilitiesRequest,
@@ -151,7 +151,7 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of supported countries
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getAllSupportedCountries(
     options?: PhoneNumberAdministrationGetAllSupportedCountriesOptionalParams
@@ -167,8 +167,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Endpoint for getting number configurations
-   * @param body The phone number whose configuration is to be fetched
-   * @param options The options parameters.
+   * @param body - The phone number whose configuration is to be fetched
+   * @param options - The options parameters.
    */
   getNumberConfiguration(
     body: NumberConfigurationPhoneNumber,
@@ -185,8 +185,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Endpoint for configuring a pstn number
-   * @param body Details of pstn number configuration of the given phoneNumber
-   * @param options The options parameters.
+   * @param body - Details of pstn number configuration of the given phoneNumber
+   * @param options - The options parameters.
    */
   configureNumber(
     body: NumberConfiguration,
@@ -203,8 +203,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Endpoint for unconfiguring a pstn number by removing the configuration
-   * @param body The phone number to un-configure
-   * @param options The options parameters.
+   * @param body - The phone number to un-configure
+   * @param options - The options parameters.
    */
   unconfigureNumber(
     body: NumberConfigurationPhoneNumber,
@@ -221,8 +221,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of phone plan groups for the given country
-   * @param countryCode The ISO 3166-2 country code.
-   * @param options The options parameters.
+   * @param countryCode - The ISO 3166-2 country code.
+   * @param options - The options parameters.
    */
   getPhonePlanGroups(
     countryCode: string,
@@ -239,9 +239,9 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of phone plans for a phone plan group
-   * @param countryCode The ISO 3166-2 country code.
+   * @param countryCode - The ISO 3166-2 country code.
    * @param phonePlanGroupId
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getPhonePlans(
     countryCode: string,
@@ -259,10 +259,10 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of location options for a phone plan
-   * @param countryCode The ISO 3166-2 country code.
+   * @param countryCode - The ISO 3166-2 country code.
    * @param phonePlanGroupId
    * @param phonePlanId
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getPhonePlanLocationOptions(
     countryCode: string,
@@ -281,8 +281,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a release by a release id
-   * @param releaseId Represents the release id
-   * @param options The options parameters.
+   * @param releaseId - Represents the release id
+   * @param options - The options parameters.
    */
   getReleaseById(
     releaseId: string,
@@ -299,8 +299,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Creates a release for the given phone numbers
-   * @param body Config api Release request
-   * @param options The options parameters.
+   * @param body - Config api Release request
+   * @param options - The options parameters.
    */
   releasePhoneNumbers(
     body: ReleaseRequest,
@@ -317,7 +317,7 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of all releases
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getAllReleases(
     options?: PhoneNumberAdministrationGetAllReleasesOptionalParams
@@ -333,8 +333,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Get search by search id
-   * @param searchId The search id to be searched for
-   * @param options The options parameters.
+   * @param searchId - The search id to be searched for
+   * @param options - The options parameters.
    */
   getSearchById(
     searchId: string,
@@ -351,8 +351,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Creates a phone number search
-   * @param body Defines the search options
-   * @param options The options parameters.
+   * @param body - Defines the search options
+   * @param options - The options parameters.
    */
   createSearch(
     body: CreateSearchOptions,
@@ -369,7 +369,7 @@ export class PhoneNumberAdministration {
 
   /**
    * Gets a list of all searches
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getAllSearches(
     options?: PhoneNumberAdministrationGetAllSearchesOptionalParams
@@ -385,8 +385,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Cancels the search. This means existing numbers in the search will be made available.
-   * @param searchId The search id to be canceled
-   * @param options The options parameters.
+   * @param searchId - The search id to be canceled
+   * @param options - The options parameters.
    */
   cancelSearch(
     searchId: string,
@@ -403,8 +403,8 @@ export class PhoneNumberAdministration {
 
   /**
    * Purchases the phone number search.
-   * @param searchId The search id to be purchased
-   * @param options The options parameters.
+   * @param searchId - The search id to be purchased
+   * @param options - The options parameters.
    */
   purchaseSearch(
     searchId: string,
@@ -421,8 +421,8 @@ export class PhoneNumberAdministration {
 
   /**
    * GetAllPhoneNumbersNext
-   * @param nextLink The nextLink from the previous successful call to the GetAllPhoneNumbers method.
-   * @param options The options parameters.
+   * @param nextLink - The nextLink from the previous successful call to the GetAllPhoneNumbers method.
+   * @param options - The options parameters.
    */
   getAllPhoneNumbersNext(
     nextLink: string,
@@ -439,9 +439,9 @@ export class PhoneNumberAdministration {
 
   /**
    * GetAllSupportedCountriesNext
-   * @param nextLink The nextLink from the previous successful call to the GetAllSupportedCountries
+   * @param nextLink - The nextLink from the previous successful call to the GetAllSupportedCountries
    *                 method.
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   getAllSupportedCountriesNext(
     nextLink: string,
@@ -458,9 +458,9 @@ export class PhoneNumberAdministration {
 
   /**
    * GetPhonePlanGroupsNext
-   * @param countryCode The ISO 3166-2 country code.
-   * @param nextLink The nextLink from the previous successful call to the GetPhonePlanGroups method.
-   * @param options The options parameters.
+   * @param countryCode - The ISO 3166-2 country code.
+   * @param nextLink - The nextLink from the previous successful call to the GetPhonePlanGroups method.
+   * @param options - The options parameters.
    */
   getPhonePlanGroupsNext(
     countryCode: string,
@@ -478,10 +478,10 @@ export class PhoneNumberAdministration {
 
   /**
    * GetPhonePlansNext
-   * @param countryCode The ISO 3166-2 country code.
+   * @param countryCode - The ISO 3166-2 country code.
    * @param phonePlanGroupId
-   * @param nextLink The nextLink from the previous successful call to the GetPhonePlans method.
-   * @param options The options parameters.
+   * @param nextLink - The nextLink from the previous successful call to the GetPhonePlans method.
+   * @param options - The options parameters.
    */
   getPhonePlansNext(
     countryCode: string,
@@ -500,8 +500,8 @@ export class PhoneNumberAdministration {
 
   /**
    * GetAllReleasesNext
-   * @param nextLink The nextLink from the previous successful call to the GetAllReleases method.
-   * @param options The options parameters.
+   * @param nextLink - The nextLink from the previous successful call to the GetAllReleases method.
+   * @param options - The options parameters.
    */
   getAllReleasesNext(
     nextLink: string,
@@ -518,8 +518,8 @@ export class PhoneNumberAdministration {
 
   /**
    * GetAllSearchesNext
-   * @param nextLink The nextLink from the previous successful call to the GetAllSearches method.
-   * @param options The options parameters.
+   * @param nextLink - The nextLink from the previous successful call to the GetAllSearches method.
+   * @param options - The options parameters.
    */
   getAllSearchesNext(
     nextLink: string,

--- a/sdk/communication/communication-administration/src/phoneNumber/generated/src/phoneNumberRestClient.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/generated/src/phoneNumberRestClient.ts
@@ -15,8 +15,8 @@ import { PhoneNumberRestClientOptionalParams } from "./models";
 class PhoneNumberRestClient extends PhoneNumberRestClientContext {
   /**
    * Initializes a new instance of the PhoneNumberRestClient class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param options The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: PhoneNumberRestClientOptionalParams) {
     super(endpoint, options);

--- a/sdk/communication/communication-administration/src/phoneNumber/generated/src/phoneNumberRestClientContext.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/generated/src/phoneNumberRestClientContext.ts
@@ -18,8 +18,8 @@ export class PhoneNumberRestClientContext extends coreHttp.ServiceClient {
 
   /**
    * Initializes a new instance of the PhoneNumberRestClientContext class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param options The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: PhoneNumberRestClientOptionalParams) {
     if (endpoint === undefined) {

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/phoneNumberPollerBase.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/phoneNumberPollerBase.ts
@@ -36,8 +36,8 @@ export class PhoneNumberPollOperationBase<TState, TResult>
   /**
    * Initializes a new instance of the phone number poll operation
    *
-   * @param {TState} state The state of the poll operation
-   * @param {string} cancelMessage A message to dispaly when a poll operation is cancelled.
+   * @param state - The state of the poll operation
+   * @param cancelMessage - A message to dispaly when a poll operation is cancelled.
    */
   constructor(public state: TState, private cancelMessage: string = "Canceling not supported.") {}
 
@@ -73,9 +73,9 @@ export class PhoneNumberReservationPollOperationBase<TState, TResult>
   /**
    * Initializes a new instance of the phone number reservation poll operation
    *
-   * @param {TState} state The state of the poll operation
-   * @param {PhoneNumberAdministration} client A reference to the generated client used to make requests internally.
-   * @param {string} cancelMessage A message to dispaly when a poll operation is cancelled.
+   * @param state - The state of the poll operation
+   * @param client - A reference to the generated client used to make requests internally.
+   * @param cancelMessage - A message to dispaly when a poll operation is cancelled.
    */
   constructor(
     public state: TState,
@@ -86,8 +86,8 @@ export class PhoneNumberReservationPollOperationBase<TState, TResult>
   /**
    * Gets the reservation associated with a given id.
    *
-   * @param {string} reservationId The id of the reservation to fetch.
-   * @param {GetReservationOptions} options Additional request options.
+   * @param reservationId - The id of the reservation to fetch.
+   * @param options - Additional request options.
    */
   public async getReservation(
     reservationId: string,
@@ -117,8 +117,8 @@ export class PhoneNumberReservationPollOperationBase<TState, TResult>
   /**
    * Cancels the reservation associated with a given id.
    *
-   * @param {string} reservationId The id of the reservation to cancel.
-   * @param {CancelReservationOptions} options Additional request options.
+   * @param reservationId - The id of the reservation to cancel.
+   * @param options - Additional request options.
    */
   public async cancelReservation(
     reservationId: string,

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/purchase/operation.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/purchase/operation.ts
@@ -22,9 +22,9 @@ export class PurchaseReservationPollOperation extends PhoneNumberReservationPoll
   /**
    * Initializes an instance of PurchaseReservationPollOperation
    *
-   * @param {PurchaseReservationPollOperationState} state The state of the poll operation
-   * @param {PhoneNumberAdministration} _client A reference to the generated client used to make requests internally.
-   * @param {OperationOptions} requestOptions Additional options for the underlying requests.
+   * @param state - The state of the poll operation
+   * @param _client - A reference to the generated client used to make requests internally.
+   * @param requestOptions - Additional options for the underlying requests.
    */
   constructor(
     public state: PurchaseReservationPollOperationState,
@@ -37,8 +37,8 @@ export class PurchaseReservationPollOperation extends PhoneNumberReservationPoll
   /**
    * Purchases the phone number(s) in the reservation associated with a given id.
    *
-   * @param {string} reservationId The id of the reservation being purchased.
-   * @param {PurchaseReservationOptions} options Additional request options.
+   * @param reservationId - The id of the reservation being purchased.
+   * @param options - Additional request options.
    */
   private async purchaseReservation(
     reservationId: string,
@@ -68,7 +68,7 @@ export class PurchaseReservationPollOperation extends PhoneNumberReservationPoll
   /**
    * Reaches to the service and queries the status of the operation.
    *
-   * @param {UpdatePollerOptions<PurchaseReservationPollOperationState>} [options={}] Additional options for the poll operation
+   * @param options - Additional options for the poll operation
    */
   public async update(
     options: UpdatePollerOptions<PurchaseReservationPollOperationState> = {}

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/purchase/poller.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/purchase/poller.ts
@@ -18,7 +18,7 @@ export class PurchaseReservationPoller extends PhoneNumberPollerBase<
   /**
    * Initializes an instance of PurchaseReservationPoller
    *
-   * @param {PurchaseReservationPollerOptions} options Options for initializing the poller.
+   * @param options - Options for initializing the poller.
    */
   constructor(options: PurchaseReservationPollerOptions) {
     const { client, reservationId, requestOptions = {}, pollInterval = 2000, resumeFrom } = options;

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/release/operation.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/release/operation.ts
@@ -27,9 +27,9 @@ export class ReleasePhoneNumbersPollOperation extends PhoneNumberPollOperationBa
   /**
    * Initializes an instance of PurchaseReservationPollOperation
    *
-   * @param {ReleasePhoneNumbersPollOperationState} state The state of the poll operation
-   * @param {PhoneNumberAdministration} client A reference to the generated client used to make requests internally.
-   * @param {OperationOptions} requestOptions Additional options for the underlying requests.
+   * @param state - The state of the poll operation
+   * @param client - A reference to the generated client used to make requests internally.
+   * @param requestOptions - Additional options for the underlying requests.
    */
   constructor(
     public state: ReleasePhoneNumbersPollOperationState,
@@ -42,8 +42,8 @@ export class ReleasePhoneNumbersPollOperation extends PhoneNumberPollOperationBa
   /**
    * Request the release of a list of acquired phone numbers.
    *
-   * @param {string[]} phoneNumbers The phone numbers to be released.
-   * @param {ReleasePhoneNumbersOptions} options Additional request options.
+   * @param phoneNumbers - The phone numbers to be released.
+   * @param options - Additional request options.
    */
   private async releasePhoneNumbers(
     phoneNumbers: string[],
@@ -75,8 +75,8 @@ export class ReleasePhoneNumbersPollOperation extends PhoneNumberPollOperationBa
   /**
    * Gets the release associated with a given id.
    *
-   * @param {string} releaseId The id of the release returned by releasePhoneNumbers.
-   * @param {GetReleaseOptions} options Additional request options.
+   * @param releaseId - The id of the release returned by releasePhoneNumbers.
+   * @param options - Additional request options.
    */
   private async getRelease(
     releaseId: string,
@@ -106,7 +106,7 @@ export class ReleasePhoneNumbersPollOperation extends PhoneNumberPollOperationBa
   /**
    * Reaches to the service and queries the status of the operation.
    *
-   * @param {UpdatePollerOptions<ReleasePhoneNumbersPollOperationState>} [options={}] Additional options for the poll operation
+   * @param options - Additional options for the poll operation
    */
   public async update(
     options: UpdatePollerOptions<ReleasePhoneNumbersPollOperationState> = {}

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/release/poller.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/release/poller.ts
@@ -19,7 +19,7 @@ export class ReleasePhoneNumbersPoller extends PhoneNumberPollerBase<
   /**
    * Initializes an instance of ReleasePhoneNumbersPoller
    *
-   * @param {ReleasePhoneNumbersPollerOptions} options Options for initializing the poller.
+   * @param options - Options for initializing the poller.
    */
   constructor(options: ReleasePhoneNumbersPollerOptions) {
     const { client, phoneNumbers, requestOptions = {}, pollInterval = 2000, resumeFrom } = options;

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/reserve/operation.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/reserve/operation.ts
@@ -27,9 +27,9 @@ export class ReservePhoneNumbersPollOperation extends PhoneNumberReservationPoll
   /**
    * Initializes an instance of ReservePhoneNumbersPollOperation
    *
-   * @param {PurchaseReservationPollOperationState} state The state of the poll operation
-   * @param {PhoneNumberAdministration} _client A reference to the generated client used to make requests internally.
-   * @param {OperationOptions} requestOptions Additional options for the underlying requests.
+   * @param state - The state of the poll operation
+   * @param _client - A reference to the generated client used to make requests internally.
+   * @param requestOptions - Additional options for the underlying requests.
    */
   constructor(
     public state: ReservePhoneNumbersPollOperationState,
@@ -43,8 +43,8 @@ export class ReservePhoneNumbersPollOperation extends PhoneNumberReservationPoll
    * Starts a search for phone numbers given some constraints such as name or area code. The phone numbers that are
    * found will then be reserved.
    *
-   * @param {CreateReservationRequest} reservationRequest Request properties to constraint the search scope.
-   * @param {CreateReservationOptions} options Additional request options.
+   * @param reservationRequest - Request properties to constraint the search scope.
+   * @param options - Additional request options.
    */
   private async createReservation(
     reservationRequest: CreateReservationRequest,
@@ -81,7 +81,7 @@ export class ReservePhoneNumbersPollOperation extends PhoneNumberReservationPoll
   /**
    * Reaches to the service and queries the status of the operation.
    *
-   * @param {UpdatePollerOptions<ReservePhoneNumbersPollOperationState>} [options={}] Additional options for the poll operation
+   * @param options - Additional options for the poll operation
    */
   public async update(
     options: UpdatePollerOptions<ReservePhoneNumbersPollOperationState> = {}

--- a/sdk/communication/communication-administration/src/phoneNumber/lro/reserve/poller.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/lro/reserve/poller.ts
@@ -19,7 +19,7 @@ export class ReservePhoneNumbersPoller extends PhoneNumberPollerBase<
   /**
    * Initializes an instance of ReservePhoneNumbersPoller
    *
-   * @param {ReservePhoneNumbersPollerOptions} options Options for initializing the poller.
+   * @param options - Options for initializing the poller.
    */
   constructor(options: ReservePhoneNumbersPollerOptions) {
     const {

--- a/sdk/communication/communication-administration/src/phoneNumber/phoneNumberAdministrationClient.ts
+++ b/sdk/communication/communication-administration/src/phoneNumber/phoneNumberAdministrationClient.ts
@@ -98,17 +98,17 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class.
-   * @param connectionString Connection string to connect to an Azure Communication Service resource.
+   * @param connectionString - Connection string to connect to an Azure Communication Service resource.
    *                         Example: "endpoint=https://contoso.eastus.communications.azure.net/;accesskey=secret";
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(connectionString: string, options?: PhoneNumberAdministrationClientOptions);
 
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class using an Azure KeyCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(
     url: string,
@@ -118,9 +118,9 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class using a TokenCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential TokenCredential that is used to authenticate requests to the service.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - TokenCredential that is used to authenticate requests to the service.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(
     url: string,
@@ -165,8 +165,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Configures a phone number, for example to assign a callbackUrl.
-   * @param config The configuration details
-   * @param options Additional request options.
+   * @param config - The configuration details
+   * @param options - Additional request options.
    */
   public async configurePhoneNumber(
     config: ConfigurePhoneNumberRequest,
@@ -202,8 +202,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Unconfigure a phone number, resetting its' configuration.
-   * @param phoneNumber Phone Number to unconfigure.
-   * @param options Additional request options.
+   * @param phoneNumber - Phone Number to unconfigure.
+   * @param options - Additional request options.
    */
   public async unconfigurePhoneNumber(
     phoneNumber: string,
@@ -234,8 +234,8 @@ export class PhoneNumberAdministrationClient {
    * Updates the capabilities for a list of phone numbers.
    * The response includes the id of the created update capabilities request,
    * remember that id for subsequent calls to getCapabilitiesUpdate.
-   * @param phoneNumberCapabilitiesUpdates Dictionary containing a list of phone numbers and their capabilities updates.
-   * @param options Additional request options.
+   * @param phoneNumberCapabilitiesUpdates - Dictionary containing a list of phone numbers and their capabilities updates.
+   * @param options - Additional request options.
    */
   public async updatePhoneNumbersCapabilities(
     phoneNumberCapabilitiesUpdates: PhoneNumberCapabilitiesUpdates,
@@ -269,8 +269,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Get the update capabilities request associated with a given id.
-   * @param capabilitiesUpdateId  The id associated with the request.
-   * @param options Additional request options.
+   * @param capabilitiesUpdateId -  The id associated with the request.
+   * @param options - Additional request options.
    */
   public async getCapabilitiesUpdate(
     capabilitiesUpdateId: string,
@@ -299,8 +299,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Gets a list of the supported area codes based on location.
-   * @param request Request properties to constraint the search scope.
-   * @param options Additional request options.
+   * @param request - Request properties to constraint the search scope.
+   * @param options - Additional request options.
    */
   public async getAreaCodes(
     request: GetAreaCodesRequest,
@@ -333,8 +333,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Gets the configuration for a given phone number.
-   * @param phoneNumber The E.164 representation of the phone number whose configuration is requested.
-   * @param options Additional request options.
+   * @param phoneNumber - The E.164 representation of the phone number whose configuration is requested.
+   * @param options - Additional request options.
    */
   public async getPhoneNumberConfiguration(
     phoneNumber: string,
@@ -363,8 +363,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Gets the location options for a given phone plan.
-   * @param request Request properties to constraint the search scope.
-   * @param options Additional request options.
+   * @param request - Request properties to constraint the search scope.
+   * @param options - Additional request options.
    */
   public async getPhonePlanLocationOptions(
     request: GetPhonePlanLocationOptionsRequest,
@@ -397,8 +397,8 @@ export class PhoneNumberAdministrationClient {
   /**
    * Gets the reservation associated with a given id.
    * Use this function to query the status of a phone number reservation.
-   * @param reservationId The id of the reservation returned by createReservation.
-   * @param options Additional request options.
+   * @param reservationId - The id of the reservation returned by createReservation.
+   * @param options - Additional request options.
    */
   public async getReservation(
     reservationId: string,
@@ -427,8 +427,8 @@ export class PhoneNumberAdministrationClient {
 
   /**
    * Cancels the reservation associated with a given id.
-   * @param reservationId The id of the reservation returned by createReservation.
-   * @param options Additional request options.
+   * @param reservationId - The id of the reservation returned by createReservation.
+   * @param options - Additional request options.
    */
   public async cancelReservation(
     reservationId: string,
@@ -459,8 +459,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listSearches.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listSearchesPage(
     continuationState: PageSettings,
@@ -492,7 +492,7 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listSearches.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listSearchesAll(
     options: PageableOptions = {}
@@ -513,7 +513,7 @@ export class PhoneNumberAdministrationClient {
    * }
    * ```
    * Gets all searches created by the Azure resource.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   public listSearches(
     options: PageableOptions = {}
@@ -540,8 +540,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listReleases.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listReleasesPage(
     continuationState: PageSettings,
@@ -573,7 +573,7 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listReleases.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listReleasesAll(
     options: PageableOptions = {}
@@ -594,7 +594,7 @@ export class PhoneNumberAdministrationClient {
    * }
    * ```
    * Gets all releases created by the Azure resource.
-   * @param {PageableOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   public listReleases(
     options: PageableOptions = {}
@@ -621,8 +621,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listSupportedCountries.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {ListSupportedCountriesOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listSupportedCountriesPage(
     continuationState: PageSettings,
@@ -654,7 +654,7 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listSupportedCountries.
-   * @param {ListSupportedCountriesOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listSupportedCountriesAll(
     options: ListSupportedCountriesOptions = {}
@@ -675,7 +675,7 @@ export class PhoneNumberAdministrationClient {
    * }
    * ```
    * @summary List all supported countries.
-   * @param {ListSupportedCountriesOptions} [options] The optional parameters.
+   * @param options - The optional parameters.
    */
   public listSupportedCountries(
     options: ListSupportedCountriesOptions = {}
@@ -703,8 +703,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listPhoneNumbers.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param {ListPhoneNumbersOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhoneNumbersPage(
     continuationState: PageSettings,
@@ -736,7 +736,7 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listPhoneNumbers.
-   * @param {ListPhoneNumbersOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhoneNumbersAll(
     options: ListPhoneNumbersOptions = {}
@@ -757,7 +757,7 @@ export class PhoneNumberAdministrationClient {
    * }
    * ```
    * @summary List all acquired phone numbers.
-   * @param {ListPhoneNumbersOptions} [options] The optional parameters.
+   * @param options - The optional parameters.
    */
   public listPhoneNumbers(
     options: ListPhoneNumbersOptions = {}
@@ -784,9 +784,9 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listPhonePlanGroups.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param countryCode The ISO 3166-2 country code, for example "FR" or "CN".
-   * @param {ListPhonePlanGroupsOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param countryCode - The ISO 3166-2 country code, for example "FR" or "CN".
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhonePlanGroupsPage(
     continuationState: PageSettings,
@@ -820,8 +820,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listPhonePlanGroups.
-   * @param countryCode The ISO 3166-2 country code, for example "FR" or "CN".
-   * @param {ListPlansForCountryOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param countryCode - The ISO 3166-2 country code, for example "FR" or "CN".
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhonePlanGroupsAll(
     countryCode: string,
@@ -843,7 +843,7 @@ export class PhoneNumberAdministrationClient {
    * }
    * ```
    * @summary List all available phone plan groups for a country.
-   * @param {ListPhonePlanGroupsOptions} [options] The optional parameters.
+   * @param options - The optional parameters.
    */
   public listPhonePlanGroups(
     countryCode: string,
@@ -872,9 +872,9 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the pagination of listPhonePlans.
-   * @param {PageSettings} continuationState An object that indicates the position of the paginated request.
-   * @param planGroupInfo Information need to search for plans.
-   * @param {GetPhonePlansOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param continuationState - An object that indicates the position of the paginated request.
+   * @param planGroupInfo - Information need to search for plans.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhonePlansPage(
     continuationState: PageSettings,
@@ -913,8 +913,8 @@ export class PhoneNumberAdministrationClient {
    * @internal
    * @ignore
    * Deals with the iteration of all the available results of listPhonePlans.
-   * @param planGroupInfo Information need to search for plans.
-   * @param {ListPhonePlansOptions} [options] Optional parameters for the underlying HTTP request.
+   * @param planGroupInfo - Information need to search for plans.
+   * @param options - Optional parameters for the underlying HTTP request.
    */
   private async *listPhonePlansAll(
     planGroupInfo: ListPhonePlansRequest,
@@ -936,8 +936,8 @@ export class PhoneNumberAdministrationClient {
    * }
    *
    * Gets all available phone plans for a given plan group.
-   * @param planGroupInfo Information need to search for plans.
-   * @param options Additional request options.
+   * @param planGroupInfo - Information need to search for plans.
+   * @param options - Additional request options.
    */
   public listPhonePlans(
     planGroupInfo: ListPhonePlansRequest,
@@ -979,8 +979,8 @@ export class PhoneNumberAdministrationClient {
    * const results = await releasePoller.pollUntilDone();
    * console.log(results);
    * ```
-   * @param {string[]} phoneNumbers The phone numbers to be released.
-   * @param {BeginReleasePhoneNumbersOptions} options Additional request options.
+   * @param phoneNumbers - The phone numbers to be released.
+   * @param options - Additional request options.
    */
   public async beginReleasePhoneNumbers(
     phoneNumbers: string[],
@@ -1018,8 +1018,8 @@ export class PhoneNumberAdministrationClient {
    * console.log(results);
    * ```
    *
-   * @param {CreateReservationRequest} reservationRequest Request properties to constraint the search scope.
-   * @param {BeginReservePhoneNumbersOptions} options Additional request options.
+   * @param reservationRequest - Request properties to constraint the search scope.
+   * @param options - Additional request options.
    */
   public async beginReservePhoneNumbers(
     reservationRequest: CreateReservationRequest,
@@ -1056,8 +1056,8 @@ export class PhoneNumberAdministrationClient {
    * console.log(results);
    * ```
    *
-   * @param {string} reservationId The id of the reservation to purchase.
-   * @param {BeginPurchaseReservationOptions} options Additional request options.
+   * @param reservationId - The id of the reservation to purchase.
+   * @param options - Additional request options.
    */
   public async beginPurchaseReservation(
     reservationId: string,

--- a/sdk/communication/communication-chat/src/chatClient.ts
+++ b/sdk/communication/communication-chat/src/chatClient.ts
@@ -65,9 +65,9 @@ export class ChatClient {
   /**
    * Creates an instance of the ChatClient for a given resource and user.
    *
-   * @param url The url of the Communication Services resouce.
-   * @param credential The token credential. Use AzureCommunicationTokenCredential from @azure/communication-common to create a credential.
-   * @param options Additional client options.
+   * @param url - The url of the Communication Services resouce.
+   * @param credential - The token credential. Use AzureCommunicationTokenCredential from @azure/communication-common to create a credential.
+   * @param options - Additional client options.
    */
   constructor(
     private readonly url: string,
@@ -109,7 +109,7 @@ export class ChatClient {
 
   /**
    * Returns ChatThreadClient with the specific thread id.
-   * @param threadId Thread ID for the ChatThreadClient
+   * @param threadId - Thread ID for the ChatThreadClient
    */
   public async getChatThreadClient(threadId: string): Promise<ChatThreadClient> {
     return new ChatThreadClient(threadId, this.url, this.tokenCredential, this.clientOptions);
@@ -118,8 +118,8 @@ export class ChatClient {
   /**
    * Creates a chat thread.
    * Returns thread client with the id of the created thread.
-   * @param request Request for creating a chat thread.
-   * @param options Operation options.
+   * @param request - Request for creating a chat thread.
+   * @param options - Operation options.
    */
   public async createChatThread(
     request: CreateChatThreadRequest,
@@ -151,8 +151,8 @@ export class ChatClient {
   /**
    * Gets a chat thread.
    * Returns the chat thread.
-   * @param threadId The ID of the thread to get.
-   * @param options  Operation options.
+   * @param threadId - The ID of the thread to get.
+   * @param options -  Operation options.
    */
   public async getChatThread(
     threadId: string,
@@ -215,7 +215,7 @@ export class ChatClient {
 
   /**
    * Gets the list of chat threads of a user.
-   * @param options List chat threads options.
+   * @param options - List chat threads options.
    */
   public listChatThreads(
     options: ListChatThreadsOptions = {}
@@ -247,8 +247,8 @@ export class ChatClient {
 
   /**
    * Deletes a chat thread.
-   * @param threadId The ID of the thread to delete.
-   * @param options  Operation options.
+   * @param threadId - The ID of the thread to delete.
+   * @param options -  Operation options.
    */
   public async deleteChatThread(
     threadId: string,
@@ -308,32 +308,32 @@ export class ChatClient {
    * Subscribe function for chatMessageReceived.
    * The initial sender will also receive this event.
    * You need to call startRealtimeNotifications before subscribing to any event.
-   * @param event The ChatMessageReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public on(event: "chatMessageReceived", listener: (e: ChatMessageReceivedEvent) => void): void;
 
   /**
    * Subscribe function for chatMessageEdited.
    * The initial sender will also receive this event.
-   * @param event The ChatMessageEditedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageEditedEvent.
+   * @param listener - The listener to handle the event.
    */
   public on(event: "chatMessageEdited", listener: (e: ChatMessageEditedEvent) => void): void;
 
   /**
    * Subscribe function for chatMessageDeleted.
    * The initial sender will also receive this event.
-   * @param event The ChatMessageDeletedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageDeletedEvent.
+   * @param listener - The listener to handle the event.
    */
   public on(event: "chatMessageDeleted", listener: (e: ChatMessageDeletedEvent) => void): void;
 
   /**
    * Subscribe function for typingIndicatorReceived.
    * The initial sender will also receive this event.
-   * @param event The TypingIndicatorReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The TypingIndicatorReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public on(
     event: "typingIndicatorReceived",
@@ -342,8 +342,8 @@ export class ChatClient {
 
   /**
    * Subscribe function for readReceiptReceived.
-   * @param event The ReadReceiptReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ReadReceiptReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public on(event: "readReceiptReceived", listener: (e: ReadReceiptReceivedEvent) => void): void;
 
@@ -363,29 +363,29 @@ export class ChatClient {
 
   /**
    * Unsubscribe from chatMessageReceived.
-   * @param event The ChatMessageReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public off(event: "chatMessageReceived", listener: (e: ChatMessageReceivedEvent) => void): void;
 
   /**
    * Unsubscribe from chatMessageEdited.
-   * @param event The ChatMessageEditedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageEditedEvent.
+   * @param listener - The listener to handle the event.
    */
   public off(event: "chatMessageEdited", listener: (e: ChatMessageEditedEvent) => void): void;
 
   /**
    * Unsubscribe from chatMessageDeleted.
-   * @param event The ChatMessageDeletedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ChatMessageDeletedEvent.
+   * @param listener - The listener to handle the event.
    */
   public off(event: "chatMessageDeleted", listener: (e: ChatMessageDeletedEvent) => void): void;
 
   /**
    * Unsubscribe from typingIndicatorReceived.
-   * @param event The TypingIndicatorReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The TypingIndicatorReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public off(
     event: "typingIndicatorReceived",
@@ -394,8 +394,8 @@ export class ChatClient {
 
   /**
    * Unsubscribe from readReceiptReceived.
-   * @param event The ReadReceiptReceivedEvent.
-   * @param listener The listener to handle the event.
+   * @param event - The ReadReceiptReceivedEvent.
+   * @param listener - The listener to handle the event.
    */
   public off(event: "readReceiptReceived", listener: (e: ReadReceiptReceivedEvent) => void): void;
 

--- a/sdk/communication/communication-chat/src/chatThreadClient.ts
+++ b/sdk/communication/communication-chat/src/chatThreadClient.ts
@@ -107,7 +107,7 @@ export class ChatThreadClient {
 
   /**
    * Updates a thread's properties.
-   * @param options Operation options.
+   * @param options - Operation options.
    */
   public async updateThread(options: UpdateThreadOptions = {}): Promise<OperationResponse> {
     const { span, updatedOptions } = createSpan("ChatThreadClient-UpdateThread", options);
@@ -132,8 +132,8 @@ export class ChatThreadClient {
   /**
    * Sends a chat message to a thread identified by threadId.
    * Returns the id of the created message.
-   * @param request Request for sending a message.
-   * @param options Operation options.
+   * @param request - Request for sending a message.
+   * @param options - Operation options.
    */
   public async sendMessage(
     request: SendMessageRequest,
@@ -164,8 +164,8 @@ export class ChatThreadClient {
   /**
    * Gets a chat message identified by messageId.
    * Returns the specific message.\
-   * @param messageId The message id of the message.
-   * @param options Operation options.
+   * @param messageId - The message id of the message.
+   * @param options - Operation options.
    */
   public async getMessage(
     messageId: string,
@@ -232,7 +232,7 @@ export class ChatThreadClient {
   /**
    * Gets a list of message from a thread identified by threadId.
    * Returns the list of the messages.
-   * @param options Get messages options.
+   * @param options - Get messages options.
    */
   public listMessages(options: ListMessagesOptions = {}): PagedAsyncIterableIterator<ChatMessage> {
     const { span, updatedOptions } = createSpan("ChatThreadClient-ListMessages", options);
@@ -263,8 +263,8 @@ export class ChatThreadClient {
 
   /**
    * Deletes a message identified by threadId and messageId
-   * @param messageId The message id of the message.
-   * @param options Operation options.
+   * @param messageId - The message id of the message.
+   * @param options - Operation options.
    */
   public async deleteMessage(
     messageId: string,
@@ -291,8 +291,8 @@ export class ChatThreadClient {
 
   /**
    * Updates a message identified by threadId and messageId
-   * @param messageId The message id of the message.
-   * @param options Operation options.
+   * @param messageId - The message id of the message.
+   * @param options - Operation options.
    */
   public async updateMessage(
     messageId: string,
@@ -320,8 +320,8 @@ export class ChatThreadClient {
 
   /**
    * Adds the details of chat participants belonging to the thread identified by threadId.
-   * @param request Thread participants' details to add in the thread roster
-   * @param options Operation options.
+   * @param request - Thread participants' details to add in the thread roster
+   * @param options - Operation options.
    */
   public async addParticipants(
     request: AddChatParticipantsRequest,
@@ -388,7 +388,7 @@ export class ChatThreadClient {
   /**
    * Gets the participants of the thread identified by threadId.
    * Returns the lists of the participants.
-   * @param options Operation options.
+   * @param options - Operation options.
    */
   public listParticipants(
     options: ListParticipantsOptions = {}
@@ -421,8 +421,8 @@ export class ChatThreadClient {
 
   /**
    * Removes participant from the thread identified by threadId.
-   * @param participant Thread participant to remove from the thread roster
-   * @param options Operation options.
+   * @param participant - Thread participant to remove from the thread roster
+   * @param options - Operation options.
    */
   public async removeParticipant(
     participant: CommunicationUserIdentifier,
@@ -450,7 +450,7 @@ export class ChatThreadClient {
   /**
    * Sends a typing notification to the thread.
    * Doesn't attempt to send if the time since last notification is smaller than the minimum typing interval
-   * @param options - Operation options
+   * @param options - - Operation options
    * @returns True if the typing message notification could be sent, otherwise false.
    */
   public async sendTypingNotification(
@@ -485,9 +485,9 @@ export class ChatThreadClient {
 
   /**
    * Sends a read receipt to the thread identified by threadId.
-   * @param messageId The message id of the message that user latest read.
-   * @param request Request for sending a read receipt
-   * @param options Operation options.
+   * @param messageId - The message id of the message that user latest read.
+   * @param request - Request for sending a read receipt
+   * @param options - Operation options.
    */
   public async sendReadReceipt(
     request: SendReadReceiptRequest,
@@ -554,7 +554,7 @@ export class ChatThreadClient {
   /**
    * Gets a list of read receipt from a thread identified by threadId.
    * Returns the list of the messages.
-   * @param options Get messages options.
+   * @param options - Get messages options.
    */
   public listReadReceipts(
     options: ListReadReceiptsOptions = {}

--- a/sdk/communication/communication-chat/src/credential/communicationTokenCredentialPolicy.ts
+++ b/sdk/communication/communication-chat/src/credential/communicationTokenCredentialPolicy.ts
@@ -7,7 +7,7 @@ import { RequestPolicyFactory, bearerTokenAuthenticationPolicy } from "@azure/co
 /**
  * Creates a new CommunicationTokenCredentialPolicy factory.
  *
- * @param credential The CommunicationTokenCredential implementation that can supply the user credential.
+ * @param credential - The CommunicationTokenCredential implementation that can supply the user credential.
  */
 export const createCommunicationTokenCredentialPolicy = (
   credential: CommunicationTokenCredential

--- a/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
+++ b/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
@@ -13,8 +13,8 @@ import { ChatApiClientOptionalParams } from "./models";
 export class ChatApiClient extends ChatApiClientContext {
   /**
    * Initializes a new instance of the ChatApiClient class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param options The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: ChatApiClientOptionalParams) {
     super(endpoint, options);

--- a/sdk/communication/communication-chat/src/generated/src/chatApiClientContext.ts
+++ b/sdk/communication/communication-chat/src/generated/src/chatApiClientContext.ts
@@ -18,8 +18,8 @@ export class ChatApiClientContext extends coreHttp.ServiceClient {
 
   /**
    * Initializes a new instance of the ChatApiClientContext class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param options The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: ChatApiClientOptionalParams) {
     if (endpoint === undefined) {

--- a/sdk/communication/communication-chat/src/generated/src/operations/chat.ts
+++ b/sdk/communication/communication-chat/src/generated/src/operations/chat.ts
@@ -27,7 +27,7 @@ export class Chat {
 
   /**
    * Initialize a new instance of the class Chat class.
-   * @param client Reference to the service client
+   * @param client - Reference to the service client
    */
   constructor(client: ChatApiClient) {
     this.client = client;
@@ -35,8 +35,8 @@ export class Chat {
 
   /**
    * Creates a chat thread.
-   * @param createChatThreadRequest Request payload for creating a chat thread.
-   * @param options The options parameters.
+   * @param createChatThreadRequest - Request payload for creating a chat thread.
+   * @param options - The options parameters.
    */
   createChatThread(
     createChatThreadRequest: CreateChatThreadRequest,
@@ -54,7 +54,7 @@ export class Chat {
 
   /**
    * Gets the list of chat threads of a user.
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   listChatThreads(
     options?: ChatListChatThreadsOptionalParams
@@ -70,8 +70,8 @@ export class Chat {
 
   /**
    * Gets a chat thread.
-   * @param chatThreadId Id of the thread.
-   * @param options The options parameters.
+   * @param chatThreadId - Id of the thread.
+   * @param options - The options parameters.
    */
   getChatThread(
     chatThreadId: string,
@@ -89,8 +89,8 @@ export class Chat {
 
   /**
    * Deletes a thread.
-   * @param chatThreadId Id of the thread to be deleted.
-   * @param options The options parameters.
+   * @param chatThreadId - Id of the thread to be deleted.
+   * @param options - The options parameters.
    */
   deleteChatThread(
     chatThreadId: string,
@@ -108,8 +108,8 @@ export class Chat {
 
   /**
    * ListChatThreadsNext
-   * @param nextLink The nextLink from the previous successful call to the ListChatThreads method.
-   * @param options The options parameters.
+   * @param nextLink - The nextLink from the previous successful call to the ListChatThreads method.
+   * @param options - The options parameters.
    */
   listChatThreadsNext(
     nextLink: string,

--- a/sdk/communication/communication-chat/src/generated/src/operations/chatThread.ts
+++ b/sdk/communication/communication-chat/src/generated/src/operations/chatThread.ts
@@ -39,7 +39,7 @@ export class ChatThread {
 
   /**
    * Initialize a new instance of the class ChatThread class.
-   * @param client Reference to the service client
+   * @param client - Reference to the service client
    */
   constructor(client: ChatApiClient) {
     this.client = client;
@@ -47,8 +47,8 @@ export class ChatThread {
 
   /**
    * Gets chat message read receipts for a thread.
-   * @param chatThreadId Thread id to get the chat message read receipts for.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to get the chat message read receipts for.
+   * @param options - The options parameters.
    */
   listChatReadReceipts(
     chatThreadId: string,
@@ -66,9 +66,9 @@ export class ChatThread {
 
   /**
    * Sends a read receipt event to a thread, on behalf of a user.
-   * @param chatThreadId Thread id to send the read receipt event to.
-   * @param sendReadReceiptRequest Read receipt details.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to send the read receipt event to.
+   * @param sendReadReceiptRequest - Read receipt details.
+   * @param options - The options parameters.
    */
   sendChatReadReceipt(
     chatThreadId: string,
@@ -88,9 +88,9 @@ export class ChatThread {
 
   /**
    * Sends a message to a thread.
-   * @param chatThreadId The thread id to send the message to.
-   * @param sendChatMessageRequest Details of the message to send.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id to send the message to.
+   * @param sendChatMessageRequest - Details of the message to send.
+   * @param options - The options parameters.
    */
   sendChatMessage(
     chatThreadId: string,
@@ -110,8 +110,8 @@ export class ChatThread {
 
   /**
    * Gets a list of messages from a thread.
-   * @param chatThreadId The thread id of the message.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id of the message.
+   * @param options - The options parameters.
    */
   listChatMessages(
     chatThreadId: string,
@@ -129,9 +129,9 @@ export class ChatThread {
 
   /**
    * Gets a message by id.
-   * @param chatThreadId The thread id to which the message was sent.
-   * @param chatMessageId The message id.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id to which the message was sent.
+   * @param chatMessageId - The message id.
+   * @param options - The options parameters.
    */
   getChatMessage(
     chatThreadId: string,
@@ -151,10 +151,10 @@ export class ChatThread {
 
   /**
    * Updates a message.
-   * @param chatThreadId The thread id to which the message was sent.
-   * @param chatMessageId The message id.
-   * @param updateChatMessageRequest Details of the request to update the message.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id to which the message was sent.
+   * @param chatMessageId - The message id.
+   * @param updateChatMessageRequest - Details of the request to update the message.
+   * @param options - The options parameters.
    */
   updateChatMessage(
     chatThreadId: string,
@@ -176,9 +176,9 @@ export class ChatThread {
 
   /**
    * Deletes a message.
-   * @param chatThreadId The thread id to which the message was sent.
-   * @param chatMessageId The message id.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id to which the message was sent.
+   * @param chatMessageId - The message id.
+   * @param options - The options parameters.
    */
   deleteChatMessage(
     chatThreadId: string,
@@ -198,8 +198,8 @@ export class ChatThread {
 
   /**
    * Posts a typing event to a thread, on behalf of a user.
-   * @param chatThreadId Id of the thread.
-   * @param options The options parameters.
+   * @param chatThreadId - Id of the thread.
+   * @param options - The options parameters.
    */
   sendTypingNotification(
     chatThreadId: string,
@@ -217,8 +217,8 @@ export class ChatThread {
 
   /**
    * Gets the participants of a thread.
-   * @param chatThreadId Thread id to get participants for.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to get participants for.
+   * @param options - The options parameters.
    */
   listChatParticipants(
     chatThreadId: string,
@@ -236,9 +236,9 @@ export class ChatThread {
 
   /**
    * Remove a participant from a thread.
-   * @param chatThreadId Thread id to remove the participant from.
-   * @param chatParticipantId Id of the thread participant to remove from the thread.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to remove the participant from.
+   * @param chatParticipantId - Id of the thread participant to remove from the thread.
+   * @param options - The options parameters.
    */
   removeChatParticipant(
     chatThreadId: string,
@@ -258,9 +258,9 @@ export class ChatThread {
 
   /**
    * Adds thread participants to a thread. If participants already exist, no change occurs.
-   * @param chatThreadId Id of the thread to add participants to.
-   * @param addChatParticipantsRequest Thread participants to be added to the thread.
-   * @param options The options parameters.
+   * @param chatThreadId - Id of the thread to add participants to.
+   * @param addChatParticipantsRequest - Thread participants to be added to the thread.
+   * @param options - The options parameters.
    */
   addChatParticipants(
     chatThreadId: string,
@@ -280,9 +280,9 @@ export class ChatThread {
 
   /**
    * Updates a thread's properties.
-   * @param chatThreadId The id of the thread to update.
-   * @param updateChatThreadRequest Request payload for updating a chat thread.
-   * @param options The options parameters.
+   * @param chatThreadId - The id of the thread to update.
+   * @param updateChatThreadRequest - Request payload for updating a chat thread.
+   * @param options - The options parameters.
    */
   updateChatThread(
     chatThreadId: string,
@@ -302,9 +302,9 @@ export class ChatThread {
 
   /**
    * ListChatReadReceiptsNext
-   * @param chatThreadId Thread id to get the chat message read receipts for.
-   * @param nextLink The nextLink from the previous successful call to the ListChatReadReceipts method.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to get the chat message read receipts for.
+   * @param nextLink - The nextLink from the previous successful call to the ListChatReadReceipts method.
+   * @param options - The options parameters.
    */
   listChatReadReceiptsNext(
     chatThreadId: string,
@@ -324,9 +324,9 @@ export class ChatThread {
 
   /**
    * ListChatMessagesNext
-   * @param chatThreadId The thread id of the message.
-   * @param nextLink The nextLink from the previous successful call to the ListChatMessages method.
-   * @param options The options parameters.
+   * @param chatThreadId - The thread id of the message.
+   * @param nextLink - The nextLink from the previous successful call to the ListChatMessages method.
+   * @param options - The options parameters.
    */
   listChatMessagesNext(
     chatThreadId: string,
@@ -346,9 +346,9 @@ export class ChatThread {
 
   /**
    * ListChatParticipantsNext
-   * @param chatThreadId Thread id to get participants for.
-   * @param nextLink The nextLink from the previous successful call to the ListChatParticipants method.
-   * @param options The options parameters.
+   * @param chatThreadId - Thread id to get participants for.
+   * @param nextLink - The nextLink from the previous successful call to the ListChatParticipants method.
+   * @param options - The options parameters.
    */
   listChatParticipantsNext(
     chatThreadId: string,

--- a/sdk/communication/communication-chat/src/tracing.ts
+++ b/sdk/communication/communication-chat/src/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @ignore
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,

--- a/sdk/communication/communication-common/src/communicationTokenCredential.ts
+++ b/sdk/communication/communication-common/src/communicationTokenCredential.ts
@@ -17,7 +17,7 @@ export type TokenCredential = Pick<AzureCommunicationTokenCredential, "getToken"
 export interface CommunicationTokenCredential {
   /**
    * Gets an `AccessToken` for the user. Throws if already disposed.
-   * @param abortSignal An implementation of `AbortSignalLike` to cancel the operation.
+   * @param abortSignal - An implementation of `AbortSignalLike` to cancel the operation.
    */
   getToken(abortSignal?: AbortSignalLike): Promise<AccessToken>;
   /**
@@ -35,13 +35,13 @@ export class AzureCommunicationTokenCredential implements CommunicationTokenCred
 
   /**
    * Creates an instance of CommunicationTokenCredential with a static token and no proactive refreshing.
-   * @param token A user access token issued by Communication Services.
+   * @param token - A user access token issued by Communication Services.
    */
   constructor(token: string);
   /**
    * Creates an instance of CommunicationTokenCredential with a lambda to get a token and options
    * to configure proactive refreshing.
-   * @param refreshOptions Options to configure refresh and opt-in to proactive refreshing.
+   * @param refreshOptions - Options to configure refresh and opt-in to proactive refreshing.
    */
   constructor(refreshOptions: CommunicationTokenRefreshOptions);
   constructor(tokenOrRefreshOptions: string | CommunicationTokenRefreshOptions) {
@@ -54,7 +54,7 @@ export class AzureCommunicationTokenCredential implements CommunicationTokenCred
 
   /**
    * Gets an `AccessToken` for the user. Throws if already disposed.
-   * @param abortSignal An implementation of `AbortSignalLike` to cancel the operation.
+   * @param abortSignal - An implementation of `AbortSignalLike` to cancel the operation.
    */
   public async getToken(abortSignal?: AbortSignalLike): Promise<AccessToken> {
     this.throwIfDisposed();

--- a/sdk/communication/communication-common/src/credential/clientArguments.ts
+++ b/sdk/communication/communication-common/src/credential/clientArguments.ts
@@ -25,7 +25,7 @@ const assertValidEndpoint = (host: string): void => {
 /**
  * Checks whether a value is a KeyCredential.
  *
- * @param {*} credential The credential being checked.
+ * @param credential - The credential being checked.
  */
 export const isKeyCredential = (credential: any): credential is KeyCredential => {
   return credential && typeof credential.key === "string" && credential.getToken === undefined;
@@ -42,8 +42,8 @@ export type UrlWithCredential = {
 /**
  * Parses arguments passed to a communication client.
  *
- * @param {string} connectionStringOrUrl
- * @param {*} [credentialOrOptions]
+ * @param connectionStringOrUrl
+ * @param [credentialOrOptions]
  */
 export const parseClientArguments = (
   connectionStringOrUrl: string,

--- a/sdk/communication/communication-common/src/credential/communicationAccessKeyCredentialPolicy.ts
+++ b/sdk/communication/communication-common/src/credential/communicationAccessKeyCredentialPolicy.ts
@@ -19,7 +19,7 @@ import { shaHash, shaHMAC } from "./cryptoUtils";
  * Creates an HTTP pipeline policy to authenticate a request
  * using an `KeyCredential`
  *
- * @param {KeyCredential} credential The key credential
+ * @param credential - The key credential
  */
 export const createCommunicationAccessKeyCredentialPolicy = (
   credential: KeyCredential
@@ -39,7 +39,7 @@ class CommunicationAccessKeyCredentialPolicy extends BaseRequestPolicy {
   /**
    * Initializes a new instance of the CommunicationAccessKeyCredential class
    * using a base64 encoded key.
-   * @param accessKey The base64 encoded key to be used for signing.
+   * @param accessKey - The base64 encoded key to be used for signing.
    */
   constructor(
     private readonly accessKey: KeyCredential,
@@ -52,7 +52,7 @@ class CommunicationAccessKeyCredentialPolicy extends BaseRequestPolicy {
   /**
    * Signs a request with the provided access key.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
+   * @param webResource - The WebResource to be signed.
    */
   private async signRequest(webResource: WebResource): Promise<WebResource> {
     const verb = webResource.method.toUpperCase();
@@ -87,7 +87,7 @@ class CommunicationAccessKeyCredentialPolicy extends BaseRequestPolicy {
   /**
    * Signs the request and calls the next policy in the factory.
    *
-   * @param {WebResourceLike} webResource
+   * @param webResource
    */
   public async sendRequest(webResource: WebResourceLike): Promise<HttpOperationResponse> {
     if (!webResource) {

--- a/sdk/communication/communication-common/src/credential/communicationAuthPolicy.ts
+++ b/sdk/communication/communication-common/src/credential/communicationAuthPolicy.ts
@@ -5,7 +5,7 @@ import { createCommunicationAccessKeyCredentialPolicy } from "./communicationAcc
  * Creates a pipeline policy to authenticate request based
  * on the credential passed in
  *
- * @param {KeyCredential | TokenCredential} credential The key credential
+ * @param credential - The key credential
  */
 export const createCommunicationAuthPolicy = (
   credential: KeyCredential | TokenCredential

--- a/sdk/communication/communication-common/src/credential/connectionString.ts
+++ b/sdk/communication/communication-common/src/credential/connectionString.ts
@@ -30,7 +30,7 @@ const tryParseConnectionString = (s: string): EndpointCredential | undefined => 
 /**
  * Returns an EndpointCredential to easily access properties of the connection string
  *
- * @param {string} connectionString The connection string to parse
+ * @param connectionString - The connection string to parse
  * @returns {EndpointCredential} Object to access the endpoint and the credenials
  */
 export const parseConnectionString = (connectionString: string): EndpointCredential => {

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -80,7 +80,7 @@ export type _SerializedCommunicationCloudEnvironment = "public" | "dod" | "gcch"
 /**
  * @internal
  * Translates a CommunicationIdentifier to its serialized format for sending a request.
- * @param identifier The CommunicationIdentifier to be serialized.
+ * @param identifier - The CommunicationIdentifier to be serialized.
  */
 export const _serializeCommunicationIdentifier = (
   identifier: CommunicationIdentifier
@@ -115,7 +115,7 @@ export const _serializeCommunicationIdentifier = (
 /**
  * @internal
  * Translates the serialized format of a communication identifier to CommunicationIdentifier.
- * @param serializedIdentifier The SerializedCommunicationIdentifier to be deserialized.
+ * @param serializedIdentifier - The SerializedCommunicationIdentifier to be deserialized.
  */
 export const _deserializeCommunicationIdentifier = (
   serializedIdentifier: _SerializedCommunicationIdentifier

--- a/sdk/communication/communication-common/src/identifierModels.ts
+++ b/sdk/communication/communication-common/src/identifierModels.ts
@@ -70,7 +70,7 @@ export interface UnknownIdentifier {
 /**
  * Tests an Identifier to determine whether it implements CommunicationUserIdentifier.
  *
- * @param identifier The assumed CommunicationUserIdentifier to be tested.
+ * @param identifier - The assumed CommunicationUserIdentifier to be tested.
  */
 export const isCommunicationUserIdentifier = (
   identifier: CommunicationIdentifier
@@ -81,7 +81,7 @@ export const isCommunicationUserIdentifier = (
 /**
  * Tests an Identifier to determine whether it implements PhoneNumberIdentifier.
  *
- * @param identifier The assumed PhoneNumberIdentifier to be tested.
+ * @param identifier - The assumed PhoneNumberIdentifier to be tested.
  */
 export const isPhoneNumberIdentifier = (
   identifier: CommunicationIdentifier
@@ -92,7 +92,7 @@ export const isPhoneNumberIdentifier = (
 /**
  * Tests an Identifier to determine whether it implements MicrosoftTeamsUserIdentifier.
  *
- * @param identifier The assumed available to be tested.
+ * @param identifier - The assumed available to be tested.
  */
 export const isMicrosoftTeamsUserIdentifier = (
   identifier: CommunicationIdentifier
@@ -103,7 +103,7 @@ export const isMicrosoftTeamsUserIdentifier = (
 /**
  * Tests an Identifier to determine whether it implements UnknownIdentifier.
  *
- * @param identifier The assumed UnknownIdentifier to be tested.
+ * @param identifier - The assumed UnknownIdentifier to be tested.
  */
 export const isUnknownIdentifier = (
   identifier: CommunicationIdentifier
@@ -163,7 +163,7 @@ export interface UnknownIdentifierKind extends UnknownIdentifier {
 /**
  * Returns the CommunicationIdentifierKind for a given CommunicationIdentifier. Returns undefined if the kind couldn't be inferred.
  *
- * @param identifier The identifier whose kind is to be inferred.
+ * @param identifier - The identifier whose kind is to be inferred.
  */
 export const getIdentifierKind = (
   identifier: CommunicationIdentifier

--- a/sdk/communication/communication-identity/src/common/tracing.ts
+++ b/sdk/communication/communication-identity/src/common/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @ignore
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,

--- a/sdk/communication/communication-identity/src/communicationIdentityClient.ts
+++ b/sdk/communication/communication-identity/src/communicationIdentityClient.ts
@@ -44,17 +44,17 @@ export class CommunicationIdentityClient {
 
   /**
    * Initializes a new instance of the CommunicationIdentity class.
-   * @param connectionString Connection string to connect to an Azure Communication Service resource.
+   * @param connectionString - Connection string to connect to an Azure Communication Service resource.
    *                         Example: "endpoint=https://contoso.eastus.communications.azure.net/;accesskey=secret";
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(connectionString: string, options?: CommunicationIdentityOptions);
 
   /**
    * Initializes a new instance of the CommunicationIdentity class using an Azure KeyCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential An object that is used to authenticate requests to the service. Use the AzureKeyCredential or `@azure/identity` to create a credential.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - An object that is used to authenticate requests to the service. Use the AzureKeyCredential or `@azure/identity` to create a credential.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(
     url: string,
@@ -63,9 +63,9 @@ export class CommunicationIdentityClient {
   );
   /**
    * Initializes a new instance of the CommunicationIdentity class using a TokenCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net)
-   * @param credential TokenCredential that is used to authenticate requests to the service.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net)
+   * @param credential - TokenCredential that is used to authenticate requests to the service.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(
     url: string,
@@ -75,9 +75,9 @@ export class CommunicationIdentityClient {
   /**
    * Creates an instance of CommunicationIdentity.
    *
-   * @param {string} url The endpoint to the service
-   * @param {KeyCredential} credential An object that is used to authenticate requests to the service. Use the AzureKeyCredential or `@azure/identity` to create a credential.
-   * @param {CommunicationIdentityOptions} [options={}] Options to configure the HTTP pipeline.
+   * @param url - The endpoint to the service
+   * @param credential - An object that is used to authenticate requests to the service. Use the AzureKeyCredential or `@azure/identity` to create a credential.
+   * @param options - Options to configure the HTTP pipeline.
    */
   public constructor(
     connectionStringOrUrl: string,
@@ -117,9 +117,9 @@ export class CommunicationIdentityClient {
   /**
    * Creates a scoped user token.
    *
-   * @param {CommunicationUser} user The user whose tokens are being revoked.
-   * @param {TokenScope[]} scopes Scopes to include in the token.
-   * @param {OperationOptions} [options={}] Additional options for the request.
+   * @param user - The user whose tokens are being revoked.
+   * @param scopes - Scopes to include in the token.
+   * @param options - Additional options for the request.
    */
   public async issueToken(
     user: CommunicationUserIdentifier,
@@ -148,8 +148,8 @@ export class CommunicationIdentityClient {
   /**
    * Revokes all data and tokens created for a user.
    *
-   * @param {CommunicationUser} user The user whose tokens are being revoked.
-   * @param {OperationOptions} [options={}] Additional options for the request.
+   * @param user - The user whose tokens are being revoked.
+   * @param options - Additional options for the request.
    */
   public async revokeTokens(
     user: CommunicationUserIdentifier,
@@ -176,7 +176,7 @@ export class CommunicationIdentityClient {
   /**
    * Creates a single user.
    *
-   * @param {OperationOptions} [options={}] Additional options for the request.
+   * @param options - Additional options for the request.
    */
   public async createUser(options: OperationOptions = {}): Promise<CreateUserResponse> {
     const { span, updatedOptions } = createSpan("CommunicationIdentity-createUser", options);
@@ -200,8 +200,8 @@ export class CommunicationIdentityClient {
   /**
    * Creates a single user and a token simultaneously.
    *
-   * @param {TokenScope[]} scopes Scopes to include in the token.
-   * @param {OperationOptions} [options={}] Additional options for the request.
+   * @param scopes - Scopes to include in the token.
+   * @param options - Additional options for the request.
    */
   public async createUserWithToken(
     scopes: TokenScope[],
@@ -235,8 +235,8 @@ export class CommunicationIdentityClient {
   /**
    * Triggers revocation event for user and deletes all its data.
    *
-   * @param {CommunicationUser} user The user being deleted.
-   * @param {OperationOptions} [options={}] Additional options for the request.
+   * @param user - The user being deleted.
+   * @param options - Additional options for the request.
    */
   public async deleteUser(
     user: CommunicationUserIdentifier,

--- a/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
+++ b/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
@@ -15,8 +15,8 @@ import { IdentityRestClientOptionalParams } from "./models";
 class IdentityRestClient extends IdentityRestClientContext {
   /**
    * Initializes a new instance of the IdentityRestClient class.
-   * @param endpoint The communication resource, for example https://my-resource.communication.azure.com
-   * @param options The parameter options
+   * @param endpoint - The communication resource, for example https://my-resource.communication.azure.com
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: IdentityRestClientOptionalParams) {
     super(endpoint, options);

--- a/sdk/communication/communication-identity/src/generated/src/identityRestClientContext.ts
+++ b/sdk/communication/communication-identity/src/generated/src/identityRestClientContext.ts
@@ -18,8 +18,8 @@ export class IdentityRestClientContext extends coreHttp.ServiceClient {
 
   /**
    * Initializes a new instance of the IdentityRestClientContext class.
-   * @param endpoint The communication resource, for example https://my-resource.communication.azure.com
-   * @param options The parameter options
+   * @param endpoint - The communication resource, for example https://my-resource.communication.azure.com
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: IdentityRestClientOptionalParams) {
     if (endpoint === undefined) {

--- a/sdk/communication/communication-identity/src/generated/src/operations/communicationIdentity.ts
+++ b/sdk/communication/communication-identity/src/generated/src/operations/communicationIdentity.ts
@@ -25,7 +25,7 @@ export class CommunicationIdentity {
 
   /**
    * Initialize a new instance of the class CommunicationIdentity class.
-   * @param client Reference to the service client
+   * @param client - Reference to the service client
    */
   constructor(client: IdentityRestClient) {
     this.client = client;
@@ -33,7 +33,7 @@ export class CommunicationIdentity {
 
   /**
    * Create a new identity.
-   * @param options The options parameters.
+   * @param options - The options parameters.
    */
   create(
     options?: CommunicationIdentityCreateOptionalParams
@@ -49,8 +49,8 @@ export class CommunicationIdentity {
 
   /**
    * Delete the identity, revoke all tokens for the identity and delete all associated data.
-   * @param id Identifier of the identity to be deleted.
-   * @param options The options parameters.
+   * @param id - Identifier of the identity to be deleted.
+   * @param options - The options parameters.
    */
   delete(id: string, options?: coreHttp.OperationOptions): Promise<coreHttp.RestResponse> {
     const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
@@ -64,8 +64,8 @@ export class CommunicationIdentity {
 
   /**
    * Revoke all access tokens for the specific identity.
-   * @param id Identifier of the identity.
-   * @param options The options parameters.
+   * @param id - Identifier of the identity.
+   * @param options - The options parameters.
    */
   revokeAccessTokens(
     id: string,
@@ -82,9 +82,9 @@ export class CommunicationIdentity {
 
   /**
    * Issue a new token for an identity.
-   * @param id Identifier of the identity to issue token for.
-   * @param body Requesting scopes for the new token.
-   * @param options The options parameters.
+   * @param id - Identifier of the identity to issue token for.
+   * @param body - Requesting scopes for the new token.
+   * @param options - The options parameters.
    */
   issueAccessToken(
     id: string,

--- a/sdk/communication/communication-sms/src/generated/src/operations/sms.ts
+++ b/sdk/communication/communication-sms/src/generated/src/operations/sms.ts
@@ -20,7 +20,7 @@ export class Sms {
 
   /**
    * Create a Sms.
-   * @param {SmsApiClientContext} client Reference to the service client.
+   * @param client - Reference to the service client.
    */
   constructor(client: SmsApiClientContext) {
     this.client = client;
@@ -28,8 +28,8 @@ export class Sms {
 
   /**
    * @summary Sends a SMS message from a phone number that belongs to the authenticated account.
-   * @param sendMessageRequest Represents the body of the send message request.
-   * @param [options] The optional parameters
+   * @param sendMessageRequest - Represents the body of the send message request.
+   * @param options - The optional parameters
    * @returns Promise<Models.SmsSendResponse>
    */
   send(
@@ -37,17 +37,17 @@ export class Sms {
     options?: coreHttp.RequestOptionsBase
   ): Promise<Models.SmsSendResponse>;
   /**
-   * @param sendMessageRequest Represents the body of the send message request.
-   * @param callback The callback
+   * @param sendMessageRequest - Represents the body of the send message request.
+   * @param callback - The callback
    */
   send(
     sendMessageRequest: Models.SendMessageRequest,
     callback: coreHttp.ServiceCallback<Models.SendSmsResponse>
   ): void;
   /**
-   * @param sendMessageRequest Represents the body of the send message request.
-   * @param options The optional parameters
-   * @param callback The callback
+   * @param sendMessageRequest - Represents the body of the send message request.
+   * @param options - The optional parameters
+   * @param callback - The callback
    */
   send(
     sendMessageRequest: Models.SendMessageRequest,

--- a/sdk/communication/communication-sms/src/generated/src/smsApiClient.ts
+++ b/sdk/communication/communication-sms/src/generated/src/smsApiClient.ts
@@ -20,8 +20,8 @@ class SmsApiClient extends SmsApiClientContext {
 
   /**
    * Initializes a new instance of the SmsApiClient class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param [options] The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: coreHttp.ServiceClientOptions) {
     super(endpoint, options);

--- a/sdk/communication/communication-sms/src/generated/src/smsApiClientContext.ts
+++ b/sdk/communication/communication-sms/src/generated/src/smsApiClientContext.ts
@@ -18,8 +18,8 @@ export class SmsApiClientContext extends coreHttp.ServiceClient {
 
   /**
    * Initializes a new instance of the SmsApiClientContext class.
-   * @param endpoint The endpoint of the Azure Communication resource.
-   * @param [options] The parameter options
+   * @param endpoint - The endpoint of the Azure Communication resource.
+   * @param options - The parameter options
    */
   constructor(endpoint: string, options?: coreHttp.ServiceClientOptions) {
     if (endpoint == undefined) {

--- a/sdk/communication/communication-sms/src/smsClient.ts
+++ b/sdk/communication/communication-sms/src/smsClient.ts
@@ -59,7 +59,7 @@ export interface SendOptions extends OperationOptions {
 /**
  * Checks whether the type of a value is SmsClientOptions or not.
  *
- * @param options The value being checked.
+ * @param options - The value being checked.
  */
 const isSmsClientOptions = (options: any): options is SmsClientOptions =>
   !!options && !isKeyCredential(options);
@@ -73,25 +73,25 @@ export class SmsClient {
 
   /**
    * Initializes a new instance of the SmsClient class.
-   * @param connectionString Connection string to connect to an Azure Communication Service resource.
+   * @param connectionString - Connection string to connect to an Azure Communication Service resource.
    *                         Example: "endpoint=https://contoso.eastus.communications.azure.net/;accesskey=secret";
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   constructor(connectionString: string, options?: SmsClientOptions);
 
   /**
    * Initializes a new instance of the SmsClient class using an Azure KeyCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   constructor(url: string, credential: KeyCredential, options?: SmsClientOptions);
 
   /**
    * Initializes a new instance of the SmsClient class using a TokenCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential TokenCredential that is used to authenticate requests to the service.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - TokenCredential that is used to authenticate requests to the service.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   constructor(url: string, credential: TokenCredential, options?: SmsClientOptions);
 
@@ -132,8 +132,8 @@ export class SmsClient {
   /**
    * Sends a SMS from a phone number that is acquired by the authenticated account, to another phone number.
    *
-   * @param sendRequest Provides the sender's and recipient's phone numbers, and the contents of the message
-   * @param options Additional request options
+   * @param sendRequest - Provides the sender's and recipient's phone numbers, and the contents of the message
+   * @param options - Additional request options
    */
   public async send(sendRequest: SendRequest, options: SendOptions = {}): Promise<RestResponse> {
     const { operationOptions, restOptions } = extractOperationOptions(options);

--- a/sdk/communication/communication-sms/src/tracing.ts
+++ b/sdk/communication/communication-sms/src/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @ignore
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,


### PR DESCRIPTION
This PR updates the usage of `@param` tag in the docs to follow TSDoc in the communication packages fixing about 300 linter errors. Related to #12950