### PR TITLE
Remove keySize override from createRsaKeyOptions

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -50,7 +50,6 @@ export interface CreateOctKeyOptions extends CreateKeyOptions {
 // @public
 export interface CreateRsaKeyOptions extends CreateKeyOptions {
     hsm?: boolean;
-    keySize?: number;
     publicExponent?: number;
 }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -292,7 +292,7 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
    */
   readonly expiresOn?: Date;
   /**
-   * Size of the key
+   * The key size in bits. For example: 2048, 3072, or 4096 for RSA.
    */
   keySize?: number;
 }
@@ -345,10 +345,6 @@ export interface CreateEcKeyOptions extends CreateKeyOptions {
  * passed to {@link createRsaKey}
  */
 export interface CreateRsaKeyOptions extends CreateKeyOptions {
-  /**
-   * The key size in bits. For example: 2048, 3072, or 4096 for RSA.
-   */
-  keySize?: number;
   /**
    * Whether to import as a hardware key (HSM) or software key.
    */


### PR DESCRIPTION
We define `keySize` in `createRsaKeyOptions` but we don't have to since it's already
defined in `createKeyOptions` which this inherits from. Having it defined in two places
adds confusion (see https://github.com/Azure/azure-sdk-for-js/pull/13522#discussion_r568994010 as an example).

This commit just removes the redefined parameter and updates the base parameter's
doc comment to be clearer.

Fixes #13589 