### PR TITLE
Use TokenCredential from core-auth than identity

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -13,7 +13,7 @@ import { PipelineOptions } from '@azure/core-http';
 import { PollerLike } from '@azure/core-lro';
 import { PollOperationState } from '@azure/core-lro';
 import { RestResponse } from '@azure/core-http';
-import { TokenCredential } from '@azure/identity';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export interface AccountProperties {

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -9,8 +9,7 @@ import {
   operationOptionsToRequestOptionsBase,
   OperationOptions
 } from "@azure/core-http";
-import { TokenCredential } from "@azure/identity";
-import { KeyCredential } from "@azure/core-auth";
+import { TokenCredential, KeyCredential } from "@azure/core-auth";
 import {
   SDK_VERSION,
   DEFAULT_COGNITIVE_SCOPE,

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -11,8 +11,7 @@ import {
   operationOptionsToRequestOptionsBase,
   RestResponse
 } from "@azure/core-http";
-import { TokenCredential } from "@azure/identity";
-import { KeyCredential } from "@azure/core-auth";
+import { TokenCredential, KeyCredential } from "@azure/core-auth";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import "@azure/core-paging";
 import {

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -9,7 +9,7 @@ import { OperationOptions } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PipelineOptions } from '@azure/core-http';
 import { RestResponse } from '@azure/core-http';
-import { TokenCredential } from '@azure/identity';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export interface AlertConfigurationsPageResponse extends Array<AnomalyAlertConfiguration> {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/createClientPipeline.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/createClientPipeline.ts
@@ -9,7 +9,7 @@ import {
   isTokenCredential
 } from "@azure/core-http";
 
-import { TokenCredential } from "@azure/identity";
+import { TokenCredential } from "@azure/core-auth";
 
 import {
   LIB_INFO,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -10,7 +10,7 @@ import {
   OperationOptions,
   RestResponse
 } from "@azure/core-http";
-import { TokenCredential } from "@azure/identity";
+import { TokenCredential } from "@azure/core-auth";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import "@azure/core-paging";
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -11,7 +11,7 @@ import {
 } from "@azure/core-http";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import "@azure/core-paging";
-import { TokenCredential } from "@azure/identity";
+import { TokenCredential } from "@azure/core-auth";
 import { GeneratedClient } from "./generated/generatedClient";
 import { createSpan } from "./tracing";
 import { MetricsAdvisorKeyCredential } from "./metricsAdvisorKeyCredentialPolicy";


### PR DESCRIPTION
Use `TokenCredential` from `core-auth` instead of `identity` package so that the latter need not be pulled into dependencies list from devDependencies in #13670