### PR TITLE
[Core Client] Fix remaining lint errors

### DIFF
--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o coreClient-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test:browser && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -42,7 +42,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
         credential: TokenCredential;
     };
     deserializationOptions?: DeserializationPolicyOptions;
-    serializationOptions?: serializationPolicyOptions;
+    serializationOptions?: SerializationPolicyOptions;
 }
 
 // @public (undocumented)
@@ -309,13 +309,13 @@ export interface SequenceMapperType {
 }
 
 // @public
-export function serializationPolicy(options?: serializationPolicyOptions): PipelinePolicy;
+export function serializationPolicy(options?: SerializationPolicyOptions): PipelinePolicy;
 
 // @public
 export const serializationPolicyName = "serializationPolicy";
 
 // @public
-export interface serializationPolicyOptions {
+export interface SerializationPolicyOptions {
     serializerOptions?: SerializerOptions;
     stringifyXML?: (obj: any, opts?: XmlOptions) => string;
 }

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -184,9 +184,9 @@ async function deserializeResponseBody(
           valueToDeserialize,
           "operationRes.parsedBody"
         );
-      } catch (error) {
+      } catch (deserializeError) {
         const restError = new RestError(
-          `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
+          `Error ${deserializeError} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
           {
             statusCode: parsedResponse.status,
             request: parsedResponse.request,

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -54,5 +54,5 @@ export {
 export {
   serializationPolicy,
   serializationPolicyName,
-  serializationPolicyOptions
+  SerializationPolicyOptions
 } from "./serializationPolicy";

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -28,7 +28,7 @@ export const serializationPolicyName = "serializationPolicy";
 /**
  * Options to configure API request serialization.
  */
-export interface serializationPolicyOptions {
+export interface SerializationPolicyOptions {
   /**
    * A function that is able to write XML. Required for XML support.
    */
@@ -44,7 +44,7 @@ export interface serializationPolicyOptions {
  * This policy handles assembling the request body and headers using
  * an OperationSpec and OperationArguments on the request.
  */
-export function serializationPolicy(options: serializationPolicyOptions = {}): PipelinePolicy {
+export function serializationPolicy(options: SerializationPolicyOptions = {}): PipelinePolicy {
   const stringifyXML = options.stringifyXML;
 
   return {
@@ -66,7 +66,7 @@ function serializeHeaders(
   request: OperationRequest,
   operationArguments: OperationArguments,
   operationSpec: OperationSpec
-) {
+): void {
   if (operationSpec.headerParameters) {
     for (const headerParameter of operationSpec.headerParameters) {
       let headerValue = getOperationArgumentValueFromParameter(operationArguments, headerParameter);

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -817,7 +817,7 @@ function getXmlObjectValue(
   serializedValue: any,
   isXml: boolean,
   options: RequiredSerializerOptions
-) {
+): any {
   if (!isXml || !propertyMapper.xmlNamespace) {
     return serializedValue;
   }

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -26,7 +26,7 @@ import { getRequestUrl } from "./urlHelpers";
 import { isPrimitiveType } from "./utils";
 import { deserializationPolicy, DeserializationPolicyOptions } from "./deserializationPolicy";
 import { URL } from "./url";
-import { serializationPolicy, serializationPolicyOptions } from "./serializationPolicy";
+import { serializationPolicy, SerializationPolicyOptions } from "./serializationPolicy";
 import { getCachedDefaultHttpsClient } from "./httpClientCache";
 import { getOperationRequestInfo } from "./operationHelpers";
 
@@ -124,7 +124,7 @@ export class ServiceClient {
 
   /**
    * Send an HTTP request that is populated using the provided OperationSpec.
-   * @typeParam T The typed result of the request, based on the OperationSpec.
+   * @typeParam T - The typed result of the request, based on the OperationSpec.
    * @param operationArguments - The arguments that the HTTP request's templated values will be populated from.
    * @param operationSpec - The OperationSpec to use to populate the httpRequest.
    */
@@ -261,7 +261,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
   /**
    * Options to customize serializationPolicy.
    */
-  serializationOptions?: serializationPolicyOptions;
+  serializationOptions?: SerializationPolicyOptions;
 }
 
 /**

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -7,7 +7,7 @@
  * @param value - Value to test
  * @hidden @internal
  */
-export function isPrimitiveType(value: any): boolean {
+export function isPrimitiveType(value: unknown): boolean {
   return (typeof value !== "object" && typeof value !== "function") || value === null;
 }
 

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -271,7 +271,7 @@ describe("ServiceClient", function() {
 
     let rawResponse: FullOperationResponse | undefined;
 
-    const response = await client.sendOperationRequest(
+    const operationResponse = await client.sendOperationRequest(
       { options: { onResponse: (response) => (rawResponse = response) } },
       {
         httpMethod: "GET",
@@ -285,7 +285,7 @@ describe("ServiceClient", function() {
     );
 
     assert(request!);
-    assert.strictEqual(JSON.stringify(response), "{}");
+    assert.strictEqual(JSON.stringify(operationResponse), "{}");
     assert.strictEqual(rawResponse?.status, 200);
     assert.strictEqual(rawResponse?.request, request!);
     assert.strictEqual(rawResponse?.headers.get("X-Extra-Info"), "foo");


### PR DESCRIPTION
This PR fixes the remaining lint errors in the core-client package and enables further regressions to break the build. It also increments the package version as doing that failed in #13615

Related to #10775