### PR TITLE
[ESLint Plugin] no require imports

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-base.ts
@@ -34,6 +34,7 @@ export default {
     "no-empty": "error",
     "no-fallthrough": "error",
     "no-invalid-this": "error",
+    "@typescript-eslint/no-require-imports": "error",
     "no-restricted-imports": ["error", { paths: ["rhea", "rhea/.*"] }],
     "no-return-await": "error",
     "no-undef": "off",

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -9,6 +9,7 @@ import path from "path";
 
 let keytar: any;
 try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   keytar = require("keytar");
 } catch (er) {
   keytar = null;

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -203,6 +203,7 @@ describe("ManagedIdentityCredential", function() {
     process.env.IMDS_ENDPOINT = "https://endpoint";
     process.env.IDENTITY_ENDPOINT = "https://endpoint";
 
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mockFs = require("mock-fs");
     const filePath = "path/to/file";
     const key = "challenge key";


### PR DESCRIPTION
Disallow `require` imports and ignore its use for keytar in identity after talking to @sadasant. Fixes https://github.com/Azure/azure-sdk-for-js/issues/4361.