### PR TITLE
[core-auth] 1.2.0 release date

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.5 (Unreleased)
+## 1.1.5 (2021-01-08)
 
 - Add `AzureSASCredential` and `SASCredential` for use by service clients which allow authenticiation using a shared access signature.
 

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.5 (2021-01-08)
+## 1.2.0 (2021-02-08)
 
 - Add `AzureSASCredential` and `SASCredential` for use by service clients which allow authenticiation using a shared access signature.
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Setting the release date for 1.2.0 🌞

Decided to use 1.2.0 since we added some new exports.