### PR TITLE
[Synapse] Update changelog, remove Library

### DIFF
--- a/sdk/synapse/synapse-access-control/CHANGELOG.md
+++ b/sdk/synapse/synapse-access-control/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-02-09)
 
+- Regenerated from the latest REST API
+- Fixed typo in the README example
+- Updated `createRoleAssignment` input types
 
 ## 1.0.0-beta.1 (2020-12-09)
 

--- a/sdk/synapse/synapse-artifacts/CHANGELOG.md
+++ b/sdk/synapse/synapse-artifacts/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-02-09)
 
+- Regenerated from the latest REST API
 
 ## 1.0.0-beta.1 (2020-12-09)
 

--- a/sdk/synapse/synapse-artifacts/review/synapse-artifacts.api.md
+++ b/sdk/synapse/synapse-artifacts/review/synapse-artifacts.api.md
@@ -180,8 +180,6 @@ export class ArtifactsClient extends ArtifactsClientContext {
     // (undocumented)
     integrationRuntimes: IntegrationRuntimesOperation;
     // (undocumented)
-    library: LibraryOperation;
-    // (undocumented)
     linkedService: LinkedServiceOperation;
     // (undocumented)
     notebook: NotebookOperation;
@@ -4075,17 +4073,6 @@ export interface LibraryListResponse {
     nextLink?: string;
     value: LibraryResource[];
 }
-
-// @public
-export class LibraryOperation {
-    constructor(client: ArtifactsClient);
-    createOrAppend(libraryName: string, content: coreHttp.HttpRequestBody, options?: LibraryCreateOrAppendOptionalParams): Promise<LROPoller<coreHttp.RestResponse>>;
-    delete(libraryName: string, options?: coreHttp.OperationOptions): Promise<LROPoller<coreHttp.RestResponse>>;
-    flush(libraryName: string, options?: coreHttp.OperationOptions): Promise<LROPoller<coreHttp.RestResponse>>;
-    get(libraryName: string, options?: coreHttp.OperationOptions): Promise<LibraryGetResponse>;
-    getOperationResult(operationId: string, options?: coreHttp.OperationOptions): Promise<LibraryGetOperationResultResponse>;
-    list(options?: coreHttp.OperationOptions): PagedAsyncIterableIterator<LibraryResource>;
-    }
 
 // @public
 export interface LibraryRequirements {

--- a/sdk/synapse/synapse-artifacts/src/artifactsClient.ts
+++ b/sdk/synapse/synapse-artifacts/src/artifactsClient.ts
@@ -17,7 +17,6 @@ import {
   SqlPools,
   BigDataPools,
   IntegrationRuntimes,
-  Library,
   WorkspaceGitRepoManagement
 } from "./operations";
 import { ArtifactsClientContext } from "./artifactsClientContext";
@@ -52,7 +51,6 @@ export class ArtifactsClient extends ArtifactsClientContext {
     this.sqlPools = new SqlPools(this);
     this.bigDataPools = new BigDataPools(this);
     this.integrationRuntimes = new IntegrationRuntimes(this);
-    this.library = new Library(this);
     this.workspaceGitRepoManagement = new WorkspaceGitRepoManagement(this);
   }
 
@@ -71,6 +69,5 @@ export class ArtifactsClient extends ArtifactsClientContext {
   sqlPools: SqlPools;
   bigDataPools: BigDataPools;
   integrationRuntimes: IntegrationRuntimes;
-  library: Library;
   workspaceGitRepoManagement: WorkspaceGitRepoManagement;
 }

--- a/sdk/synapse/synapse-artifacts/src/index.ts
+++ b/sdk/synapse/synapse-artifacts/src/index.ts
@@ -34,6 +34,5 @@ export {
   Pipeline as PipelineOperation,
   Notebook as NotebookOperation,
   LinkedService as LinkedServiceOperation,
-  IntegrationRuntimes as IntegrationRuntimesOperation,
-  Library as LibraryOperation
+  IntegrationRuntimes as IntegrationRuntimesOperation
 } from "./operations";

--- a/sdk/synapse/synapse-managed-private-endpoints/CHANGELOG.md
+++ b/sdk/synapse/synapse-managed-private-endpoints/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-02-09)
 
+- Regenerated from the latest REST API
 
 ## 1.0.0-beta.1 (2020-12-09)
 

--- a/sdk/synapse/synapse-monitoring/CHANGELOG.md
+++ b/sdk/synapse/synapse-monitoring/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-02-09)
 
+- Regenerated from the latest REST API
 
 ## 1.0.0-beta.1 (2020-12-09)
 

--- a/sdk/synapse/synapse-spark/CHANGELOG.md
+++ b/sdk/synapse/synapse-spark/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2021-02-09)
 
+- Regenerated from the latest REST API
+- Added Spark example to README
 
 ## 1.0.0-beta.1 (2020-12-09)
 


### PR DESCRIPTION
Gets the changelogs ready for release. Also removes the Library functionality from artifacts at the request of the service team.