### PR TITLE
[KeyVault] Bump KeyVault versions after release

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.0.0-beta.3 (Unreleased)
+
 ## 4.0.0-beta.2 (2021-02-09)
 
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.0.0-beta.2";
+export const SDK_VERSION: string = "4.0.0-beta.3";
 
 /**
  * The latest supported Key Vault service API version.

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-admin";
-export const packageVersion = "4.0.0-beta.2";
+export const packageVersion = "4.0.0-beta.3";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.2.0-beta.3 (Unreleased)
+
 ## 4.2.0-beta.2 (2021-02-09)
 
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
@@ -17,13 +19,13 @@
 
 ### Changes since 4.0.2
 
-- Added the optional `serviceVersion` property to the `CertificateClient` optional parameters to control the version of the Key Vault service being used by the client. 
-    - It defaults to the latest supported API version, which currently is `7.1`.
-    - Other supported service version at the moment is `7.0`.
+- Added the optional `serviceVersion` property to the `CertificateClient` optional parameters to control the version of the Key Vault service being used by the client.
+  - It defaults to the latest supported API version, which currently is `7.1`.
+  - Other supported service version at the moment is `7.0`.
 - Added `recoverableDays` as an optional property to `CertificateProperties` which denotes the number of days in which the certificate can be recovered after deletion. This is only applicable for Azure Key Vaults with the soft-delete setting enabled.
 - Now using `Poller` and `PollerLike` from the latest `@azure/core-lro` instead of `KVPoller` and `KVPollerLike`.
-    - `KVPollerLike` is now an alias of `PollerLike`.
-    - `KVPollerLike` is considered deprecated. Use `PollerLike`.
+  - `KVPollerLike` is now an alias of `PollerLike`.
+  - `KVPollerLike` is considered deprecated. Use `PollerLike`.
 - If the policy in the options has contentType `application/x-pem-file` when using the `importCertificate`
   method, we now encode the bytes of the certificate as an ASCII string instead of base64 which is the default
   treatment. This is to fix [bug 7407](https://github.com/Azure/azure-sdk-for-js/issues/7407)

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-certificates",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.2.0-beta.2",
+  "version": "4.2.0-beta.3",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/README.md",

--- a/sdk/keyvault/keyvault-certificates/src/constants.ts
+++ b/sdk/keyvault/keyvault-certificates/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.2.0-beta.2";
+export const SDK_VERSION: string = "4.2.0-beta.3";

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion72Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-certificates";
-export const packageVersion = "4.2.0-beta.2";
+export const packageVersion = "4.2.0-beta.3";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.2.0-beta.4 (Unreleased)
+
 ## 4.2.0-beta.3 (2021-02-09)
 
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.2.0-beta.3",
+  "version": "4.2.0-beta.4",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/constants.ts
+++ b/sdk/keyvault/keyvault-keys/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.2.0-beta.3";
+export const SDK_VERSION: string = "4.2.0-beta.4";

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion72Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-keys";
-export const packageVersion = "4.2.0-beta.3";
+export const packageVersion = "4.2.0-beta.4";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.2.0-beta.3 (Unreleased)
+
 ## 4.2.0-beta.2 (2021-02-09)
 
 - [Breaking] Removed `dist-browser` from the published package. To bundle the Azure SDK libraries for the browsers, please read our bundling guide: [link](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
@@ -17,8 +19,8 @@
 ### Changes since 4.0.4
 
 - Added the optional `serviceVersion` property to the `SecretClient` optional parameters to control the version of the Key Vault service being used by the client.
-    - It defaults to the latest supported API version, which currently is `7.1`.
-    - Other supported service version at the moment is `7.0`.
+  - It defaults to the latest supported API version, which currently is `7.1`.
+  - Other supported service version at the moment is `7.0`.
 - Added `recoverableDays` as an optional property to `SecretProperties` which denotes the number of days in which the secret can be recovered after deletion. This is only applicable for Azure Key Vaults with the soft-delete setting enabled.
 
 ### Changes since 4.1.0-preview.1

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-secrets",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.2.0-beta.2",
+  "version": "4.2.0-beta.3",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's secrets.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/README.md",

--- a/sdk/keyvault/keyvault-secrets/src/constants.ts
+++ b/sdk/keyvault/keyvault-secrets/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.2.0-beta.2";
+export const SDK_VERSION: string = "4.2.0-beta.3";

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion72Preview, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-secrets";
-export const packageVersion = "4.2.0-beta.2";
+export const packageVersion = "4.2.0-beta.3";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {


### PR DESCRIPTION
azure-sdk bot opened a PR bumping all the versions after release (#13713) 

But something isn't quite right, so while we investigate the issue with engSys I 
am opening this PR where I manually bumped the versions.