### PR TITLE
[Communication]Set the sender as undefined instead of empty when sender id not populated

### DIFF
--- a/sdk/communication/communication-chat/review/communication-chat.api.md
+++ b/sdk/communication/communication-chat/review/communication-chat.api.md
@@ -92,7 +92,7 @@ export interface ChatMessageContent extends Omit<RestChatMessageContent, "partic
 
 // @public
 export interface ChatMessageReadReceipt extends Omit<RestChatMessageReadReceipt, "senderId"> {
-    readonly sender?: CommunicationUserIdentifier;
+    readonly sender: CommunicationUserIdentifier;
 }
 
 // @public

--- a/sdk/communication/communication-chat/src/models/mappers.ts
+++ b/sdk/communication/communication-chat/src/models/mappers.ts
@@ -55,11 +55,18 @@ export const mapToChatContentSdkModel = (
 export const mapToChatMessageSdkModel = (chatMessage: RestModel.ChatMessage): ChatMessage => {
   const { content, senderId, ...otherChatMessage } = chatMessage;
   const contentSdkModel = content ? mapToChatContentSdkModel(content) : undefined;
-  return {
-    sender: { communicationUserId: senderId! },
-    content: contentSdkModel,
-    ...otherChatMessage
-  };
+  if (senderId) {
+    return {
+      sender: { communicationUserId: senderId! },
+      content: contentSdkModel,
+      ...otherChatMessage
+    };
+  } else {
+    return {
+      content: contentSdkModel,
+      ...otherChatMessage
+    };
+  }
 };
 
 /**
@@ -77,7 +84,7 @@ export const mapToChatMessagesSdkModelArray = (
 export const mapToChatParticipantSdkModel = (
   chatParticipant: RestModel.ChatParticipant
 ): ChatParticipant => {
-  const model = { ...chatParticipant, user: { communicationUserId: chatParticipant.id! } };
+  const model = { ...chatParticipant, user: { communicationUserId: chatParticipant.id } };
   delete (model as any).id;
   return model;
 };
@@ -102,7 +109,7 @@ export const mapToChatThreadSdkModel = (chatThread: RestModel.ChatThread): ChatT
 export const mapToReadReceiptSdkModel = (
   readReceipt: RestModel.ChatMessageReadReceipt
 ): ChatMessageReadReceipt => {
-  const model = { ...readReceipt, sender: { communicationUserId: readReceipt.senderId! } };
+  const model = { ...readReceipt, sender: { communicationUserId: readReceipt.senderId } };
   delete (model as any).senderId;
   return model;
 };

--- a/sdk/communication/communication-chat/src/models/models.ts
+++ b/sdk/communication/communication-chat/src/models/models.ts
@@ -81,7 +81,7 @@ export interface ChatMessageReadReceipt extends Omit<RestChatMessageReadReceipt,
   /**
    * The CommunicationUserIdentifier that identifies this Read receipt sender.
    */
-  readonly sender?: CommunicationUserIdentifier;
+  readonly sender: CommunicationUserIdentifier;
 }
 
 /**

--- a/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
@@ -137,8 +137,12 @@ describe("[Mocked] ChatThreadClient", async () => {
       const { participants: expectedParticipants, ...expectedContents } = expectedContent!;
       const { participants: responseParticipants, ...repsonseContents } = repsonseContent!;
 
+      if (!expectedId) {
+        assert.isUndefined(responseUser);
+      } else {
+        assert.equal(responseUser!.communicationUserId, expectedId);
+      }
       assert.deepEqual(responseMessage, expectedMessage);
-      assert.equal(responseUser?.communicationUserId, expectedId);
       assert.deepEqual(repsonseContents, expectedContents);
     }
 


### PR DESCRIPTION
The current behavior for the SDK if message sender ID is not populated from service, the SDK will return an empty sender property. This PR is to change that to undefined instead of empty in that situation.