### PR TITLE
Increment version for new core packages, fix linter errors

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -117,6 +117,19 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-+j1embyH1jqf04AIfJPdLafd5SC1y6z1Jz4i+USR1XkTp6KM8P5u4/AjmWMVoEQdM/M29PJcRDZcCEWjK9S1bw==
+  /@azure/core-client/1.0.0-beta.1:
+    dependencies:
+      '@azure/abort-controller': 1.0.2
+      '@azure/core-auth': 1.1.4
+      '@azure/core-https': 1.0.0-beta.1
+      '@azure/core-tracing': 1.0.0-preview.9
+      '@opentelemetry/api': 0.10.2
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-RGCqdHGtYepkfD5EG5DtgBpCcF4D/ZEfL7CaHfgFYsumCh0/xb0/bbe1g5LBKNPSnDBbrk8KJRzi+5rvGYdUPw==
   /@azure/core-http/1.2.2:
     dependencies:
       '@azure/abort-controller': 1.0.2
@@ -139,6 +152,22 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-9eu2OcbR7e44gqBy4U1Uv8NTWgLIMwKXMEGgO2MahsJy5rdTiAhs5fJHQffPq8uX2MFh21iBODwO9R/Xlov88A==
+  /@azure/core-https/1.0.0-beta.1:
+    dependencies:
+      '@azure/abort-controller': 1.0.2
+      '@azure/core-auth': 1.1.4
+      '@azure/core-tracing': 1.0.0-preview.9
+      '@azure/logger': 1.0.1
+      '@opentelemetry/api': 0.10.2
+      form-data: 3.0.0
+      https-proxy-agent: 5.0.0
+      tslib: 2.1.0
+      uuid: 8.3.2
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-LN1z3/6VeBdebO4vn251wz/gmWXZVw3DAjFz340ft+mWAj+NA/c5JaqJw+Dt9CCpm6i/1IvsUkNo3IvxZnVOiA==
   /@azure/core-lro/1.0.3:
     dependencies:
       '@azure/abort-controller': 1.0.2
@@ -168,6 +197,15 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==
+  /@azure/core-xml/1.0.0-beta.1:
+    dependencies:
+      tslib: 2.1.0
+      xml2js: 0.4.23
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7d2w0yd8pb1c9aj87JV/1ntOp+sCMcJ9QoGDxs6/7BLDh8Gb6kd2h3n+9JYhcLZO8wdHZb4d4GZgmRIwaAU72w==
   /@azure/event-hubs/2.1.4:
     dependencies:
       '@azure/amqp-common': 1.0.0-preview.9
@@ -8119,7 +8157,9 @@ packages:
     version: 0.0.0
   file:projects/core-client.tgz:
     dependencies:
+      '@azure/core-https': 1.0.0-beta.1
       '@azure/core-tracing': 1.0.0-preview.9
+      '@azure/core-xml': 1.0.0-beta.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8163,7 +8203,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-GEDUVu5+Gb8KSf69l5KJJDJywqK7iB/3QhBnPEpMQKD/OVzE6X7Grl+q5Nd+mnvH64KdAFHAdM7yZEolmOuU4Q==
+      integrity: sha512-ALQT28Gbi9dPhiU7UbPw2jf3KBq+wfzF6zZWFnIFyZshCcV54uTK/Os83IH3Rt3CdFiPo5+m/hdvIiF4Hd2nFg==
       tarball: file:projects/core-client.tgz
     version: 0.0.0
   file:projects/core-crypto.tgz:
@@ -8536,7 +8576,10 @@ packages:
     version: 0.0.0
   file:projects/data-tables.tgz:
     dependencies:
+      '@azure/core-client': 1.0.0-beta.1
+      '@azure/core-https': 1.0.0-beta.1
       '@azure/core-tracing': 1.0.0-preview.9
+      '@azure/core-xml': 1.0.0-beta.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8587,7 +8630,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-98utrWzotoU5BZMIgQyQYTCY6wcIJzEvEWRSG3sNGqsYmgZfnu3A7gdRUv6JCZujybxzDmcK+FLeVFpG2EDsyg==
+      integrity: sha512-m3hHFly6ovHcHiyvPoQC8OUWj3NQxxigI1j6BwX/5zenfRzKIgcgTLqgYfC90O/s6FJ1LgrkWdN9rx9T6pScvw==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -8839,6 +8882,8 @@ packages:
     version: 0.0.0
   file:projects/eventgrid.tgz:
     dependencies:
+      '@azure/core-client': 1.0.0-beta.1
+      '@azure/core-https': 1.0.0-beta.1
       '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -8891,7 +8936,7 @@ packages:
     dev: false
     name: '@rush-temp/eventgrid'
     resolution:
-      integrity: sha512-QsaxrEh4UebbcyeKK72MUE+pWx0yzgnZH7yImYzXQ7l74LjladtcHzX6qYhjc2s4Dqk2oeQJFP1sD/zZrHwoAA==
+      integrity: sha512-5bn0BXziMTpMBsY07U2lhVnTV43YD8BaE76RSU/9yZ+ttNr4QD4kxqXK0VL3blrg6sAAGtq9H4A9dcskWzTCjg==
       tarball: file:projects/eventgrid.tgz
     version: 0.0.0
   file:projects/eventhubs-checkpointstore-blob.tgz:
@@ -9683,6 +9728,7 @@ packages:
     version: 0.0.0
   file:projects/storage-blob.tgz:
     dependencies:
+      '@azure/core-https': 1.0.0-beta.1
       '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -9737,7 +9783,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-jDs4XxgDDdU5a4SvCOQGoW2vZqeCVbbR/jJl442IXqYHYYEZRK/ToiTCHmSRl3tBmvqHNqvVz4GLDK+EtWRcTA==
+      integrity: sha512-Y5eO2dJze6mrzpq31hgys53/C2KYe7JGGiiasluVq+gcoqLU6yBo/UE1ad6WgoK+I2Y7EzY2LjrO1kXE2O38yQ==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
 ## 1.0.0-beta.1 (2021-02-04)
 
 - First release of package, see README.md for details.

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -40,7 +40,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o coreClient-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test:browser && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -42,7 +42,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
         credential: TokenCredential;
     };
     deserializationOptions?: DeserializationPolicyOptions;
-    serializationOptions?: serializationPolicyOptions;
+    serializationOptions?: SerializationPolicyOptions;
 }
 
 // @public (undocumented)
@@ -309,13 +309,13 @@ export interface SequenceMapperType {
 }
 
 // @public
-export function serializationPolicy(options?: serializationPolicyOptions): PipelinePolicy;
+export function serializationPolicy(options?: SerializationPolicyOptions): PipelinePolicy;
 
 // @public
 export const serializationPolicyName = "serializationPolicy";
 
 // @public
-export interface serializationPolicyOptions {
+export interface SerializationPolicyOptions {
     serializerOptions?: SerializerOptions;
     stringifyXML?: (obj: any, opts?: XmlOptions) => string;
 }

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -184,9 +184,9 @@ async function deserializeResponseBody(
           valueToDeserialize,
           "operationRes.parsedBody"
         );
-      } catch (error) {
+      } catch (deserializeError) {
         const restError = new RestError(
-          `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
+          `Error ${deserializeError} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
           {
             statusCode: parsedResponse.status,
             request: parsedResponse.request,

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -54,5 +54,5 @@ export {
 export {
   serializationPolicy,
   serializationPolicyName,
-  serializationPolicyOptions
+  SerializationPolicyOptions
 } from "./serializationPolicy";

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -28,7 +28,7 @@ export const serializationPolicyName = "serializationPolicy";
 /**
  * Options to configure API request serialization.
  */
-export interface serializationPolicyOptions {
+export interface SerializationPolicyOptions {
   /**
    * A function that is able to write XML. Required for XML support.
    */
@@ -44,7 +44,7 @@ export interface serializationPolicyOptions {
  * This policy handles assembling the request body and headers using
  * an OperationSpec and OperationArguments on the request.
  */
-export function serializationPolicy(options: serializationPolicyOptions = {}): PipelinePolicy {
+export function serializationPolicy(options: SerializationPolicyOptions = {}): PipelinePolicy {
   const stringifyXML = options.stringifyXML;
 
   return {
@@ -66,7 +66,7 @@ function serializeHeaders(
   request: OperationRequest,
   operationArguments: OperationArguments,
   operationSpec: OperationSpec
-) {
+): void {
   if (operationSpec.headerParameters) {
     for (const headerParameter of operationSpec.headerParameters) {
       let headerValue = getOperationArgumentValueFromParameter(operationArguments, headerParameter);

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -817,7 +817,7 @@ function getXmlObjectValue(
   serializedValue: any,
   isXml: boolean,
   options: RequiredSerializerOptions
-) {
+): any {
   if (!isXml || !propertyMapper.xmlNamespace) {
     return serializedValue;
   }

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -26,7 +26,7 @@ import { getRequestUrl } from "./urlHelpers";
 import { isPrimitiveType } from "./utils";
 import { deserializationPolicy, DeserializationPolicyOptions } from "./deserializationPolicy";
 import { URL } from "./url";
-import { serializationPolicy, serializationPolicyOptions } from "./serializationPolicy";
+import { serializationPolicy, SerializationPolicyOptions } from "./serializationPolicy";
 import { getCachedDefaultHttpsClient } from "./httpClientCache";
 import { getOperationRequestInfo } from "./operationHelpers";
 
@@ -124,7 +124,7 @@ export class ServiceClient {
 
   /**
    * Send an HTTP request that is populated using the provided OperationSpec.
-   * @typeParam T The typed result of the request, based on the OperationSpec.
+   * @typeParam T - The typed result of the request, based on the OperationSpec.
    * @param operationArguments - The arguments that the HTTP request's templated values will be populated from.
    * @param operationSpec - The OperationSpec to use to populate the httpRequest.
    */
@@ -261,7 +261,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
   /**
    * Options to customize serializationPolicy.
    */
-  serializationOptions?: serializationPolicyOptions;
+  serializationOptions?: SerializationPolicyOptions;
 }
 
 /**

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -7,7 +7,7 @@
  * @param value - Value to test
  * @hidden @internal
  */
-export function isPrimitiveType(value: any): boolean {
+export function isPrimitiveType(value: unknown): boolean {
   return (typeof value !== "object" && typeof value !== "function") || value === null;
 }
 

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -271,7 +271,7 @@ describe("ServiceClient", function() {
 
     let rawResponse: FullOperationResponse | undefined;
 
-    const response = await client.sendOperationRequest(
+    const operationResponse = await client.sendOperationRequest(
       { options: { onResponse: (response) => (rawResponse = response) } },
       {
         httpMethod: "GET",
@@ -285,7 +285,7 @@ describe("ServiceClient", function() {
     );
 
     assert(request!);
-    assert.strictEqual(JSON.stringify(response), "{}");
+    assert.strictEqual(JSON.stringify(operationResponse), "{}");
     assert.strictEqual(rawResponse?.status, 200);
     assert.strictEqual(rawResponse?.request, request!);
     assert.strictEqual(rawResponse?.headers.get("X-Extra-Info"), "foo");

--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
 ## 1.0.0-beta.1 (2021-02-04)
 
 - Changes from `core-http`:

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -45,7 +45,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o coreHttps-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test:browser && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-https",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Isomorphic client library for making HTTPS requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-https/src/constants.ts
+++ b/sdk/core/core-https/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0-beta.1";
+export const SDK_VERSION: string = "1.0.0-beta.2";

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -39,6 +39,8 @@ function isArrayBuffer(body: any): body is ArrayBuffer | ArrayBufferView {
 class ReportTransform extends Transform {
   private loadedBytes = 0;
   private progressCallback: (progress: TransferProgressEvent) => void;
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
   _transform(chunk: string | Buffer, _encoding: string, callback: Function): void {
     this.push(chunk);
     this.loadedBytes += chunk.length;
@@ -127,7 +129,7 @@ export class NodeHttpsClient implements HttpsClient {
             request
           };
 
-          let responseStream = shouldDecompress ? getDecodedResponseStream(res, headers) : res;
+          responseStream = shouldDecompress ? getDecodedResponseStream(res, headers) : res;
 
           const onDownloadProgress = request.onDownloadProgress;
           if (onDownloadProgress) {

--- a/sdk/core/core-https/src/pipeline.ts
+++ b/sdk/core/core-https/src/pipeline.ts
@@ -182,11 +182,11 @@ class HttpsPipeline implements Pipeline {
 
     const pipeline = policies.reduceRight<SendRequest>(
       (next, policy) => {
-        return (request: PipelineRequest) => {
-          return policy.sendRequest(request, next);
+        return (req: PipelineRequest) => {
+          return policy.sendRequest(req, next);
         };
       },
-      (request: PipelineRequest) => httpsClient.sendRequest(request)
+      (req: PipelineRequest) => httpsClient.sendRequest(req)
     );
 
     return pipeline(request);
@@ -346,7 +346,7 @@ class HttpsPipeline implements Pipeline {
       }
     }
 
-    function walkPhases() {
+    function walkPhases(): void {
       let noPhaseRan = false;
 
       for (const phase of orderedPhases) {

--- a/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -34,10 +34,10 @@ export function bearerTokenAuthenticationPolicy(
 ): PipelinePolicy {
   const { credential, scopes } = options;
   const tokenCache: AccessTokenCache = new ExpiringAccessTokenCache();
-  async function getToken(options: GetTokenOptions): Promise<string | undefined> {
+  async function getToken(tokenOptions: GetTokenOptions): Promise<string | undefined> {
     let accessToken = tokenCache.getCachedToken();
     if (accessToken === undefined) {
-      accessToken = (await credential.getToken(scopes, options)) || undefined;
+      accessToken = (await credential.getToken(scopes, tokenOptions)) || undefined;
       tokenCache.setCachedToken(accessToken);
     }
 

--- a/sdk/core/core-https/src/util/sanitizer.ts
+++ b/sdk/core/core-https/src/util/sanitizer.ts
@@ -91,7 +91,7 @@ export class Sanitizer {
     this.allowedQueryParameters = new Set(allowedQueryParameters.map((p) => p.toLowerCase()));
   }
 
-  public sanitize(obj: object): string {
+  public sanitize(obj: unknown): string {
     return JSON.stringify(obj, this.replacer.bind(this), 2);
   }
 

--- a/sdk/core/core-https/src/xhrHttpsClient.ts
+++ b/sdk/core/core-https/src/xhrHttpsClient.ts
@@ -93,7 +93,7 @@ function handleBlobResponse(
   request: PipelineRequest,
   res: (value: PipelineResponse | PromiseLike<PipelineResponse>) => void,
   rej: (reason?: any) => void
-) {
+): void {
   xhr.addEventListener("readystatechange", () => {
     // Resolve as soon as headers are loaded
     if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
 ## 1.0.0-beta.1 (2021-02-04)
 
 - First release of package. Exported XML helpers for client packages that need XML support, see README.md for details.

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Among other things this PR is a replacement for #13615 after including changes from running `rush update --recheck`.
Rest of the changes are to fix linter errors in core-client and core-https packages, and enabling further regressions to break the build

Related to https://github.com/Azure/azure-sdk-for-js/issues/10775