### PR TITLE
[Storage] Update param, returns tags to follow TSDoc

### DIFF
--- a/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
+++ b/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
@@ -51,7 +51,7 @@ export class BlobChangeFeedEventPage {
  * @export
  * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
  * @param pipelineOptions - Optional. Options.
- * @returnsA new Pipeline object.
+ * @returns A new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
@@ -323,7 +323,7 @@ export class BlobChangeFeedClient {
    * ```
    *
    * @param options - Options to list change feed events.
-   * @returnsAn asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    * @memberof BlobChangeFeedClient
    */
   public listChanges(

--- a/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
+++ b/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
@@ -49,9 +49,9 @@ export class BlobChangeFeedEventPage {
  * Creates a new Pipeline object with Credential provided.
  *
  * @export
- * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
- * @param {StoragePipelineOptions} [pipelineOptions] Optional. Options.
- * @returns {Pipeline} A new Pipeline object.
+ * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+ * @param pipelineOptions - Optional. Options.
+ * @returnsA new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
@@ -99,13 +99,13 @@ export class BlobChangeFeedClient {
    *
    * Creates an instance of BlobChangeFeedClient from connection string.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobChangeFeedClient
    */
   public static fromConnectionString(
@@ -123,11 +123,11 @@ export class BlobChangeFeedClient {
   /**
    * Creates an instance of BlobChangeFeedClient.
    *
-   * @param {string} url A Client string pointing to Azure Storage blob service, such as
+   * @param url - A Client string pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobChangeFeedClient
    *
    * Example using DefaultAzureCredential from `@azure/identity`:
@@ -164,10 +164,10 @@ export class BlobChangeFeedClient {
   /**
    * Creates an instance of BlobChangeFeedClient.
    *
-   * @param {string} url A Client string pointing to Azure Storage blob service, such as
+   * @param url - A Client string pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof BlobChangeFeedClient
    */
@@ -322,8 +322,8 @@ export class BlobChangeFeedClient {
    * }
    * ```
    *
-   * @param {BlobChangeFeedListChangesOptions} [options={}] Options to list change feed events.
-   * @returns {PagedAsyncIterableIterator<BlobChangeFeedEvent, BlobChangeFeedEventPage>} An asyncIterableIterator that supports paging.
+   * @param options - Options to list change feed events.
+   * @returnsAn asyncIterableIterator that supports paging.
    * @memberof BlobChangeFeedClient
    */
   public listChanges(

--- a/sdk/storage/storage-blob-changefeed/src/LazyLoadingBlobStream.ts
+++ b/sdk/storage/storage-blob-changefeed/src/LazyLoadingBlobStream.ts
@@ -70,7 +70,7 @@ export class LazyLoadingBlobStream extends Readable {
   /**
    * Creates an instance of LazyLoadingBlobStream.
    *
-   * @param {number} byteLength The total length of data contained in the buffers
+   * @param byteLength - The total length of data contained in the buffers
    * @memberof LazyLoadingBlobStream
    */
   constructor(
@@ -129,7 +129,7 @@ export class LazyLoadingBlobStream extends Readable {
   /**
    * Internal _read() that will be called when the stream wants to pull more data in.
    *
-   * @param {number} size Optional. The size of data to be read
+   * @param size - Optional. The size of data to be read
    * @memberof LazyLoadingBlobStream
    */
   public async _read(size?: number) {

--- a/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
@@ -26,8 +26,8 @@ export function floorToNearestHour(date: Date | undefined): Date | undefined {
  * Get host from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getHost(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -38,8 +38,8 @@ export function getHost(url: string): string | undefined {
  * Get URI from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURI(url: string): string {
   const urlParsed = URLBuilder.parse(url);

--- a/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
@@ -79,7 +79,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returnsThe access token details.
+   * @returns The access token details.
    */
   async getToken(
     _scopes: string | string[],

--- a/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
@@ -67,7 +67,7 @@ export class SimpleTokenCredential implements TokenCredential {
 
   /**
    * Creates an instance of TokenCredential.
-   * @param {string} token
+   * @param token -
    */
   constructor(token: string, expiresOn?: Date) {
     this.token = token;
@@ -79,7 +79,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returns {AccessToken} The access token details.
+   * @returnsThe access token details.
    */
   async getToken(
     _scopes: string | string[],
@@ -138,8 +138,8 @@ export function isSuperSet(m1?: BlobMetadata, m2?: BlobMetadata): boolean {
  * Sleep for seconds.
  *
  * @export
- * @param {number} seconds
- * @returns {Promise<void>}
+ * @param seconds -
+ *
  */
 export function sleep(seconds: number): Promise<void> {
   return new Promise((resolve) => {
@@ -151,10 +151,10 @@ export function sleep(seconds: number): Promise<void> {
  * String.prototype.padStart()
  *
  * @export
- * @param {string} currentString
- * @param {number} targetLength
- * @param {string} [padString=" "]
- * @returns {string}
+ * @param currentString -
+ * @param targetLength -
+ * @param [padString=" - "]
+ *
  */
 export function padStart(
   currentString: string,

--- a/sdk/storage/storage-blob/src/BlobBatch.ts
+++ b/sdk/storage/storage-blob/src/BlobBatch.ts
@@ -128,10 +128,10 @@ export class BlobBatch {
    * The operation will be authenticated and authorized with specified credential.
    * See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {string} url The url of the blob resource to delete.
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {BlobDeleteOptions} [options]
-   * @returns {Promise<void>}
+   * @param url - The url of the blob resource to delete.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options -
+   *
    * @memberof BlobBatch
    */
   public async deleteBlob(
@@ -150,9 +150,9 @@ export class BlobBatch {
    * The operation will be authenticated and authorized with specified credential.
    * See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {BlobClient} blobClient The BlobClient.
-   * @param {BlobDeleteOptions} [options]
-   * @returns {Promise<void>}
+   * @param blobClient - The BlobClient.
+   * @param options -
+   *
    * @memberof BlobBatch
    */
   public async deleteBlob(blobClient: BlobClient, options?: BlobDeleteOptions): Promise<void>;
@@ -236,11 +236,11 @@ export class BlobBatch {
    * The operation will be authenticated and authorized
    * with specified credential. See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {string} url The url of the blob resource to delete.
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {AccessTier} tier
-   * @param {BlobSetTierOptions} [options]
-   * @returns {Promise<void>}
+   * @param url - The url of the blob resource to delete.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param tier -
+   * @param options -
+   *
    * @memberof BlobBatch
    */
   public async setBlobAccessTier(
@@ -262,10 +262,10 @@ export class BlobBatch {
    * The operation will be authenticated and authorized
    * with specified credential. See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {BlobClient} blobClient The BlobClient.
-   * @param {AccessTier} tier
-   * @param {BlobSetTierOptions} [options]
-   * @returns {Promise<void>}
+   * @param blobClient - The BlobClient.
+   * @param tier -
+   * @param options -
+   *
    * @memberof BlobBatch
    */
   public async setBlobAccessTier(
@@ -389,7 +389,7 @@ class InnerBatchRequest {
    * credential and serialization/deserialization components, with additional policies to
    * filter unnecessary headers, assemble sub requests into request's body
    * and intercept request from going to wire.
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
    */
   public createPipeline(
     credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -80,11 +80,11 @@ export class BlobBatchClient {
   /**
    * Creates an instance of BlobBatchClient.
    *
-   * @param {string} url A url pointing to Azure Storage blob service, such as
+   * @param url - A url pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Options to configure the HTTP pipeline.
    * @memberof BlobBatchClient
    */
   constructor(
@@ -95,10 +95,10 @@ export class BlobBatchClient {
   /**
    * Creates an instance of BlobBatchClient.
    *
-   * @param {string} url A url pointing to Azure Storage blob service, such as
+   * @param url - A url pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof BlobBatchClient
    */
@@ -148,10 +148,10 @@ export class BlobBatchClient {
    * The operations will be authenticated and authorized with specified credential.
    * See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {string[]} urls The urls of the blob resources to delete.
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {BlobDeleteOptions} [options]
-   * @returns {Promise<BlobBatchDeleteBlobsResponse>}
+   * @param urls - The urls of the blob resources to delete.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options -
+   *
    * @memberof BlobBatchClient
    */
   public async deleteBlobs(
@@ -167,9 +167,9 @@ export class BlobBatchClient {
    * The operation(subrequest) will be authenticated and authorized with specified credential.
    * See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {BlobClient[]} blobClients The BlobClients for the blobs to delete.
-   * @param {BlobDeleteOptions} [options]
-   * @returns {Promise<BlobBatchDeleteBlobsResponse>}
+   * @param blobClients - The BlobClients for the blobs to delete.
+   * @param options -
+   *
    * @memberof BlobBatchClient
    */
   public async deleteBlobs(
@@ -209,11 +209,11 @@ export class BlobBatchClient {
    * The operation(subrequest) will be authenticated and authorized
    * with specified credential.See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {string[]} urls The urls of the blob resource to delete.
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {AccessTier} tier
-   * @param {BlobSetTierOptions} [options]
-   * @returns {Promise<BlobBatchSetBlobsAccessTierResponse>}
+   * @param urls - The urls of the blob resource to delete.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param tier -
+   * @param options -
+   *
    * @memberof BlobBatchClient
    */
   public async setBlobsAccessTier(
@@ -234,10 +234,10 @@ export class BlobBatchClient {
    * The operation(subrequest) will be authenticated and authorized
    * with specified credential.See [blob batch authorization details](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#authorization).
    *
-   * @param {BlobClient[]} blobClients The BlobClients for the blobs which should have a new tier set.
-   * @param {AccessTier} tier
-   * @param {BlobSetTierOptions} [options]
-   * @returns {Promise<BlobBatchSetBlobsAccessTierResponse>}
+   * @param blobClients - The BlobClients for the blobs which should have a new tier set.
+   * @param tier -
+   * @param options -
+   *
    * @memberof BlobBatchClient
    */
   public async setBlobsAccessTier(
@@ -308,9 +308,9 @@ export class BlobBatchClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *
-   * @param {BlobBatch} batchRequest A set of Delete or SetTier operations.
-   * @param {BlobBatchSubmitBatchOptionalParams} [options]
-   * @returns {Promise<BlobBatchSubmitBatchResponse>}
+   * @param batchRequest - A set of Delete or SetTier operations.
+   * @param options -
+   *
    * @memberof BlobBatchClient
    */
   public async submitBatch(

--- a/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
@@ -572,11 +572,11 @@ export class BlobDownloadResponse implements BlobDownloadResponseParsed {
   /**
    * Creates an instance of BlobDownloadResponse.
    *
-   * @param {BlobDownloadResponseParsed} originalResponse
-   * @param {ReadableStreamGetter} getter
-   * @param {number} offset
-   * @param {number} count
-   * @param {RetriableReadableStreamOptions} [options={}]
+   * @param originalResponse -
+   * @param getter -
+   * @param offset -
+   * @param count -
+   * @param options -
    * @memberof BlobDownloadResponse
    */
   public constructor(

--- a/sdk/storage/storage-blob/src/BlobLeaseClient.ts
+++ b/sdk/storage/storage-blob/src/BlobLeaseClient.ts
@@ -174,7 +174,7 @@ export class BlobLeaseClient {
    *
    * @param duration - Must be between 15 to 60 seconds, or infinite (-1)
    * @param options - option to configure lease management operations.
-   * @returnsResponse data for acquire lease operation.
+   * @returns Response data for acquire lease operation.
    * @memberof BlobLeaseClient
    */
   public async acquireLease(
@@ -227,7 +227,7 @@ export class BlobLeaseClient {
    *
    * @param proposedLeaseId - the proposed new lease Id.
    * @param options - option to configure lease management operations.
-   * @returnsResponse data for change lease operation.
+   * @returns Response data for change lease operation.
    * @memberof BlobLeaseClient
    */
   public async changeLease(
@@ -281,7 +281,7 @@ export class BlobLeaseClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
    * @param options - option to configure lease management operations.
-   * @returnsResponse data for release lease operation.
+   * @returns Response data for release lease operation.
    * @memberof BlobLeaseClient
    */
   public async releaseLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -328,7 +328,7 @@ export class BlobLeaseClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
    * @param options - Optional option to configure lease management operations.
-   * @returnsResponse data for renew lease operation.
+   * @returns Response data for renew lease operation.
    * @memberof BlobLeaseClient
    */
   public async renewLease(options: LeaseOperationOptions = {}): Promise<Lease> {
@@ -375,7 +375,7 @@ export class BlobLeaseClient {
    * @static
    * @param breakPeriod - Break period
    * @param options - Optional options to configure lease management operations.
-   * @returnsResponse data for break lease operation.
+   * @returns Response data for break lease operation.
    * @memberof BlobLeaseClient
    */
   public async breakLease(

--- a/sdk/storage/storage-blob/src/BlobLeaseClient.ts
+++ b/sdk/storage/storage-blob/src/BlobLeaseClient.ts
@@ -139,8 +139,8 @@ export class BlobLeaseClient {
 
   /**
    * Creates an instance of BlobLeaseClient.
-   * @param {(ContainerClient | BlobClient)} client The client to make the lease operation requests.
-   * @param {string} leaseId Initial proposed lease id.
+   * @param client - The client to make the lease operation requests.
+   * @param leaseId - Initial proposed lease id.
    * @memberof BlobLeaseClient
    */
   constructor(client: ContainerClient | BlobClient, leaseId?: string) {
@@ -172,9 +172,9 @@ export class BlobLeaseClient {
    * and
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
-   * @param {number} duration Must be between 15 to 60 seconds, or infinite (-1)
-   * @param {LeaseOperationOptions} [options={}] option to configure lease management operations.
-   * @returns {Promise<LeaseOperationResponse>} Response data for acquire lease operation.
+   * @param duration - Must be between 15 to 60 seconds, or infinite (-1)
+   * @param options - option to configure lease management operations.
+   * @returnsResponse data for acquire lease operation.
    * @memberof BlobLeaseClient
    */
   public async acquireLease(
@@ -225,9 +225,9 @@ export class BlobLeaseClient {
    * and
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
-   * @param {string} proposedLeaseId the proposed new lease Id.
-   * @param {LeaseOperationOptions} [options={}] option to configure lease management operations.
-   * @returns {Promise<LeaseOperationResponse>} Response data for change lease operation.
+   * @param proposedLeaseId - the proposed new lease Id.
+   * @param options - option to configure lease management operations.
+   * @returnsResponse data for change lease operation.
    * @memberof BlobLeaseClient
    */
   public async changeLease(
@@ -280,8 +280,8 @@ export class BlobLeaseClient {
    * and
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
-   * @param {LeaseOperationOptions} [options={}] option to configure lease management operations.
-   * @returns {Promise<LeaseOperationResponse>} Response data for release lease operation.
+   * @param options - option to configure lease management operations.
+   * @returnsResponse data for release lease operation.
    * @memberof BlobLeaseClient
    */
   public async releaseLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -327,8 +327,8 @@ export class BlobLeaseClient {
    * and
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
-   * @param {LeaseOperationOptions} [options={}] Optional option to configure lease management operations.
-   * @returns {Promise<LeaseOperationResponse>} Response data for renew lease operation.
+   * @param options - Optional option to configure lease management operations.
+   * @returnsResponse data for renew lease operation.
    * @memberof BlobLeaseClient
    */
   public async renewLease(options: LeaseOperationOptions = {}): Promise<Lease> {
@@ -373,9 +373,9 @@ export class BlobLeaseClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
    *
    * @static
-   * @param {number} breakPeriod Break period
-   * @param {LeaseOperationOptions} [options={}] Optional options to configure lease management operations.
-   * @returns {Promise<LeaseOperationResponse>} Response data for break lease operation.
+   * @param breakPeriod - Break period
+   * @param options - Optional options to configure lease management operations.
+   * @returnsResponse data for break lease operation.
    * @memberof BlobLeaseClient
    */
   public async breakLease(

--- a/sdk/storage/storage-blob/src/BlobQueryResponse.browser.ts
+++ b/sdk/storage/storage-blob/src/BlobQueryResponse.browser.ts
@@ -486,8 +486,8 @@ export class BlobQueryResponse implements BlobDownloadResponseModel {
   /**
    * Creates an instance of BlobQueryResponse.
    *
-   * @param {BlobQueryResponseModel} originalResponse
-   * @param {BlobQuickQueryStreamOptions} [options={}]
+   * @param originalResponse -
+   * @param options -
    * @memberof BlobQueryResponse
    */
   public constructor(

--- a/sdk/storage/storage-blob/src/BlobQueryResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobQueryResponse.ts
@@ -489,8 +489,8 @@ export class BlobQueryResponse implements BlobDownloadResponseModel {
   /**
    * Creates an instance of BlobQueryResponse.
    *
-   * @param {BlobQueryResponseModel} originalResponse
-   * @param {BlobQuickQueryStreamOptions} [options={}]
+   * @param originalResponse -
+   * @param options -
    * @memberof BlobQueryResponse
    */
   public constructor(

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -639,7 +639,7 @@ export class BlobServiceClient extends StorageClient {
    * Creates a {@link ContainerClient} object
    *
    * @param containerName - A container name
-   * @returnsA new ContainerClient object for the given container name.
+   * @returns A new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
    *
    * Example usage:
@@ -660,7 +660,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @param containerName - Name of the container to create.
    * @param options - Options to configure Container Create operation.
-   * @returnsContainer creation response and the corresponding container client.
+   * @returns Container creation response and the corresponding container client.
    * @memberof BlobServiceClient
    */
   public async createContainer(
@@ -700,7 +700,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @param containerName - Name of the container to delete.
    * @param options - Options to configure Container Delete operation.
-   * @returnsContainer deletion response.
+   * @returns Container deletion response.
    * @memberof BlobServiceClient
    */
   public async deleteContainer(
@@ -735,7 +735,7 @@ export class BlobServiceClient extends StorageClient {
    * @param deletedContainerName - Name of the previously deleted container.
    * @param deletedContainerVersion - Version of the previously deleted container, used to uniquely identify the deleted container.
    * @param options - Options to configure Container Restore operation.
-   * @returnsContainer deletion response.
+   * @returns Container deletion response.
    * @memberof BlobServiceClient
    */
   public async undeleteContainer(
@@ -822,7 +822,7 @@ export class BlobServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties
    *
    * @param options - Options to the Service Get Properties operation.
-   * @returnsResponse data for the Service Get Properties operation.
+   * @returns Response data for the Service Get Properties operation.
    * @memberof BlobServiceClient
    */
   public async getProperties(
@@ -855,7 +855,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @param properties -
    * @param options - Options to the Service Set Properties operation.
-   * @returnsResponse data for the Service Set Properties operation.
+   * @returns Response data for the Service Set Properties operation.
    * @memberof BlobServiceClient
    */
   public async setProperties(
@@ -889,7 +889,7 @@ export class BlobServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats}
    *
    * @param options - Options to the Service Get Statistics operation.
-   * @returnsResponse data for the Service Get Statistics operation.
+   * @returns Response data for the Service Get Statistics operation.
    * @memberof BlobServiceClient
    */
   public async getStatistics(
@@ -923,7 +923,7 @@ export class BlobServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information
    *
    * @param options - Options to the Service Get Account Info operation.
-   * @returnsResponse data for the Service Get Account Info operation.
+   * @returns Response data for the Service Get Account Info operation.
    * @memberof BlobServiceClient
    */
   public async getAccountInfo(
@@ -961,7 +961,7 @@ export class BlobServiceClient extends StorageClient {
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
    * @param options - Options to the Service List Container Segment operation.
-   * @returnsResponse data for the Service List Container Segment operation.
+   * @returns Response data for the Service List Container Segment operation.
    * @memberof BlobServiceClient
    */
   private async listContainersSegment(
@@ -1352,7 +1352,7 @@ export class BlobServiceClient extends StorageClient {
    * ```
    *
    * @param options - Options to list containers.
-   * @returnsAn asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    * @memberof BlobServiceClient
    */
   public listContainers(
@@ -1473,7 +1473,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *
-   * @returnsA new BlobBatchClient object for this service.
+   * @returns A new BlobBatchClient object for this service.
    * @memberof BlobServiceClient
    */
   public getBlobBatchClient(): BlobBatchClient {
@@ -1492,7 +1492,7 @@ export class BlobServiceClient extends StorageClient {
    * @param permissions - Specifies the list of permissions to be associated with the SAS.
    * @param resourceTypes - Specifies the resource types associated with the shared access signature.
    * @param options - Optional parameters.
-   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof BlobServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -524,13 +524,13 @@ export class BlobServiceClient extends StorageClient {
    *
    * Creates an instance of BlobServiceClient from connection string.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
    */
   public static fromConnectionString(connectionString: string, options?: StoragePipelineOptions) {
@@ -561,11 +561,11 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Creates an instance of BlobServiceClient.
    *
-   * @param {string} url A Client string pointing to Azure Storage blob service, such as
+   * @param url - A Client string pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
    *
    * Example using DefaultAzureCredential from `@azure/identity`:
@@ -601,10 +601,10 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Creates an instance of BlobServiceClient.
    *
-   * @param {string} url A Client string pointing to Azure Storage blob service, such as
+   * @param url - A Client string pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof BlobServiceClient
    */
@@ -638,8 +638,8 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Creates a {@link ContainerClient} object
    *
-   * @param {string} containerName A container name
-   * @returns {ContainerClient} A new ContainerClient object for the given container name.
+   * @param containerName - A container name
+   * @returnsA new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
    *
    * Example usage:
@@ -658,9 +658,9 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Create a Blob container.
    *
-   * @param {string} containerName Name of the container to create.
-   * @param {ContainerCreateOptions} [options] Options to configure Container Create operation.
-   * @returns {Promise<{ containerClient: ContainerClient; containerCreateResponse: ContainerCreateResponse }>} Container creation response and the corresponding container client.
+   * @param containerName - Name of the container to create.
+   * @param options - Options to configure Container Create operation.
+   * @returnsContainer creation response and the corresponding container client.
    * @memberof BlobServiceClient
    */
   public async createContainer(
@@ -698,9 +698,9 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Deletes a Blob container.
    *
-   * @param {string} containerName Name of the container to delete.
-   * @param {ContainerDeleteMethodOptions} [options] Options to configure Container Delete operation.
-   * @returns {Promise<ContainerDeleteResponse>} Container deletion response.
+   * @param containerName - Name of the container to delete.
+   * @param options - Options to configure Container Delete operation.
+   * @returnsContainer deletion response.
    * @memberof BlobServiceClient
    */
   public async deleteContainer(
@@ -732,10 +732,10 @@ export class BlobServiceClient extends StorageClient {
    * Restore a previously deleted Blob container.
    * This API is only functional if Container Soft Delete is enabled for the storage account associated with the container.
    *
-   * @param {string} deletedContainerName Name of the previously deleted container.
-   * @param {string} deletedContainerVersion Version of the previously deleted container, used to uniquely identify the deleted container.
-   * @param {ServiceUndeleteContainerOptions} [options] Options to configure Container Restore operation.
-   * @returns {Promise<ContainerUndeleteResponse>} Container deletion response.
+   * @param deletedContainerName - Name of the previously deleted container.
+   * @param deletedContainerVersion - Version of the previously deleted container, used to uniquely identify the deleted container.
+   * @param options - Options to configure Container Restore operation.
+   * @returnsContainer deletion response.
    * @memberof BlobServiceClient
    */
   public async undeleteContainer(
@@ -777,9 +777,9 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Rename an existing Blob Container.
    *
-   * @param {string} sourceContainerName The name of the source container.
-   * @param {string} destinationContainerName The new name of the container.
-   * @param {ServiceRenameContainerOptions} [options] Options to configure Container Rename operation.
+   * @param sourceContainerName - The name of the source container.
+   * @param destinationContainerName - The new name of the container.
+   * @param options - Options to configure Container Rename operation.
    * @memberof BlobServiceClient
    */
   // @ts-ignore Need to hide this interface for now. Make it public and turn on the live tests for it when the service is ready.
@@ -821,8 +821,8 @@ export class BlobServiceClient extends StorageClient {
    * for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties
    *
-   * @param {ServiceGetPropertiesOptions} [options] Options to the Service Get Properties operation.
-   * @returns {Promise<ServiceGetPropertiesResponse>} Response data for the Service Get Properties operation.
+   * @param options - Options to the Service Get Properties operation.
+   * @returnsResponse data for the Service Get Properties operation.
    * @memberof BlobServiceClient
    */
   public async getProperties(
@@ -853,9 +853,9 @@ export class BlobServiceClient extends StorageClient {
    * for Storage Analytics, CORS (Cross-Origin Resource Sharing) rules and soft delete settings.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties}
    *
-   * @param {BlobServiceProperties} properties
-   * @param {ServiceSetPropertiesOptions} [options] Options to the Service Set Properties operation.
-   * @returns {Promise<ServiceSetPropertiesResponse>} Response data for the Service Set Properties operation.
+   * @param properties -
+   * @param options - Options to the Service Set Properties operation.
+   * @returnsResponse data for the Service Set Properties operation.
    * @memberof BlobServiceClient
    */
   public async setProperties(
@@ -888,8 +888,8 @@ export class BlobServiceClient extends StorageClient {
    * replication is enabled for the storage account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats}
    *
-   * @param {ServiceGetStatisticsOptions} [options] Options to the Service Get Statistics operation.
-   * @returns {Promise<ServiceGetStatisticsResponse>} Response data for the Service Get Statistics operation.
+   * @param options - Options to the Service Get Statistics operation.
+   * @returnsResponse data for the Service Get Statistics operation.
    * @memberof BlobServiceClient
    */
   public async getStatistics(
@@ -922,8 +922,8 @@ export class BlobServiceClient extends StorageClient {
    * with version 2018-03-28.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information
    *
-   * @param {ServiceGetAccountInfoOptions} [options] Options to the Service Get Account Info operation.
-   * @returns {Promise<ServiceGetAccountInfoResponse>} Response data for the Service Get Account Info operation.
+   * @param options - Options to the Service Get Account Info operation.
+   * @returnsResponse data for the Service Get Account Info operation.
    * @memberof BlobServiceClient
    */
   public async getAccountInfo(
@@ -953,15 +953,15 @@ export class BlobServiceClient extends StorageClient {
    * Returns a list of the containers under the specified account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2
    *
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                        the list of containers to be returned with the next listing operation. The
    *                        operation returns the continuationToken value within the response body if the
    *                        listing operation did not return all containers remaining to be listed
    *                        with the current page. The continuationToken value can be used as the value for
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
-   * @param {ServiceListContainersSegmentOptions} [options] Options to the Service List Container Segment operation.
-   * @returns {Promise<ServiceListContainersSegmentResponse>} Response data for the Service List Container Segment operation.
+   * @param options - Options to the Service List Container Segment operation.
+   * @returnsResponse data for the Service List Container Segment operation.
    * @memberof BlobServiceClient
    */
   private async listContainersSegment(
@@ -998,19 +998,19 @@ export class BlobServiceClient extends StorageClient {
    * storage account but can be scoped within the expression to a single container.
    *
    * @private
-   * @param {string} tagFilterSqlExpression The where parameter enables the caller to query blobs whose tags match a given expression.
+   * @param tagFilterSqlExpression - The where parameter enables the caller to query blobs whose tags match a given expression.
    *                                        The given expression must evaluate to true for a blob to be returned in the results.
    *                                        The[OData - ABNF] filter syntax rule defines the formal grammar for the value of the where query parameter;
    *                                        however, only a subset of the OData filter syntax is supported in the Blob service.
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list of blobs to be returned with the next listing operation. The
    *                          operation returns the continuationToken value within the response body if the
    *                          listing operation did not return all blobs remaining to be listed
    *                          with the current page. The continuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {ServiceFindBlobsByTagsSegmentOptions} [options={}] Options to find blobs by tags.
-   * @returns {Promise<ServiceFindBlobsByTagsSegmentResponse>}
+   * @param options - Options to find blobs by tags.
+   *
    * @memberof BlobServiceClient
    */
   private async findBlobsByTagsSegment(
@@ -1059,19 +1059,19 @@ export class BlobServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for ServiceFindBlobsByTagsSegmentResponse.
    *
    * @private
-   * @param {string} tagFilterSqlExpression  The where parameter enables the caller to query blobs whose tags match a given expression.
+   * @param tagFilterSqlExpression -  The where parameter enables the caller to query blobs whose tags match a given expression.
    *                                         The given expression must evaluate to true for a blob to be returned in the results.
    *                                         The[OData - ABNF] filter syntax rule defines the formal grammar for the value of the where query parameter;
    *                                         however, only a subset of the OData filter syntax is supported in the Blob service.
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list of blobs to be returned with the next listing operation. The
    *                          operation returns the continuationToken value within the response body if the
    *                          listing operation did not return all blobs remaining to be listed
    *                          with the current page. The continuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {ServiceFindBlobsByTagsSegmentOptions} [options={}] Options to find blobs by tags.
-   * @returns {AsyncIterableIterator<ServiceFindBlobsByTagsSegmentResponse>}
+   * @param options - Options to find blobs by tags.
+   *
    * @memberof BlobServiceClient
    */
   private async *findBlobsByTagsSegments(
@@ -1094,12 +1094,12 @@ export class BlobServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for blobs.
    *
    * @private
-   * @param {string} tagFilterSqlExpression  The where parameter enables the caller to query blobs whose tags match a given expression.
+   * @param tagFilterSqlExpression -  The where parameter enables the caller to query blobs whose tags match a given expression.
    *                                         The given expression must evaluate to true for a blob to be returned in the results.
    *                                         The[OData - ABNF] filter syntax rule defines the formal grammar for the value of the where query parameter;
    *                                         however, only a subset of the OData filter syntax is supported in the Blob service.
-   * @param {ServiceFindBlobsByTagsSegmentOptions} [options={}] Options to findBlobsByTagsItems.
-   * @returns {AsyncIterableIterator<FilterBlobItem>}
+   * @param options - Options to findBlobsByTagsItems.
+   *
    * @memberof BlobServiceClient
    */
   private async *findBlobsByTagsItems(
@@ -1189,12 +1189,12 @@ export class BlobServiceClient extends StorageClient {
    * }
    * ```
    *
-   * @param {string} tagFilterSqlExpression  The where parameter enables the caller to query blobs whose tags match a given expression.
+   * @param tagFilterSqlExpression -  The where parameter enables the caller to query blobs whose tags match a given expression.
    *                                         The given expression must evaluate to true for a blob to be returned in the results.
    *                                         The[OData - ABNF] filter syntax rule defines the formal grammar for the value of the where query parameter;
    *                                         however, only a subset of the OData filter syntax is supported in the Blob service.
-   * @param {ServiceFindBlobByTagsOptions} [options={}] Options to find blobs by tags.
-   * @returns {PagedAsyncIterableIterator<FilterBlobItem, ServiceFindBlobsByTagsSegmentResponse>}
+   * @param options - Options to find blobs by tags.
+   *
    * @memberof BlobServiceClient
    */
   public findBlobsByTags(
@@ -1236,15 +1236,15 @@ export class BlobServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for ServiceListContainersSegmentResponses
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                        the list of containers to be returned with the next listing operation. The
    *                        operation returns the continuationToken value within the response body if the
    *                        listing operation did not return all containers remaining to be listed
    *                        with the current page. The continuationToken value can be used as the value for
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
-   * @param {ServiceListContainersSegmentOptions} [options] Options to list containers operation.
-   * @returns {AsyncIterableIterator<ServiceListContainersSegmentResponse>}
+   * @param options - Options to list containers operation.
+   *
    * @memberof BlobServiceClient
    */
   private async *listSegments(
@@ -1267,8 +1267,8 @@ export class BlobServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for Container Items
    *
    * @private
-   * @param {ServiceListContainersSegmentOptions} [options] Options to list containers operation.
-   * @returns {AsyncIterableIterator<ContainerItem>}
+   * @param options - Options to list containers operation.
+   *
    * @memberof BlobServiceClient
    */
   private async *listItems(
@@ -1351,8 +1351,8 @@ export class BlobServiceClient extends StorageClient {
    * }
    * ```
    *
-   * @param {ServiceListContainersOptions} [options={}] Options to list containers.
-   * @returns {PagedAsyncIterableIterator<ContainerItem, ServiceListContainersSegmentResponse>} An asyncIterableIterator that supports paging.
+   * @param options - Options to list containers.
+   * @returnsAn asyncIterableIterator that supports paging.
    * @memberof BlobServiceClient
    */
   public listContainers(
@@ -1410,9 +1410,9 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key
    *
-   * @param {Date} startsOn      The start time for the user delegation SAS. Must be within 7 days of the current time
-   * @param {Date} expiresOn     The end time for the user delegation SAS. Must be within 7 days of the current time
-   * @returns {Promise<ServiceGetUserDelegationKeyResponse>}
+   * @param startsOn -      The start time for the user delegation SAS. Must be within 7 days of the current time
+   * @param expiresOn -     The end time for the user delegation SAS. Must be within 7 days of the current time
+   *
    * @memberof BlobServiceClient
    */
   public async getUserDelegationKey(
@@ -1473,7 +1473,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *
-   * @returns {BlobBatchClient} A new BlobBatchClient object for this service.
+   * @returnsA new BlobBatchClient object for this service.
    * @memberof BlobServiceClient
    */
   public getBlobBatchClient(): BlobBatchClient {
@@ -1488,11 +1488,11 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas
    *
-   * @param {Date} expiresOn Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not provided.
-   * @param {AccountSASPermissions} [permissions=AccountSASPermissions.parse("r")] Specifies the list of permissions to be associated with the SAS.
-   * @param {string} [resourceTypes="sco"] Specifies the resource types associated with the shared access signature.
-   * @param {ServiceGenerateAccountSasUrlOptions} [options={}] Optional parameters.
-   * @returns {string} An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param expiresOn - Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not provided.
+   * @param permissions - Specifies the list of permissions to be associated with the SAS.
+   * @param resourceTypes - Specifies the resource types associated with the shared access signature.
+   * @param options - Optional parameters.
+   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof BlobServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1146,15 +1146,15 @@ export class BlobClient extends StorageClient {
    *
    * Creates an instance of BlobClient from connection string.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} containerName Container name.
-   * @param {string} blobName Blob name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param containerName - Container name.
+   * @param blobName - Blob name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobClient
    */
   constructor(
@@ -1169,11 +1169,11 @@ export class BlobClient extends StorageClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A Client string pointing to Azure Storage blob service, such as
+   * @param url - A Client string pointing to Azure Storage blob service, such as
    *                     "https://myaccount.blob.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlobClient
    */
   constructor(
@@ -1187,7 +1187,7 @@ export class BlobClient extends StorageClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage blob, such as
+   * @param url - A URL string pointing to Azure Storage blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blob".
    *                     You can append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blob?sasString".
@@ -1195,7 +1195,7 @@ export class BlobClient extends StorageClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof BlobClient
    */
@@ -1295,8 +1295,8 @@ export class BlobClient extends StorageClient {
    * Creates a new BlobClient object identical to the source but with the specified snapshot timestamp.
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
-   * @param {string} snapshot The snapshot timestamp.
-   * @returns {BlobClient} A new BlobClient object identical to the source but with the specified snapshot timestamp
+   * @param snapshot - The snapshot timestamp.
+   * @returnsA new BlobClient object identical to the source but with the specified snapshot timestamp
    * @memberof BlobClient
    */
   public withSnapshot(snapshot: string): BlobClient {
@@ -1314,8 +1314,8 @@ export class BlobClient extends StorageClient {
    * Creates a new BlobClient object pointing to a version of this blob.
    * Provide "" will remove the versionId and return a Client to the base blob.
    *
-   * @param {string} versionId The versionId.
-   * @returns {BlobClient} A new BlobClient object pointing to the version of this blob.
+   * @param versionId - The versionId.
+   * @returnsA new BlobClient object pointing to the version of this blob.
    * @memberof BlobClient
    */
   public withVersion(versionId: string): BlobClient {
@@ -1332,7 +1332,7 @@ export class BlobClient extends StorageClient {
   /**
    * Creates a AppendBlobClient object.
    *
-   * @returns {AppendBlobClient}
+   *
    * @memberof BlobClient
    */
   public getAppendBlobClient(): AppendBlobClient {
@@ -1342,7 +1342,7 @@ export class BlobClient extends StorageClient {
   /**
    * Creates a BlockBlobClient object.
    *
-   * @returns {BlockBlobClient}
+   *
    * @memberof BlobClient
    */
   public getBlockBlobClient(): BlockBlobClient {
@@ -1352,7 +1352,7 @@ export class BlobClient extends StorageClient {
   /**
    * Creates a PageBlobClient object.
    *
-   * @returns {PageBlobClient}
+   *
    * @memberof BlobClient
    */
   public getPageBlobClient(): PageBlobClient {
@@ -1368,10 +1368,10 @@ export class BlobClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob
    *
-   * @param {number} [offset] From which position of the blob to download, >= 0
-   * @param {number} [count] How much data to be downloaded, > 0. Will download to the end when undefined
-   * @param {BlobDownloadOptions} [options] Optional options to Blob Download operation.
-   * @returns {Promise<BlobDownloadResponseParsed>}
+   * @param offset - From which position of the blob to download, >= 0
+   * @param count - How much data to be downloaded, > 0. Will download to the end when undefined
+   * @param options - Optional options to Blob Download operation.
+   *
    * @memberof BlobClient
    *
    * Example usage (Node.js):
@@ -1537,8 +1537,8 @@ export class BlobClient extends StorageClient {
    * applications. Vice versa new blobs might be added by other clients or applications after this
    * function completes.
    *
-   * @param {BlobExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof BlobClient
    */
   public async exists(options: BlobExistsOptions = {}): Promise<boolean> {
@@ -1583,8 +1583,8 @@ export class BlobClient extends StorageClient {
    * the methods of {@link ContainerClient} that list blobs using the `includeMetadata` option, which
    * will retain their original casing.
    *
-   * @param {BlobGetPropertiesOptions} [options] Optional options to Get Properties operation.
-   * @returns {Promise<BlobGetPropertiesResponse>}
+   * @param options - Optional options to Get Properties operation.
+   *
    * @memberof BlobClient
    */
   public async getProperties(
@@ -1629,8 +1629,8 @@ export class BlobClient extends StorageClient {
    * Blob operation.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob
    *
-   * @param {BlobDeleteOptions} [options] Optional options to Blob Delete operation.
-   * @returns {Promise<BlobDeleteResponse>}
+   * @param options - Optional options to Blob Delete operation.
+   *
    * @memberof BlobClient
    */
   public async delete(options: BlobDeleteOptions = {}): Promise<BlobDeleteResponse> {
@@ -1665,8 +1665,8 @@ export class BlobClient extends StorageClient {
    * Blob operation.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob
    *
-   * @param {BlobDeleteOptions} [options] Optional options to Blob Delete operation.
-   * @returns {Promise<BlobDeleteIfExistsResponse>}
+   * @param options - Optional options to Blob Delete operation.
+   *
    * @memberof BlobClient
    */
   public async deleteIfExists(
@@ -1711,8 +1711,8 @@ export class BlobClient extends StorageClient {
    * or later.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/undelete-blob
    *
-   * @param {BlobUndeleteOptions} [options] Optional options to Blob Undelete operation.
-   * @returns {Promise<BlobUndeleteResponse>}
+   * @param options - Optional options to Blob Undelete operation.
+   *
    * @memberof BlobClient
    */
   public async undelete(options: BlobUndeleteOptions = {}): Promise<BlobUndeleteResponse> {
@@ -1740,11 +1740,11 @@ export class BlobClient extends StorageClient {
    * these blob HTTP headers without a value will be cleared.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
    *
-   * @param {BlobHTTPHeaders} [blobHTTPHeaders] If no value provided, or no value provided for
+   * @param blobHTTPHeaders - If no value provided, or no value provided for
    *                                                   the specified blob HTTP headers, these blob HTTP
    *                                                   headers without a value will be cleared.
-   * @param {BlobSetHTTPHeadersOptions} [options] Optional options to Blob Set HTTP Headers operation.
-   * @returns {Promise<BlobSetHTTPHeadersResponse>}
+   * @param options - Optional options to Blob Set HTTP Headers operation.
+   *
    * @memberof BlobClient
    */
   public async setHTTPHeaders(
@@ -1784,10 +1784,10 @@ export class BlobClient extends StorageClient {
    * metadata will be removed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-metadata
    *
-   * @param {Metadata} [metadata] Replace existing metadata with this value.
+   * @param metadata - Replace existing metadata with this value.
    *                               If no value provided the existing metadata will be removed.
-   * @param {BlobSetMetadataOptions} [options] Optional options to Set Metadata operation.
-   * @returns {Promise<BlobSetMetadataResponse>}
+   * @param options - Optional options to Set Metadata operation.
+   *
    * @memberof BlobClient
    */
   public async setMetadata(
@@ -1827,9 +1827,9 @@ export class BlobClient extends StorageClient {
    * Valid tag key and value characters include lower and upper case letters, digits (0-9),
    * space (' '), plus ('+'), minus ('-'), period ('.'), foward slash ('/'), colon (':'), equals ('='), and underscore ('_').
    *
-   * @param {Tags} tags
-   * @param {BlobSetTagsOptions} [options={}]
-   * @returns {Promise<BlobSetTagsResponse>}
+   * @param tags -
+   * @param options -
+   *
    * @memberof BlobClient
    */
   public async setTags(tags: Tags, options: BlobSetTagsOptions = {}): Promise<BlobSetTagsResponse> {
@@ -1859,8 +1859,8 @@ export class BlobClient extends StorageClient {
   /**
    * Gets the tags associated with the underlying blob.
    *
-   * @param {BlobGetTagsOptions} [options={}]
-   * @returns {Promise<BlobGetTagsResponse>}
+   * @param options -
+   *
    * @memberof BlobClient
    */
   public async getTags(options: BlobGetTagsOptions = {}): Promise<BlobGetTagsResponse> {
@@ -1895,8 +1895,8 @@ export class BlobClient extends StorageClient {
   /**
    * Get a {@link BlobLeaseClient} that manages leases on the blob.
    *
-   * @param {string} [proposeLeaseId] Initial proposed lease Id.
-   * @returns {BlobLeaseClient} A new BlobLeaseClient object for managing leases on the blob.
+   * @param proposeLeaseId - Initial proposed lease Id.
+   * @returnsA new BlobLeaseClient object for managing leases on the blob.
    * @memberof BlobClient
    */
   public getBlobLeaseClient(proposeLeaseId?: string): BlobLeaseClient {
@@ -1907,8 +1907,8 @@ export class BlobClient extends StorageClient {
    * Creates a read-only snapshot of a blob.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-blob
    *
-   * @param {BlobCreateSnapshotOptions} [options] Optional options to the Blob Create Snapshot operation.
-   * @returns {Promise<BlobCreateSnapshotResponse>}
+   * @param options - Optional options to the Blob Create Snapshot operation.
+   *
    * @memberof BlobClient
    */
   public async createSnapshot(
@@ -2010,8 +2010,8 @@ export class BlobClient extends StorageClient {
    * }
    * ```
    *
-   * @param {string} copySource url to the source Azure Blob/File.
-   * @param {BlobBeginCopyFromURLOptions} [options] Optional options to the Blob Start Copy From URL operation.
+   * @param copySource - url to the source Azure Blob/File.
+   * @param options - Optional options to the Blob Start Copy From URL operation.
    */
   public async beginCopyFromURL(
     copySource: string,
@@ -2045,9 +2045,9 @@ export class BlobClient extends StorageClient {
    * length and full metadata. Version 2012-02-12 and newer.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob
    *
-   * @param {string} copyId Id of the Copy From URL operation.
-   * @param {BlobAbortCopyFromURLOptions} [options] Optional options to the Blob Abort Copy From URL operation.
-   * @returns {Promise<BlobAbortCopyFromURLResponse>}
+   * @param copyId - Id of the Copy From URL operation.
+   * @param options - Optional options to the Blob Abort Copy From URL operation.
+   *
    * @memberof BlobClient
    */
   public async abortCopyFromURL(
@@ -2077,9 +2077,9 @@ export class BlobClient extends StorageClient {
    * return a response until the copy is complete.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url
    *
-   * @param {string} copySource The source URL to copy from, Shared Access Signature(SAS) maybe needed for authentication
-   * @param {BlobSyncCopyFromURLOptions} [options={}]
-   * @returns {Promise<BlobCopyFromURLResponse>}
+   * @param copySource - The source URL to copy from, Shared Access Signature(SAS) maybe needed for authentication
+   * @param options -
+   *
    * @memberof BlobClient
    */
   public async syncCopyFromURL(
@@ -2128,9 +2128,9 @@ export class BlobClient extends StorageClient {
    * storage type. This operation does not update the blob's ETag.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-tier
    *
-   * @param {BlockBlobTier | PremiumPageBlobTier | string} tier The tier to be set on the blob. Valid values are Hot, Cool, or Archive.
-   * @param {BlobSetTierOptions} [options] Optional options to the Blob Set Tier operation.
-   * @returns {Promise<BlobsSetTierResponse>}
+   * @param tier - The tier to be set on the blob. Valid values are Hot, Cool, or Archive.
+   * @param options - Optional options to the Blob Set Tier operation.
+   *
    * @memberof BlobClient
    */
   public async setAccessTier(
@@ -2173,10 +2173,10 @@ export class BlobClient extends StorageClient {
    * consider {@link downloadToFile}.
    *
    * @export
-   * @param {number} offset From which position of the block blob to download(in bytes)
-   * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
-   * @param {BlobDownloadToBufferOptions} [options] BlobDownloadToBufferOptions
-   * @returns {Promise<Buffer>}
+   * @param offset - From which position of the block blob to download(in bytes)
+   * @param count - How much data(in bytes) to be downloaded. Will download to the end when passing undefined
+   * @param options - BlobDownloadToBufferOptions
+   *
    */
   public async downloadToBuffer(
     offset?: number,
@@ -2195,11 +2195,11 @@ export class BlobClient extends StorageClient {
    * consider {@link downloadToFile}.
    *
    * @export
-   * @param {Buffer} buffer Buffer to be fill, must have length larger than count
-   * @param {number} offset From which position of the block blob to download(in bytes)
-   * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
-   * @param {BlobDownloadToBufferOptions} [options] BlobDownloadToBufferOptions
-   * @returns {Promise<Buffer>}
+   * @param buffer - Buffer to be fill, must have length larger than count
+   * @param offset - From which position of the block blob to download(in bytes)
+   * @param count - How much data(in bytes) to be downloaded. Will download to the end when passing undefined
+   * @param options - BlobDownloadToBufferOptions
+   *
    */
   public async downloadToBuffer(
     buffer: Buffer,
@@ -2336,11 +2336,11 @@ export class BlobClient extends StorageClient {
    * Fails if the the given file path already exits.
    * Offset and count are optional, pass 0 and undefined respectively to download the entire blob.
    *
-   * @param {string} filePath
-   * @param {number} [offset] From which position of the block blob to download.
-   * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined.
-   * @param {BlobDownloadOptions} [options] Options to Blob download options.
-   * @returns {Promise<BlobDownloadResponseParsed>} The response data for blob download operation,
+   * @param filePath -
+   * @param offset - From which position of the block blob to download.
+   * @param count - How much data to be downloaded. Will download to the end when passing undefined.
+   * @param options - Options to Blob download options.
+   * @returnsThe response data for blob download operation,
    *                                                 but with readableStreamBody set to undefined since its
    *                                                 content is already read and written into a local file
    *                                                 at the specified path.
@@ -2442,9 +2442,9 @@ export class BlobClient extends StorageClient {
    * operation to copy from another storage account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob
    *
-   * @param {string} copySource url to the source Azure Blob/File.
-   * @param {BlobStartCopyFromURLOptions} [options] Optional options to the Blob Start Copy From URL operation.
-   * @returns {Promise<BlobStartCopyFromURLResponse>}
+   * @param copySource - url to the source Azure Blob/File.
+   * @param options - Optional options to the Blob Start Copy From URL operation.
+   *
    * @memberof BlobClient
    */
   private async startCopyFromURL(
@@ -2496,8 +2496,8 @@ export class BlobClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {BlobGenerateSasUrlOptions} options Optional parameters.
-   * @returns {Promise<string>} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof BlobClient
    */
   public generateSasUrl(options: BlobGenerateSasUrlOptions): Promise<string> {
@@ -2835,15 +2835,15 @@ export class AppendBlobClient extends BlobClient {
    *
    * Creates an instance of AppendBlobClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} containerName Container name.
-   * @param {string} blobName Blob name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param containerName - Container name.
+   * @param blobName - Blob name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof AppendBlobClient
    */
   constructor(
@@ -2858,7 +2858,7 @@ export class AppendBlobClient extends BlobClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage append blob, such as
+   * @param url - A URL string pointing to Azure Storage append blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/appendblob". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/appendblob?sasString".
@@ -2866,8 +2866,8 @@ export class AppendBlobClient extends BlobClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof AppendBlobClient
    */
   constructor(
@@ -2881,7 +2881,7 @@ export class AppendBlobClient extends BlobClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage append blob, such as
+   * @param url - A URL string pointing to Azure Storage append blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/appendblob". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/appendblob?sasString".
@@ -2889,7 +2889,7 @@ export class AppendBlobClient extends BlobClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof AppendBlobClient
    */
@@ -2983,8 +2983,8 @@ export class AppendBlobClient extends BlobClient {
    * specified snapshot timestamp.
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
-   * @param {string} snapshot The snapshot timestamp.
-   * @returns {AppendBlobClient} A new AppendBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @param snapshot - The snapshot timestamp.
+   * @returnsA new AppendBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof AppendBlobClient
    */
   public withSnapshot(snapshot: string): AppendBlobClient {
@@ -3002,8 +3002,8 @@ export class AppendBlobClient extends BlobClient {
    * Creates a 0-length append blob. Call AppendBlock to append data to an append blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {AppendBlobCreateOptions} [options] Options to the Append Block Create operation.
-   * @returns {Promise<AppendBlobCreateResponse>}
+   * @param options - Options to the Append Block Create operation.
+   *
    * @memberof AppendBlobClient
    *
    * Example usage:
@@ -3049,8 +3049,8 @@ export class AppendBlobClient extends BlobClient {
    * If the blob with the same name already exists, the content of the existing blob will remain unchanged.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {AppendBlobCreateIfNotExistsOptions} [options]
-   * @returns {Promise<AppendBlobCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof AppendBlobClient
    */
   public async createIfNotExists(
@@ -3098,8 +3098,8 @@ export class AppendBlobClient extends BlobClient {
   /**
    * Seals the append blob, making it read only.
    *
-   * @param {AppendBlobSealOptions} [options={}]
-   * @returns {Promise<AppendBlobAppendBlockResponse>}
+   * @param options -
+   *
    * @memberof AppendBlobClient
    */
   public async seal(options: AppendBlobSealOptions = {}): Promise<AppendBlobAppendBlockResponse> {
@@ -3131,10 +3131,10 @@ export class AppendBlobClient extends BlobClient {
    * Commits a new block of data to the end of the existing append blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/append-block
    *
-   * @param {HttpRequestBody} body Data to be appended.
-   * @param {number} contentLength Length of the body in bytes.
-   * @param {AppendBlobAppendBlockOptions} [options] Options to the Append Block operation.
-   * @returns {Promise<AppendBlobAppendBlockResponse>}
+   * @param body - Data to be appended.
+   * @param contentLength - Length of the body in bytes.
+   * @param options - Options to the Append Block operation.
+   *
    * @memberof AppendBlobClient
    *
    * Example usage:
@@ -3196,15 +3196,15 @@ export class AppendBlobClient extends BlobClient {
    * where the contents are read from a source url.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url
    *
-   * @param {string} sourceURL
+   * @param sourceURL -
    *                 The url to the blob that will be the source of the copy. A source blob in the same storage account can
    *                 be authenticated via Shared Key. However, if the source is a blob in another account, the source blob
    *                 must either be public or must be authenticated via a shared access signature. If the source blob is
    *                 public, no authentication is required to perform the operation.
-   * @param {number} sourceOffset Offset in source to be appended
-   * @param {number} count Number of bytes to be appended as a block
-   * @param {AppendBlobAppendBlockFromURLOptions} [options={}]
-   * @returns {Promise<AppendBlobAppendBlockFromUrlResponse>}
+   * @param sourceOffset - Offset in source to be appended
+   * @param count - Number of bytes to be appended as a block
+   * @param options -
+   *
    * @memberof AppendBlobClient
    */
   public async appendBlockFromURL(
@@ -4097,15 +4097,15 @@ export class BlockBlobClient extends BlobClient {
    *
    * Creates an instance of BlockBlobClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} containerName Container name.
-   * @param {string} blobName Blob name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param containerName - Container name.
+   * @param blobName - Blob name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlockBlobClient
    */
   constructor(
@@ -4120,7 +4120,7 @@ export class BlockBlobClient extends BlobClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage block blob, such as
+   * @param url - A URL string pointing to Azure Storage block blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blockblob". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blockblob?sasString".
@@ -4128,8 +4128,8 @@ export class BlockBlobClient extends BlobClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof BlockBlobClient
    */
   constructor(
@@ -4143,7 +4143,7 @@ export class BlockBlobClient extends BlobClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage block blob, such as
+   * @param url - A URL string pointing to Azure Storage block blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blockblob". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/blockblob?sasString".
@@ -4151,7 +4151,7 @@ export class BlockBlobClient extends BlobClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof BlockBlobClient
    */
@@ -4246,8 +4246,8 @@ export class BlockBlobClient extends BlobClient {
    * specified snapshot timestamp.
    * Provide "" will remove the snapshot and return a URL to the base blob.
    *
-   * @param {string} snapshot The snapshot timestamp.
-   * @returns {BlockBlobClient} A new BlockBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @param snapshot - The snapshot timestamp.
+   * @returnsA new BlockBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof BlockBlobClient
    */
   public withSnapshot(snapshot: string): BlockBlobClient {
@@ -4288,9 +4288,9 @@ export class BlockBlobClient extends BlobClient {
    * }
    * ```
    *
-   * @param {string} query
-   * @param {BlockBlobQueryOptions} [options={}]
-   * @returns {Promise<BlobDownloadResponseModel>}
+   * @param query -
+   * @param options -
+   *
    * @memberof BlockBlobClient
    */
   public async query(
@@ -4349,12 +4349,12 @@ export class BlockBlobClient extends BlobClient {
    *
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {HttpRequestBody} body Blob, string, ArrayBuffer, ArrayBufferView or a function
+   * @param body - Blob, string, ArrayBuffer, ArrayBufferView or a function
    *                               which returns a new Readable stream whose offset is from data source beginning.
-   * @param {number} contentLength Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
+   * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
-   * @param {BlockBlobUploadOptions} [options] Options to the Block Blob Upload operation.
-   * @returns {Promise<BlockBlobUploadResponse>} Response data for the Block Blob Upload operation.
+   * @param options - Options to the Block Blob Upload operation.
+   * @returnsResponse data for the Block Blob Upload operation.
    * @memberof BlockBlobClient
    *
    * Example usage:
@@ -4407,7 +4407,7 @@ export class BlockBlobClient extends BlobClient {
    * the content of the new blob.  To perform partial updates to a block blob’s contents using a
    * source URL, use {@link stageBlockFromURL} and {@link commitBlockList}.
    *
-   * @param {string} sourceURL Specifies the URL of the blob. The value
+   * @param sourceURL - Specifies the URL of the blob. The value
    *                           may be a URL of up to 2 KB in length that specifies a blob.
    *                           The value should be URL-encoded as it would appear
    *                           in a request URI. The source blob must either be public
@@ -4416,7 +4416,7 @@ export class BlockBlobClient extends BlobClient {
    *                           to perform the operation. Here are some examples of source object URLs:
    *                           - https://myaccount.blob.core.windows.net/mycontainer/myblob
    *                           - https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-   * @param {BlockBlobSyncUploadFromURLOptions} [options={}] Optional parameters.
+   * @param options - Optional parameters.
    * @returns Promise<Models.BlockBlobPutBlobFromUrlResponse>
    * @memberof BlockBlobClient
    */
@@ -4467,11 +4467,11 @@ export class BlockBlobClient extends BlobClient {
    * committed by a call to commitBlockList.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-block
    *
-   * @param {string} blockId A 64-byte value that is base64-encoded
-   * @param {HttpRequestBody} body Data to upload to the staging area.
-   * @param {number} contentLength Number of bytes to upload.
-   * @param {BlockBlobStageBlockOptions} [options] Options to the Block Blob Stage Block operation.
-   * @returns {Promise<BlockBlobStageBlockResponse>} Response data for the Block Blob Stage Block operation.
+   * @param blockId - A 64-byte value that is base64-encoded
+   * @param body - Data to upload to the staging area.
+   * @param contentLength - Number of bytes to upload.
+   * @param options - Options to the Block Blob Stage Block operation.
+   * @returnsResponse data for the Block Blob Stage Block operation.
    * @memberof BlockBlobClient
    */
   public async stageBlock(
@@ -4510,8 +4510,8 @@ export class BlockBlobClient extends BlobClient {
    * This API is available starting in version 2018-03-28.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-from-url
    *
-   * @param {string} blockId A 64-byte value that is base64-encoded
-   * @param {string} sourceURL Specifies the URL of the blob. The value
+   * @param blockId - A 64-byte value that is base64-encoded
+   * @param sourceURL - Specifies the URL of the blob. The value
    *                           may be a URL of up to 2 KB in length that specifies a blob.
    *                           The value should be URL-encoded as it would appear
    *                           in a request URI. The source blob must either be public
@@ -4520,10 +4520,10 @@ export class BlockBlobClient extends BlobClient {
    *                           to perform the operation. Here are some examples of source object URLs:
    *                           - https://myaccount.blob.core.windows.net/mycontainer/myblob
    *                           - https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-   * @param {number} [offset] From which position of the blob to download, >= 0
-   * @param {number} [count] How much data to be downloaded, > 0. Will download to the end when undefined
-   * @param {BlockBlobStageBlockFromURLOptions} [options={}] Options to the Block Blob Stage Block From URL operation.
-   * @returns {Promise<BlockBlobStageBlockFromURLResponse>} Response data for the Block Blob Stage Block From URL operation.
+   * @param offset - From which position of the blob to download, >= 0
+   * @param count - How much data to be downloaded, > 0. Will download to the end when undefined
+   * @param options - Options to the Block Blob Stage Block From URL operation.
+   * @returnsResponse data for the Block Blob Stage Block From URL operation.
    * @memberof BlockBlobClient
    */
   public async stageBlockFromURL(
@@ -4568,9 +4568,9 @@ export class BlockBlobClient extends BlobClient {
    * blocks together. Any blocks not specified in the block list and permanently deleted.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-block-list
    *
-   * @param {string[]} blocks  Array of 64-byte value that is base64-encoded
-   * @param {BlockBlobCommitBlockListOptions} [options] Options to the Block Blob Commit Block List operation.
-   * @returns {Promise<BlockBlobCommitBlockListResponse>} Response data for the Block Blob Commit Block List operation.
+   * @param blocks -  Array of 64-byte value that is base64-encoded
+   * @param options - Options to the Block Blob Commit Block List operation.
+   * @returnsResponse data for the Block Blob Commit Block List operation.
    * @memberof BlockBlobClient
    */
   public async commitBlockList(
@@ -4618,10 +4618,10 @@ export class BlockBlobClient extends BlobClient {
    * using the specified block list filter.
    * @see https://docs.microsoft.com/rest/api/storageservices/get-block-list
    *
-   * @param {BlockListType} listType Specifies whether to return the list of committed blocks,
+   * @param listType - Specifies whether to return the list of committed blocks,
    *                                        the list of uncommitted blocks, or both lists together.
-   * @param {BlockBlobGetBlockListOptions} [options] Options to the Block Blob Get Block List operation.
-   * @returns {Promise<BlockBlobGetBlockListResponse>} Response data for the Block Blob Get Block List operation.
+   * @param options - Options to the Block Blob Get Block List operation.
+   * @returnsResponse data for the Block Blob Get Block List operation.
    * @memberof BlockBlobClient
    */
   public async getBlockList(
@@ -4674,9 +4674,9 @@ export class BlockBlobClient extends BlobClient {
    * to commit the block list.
    *
    * @export
-   * @param {Buffer | Blob | ArrayBuffer | ArrayBufferView} data Buffer(Node.js), Blob, ArrayBuffer or ArrayBufferView
-   * @param {BlockBlobParallelUploadOptions} [options]
-   * @returns {Promise<BlobUploadCommonResponse>}
+   * @param data - Buffer(Node.js), Blob, ArrayBuffer or ArrayBufferView
+   * @param options -
+   *
    * @memberof BlockBlobClient
    */
   public async uploadData(
@@ -4735,9 +4735,9 @@ export class BlockBlobClient extends BlobClient {
    * @deprecated Use {@link uploadData} instead.
    *
    * @export
-   * @param {Blob | ArrayBuffer | ArrayBufferView} browserData Blob, File, ArrayBuffer or ArrayBufferView
-   * @param {BlockBlobParallelUploadOptions} [options] Options to upload browser data.
-   * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
+   * @param browserData - Blob, File, ArrayBuffer or ArrayBufferView
+   * @param options - Options to upload browser data.
+   * @returnsResponse data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   public async uploadBrowserData(
@@ -4776,10 +4776,10 @@ export class BlockBlobClient extends BlobClient {
    * Otherwise, this method will call {@link stageBlock} to upload blocks, and finally call {@link commitBlockList}
    * to commit the block list.
    *
-   * @param {(offset: number, size: number) => HttpRequestBody} bodyFactory
-   * @param {number} size size of the data to upload.
-   * @param {BlockBlobParallelUploadOptions} [options] Options to Upload to Block Blob operation.
-   * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
+   * @param bodyFactory -
+   * @param size - size of the data to upload.
+   * @param options - Options to Upload to Block Blob operation.
+   * @returnsResponse data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   private async uploadSeekableInternal(
@@ -4903,9 +4903,9 @@ export class BlockBlobClient extends BlobClient {
    * Otherwise, this method will call stageBlock to upload blocks, and finally call commitBlockList
    * to commit the block list.
    *
-   * @param {string} filePath Full path of local file
-   * @param {BlockBlobParallelUploadOptions} [options] Options to Upload to Block Blob operation.
-   * @returns {(Promise<BlobUploadCommonResponse>)}  Response data for the Blob Upload operation.
+   * @param filePath - Full path of local file
+   * @param options - Options to Upload to Block Blob operation.
+   * @returns Response data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   public async uploadFile(
@@ -4947,12 +4947,12 @@ export class BlockBlobClient extends BlobClient {
    * * Input stream highWaterMark is better to set a same value with bufferSize
    *    parameter, which will avoid Buffer.concat() operations.
    *
-   * @param {Readable} stream Node.js Readable stream
-   * @param {number} bufferSize Size of every buffer allocated, also the block size in the uploaded block blob. Default value is 8MB
-   * @param {number} maxConcurrency  Max concurrency indicates the max number of buffers that can be allocated,
+   * @param stream - Node.js Readable stream
+   * @param bufferSize - Size of every buffer allocated, also the block size in the uploaded block blob. Default value is 8MB
+   * @param maxConcurrency -  Max concurrency indicates the max number of buffers that can be allocated,
    *                                 positive correlation with max uploading concurrency. Default value is 5
-   * @param {BlockBlobUploadStreamOptions} [options] Options to Upload Stream to Block Blob operation.
-   * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
+   * @param options - Options to Upload Stream to Block Blob operation.
+   * @returnsResponse data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   public async uploadStream(
@@ -5519,15 +5519,15 @@ export class PageBlobClient extends BlobClient {
    *
    * Creates an instance of PageBlobClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} containerName Container name.
-   * @param {string} blobName Blob name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param containerName - Container name.
+   * @param blobName - Blob name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof PageBlobClient
    */
   constructor(
@@ -5542,11 +5542,11 @@ export class PageBlobClient extends BlobClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A Client string pointing to Azure Storage page blob, such as
+   * @param url - A Client string pointing to Azure Storage page blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/pageblob". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.blob.core.windows.net/mycontainer/pageblob?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof PageBlobClient
    */
   constructor(
@@ -5557,7 +5557,7 @@ export class PageBlobClient extends BlobClient {
   /**
    * Creates an instance of PageBlobClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage page blob, such as
+   * @param url - A URL string pointing to Azure Storage page blob, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/pageblob".
    *                     You can append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer/pageblob?sasString".
@@ -5565,7 +5565,7 @@ export class PageBlobClient extends BlobClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a blob name includes ? or %, blob name must be encoded in the URL.
    *                     Such as a blob named "my?blob%", the URL should be "https://myaccount.blob.core.windows.net/mycontainer/my%3Fblob%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof PageBlobClient
    */
@@ -5659,8 +5659,8 @@ export class PageBlobClient extends BlobClient {
    * specified snapshot timestamp.
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
-   * @param {string} snapshot The snapshot timestamp.
-   * @returns {PageBlobClient} A new PageBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @param snapshot - The snapshot timestamp.
+   * @returnsA new PageBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof PageBlobClient
    */
   public withSnapshot(snapshot: string): PageBlobClient {
@@ -5679,9 +5679,9 @@ export class PageBlobClient extends BlobClient {
    * data to a page blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {number} size size of the page blob.
-   * @param {PageBlobCreateOptions} [options] Options to the Page Blob Create operation.
-   * @returns {Promise<PageBlobCreateResponse>} Response data for the Page Blob Create operation.
+   * @param size - size of the page blob.
+   * @param options - Options to the Page Blob Create operation.
+   * @returnsResponse data for the Page Blob Create operation.
    * @memberof PageBlobClient
    */
   public async create(
@@ -5725,9 +5725,9 @@ export class PageBlobClient extends BlobClient {
    * of the existing blob will remain unchanged.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {number} size size of the page blob.
-   * @param {PageBlobCreateIfNotExistsOptions} [options]
-   * @returns {Promise<PageBlobCreateIfNotExistsResponse>}
+   * @param size - size of the page blob.
+   * @param options -
+   *
    * @memberof PageBlobClient
    */
   public async createIfNotExists(
@@ -5777,11 +5777,11 @@ export class PageBlobClient extends BlobClient {
    * Writes 1 or more pages to the page blob. The start and end offsets must be a multiple of 512.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-page
    *
-   * @param {HttpRequestBody} body Data to upload
-   * @param {number} offset Offset of destination page blob
-   * @param {number} count Content length of the body, also number of bytes to be uploaded
-   * @param {PageBlobUploadPagesOptions} [options] Options to the Page Blob Upload Pages operation.
-   * @returns {Promise<PageBlobsUploadPagesResponse>} Response data for the Page Blob Upload Pages operation.
+   * @param body - Data to upload
+   * @param offset - Offset of destination page blob
+   * @param count - Content length of the body, also number of bytes to be uploaded
+   * @param options - Options to the Page Blob Upload Pages operation.
+   * @returnsResponse data for the Page Blob Upload Pages operation.
    * @memberof PageBlobClient
    */
   public async uploadPages(
@@ -5826,12 +5826,12 @@ export class PageBlobClient extends BlobClient {
    * contents are read from a URL.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url
    *
-   * @param {string} sourceURL Specify a URL to the copy source, Shared Access Signature(SAS) maybe needed for authentication
-   * @param {number} sourceOffset The source offset to copy from. Pass 0 to copy from the beginning of source page blob
-   * @param {number} destOffset Offset of destination page blob
-   * @param {number} count Number of bytes to be uploaded from source page blob
-   * @param {PageBlobUploadPagesFromURLOptions} [options={}]
-   * @returns {Promise<PageBlobUploadPagesFromURLResponse>}
+   * @param sourceURL - Specify a URL to the copy source, Shared Access Signature(SAS) maybe needed for authentication
+   * @param sourceOffset - The source offset to copy from. Pass 0 to copy from the beginning of source page blob
+   * @param destOffset - Offset of destination page blob
+   * @param count - Number of bytes to be uploaded from source page blob
+   * @param options -
+   *
    * @memberof PageBlobClient
    */
   public async uploadPagesFromURL(
@@ -5890,10 +5890,10 @@ export class PageBlobClient extends BlobClient {
    * Frees the specified pages from the page blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-page
    *
-   * @param {number} [offset] Starting byte position of the pages to clear.
-   * @param {number} [count] Number of bytes to clear.
-   * @param {PageBlobClearPagesOptions} [options] Options to the Page Blob Clear Pages operation.
-   * @returns {Promise<PageBlobClearPagesResponse>} Response data for the Page Blob Clear Pages operation.
+   * @param offset - Starting byte position of the pages to clear.
+   * @param count - Number of bytes to clear.
+   * @param options - Options to the Page Blob Clear Pages operation.
+   * @returnsResponse data for the Page Blob Clear Pages operation.
    * @memberof PageBlobClient
    */
   public async clearPages(
@@ -5932,10 +5932,10 @@ export class PageBlobClient extends BlobClient {
    * Returns the list of valid page ranges for a page blob or snapshot of a page blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/get-page-ranges
    *
-   * @param {number} [offset] Starting byte position of the page ranges.
-   * @param {number} [count] Number of bytes to get.
-   * @param {PageBlobGetPageRangesOptions} [options] Options to the Page Blob Get Ranges operation.
-   * @returns {Promise<PageBlobGetPageRangesResponse>} Response data for the Page Blob Get Ranges operation.
+   * @param offset - Starting byte position of the page ranges.
+   * @param count - Number of bytes to get.
+   * @param options - Options to the Page Blob Get Ranges operation.
+   * @returnsResponse data for the Page Blob Get Ranges operation.
    * @memberof PageBlobClient
    */
   public async getPageRanges(
@@ -5976,11 +5976,11 @@ export class PageBlobClient extends BlobClient {
    * Gets the collection of page ranges that differ between a specified snapshot and this page blob.
    * @see https://docs.microsoft.com/rest/api/storageservices/get-page-ranges
    *
-   * @param {number} offset Starting byte position of the page blob
-   * @param {number} count Number of bytes to get ranges diff.
-   * @param {string} prevSnapshot Timestamp of snapshot to retrieve the difference.
-   * @param {PageBlobGetPageRangesDiffOptions} [options] Options to the Page Blob Get Page Ranges Diff operation.
-   * @returns {Promise<PageBlobGetPageRangesDiffResponse>} Response data for the Page Blob Get Page Range Diff operation.
+   * @param offset - Starting byte position of the page blob
+   * @param count - Number of bytes to get ranges diff.
+   * @param prevSnapshot - Timestamp of snapshot to retrieve the difference.
+   * @param options - Options to the Page Blob Get Page Ranges Diff operation.
+   * @returnsResponse data for the Page Blob Get Page Range Diff operation.
    * @memberof PageBlobClient
    */
   public async getPageRangesDiff(
@@ -6024,11 +6024,11 @@ export class PageBlobClient extends BlobClient {
    * Gets the collection of page ranges that differ between a specified snapshot and this page blob for managed disks.
    * @see https://docs.microsoft.com/rest/api/storageservices/get-page-ranges
    *
-   * @param {number} offset Starting byte position of the page blob
-   * @param {number} count Number of bytes to get ranges diff.
-   * @param {string} prevSnapshotUrl URL of snapshot to retrieve the difference.
-   * @param {PageBlobGetPageRangesDiffOptions} [options] Options to the Page Blob Get Page Ranges Diff operation.
-   * @returns {Promise<PageBlobGetPageRangesDiffResponse>} Response data for the Page Blob Get Page Range Diff operation.
+   * @param offset - Starting byte position of the page blob
+   * @param count - Number of bytes to get ranges diff.
+   * @param prevSnapshotUrl - URL of snapshot to retrieve the difference.
+   * @param options - Options to the Page Blob Get Page Ranges Diff operation.
+   * @returnsResponse data for the Page Blob Get Page Range Diff operation.
    * @memberof PageBlobClient
    */
   public async getPageRangesDiffForManagedDisks(
@@ -6072,9 +6072,9 @@ export class PageBlobClient extends BlobClient {
    * Resizes the page blob to the specified size (which must be a multiple of 512).
    * @see https://docs.microsoft.com/rest/api/storageservices/set-blob-properties
    *
-   * @param {number} size Target size
-   * @param {PageBlobResizeOptions} [options] Options to the Page Blob Resize operation.
-   * @returns {Promise<PageBlobResizeResponse>} Response data for the Page Blob Resize operation.
+   * @param size - Target size
+   * @param options - Options to the Page Blob Resize operation.
+   * @returnsResponse data for the Page Blob Resize operation.
    * @memberof PageBlobClient
    */
   public async resize(
@@ -6109,10 +6109,10 @@ export class PageBlobClient extends BlobClient {
    * Sets a page blob's sequence number.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
    *
-   * @param {SequenceNumberActionType} sequenceNumberAction Indicates how the service should modify the blob's sequence number.
-   * @param {number} [sequenceNumber] Required if sequenceNumberAction is max or update
-   * @param {PageBlobUpdateSequenceNumberOptions} [options] Options to the Page Blob Update Sequence Number operation.
-   * @returns {Promise<PageBlobUpdateSequenceNumberResponse>} Response data for the Page Blob Update Sequence Number operation.
+   * @param sequenceNumberAction - Indicates how the service should modify the blob's sequence number.
+   * @param sequenceNumber - Required if sequenceNumberAction is max or update
+   * @param options - Options to the Page Blob Update Sequence Number operation.
+   * @returnsResponse data for the Page Blob Update Sequence Number operation.
    * @memberof PageBlobClient
    */
   public async updateSequenceNumber(
@@ -6155,10 +6155,10 @@ export class PageBlobClient extends BlobClient {
    * @see https://docs.microsoft.com/rest/api/storageservices/incremental-copy-blob
    * @see https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots
    *
-   * @param {string} copySource Specifies the name of the source page blob snapshot. For example,
+   * @param copySource - Specifies the name of the source page blob snapshot. For example,
    *                            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-   * @param {PageBlobStartCopyIncrementalOptions} [options] Options to the Page Blob Copy Incremental operation.
-   * @returns {Promise<PageBlobCopyIncrementalResponse>} Response data for the Page Blob Copy Incremental operation.
+   * @param options - Options to the Page Blob Copy Incremental operation.
+   * @returnsResponse data for the Page Blob Copy Incremental operation.
    * @memberof PageBlobClient
    */
   public async startCopyIncremental(

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1296,7 +1296,7 @@ export class BlobClient extends StorageClient {
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
    * @param snapshot - The snapshot timestamp.
-   * @returnsA new BlobClient object identical to the source but with the specified snapshot timestamp
+   * @returns A new BlobClient object identical to the source but with the specified snapshot timestamp
    * @memberof BlobClient
    */
   public withSnapshot(snapshot: string): BlobClient {
@@ -1315,7 +1315,7 @@ export class BlobClient extends StorageClient {
    * Provide "" will remove the versionId and return a Client to the base blob.
    *
    * @param versionId - The versionId.
-   * @returnsA new BlobClient object pointing to the version of this blob.
+   * @returns A new BlobClient object pointing to the version of this blob.
    * @memberof BlobClient
    */
   public withVersion(versionId: string): BlobClient {
@@ -1896,7 +1896,7 @@ export class BlobClient extends StorageClient {
    * Get a {@link BlobLeaseClient} that manages leases on the blob.
    *
    * @param proposeLeaseId - Initial proposed lease Id.
-   * @returnsA new BlobLeaseClient object for managing leases on the blob.
+   * @returns A new BlobLeaseClient object for managing leases on the blob.
    * @memberof BlobClient
    */
   public getBlobLeaseClient(proposeLeaseId?: string): BlobLeaseClient {
@@ -2340,7 +2340,7 @@ export class BlobClient extends StorageClient {
    * @param offset - From which position of the block blob to download.
    * @param count - How much data to be downloaded. Will download to the end when passing undefined.
    * @param options - Options to Blob download options.
-   * @returnsThe response data for blob download operation,
+   * @returns The response data for blob download operation,
    *                                                 but with readableStreamBody set to undefined since its
    *                                                 content is already read and written into a local file
    *                                                 at the specified path.
@@ -2497,7 +2497,7 @@ export class BlobClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof BlobClient
    */
   public generateSasUrl(options: BlobGenerateSasUrlOptions): Promise<string> {
@@ -2984,7 +2984,7 @@ export class AppendBlobClient extends BlobClient {
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
    * @param snapshot - The snapshot timestamp.
-   * @returnsA new AppendBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @returns A new AppendBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof AppendBlobClient
    */
   public withSnapshot(snapshot: string): AppendBlobClient {
@@ -4247,7 +4247,7 @@ export class BlockBlobClient extends BlobClient {
    * Provide "" will remove the snapshot and return a URL to the base blob.
    *
    * @param snapshot - The snapshot timestamp.
-   * @returnsA new BlockBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @returns A new BlockBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof BlockBlobClient
    */
   public withSnapshot(snapshot: string): BlockBlobClient {
@@ -4354,7 +4354,7 @@ export class BlockBlobClient extends BlobClient {
    * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
    * @param options - Options to the Block Blob Upload operation.
-   * @returnsResponse data for the Block Blob Upload operation.
+   * @returns Response data for the Block Blob Upload operation.
    * @memberof BlockBlobClient
    *
    * Example usage:
@@ -4471,7 +4471,7 @@ export class BlockBlobClient extends BlobClient {
    * @param body - Data to upload to the staging area.
    * @param contentLength - Number of bytes to upload.
    * @param options - Options to the Block Blob Stage Block operation.
-   * @returnsResponse data for the Block Blob Stage Block operation.
+   * @returns Response data for the Block Blob Stage Block operation.
    * @memberof BlockBlobClient
    */
   public async stageBlock(
@@ -4523,7 +4523,7 @@ export class BlockBlobClient extends BlobClient {
    * @param offset - From which position of the blob to download, >= 0
    * @param count - How much data to be downloaded, > 0. Will download to the end when undefined
    * @param options - Options to the Block Blob Stage Block From URL operation.
-   * @returnsResponse data for the Block Blob Stage Block From URL operation.
+   * @returns Response data for the Block Blob Stage Block From URL operation.
    * @memberof BlockBlobClient
    */
   public async stageBlockFromURL(
@@ -4570,7 +4570,7 @@ export class BlockBlobClient extends BlobClient {
    *
    * @param blocks -  Array of 64-byte value that is base64-encoded
    * @param options - Options to the Block Blob Commit Block List operation.
-   * @returnsResponse data for the Block Blob Commit Block List operation.
+   * @returns Response data for the Block Blob Commit Block List operation.
    * @memberof BlockBlobClient
    */
   public async commitBlockList(
@@ -4621,7 +4621,7 @@ export class BlockBlobClient extends BlobClient {
    * @param listType - Specifies whether to return the list of committed blocks,
    *                                        the list of uncommitted blocks, or both lists together.
    * @param options - Options to the Block Blob Get Block List operation.
-   * @returnsResponse data for the Block Blob Get Block List operation.
+   * @returns Response data for the Block Blob Get Block List operation.
    * @memberof BlockBlobClient
    */
   public async getBlockList(
@@ -4737,7 +4737,7 @@ export class BlockBlobClient extends BlobClient {
    * @export
    * @param browserData - Blob, File, ArrayBuffer or ArrayBufferView
    * @param options - Options to upload browser data.
-   * @returnsResponse data for the Blob Upload operation.
+   * @returns Response data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   public async uploadBrowserData(
@@ -4779,7 +4779,7 @@ export class BlockBlobClient extends BlobClient {
    * @param bodyFactory -
    * @param size - size of the data to upload.
    * @param options - Options to Upload to Block Blob operation.
-   * @returnsResponse data for the Blob Upload operation.
+   * @returns Response data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   private async uploadSeekableInternal(
@@ -4952,7 +4952,7 @@ export class BlockBlobClient extends BlobClient {
    * @param maxConcurrency -  Max concurrency indicates the max number of buffers that can be allocated,
    *                                 positive correlation with max uploading concurrency. Default value is 5
    * @param options - Options to Upload Stream to Block Blob operation.
-   * @returnsResponse data for the Blob Upload operation.
+   * @returns Response data for the Blob Upload operation.
    * @memberof BlockBlobClient
    */
   public async uploadStream(
@@ -5660,7 +5660,7 @@ export class PageBlobClient extends BlobClient {
    * Provide "" will remove the snapshot and return a Client to the base blob.
    *
    * @param snapshot - The snapshot timestamp.
-   * @returnsA new PageBlobClient object identical to the source but with the specified snapshot timestamp.
+   * @returns A new PageBlobClient object identical to the source but with the specified snapshot timestamp.
    * @memberof PageBlobClient
    */
   public withSnapshot(snapshot: string): PageBlobClient {
@@ -5681,7 +5681,7 @@ export class PageBlobClient extends BlobClient {
    *
    * @param size - size of the page blob.
    * @param options - Options to the Page Blob Create operation.
-   * @returnsResponse data for the Page Blob Create operation.
+   * @returns Response data for the Page Blob Create operation.
    * @memberof PageBlobClient
    */
   public async create(
@@ -5781,7 +5781,7 @@ export class PageBlobClient extends BlobClient {
    * @param offset - Offset of destination page blob
    * @param count - Content length of the body, also number of bytes to be uploaded
    * @param options - Options to the Page Blob Upload Pages operation.
-   * @returnsResponse data for the Page Blob Upload Pages operation.
+   * @returns Response data for the Page Blob Upload Pages operation.
    * @memberof PageBlobClient
    */
   public async uploadPages(
@@ -5893,7 +5893,7 @@ export class PageBlobClient extends BlobClient {
    * @param offset - Starting byte position of the pages to clear.
    * @param count - Number of bytes to clear.
    * @param options - Options to the Page Blob Clear Pages operation.
-   * @returnsResponse data for the Page Blob Clear Pages operation.
+   * @returns Response data for the Page Blob Clear Pages operation.
    * @memberof PageBlobClient
    */
   public async clearPages(
@@ -5935,7 +5935,7 @@ export class PageBlobClient extends BlobClient {
    * @param offset - Starting byte position of the page ranges.
    * @param count - Number of bytes to get.
    * @param options - Options to the Page Blob Get Ranges operation.
-   * @returnsResponse data for the Page Blob Get Ranges operation.
+   * @returns Response data for the Page Blob Get Ranges operation.
    * @memberof PageBlobClient
    */
   public async getPageRanges(
@@ -5980,7 +5980,7 @@ export class PageBlobClient extends BlobClient {
    * @param count - Number of bytes to get ranges diff.
    * @param prevSnapshot - Timestamp of snapshot to retrieve the difference.
    * @param options - Options to the Page Blob Get Page Ranges Diff operation.
-   * @returnsResponse data for the Page Blob Get Page Range Diff operation.
+   * @returns Response data for the Page Blob Get Page Range Diff operation.
    * @memberof PageBlobClient
    */
   public async getPageRangesDiff(
@@ -6028,7 +6028,7 @@ export class PageBlobClient extends BlobClient {
    * @param count - Number of bytes to get ranges diff.
    * @param prevSnapshotUrl - URL of snapshot to retrieve the difference.
    * @param options - Options to the Page Blob Get Page Ranges Diff operation.
-   * @returnsResponse data for the Page Blob Get Page Range Diff operation.
+   * @returns Response data for the Page Blob Get Page Range Diff operation.
    * @memberof PageBlobClient
    */
   public async getPageRangesDiffForManagedDisks(
@@ -6074,7 +6074,7 @@ export class PageBlobClient extends BlobClient {
    *
    * @param size - Target size
    * @param options - Options to the Page Blob Resize operation.
-   * @returnsResponse data for the Page Blob Resize operation.
+   * @returns Response data for the Page Blob Resize operation.
    * @memberof PageBlobClient
    */
   public async resize(
@@ -6112,7 +6112,7 @@ export class PageBlobClient extends BlobClient {
    * @param sequenceNumberAction - Indicates how the service should modify the blob's sequence number.
    * @param sequenceNumber - Required if sequenceNumberAction is max or update
    * @param options - Options to the Page Blob Update Sequence Number operation.
-   * @returnsResponse data for the Page Blob Update Sequence Number operation.
+   * @returns Response data for the Page Blob Update Sequence Number operation.
    * @memberof PageBlobClient
    */
   public async updateSequenceNumber(
@@ -6158,7 +6158,7 @@ export class PageBlobClient extends BlobClient {
    * @param copySource - Specifies the name of the source page blob snapshot. For example,
    *                            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
    * @param options - Options to the Page Blob Copy Incremental operation.
-   * @returnsResponse data for the Page Blob Copy Incremental operation.
+   * @returns Response data for the Page Blob Copy Incremental operation.
    * @memberof PageBlobClient
    */
   public async startCopyIncremental(

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -725,14 +725,14 @@ export class ContainerClient extends StorageClient {
    *
    * Creates an instance of ContainerClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} containerName Container name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param containerName - Container name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ContainerClient
    */
   constructor(connectionString: string, containerName: string, options?: StoragePipelineOptions);
@@ -742,12 +742,12 @@ export class ContainerClient extends StorageClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage container, such as
+   * @param url - A URL string pointing to Azure Storage container, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ContainerClient
    */
   constructor(
@@ -761,11 +761,11 @@ export class ContainerClient extends StorageClient {
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
    *
-   * @param {string} url A URL string pointing to Azure Storage container, such as
+   * @param url - A URL string pointing to Azure Storage container, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.blob.core.windows.net/mycontainer?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof ContainerClient
    */
@@ -847,8 +847,8 @@ export class ContainerClient extends StorageClient {
    * the same name already exists, the operation fails.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    *
-   * @param {ContainerCreateOptions} [options] Options to Container Create operation.
-   * @returns {Promise<ContainerCreateResponse>}
+   * @param options - Options to Container Create operation.
+   *
    * @memberof ContainerClient
    *
    * Example usage:
@@ -884,8 +884,8 @@ export class ContainerClient extends StorageClient {
    * the same name already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    *
-   * @param {ContainerCreateOptions} [options]
-   * @returns {Promise<ContainerCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof ContainerClient
    */
   public async createIfNotExists(
@@ -935,8 +935,8 @@ export class ContainerClient extends StorageClient {
    * applications. Vice versa new containers with the same name might be added by other clients or
    * applications after this function completes.
    *
-   * @param {ContainerExistsOptions} [options={}]
-   * @returns {Promise<boolean>}
+   * @param options -
+   *
    * @memberof ContainerClient
    */
   public async exists(options: ContainerExistsOptions = {}): Promise<boolean> {
@@ -968,8 +968,8 @@ export class ContainerClient extends StorageClient {
   /**
    * Creates a {@link BlobClient}
    *
-   * @param {string} blobName A blob name
-   * @returns {BlobClient} A new BlobClient object for the given blob name.
+   * @param blobName - A blob name
+   * @returnsA new BlobClient object for the given blob name.
    * @memberof ContainerClient
    */
   public getBlobClient(blobName: string): BlobClient {
@@ -979,8 +979,8 @@ export class ContainerClient extends StorageClient {
   /**
    * Creates an {@link AppendBlobClient}
    *
-   * @param {string} blobName An append blob name
-   * @returns {AppendBlobClient}
+   * @param blobName - An append blob name
+   *
    * @memberof ContainerClient
    */
   public getAppendBlobClient(blobName: string): AppendBlobClient {
@@ -993,8 +993,8 @@ export class ContainerClient extends StorageClient {
   /**
    * Creates a {@link BlockBlobClient}
    *
-   * @param {string} blobName A block blob name
-   * @returns {BlockBlobClient}
+   * @param blobName - A block blob name
+   *
    * @memberof ContainerClient
    *
    * Example usage:
@@ -1016,8 +1016,8 @@ export class ContainerClient extends StorageClient {
   /**
    * Creates a {@link PageBlobClient}
    *
-   * @param {string} blobName A page blob name
-   * @returns {PageBlobClient}
+   * @param blobName - A page blob name
+   *
    * @memberof ContainerClient
    */
   public getPageBlobClient(blobName: string): PageBlobClient {
@@ -1037,8 +1037,8 @@ export class ContainerClient extends StorageClient {
    * the `listContainers` method of {@link BlobServiceClient} using the `includeMetadata` option, which
    * will retain their original casing.
    *
-   * @param {ContainerGetPropertiesOptions} [options] Options to Container Get Properties operation.
-   * @returns {Promise<ContainerGetPropertiesResponse>}
+   * @param options - Options to Container Get Properties operation.
+   *
    * @memberof ContainerClient
    */
   public async getProperties(
@@ -1074,8 +1074,8 @@ export class ContainerClient extends StorageClient {
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container
    *
-   * @param {ContainerDeleteMethodOptions} [options] Options to Container Delete operation.
-   * @returns {Promise<ContainerDeleteResponse>}
+   * @param options - Options to Container Delete operation.
+   *
    * @memberof ContainerClient
    */
   public async delete(
@@ -1109,8 +1109,8 @@ export class ContainerClient extends StorageClient {
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container
    *
-   * @param {ContainerDeleteMethodOptions} [options] Options to Container Delete operation.
-   * @returns {Promise<ContainerDeleteIfExistsResponse>}
+   * @param options - Options to Container Delete operation.
+   *
    * @memberof ContainerClient
    */
   public async deleteIfExists(
@@ -1161,10 +1161,10 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-metadata
    *
-   * @param {Metadata} [metadata] Replace existing metadata with this value.
+   * @param metadata - Replace existing metadata with this value.
    *                            If no value provided the existing metadata will be removed.
-   * @param {ContainerSetMetadataOptions} [options] Options to Container Set Metadata operation.
-   * @returns {Promise<ContainerSetMetadataResponse>}
+   * @param options - Options to Container Set Metadata operation.
+   *
    * @memberof ContainerClient
    */
   public async setMetadata(
@@ -1211,8 +1211,8 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl
    *
-   * @param {ContainerGetAccessPolicyOptions} [options] Options to Container Get Access Policy operation.
-   * @returns {Promise<ContainerGetAccessPolicyResponse>}
+   * @param options - Options to Container Get Access Policy operation.
+   *
    * @memberof ContainerClient
    */
   public async getAccessPolicy(
@@ -1294,10 +1294,10 @@ export class ContainerClient extends StorageClient {
    * fail with status code 403 (Forbidden), until the access policy becomes active.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-acl
    *
-   * @param {PublicAccessType} [access] The level of public access to data in the container.
-   * @param {SignedIdentifier[]} [containerAcl] Array of elements each having a unique Id and details of the access policy.
-   * @param {ContainerSetAccessPolicyOptions} [options] Options to Container Set Access Policy operation.
-   * @returns {Promise<ContainerSetAccessPolicyResponse>}
+   * @param access - The level of public access to data in the container.
+   * @param containerAcl - Array of elements each having a unique Id and details of the access policy.
+   * @param options - Options to Container Set Access Policy operation.
+   *
    * @memberof ContainerClient
    */
   public async setAccessPolicy(
@@ -1349,8 +1349,8 @@ export class ContainerClient extends StorageClient {
   /**
    * Get a {@link BlobLeaseClient} that manages leases on the container.
    *
-   * @param {string} [proposeLeaseId] Initial proposed lease Id.
-   * @returns {BlobLeaseClient} A new BlobLeaseClient object for managing leases on the container.
+   * @param proposeLeaseId - Initial proposed lease Id.
+   * @returnsA new BlobLeaseClient object for managing leases on the container.
    * @memberof ContainerClient
    */
   public getBlobLeaseClient(proposeLeaseId?: string): BlobLeaseClient {
@@ -1371,13 +1371,13 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
-   * @param {string} blobName Name of the block blob to create or update.
-   * @param {HttpRequestBody} body Blob, string, ArrayBuffer, ArrayBufferView or a function
+   * @param blobName - Name of the block blob to create or update.
+   * @param body - Blob, string, ArrayBuffer, ArrayBufferView or a function
    *                               which returns a new Readable stream whose offset is from data source beginning.
-   * @param {number} contentLength Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
+   * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
-   * @param {BlockBlobUploadOptions} [options] Options to configure the Block Blob Upload operation.
-   * @returns {Promise<{ blockBlobClient: BlockBlobClient; response: BlockBlobUploadResponse }>} Block Blob upload response data and the corresponding BlockBlobClient instance.
+   * @param options - Options to configure the Block Blob Upload operation.
+   * @returnsBlock Blob upload response data and the corresponding BlockBlobClient instance.
    * @memberof ContainerClient
    */
   public async uploadBlockBlob(
@@ -1418,9 +1418,9 @@ export class ContainerClient extends StorageClient {
    * Blob operation.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob
    *
-   * @param {string} blobName
-   * @param {ContainerDeleteBlobOptions} [options] Options to Blob Delete operation.
-   * @returns {Promise<BlobDeleteResponse>} Block blob deletion response data.
+   * @param blobName -
+   * @param options - Options to Blob Delete operation.
+   * @returnsBlock blob deletion response data.
    * @memberof ContainerClient
    */
   public async deleteBlob(
@@ -1455,9 +1455,9 @@ export class ContainerClient extends StorageClient {
    * (passing the the previously-returned Marker) to get the next segment.
    * @see https://docs.microsoft.com/rest/api/storageservices/list-blobs
    *
-   * @param {string} [marker] A string value that identifies the portion of the list to be returned with the next list operation.
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to Container List Blob Flat Segment operation.
-   * @returns {Promise<ContainerListBlobFlatSegmentResponse>}
+   * @param marker - A string value that identifies the portion of the list to be returned with the next list operation.
+   * @param options - Options to Container List Blob Flat Segment operation.
+   *
    * @memberof ContainerClient
    */
   private async listBlobFlatSegment(
@@ -1510,10 +1510,10 @@ export class ContainerClient extends StorageClient {
    * again (passing the the previously-returned Marker) to get the next segment.
    * @see https://docs.microsoft.com/rest/api/storageservices/list-blobs
    *
-   * @param {string} delimiter The character or string used to define the virtual hierarchy
-   * @param {string} [marker] A string value that identifies the portion of the list to be returned with the next list operation.
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to Container List Blob Hierarchy Segment operation.
-   * @returns {Promise<ContainerListBlobHierarchySegmentResponse>}
+   * @param delimiter - The character or string used to define the virtual hierarchy
+   * @param marker - A string value that identifies the portion of the list to be returned with the next list operation.
+   * @param options - Options to Container List Blob Hierarchy Segment operation.
+   *
    * @memberof ContainerClient
    */
   private async listBlobHierarchySegment(
@@ -1564,15 +1564,15 @@ export class ContainerClient extends StorageClient {
    * Returns an AsyncIterableIterator for ContainerListBlobFlatSegmentResponse
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list of blobs to be returned with the next listing operation. The
    *                          operation returns the ContinuationToken value within the response body if the
    *                          listing operation did not return all blobs remaining to be listed
    *                          with the current page. The ContinuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to list blobs operation.
-   * @returns {AsyncIterableIterator<ContainerListBlobFlatSegmentResponse>}
+   * @param options - Options to list blobs operation.
+   *
    * @memberof ContainerClient
    */
   private async *listSegments(
@@ -1593,8 +1593,8 @@ export class ContainerClient extends StorageClient {
    * Returns an AsyncIterableIterator of {@link BlobItem} objects
    *
    * @private
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to list blobs operation.
-   * @returns {AsyncIterableIterator<BlobItem>}
+   * @param options - Options to list blobs operation.
+   *
    * @memberof ContainerClient
    */
   private async *listItems(
@@ -1673,8 +1673,8 @@ export class ContainerClient extends StorageClient {
    * }
    * ```
    *
-   * @param {ContainerListBlobsOptions} [options={}] Options to list blobs.
-   * @returns {PagedAsyncIterableIterator<BlobItem, ContainerListBlobFlatSegmentResponse>} An asyncIterableIterator that supports paging.
+   * @param options - Options to list blobs.
+   * @returnsAn asyncIterableIterator that supports paging.
    * @memberof ContainerClient
    */
   public listBlobsFlat(
@@ -1742,16 +1742,16 @@ export class ContainerClient extends StorageClient {
    * Returns an AsyncIterableIterator for ContainerListBlobHierarchySegmentResponse
    *
    * @private
-   * @param {string} delimiter The character or string used to define the virtual hierarchy
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param delimiter - The character or string used to define the virtual hierarchy
+   * @param marker - A string value that identifies the portion of
    *                          the list of blobs to be returned with the next listing operation. The
    *                          operation returns the ContinuationToken value within the response body if the
    *                          listing operation did not return all blobs remaining to be listed
    *                          with the current page. The ContinuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to list blobs operation.
-   * @returns {AsyncIterableIterator<ContainerListBlobHierarchySegmentResponse>}
+   * @param options - Options to list blobs operation.
+   *
    * @memberof ContainerClient
    */
   private async *listHierarchySegments(
@@ -1777,9 +1777,9 @@ export class ContainerClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link BlobPrefix} and {@link BlobItem} objects.
    *
    * @private
-   * @param {string} delimiter The character or string used to define the virtual hierarchy
-   * @param {ContainerListBlobsSegmentOptions} [options] Options to list blobs operation.
-   * @returns {AsyncIterableIterator<{ kind: "prefix" } & BlobPrefix | { kind: "blob" } & BlobItem>}
+   * @param delimiter - The character or string used to define the virtual hierarchy
+   * @param options - Options to list blobs operation.
+   * @returns& BlobItem>}
    * @memberof ContainerClient
    */
   private async *listItemsByHierarchy(
@@ -1877,8 +1877,8 @@ export class ContainerClient extends StorageClient {
    * }
    * ```
    *
-   * @param {string} delimiter The character or string used to define the virtual hierarchy
-   * @param {ContainerListBlobsOptions} [options={}] Options to list blobs operation.
+   * @param delimiter - The character or string used to define the virtual hierarchy
+   * @param options - Options to list blobs operation.
    * @returns {(PagedAsyncIterableIterator<
    *   { kind: "prefix" } & BlobPrefix | { kind: "blob" } & BlobItem,
    *     ContainerListBlobHierarchySegmentResponse>)}
@@ -2000,8 +2000,8 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {ContainerGenerateSasUrlOptions} options Optional parameters.
-   * @returns {Promise<string>} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ContainerClient
    */
   public generateSasUrl(options: ContainerGenerateSasUrlOptions): Promise<string> {
@@ -2029,7 +2029,7 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *
-   * @returns {BlobBatchClient} A new BlobBatchClient object for this container.
+   * @returnsA new BlobBatchClient object for this container.
    * @memberof ContainerClient
    */
   public getBlobBatchClient(): BlobBatchClient {

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -969,7 +969,7 @@ export class ContainerClient extends StorageClient {
    * Creates a {@link BlobClient}
    *
    * @param blobName - A blob name
-   * @returnsA new BlobClient object for the given blob name.
+   * @returns A new BlobClient object for the given blob name.
    * @memberof ContainerClient
    */
   public getBlobClient(blobName: string): BlobClient {
@@ -1350,7 +1350,7 @@ export class ContainerClient extends StorageClient {
    * Get a {@link BlobLeaseClient} that manages leases on the container.
    *
    * @param proposeLeaseId - Initial proposed lease Id.
-   * @returnsA new BlobLeaseClient object for managing leases on the container.
+   * @returns A new BlobLeaseClient object for managing leases on the container.
    * @memberof ContainerClient
    */
   public getBlobLeaseClient(proposeLeaseId?: string): BlobLeaseClient {
@@ -1377,7 +1377,7 @@ export class ContainerClient extends StorageClient {
    * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
    * @param options - Options to configure the Block Blob Upload operation.
-   * @returnsBlock Blob upload response data and the corresponding BlockBlobClient instance.
+   * @returns Block Blob upload response data and the corresponding BlockBlobClient instance.
    * @memberof ContainerClient
    */
   public async uploadBlockBlob(
@@ -1420,7 +1420,7 @@ export class ContainerClient extends StorageClient {
    *
    * @param blobName -
    * @param options - Options to Blob Delete operation.
-   * @returnsBlock blob deletion response data.
+   * @returns Block blob deletion response data.
    * @memberof ContainerClient
    */
   public async deleteBlob(
@@ -1674,7 +1674,7 @@ export class ContainerClient extends StorageClient {
    * ```
    *
    * @param options - Options to list blobs.
-   * @returnsAn asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    * @memberof ContainerClient
    */
   public listBlobsFlat(
@@ -1779,7 +1779,7 @@ export class ContainerClient extends StorageClient {
    * @private
    * @param delimiter - The character or string used to define the virtual hierarchy
    * @param options - Options to list blobs operation.
-   * @returns& BlobItem>}
+   * @returns & BlobItem>}
    * @memberof ContainerClient
    */
   private async *listItemsByHierarchy(
@@ -2001,7 +2001,7 @@ export class ContainerClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ContainerClient
    */
   public generateSasUrl(options: ContainerGenerateSasUrlOptions): Promise<string> {
@@ -2029,7 +2029,7 @@ export class ContainerClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *
-   * @returnsA new BlobBatchClient object for this container.
+   * @returns A new BlobBatchClient object for this container.
    * @memberof ContainerClient
    */
   public getBlobBatchClient(): BlobBatchClient {

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -122,7 +122,7 @@ export class Pipeline {
    * Transfer Pipeline object to ServiceClientOptions object which is required by
    * ServiceClient constructor.
    *
-   * @returnsThe ServiceClientOptions object from this Pipeline.
+   * @returns The ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -181,7 +181,7 @@ export interface StoragePipelineOptions {
  * @export
  * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
  * @param pipelineOptions - Optional. Options.
- * @returnsA new Pipeline object.
+ * @returns A new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -104,8 +104,8 @@ export class Pipeline {
   /**
    * Creates an instance of Pipeline. Customize HTTPClient by implementing IHttpClient interface.
    *
-   * @param {RequestPolicyFactory[]} factories
-   * @param {PipelineOptions} [options={}]
+   * @param factories -
+   * @param options -
    * @memberof Pipeline
    */
   constructor(factories: RequestPolicyFactory[], options: PipelineOptions = {}) {
@@ -122,7 +122,7 @@ export class Pipeline {
    * Transfer Pipeline object to ServiceClientOptions object which is required by
    * ServiceClient constructor.
    *
-   * @returns {ServiceClientOptions} The ServiceClientOptions object from this Pipeline.
+   * @returnsThe ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -179,9 +179,9 @@ export interface StoragePipelineOptions {
  * Creates a new Pipeline object with Credential provided.
  *
  * @export
- * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
- * @param {StoragePipelineOptions} [pipelineOptions] Optional. Options.
- * @returns {Pipeline} A new Pipeline object.
+ * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+ * @param pipelineOptions - Optional. Options.
+ * @returnsA new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,

--- a/sdk/storage/storage-blob/src/Range.ts
+++ b/sdk/storage/storage-blob/src/Range.ts
@@ -33,8 +33,8 @@ export interface Range {
  * "bytes=255-" or "bytes=0-511"
  *
  * @export
- * @param {Range} iRange
- * @returns {string}
+ * @param iRange -
+ *
  */
 export function rangeToString(iRange: Range): string {
   if (iRange.offset < 0) {

--- a/sdk/storage/storage-blob/src/StorageBrowserPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/StorageBrowserPolicyFactory.ts
@@ -16,9 +16,9 @@ export class StorageBrowserPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageBrowserPolicyFactory object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageBrowserPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageBrowserPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageBrowserPolicy {

--- a/sdk/storage/storage-blob/src/StorageClient.ts
+++ b/sdk/storage/storage-blob/src/StorageClient.ts
@@ -69,8 +69,8 @@ export abstract class StorageClient {
 
   /**
    * Creates an instance of StorageClient.
-   * @param {string} url url to resource
-   * @param {Pipeline} pipeline request policy pipeline.
+   * @param url - url to resource
+   * @param pipeline - request policy pipeline.
    * @memberof StorageClient
    */
   protected constructor(url: string, pipeline: Pipeline) {

--- a/sdk/storage/storage-blob/src/StorageRetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/StorageRetryPolicyFactory.ts
@@ -88,7 +88,7 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of StorageRetryPolicyFactory.
-   * @param {StorageRetryOptions} [retryOptions]
+   * @param retryOptions -
    * @memberof StorageRetryPolicyFactory
    */
   constructor(retryOptions?: StorageRetryOptions) {
@@ -98,9 +98,9 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageRetryPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageRetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageRetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy {

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -29,7 +29,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of TelemetryPolicyFactory.
-   * @param {UserAgentOptions} [telemetry]
+   * @param telemetry -
    * @memberof TelemetryPolicyFactory
    */
   constructor(telemetry?: UserAgentOptions) {
@@ -62,9 +62,9 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a TelemetryPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {TelemetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof TelemetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): TelemetryPolicy {

--- a/sdk/storage/storage-blob/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-blob/src/credentials/AnonymousCredential.ts
@@ -20,9 +20,9 @@ export class AnonymousCredential extends Credential {
   /**
    * Creates an {@link AnonymousCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {AnonymousCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof AnonymousCredential
    */
   public create(

--- a/sdk/storage/storage-blob/src/credentials/Credential.ts
+++ b/sdk/storage/storage-blob/src/credentials/Credential.ts
@@ -16,9 +16,9 @@ export abstract class Credential implements RequestPolicyFactory {
   /**
    * Creates a RequestPolicy object.
    *
-   * @param {RequestPolicy} _nextPolicy
-   * @param {RequestPolicyOptions} _options
-   * @returns {RequestPolicy}
+   * @param _nextPolicy -
+   * @param _options -
+   *
    * @memberof Credential
    */
   public create(

--- a/sdk/storage/storage-blob/src/credentials/StorageSharedKeyCredential.ts
+++ b/sdk/storage/storage-blob/src/credentials/StorageSharedKeyCredential.ts
@@ -35,8 +35,8 @@ export class StorageSharedKeyCredential extends Credential {
 
   /**
    * Creates an instance of StorageSharedKeyCredential.
-   * @param {string} accountName
-   * @param {string} accountKey
+   * @param accountName -
+   * @param accountKey -
    * @memberof StorageSharedKeyCredential
    */
   constructor(accountName: string, accountKey: string) {
@@ -48,9 +48,9 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Creates a StorageSharedKeyCredentialPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageSharedKeyCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public create(
@@ -63,8 +63,8 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-blob/src/credentials/UserDelegationKeyCredential.ts
+++ b/sdk/storage/storage-blob/src/credentials/UserDelegationKeyCredential.ts
@@ -38,8 +38,8 @@ export class UserDelegationKeyCredential {
 
   /**
    * Creates an instance of UserDelegationKeyCredential.
-   * @param {string} accountName
-   * @param {UserDelegationKey} userDelegationKey
+   * @param accountName -
+   * @param userDelegationKey -
    * @memberof UserDelegationKeyCredential
    */
   constructor(accountName: string, userDelegationKey: UserDelegationKey) {
@@ -51,8 +51,8 @@ export class UserDelegationKeyCredential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof UserDelegationKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-blob/src/policies/AnonymousCredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/AnonymousCredentialPolicy.ts
@@ -16,8 +16,8 @@ import { CredentialPolicy } from "./CredentialPolicy";
 export class AnonymousCredentialPolicy extends CredentialPolicy {
   /**
    * Creates an instance of AnonymousCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof AnonymousCredentialPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {

--- a/sdk/storage/storage-blob/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/CredentialPolicy.ts
@@ -16,8 +16,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -30,8 +30,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
    *
    * @protected
    * @abstract
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {

--- a/sdk/storage/storage-blob/src/policies/StorageBrowserPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageBrowserPolicy.ts
@@ -30,8 +30,8 @@ import { setURLParameter } from "../utils/utils.common";
 export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of StorageBrowserPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof StorageBrowserPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -41,8 +41,8 @@ export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageBrowserPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
@@ -23,7 +23,7 @@ import { logger } from "../log";
  * A factory method used to generated a RetryPolicy factory.
  *
  * @export
- * @param {StorageRetryOptions} retryOptions
+ * @param retryOptions -
  */
 export function NewRetryPolicyFactory(retryOptions?: StorageRetryOptions): RequestPolicyFactory {
   return {
@@ -81,9 +81,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of RetryPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageRetryOptions} [retryOptions=DEFAULT_RETRY_OPTIONS]
+   * @param nextPolicy -
+   * @param options -
+   * @param retryOptions -
    * @memberof StorageRetryPolicy
    */
   constructor(
@@ -133,8 +133,8 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageRetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -145,13 +145,13 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide and perform next retry. Won't mutate request parameter.
    *
    * @protected
-   * @param {WebResource} request
-   * @param {boolean} secondaryHas404  If attempt was against the secondary & it returned a StatusNotFound (404), then
+   * @param request -
+   * @param secondaryHas404 -  If attempt was against the secondary & it returned a StatusNotFound (404), then
    *                                   the resource was not found. This may be due to replication delay. So, in this
    *                                   case, we'll never try the secondary again for this operation.
-   * @param {number} attempt           How many retries has been attempted to performed, starting from 1, which includes
+   * @param attempt -           How many retries has been attempted to performed, starting from 1, which includes
    *                                   the attempt will be performed by this method call.
-   * @returns {Promise<HttpOperationResponse>}
+   *
    * @memberof StorageRetryPolicy
    */
   protected async attemptSendRequest(
@@ -204,11 +204,11 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide whether to retry according to last HTTP response and retry counters.
    *
    * @protected
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {HttpOperationResponse} [response]
-   * @param {RestError} [err]
-   * @returns {boolean}
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param response -
+   * @param err -
+   *
    * @memberof StorageRetryPolicy
    */
   protected shouldRetry(
@@ -282,9 +282,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Delay a calculated time between retries.
    *
    * @private
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {AbortSignalLike} [abortSignal]
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param abortSignal -
    * @memberof StorageRetryPolicy
    */
   private async delay(isPrimaryRetry: boolean, attempt: number, abortSignal?: AbortSignalLike) {

--- a/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -25,9 +25,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
 
   /**
    * Creates an instance of StorageSharedKeyCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageSharedKeyCredential} factory
+   * @param nextPolicy -
+   * @param options -
+   * @param factory -
    * @memberof StorageSharedKeyCredentialPolicy
    */
   constructor(
@@ -43,8 +43,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Signs request.
    *
    * @protected
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {
@@ -91,9 +91,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/authenticate-with-shared-key
    *
    * @private
-   * @param {WebResource} request
-   * @param {string} headerName
-   * @returns {string}
+   * @param request -
+   * @param headerName -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getHeaderValueToSign(request: WebResource, headerName: string): string {
@@ -125,8 +125,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    *    Construct the CanonicalizedHeaders string by concatenating all headers in this list into a single string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedHeadersString(request: WebResource): string {
@@ -160,8 +160,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Retrieves the webResource canonicalized resource string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedResourceString(request: WebResource): string {

--- a/sdk/storage/storage-blob/src/policies/TelemetryPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/TelemetryPolicy.ts
@@ -30,9 +30,9 @@ export class TelemetryPolicy extends BaseRequestPolicy {
 
   /**
    * Creates an instance of TelemetryPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {string} telemetry
+   * @param nextPolicy -
+   * @param options -
+   * @param telemetry -
    * @memberof TelemetryPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, telemetry: string) {
@@ -43,8 +43,8 @@ export class TelemetryPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof TelemetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-blob/src/sas/AccountSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASPermissions.ts
@@ -18,8 +18,8 @@ export class AccountSASPermissions {
    * Parse initializes the AccountSASPermissions fields from a string.
    *
    * @static
-   * @param {string} permissions
-   * @returns {AccountSASPermissions}
+   * @param permissions -
+   *
    * @memberof AccountSASPermissions
    */
   public static parse(permissions: string): AccountSASPermissions {
@@ -73,8 +73,8 @@ export class AccountSASPermissions {
    * and boolean values for them.
    *
    * @static
-   * @param {AccountSASPermissionsLike} permissionLike
-   * @returns {AccountSASPermissions}
+   * @param permissionLike -
+   *
    * @memberof AccountSASPermissions
    */
   public static from(permissionLike: AccountSASPermissionsLike): AccountSASPermissions {
@@ -212,7 +212,7 @@ export class AccountSASPermissions {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/AccountSASResourceTypes.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASResourceTypes.ts
@@ -19,8 +19,8 @@ export class AccountSASResourceTypes {
    * Error if it encounters a character that does not correspond to a valid resource type.
    *
    * @static
-   * @param {string} resourceTypes
-   * @returns {AccountSASResourceTypes}
+   * @param resourceTypes -
+   *
    * @memberof AccountSASResourceTypes
    */
   public static parse(resourceTypes: string): AccountSASResourceTypes {
@@ -74,7 +74,7 @@ export class AccountSASResourceTypes {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASResourceTypes
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/AccountSASServices.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASServices.ts
@@ -19,8 +19,8 @@ export class AccountSASServices {
    * Error if it encounters a character that does not correspond to a valid service.
    *
    * @static
-   * @param {string} services
-   * @returns {AccountSASServices}
+   * @param services -
+   *
    * @memberof AccountSASServices
    */
   public static parse(services: string): AccountSASServices {
@@ -83,7 +83,7 @@ export class AccountSASServices {
   /**
    * Converts the given services to a string.
    *
-   * @returns {string}
+   *
    * @memberof AccountSASServices
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASSignatureValues.ts
@@ -105,9 +105,9 @@ export interface AccountSASSignatureValues {
  *
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
  *
- * @param {AccountSASSignatureValues} accountSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param accountSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  * @memberof AccountSASSignatureValues
  */
 export function generateAccountSASQueryParameters(

--- a/sdk/storage/storage-blob/src/sas/BlobSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/sas/BlobSASPermissions.ts
@@ -19,8 +19,8 @@ export class BlobSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {BlobSASPermissions}
+   * @param permissions -
+   *
    * @memberof BlobSASPermissions
    */
   public static parse(permissions: string): BlobSASPermissions {
@@ -68,8 +68,8 @@ export class BlobSASPermissions {
    * and boolean values for them.
    *
    * @static
-   * @param {BlobSASPermissionsLike} permissionLike
-   * @returns {BlobSASPermissions}
+   * @param permissionLike -
+   *
    * @memberof BlobSASPermissions
    */
   public static from(permissionLike: BlobSASPermissionsLike): BlobSASPermissions {
@@ -180,7 +180,7 @@ export class BlobSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returns {string} A string which represents the BlobSASPermissions
+   * @returnsA string which represents the BlobSASPermissions
    * @memberof BlobSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/BlobSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/sas/BlobSASPermissions.ts
@@ -180,7 +180,7 @@ export class BlobSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returnsA string which represents the BlobSASPermissions
+   * @returns A string which represents the BlobSASPermissions
    * @memberof BlobSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
@@ -254,9 +254,9 @@ export interface BlobSASSignatureValues {
  * ```
  *
  * @export
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 export function generateBlobSASQueryParameters(
   blobSASSignatureValues: BlobSASSignatureValues,
@@ -289,10 +289,10 @@ export function generateBlobSASQueryParameters(
  * ```
  *
  * @export
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {UserDelegationKey} userDelegationKey Return value of `blobServiceClient.getUserDelegationKey()`
- * @param {string} accountName
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param userDelegationKey - Return value of `blobServiceClient.getUserDelegationKey()`
+ * @param accountName -
+ *
  */
 export function generateBlobSASQueryParameters(
   blobSASSignatureValues: BlobSASSignatureValues,
@@ -372,9 +372,9 @@ export function generateBlobSASQueryParameters(
  * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 function generateBlobSASQueryParameters20150405(
   blobSASSignatureValues: BlobSASSignatureValues,
@@ -470,9 +470,9 @@ function generateBlobSASQueryParameters20150405(
  * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 function generateBlobSASQueryParameters20181109(
   blobSASSignatureValues: BlobSASSignatureValues,
@@ -575,9 +575,9 @@ function generateBlobSASQueryParameters20181109(
  *
  * WARNING: identifier will be ignored, permissions and expiresOn are required.
  *
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {UserDelegationKeyCredential} userDelegationKeyCredential
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param userDelegationKeyCredential -
+ *
  */
 function generateBlobSASQueryParametersUDK20181109(
   blobSASSignatureValues: BlobSASSignatureValues,
@@ -687,9 +687,9 @@ function generateBlobSASQueryParametersUDK20181109(
  *
  * WARNING: identifier will be ignored, permissions and expiresOn are required.
  *
- * @param {BlobSASSignatureValues} blobSASSignatureValues
- * @param {UserDelegationKeyCredential} userDelegationKeyCredential
- * @returns {SASQueryParameters}
+ * @param blobSASSignatureValues -
+ * @param userDelegationKeyCredential -
+ *
  */
 function generateBlobSASQueryParametersUDK20200210(
   blobSASSignatureValues: BlobSASSignatureValues,

--- a/sdk/storage/storage-blob/src/sas/ContainerSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/sas/ContainerSASPermissions.ts
@@ -17,8 +17,8 @@ export class ContainerSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {ContainerSASPermissions}
+   * @param permissions -
+   *
    * @memberof ContainerSASPermissions
    */
   public static parse(permissions: string) {
@@ -69,8 +69,8 @@ export class ContainerSASPermissions {
    * and boolean values for them.
    *
    * @static
-   * @param {ContainerSASPermissionsLike} permissionLike
-   * @returns {ContainerSASPermissions}
+   * @param permissionLike -
+   *
    * @memberof ContainerSASPermissions
    */
   public static from(permissionLike: ContainerSASPermissionsLike): ContainerSASPermissions {
@@ -195,7 +195,7 @@ export class ContainerSASPermissions {
    * The order of the characters should be as specified here to ensure correctness.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @returns {string}
+   *
    * @memberof ContainerSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-blob/src/sas/SASQueryParameters.ts
+++ b/sdk/storage/storage-blob/src/sas/SASQueryParameters.ts
@@ -412,25 +412,25 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {string} [permissions] Representing the storage permissions
-   * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
-   * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
-   * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startsOn] Representing the start time for this SAS token
-   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
-   * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
-   * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
-   * @param {string} [resource] Representing the storage container or blob (only for Service SAS)
-   * @param {string} [cacheControl] Representing the cache-control header (only for Blob/File Service SAS)
-   * @param {string} [contentDisposition] Representing the content-disposition header (only for Blob/File Service SAS)
-   * @param {string} [contentEncoding] Representing the content-encoding header (only for Blob/File Service SAS)
-   * @param {string} [contentLanguage] Representing the content-language header (only for Blob/File Service SAS)
-   * @param {string} [contentType] Representing the content-type header (only for Blob/File Service SAS)
-   * @param {userDelegationKey} [userDelegationKey] Representing the user delegation key properties
-   * @param {string} [preauthorizedAgentObjectId] Representing the authorized AAD Object ID (only for User Delegation SAS)
-   * @param {string} [correlationId] Representing the correlation ID (only for User Delegation SAS)
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param permissions - Representing the storage permissions
+   * @param services - Representing the storage services being accessed (only for Account SAS)
+   * @param resourceTypes - Representing the storage resource types being accessed (only for Account SAS)
+   * @param protocol - Representing the allowed HTTP protocol(s)
+   * @param startsOn - Representing the start time for this SAS token
+   * @param expiresOn - Representing the expiry time for this SAS token
+   * @param ipRange - Representing the range of valid IP addresses for this SAS token
+   * @param identifier - Representing the signed identifier (only for Service SAS)
+   * @param resource - Representing the storage container or blob (only for Service SAS)
+   * @param cacheControl - Representing the cache-control header (only for Blob/File Service SAS)
+   * @param contentDisposition - Representing the content-disposition header (only for Blob/File Service SAS)
+   * @param contentEncoding - Representing the content-encoding header (only for Blob/File Service SAS)
+   * @param contentLanguage - Representing the content-language header (only for Blob/File Service SAS)
+   * @param contentType - Representing the content-type header (only for Blob/File Service SAS)
+   * @param userDelegationKey - Representing the user delegation key properties
+   * @param preauthorizedAgentObjectId - Representing the authorized AAD Object ID (only for User Delegation SAS)
+   * @param correlationId - Representing the correlation ID (only for User Delegation SAS)
    * @memberof SASQueryParameters
    */
   constructor(
@@ -458,9 +458,9 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {SASQueryParametersOptions} [options] Optional. Options to construct the SASQueryParameters.
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param options - Optional. Options to construct the SASQueryParameters.
    * @memberof SASQueryParameters
    */
   constructor(version: string, signature: string, options?: SASQueryParametersOptions);
@@ -550,7 +550,7 @@ export class SASQueryParameters {
   /**
    * Encodes all SAS query parameters into a string that can be appended to a URL.
    *
-   * @returns {string}
+   *
    * @memberof SASQueryParameters
    */
   public toString(): string {
@@ -685,10 +685,10 @@ export class SASQueryParameters {
    * A private helper method used to filter and append query key/value pairs into an array.
    *
    * @private
-   * @param {string[]} queries
-   * @param {string} key
-   * @param {string} [value]
-   * @returns {void}
+   * @param queries -
+   * @param key -
+   * @param value -
+   *
    * @memberof SASQueryParameters
    */
   private tryAppendQueryParameter(queries: string[], key: string, value?: string): void {

--- a/sdk/storage/storage-blob/src/sas/SasIPRange.ts
+++ b/sdk/storage/storage-blob/src/sas/SasIPRange.ts
@@ -32,8 +32,8 @@ export interface SasIPRange {
  * "8.8.8.8" or "1.1.1.1-255.255.255.255"
  *
  * @export
- * @param {SasIPRange} ipRange
- * @returns {string}
+ * @param ipRange -
+ *
  */
 export function ipRangeToString(ipRange: SasIPRange): string {
   return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;

--- a/sdk/storage/storage-blob/src/utils/Batch.ts
+++ b/sdk/storage/storage-blob/src/utils/Batch.ts
@@ -94,7 +94,7 @@ export class Batch {
 
   /**
    * Creates an instance of Batch.
-   * @param {number} [concurrency=5]
+   * @param concurrency -
    * @memberof Batch
    */
   public constructor(concurrency: number = 5) {
@@ -108,7 +108,7 @@ export class Batch {
   /**
    * Add a operation into queue.
    *
-   * @param {Operation} operation
+   * @param operation -
    * @memberof Batch
    */
   public addOperation(operation: Operation): void {
@@ -128,7 +128,7 @@ export class Batch {
   /**
    * Start execute operations in the queue.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof Batch
    */
   public async do(): Promise<void> {
@@ -152,7 +152,7 @@ export class Batch {
    * Get next operation to be executed. Return null when reaching ends.
    *
    * @private
-   * @returns {(Operation | null)}
+   *
    * @memberof Batch
    */
   private nextOperation(): Operation | null {
@@ -167,7 +167,7 @@ export class Batch {
    * this method with do() is that do() wraps as an sync method.
    *
    * @private
-   * @returns {void}
+   *
    * @memberof Batch
    */
   private parallelExecute(): void {

--- a/sdk/storage/storage-blob/src/utils/BlobQuickQueryStream.ts
+++ b/sdk/storage/storage-blob/src/utils/BlobQuickQueryStream.ts
@@ -53,8 +53,8 @@ export class BlobQuickQueryStream extends Readable {
   /**
    * Creates an instance of BlobQuickQueryStream.
    *
-   * @param {NodeJS.ReadableStream} source The current ReadableStream returned from getter
-   * @param {BlobQuickQueryStreamOptions} [options={}]
+   * @param source - The current ReadableStream returned from getter
+   * @param options -
    * @memberof BlobQuickQueryStream
    */
   public constructor(source: NodeJS.ReadableStream, options: BlobQuickQueryStreamOptions = {}) {

--- a/sdk/storage/storage-blob/src/utils/Mutex.ts
+++ b/sdk/storage/storage-blob/src/utils/Mutex.ts
@@ -17,8 +17,8 @@ export class Mutex {
    * will wait until getting the lock.
    *
    * @static
-   * @param {string} key lock key
-   * @returns {Promise<void>}
+   * @param key - lock key
+   *
    * @memberof Mutex
    */
   public static async lock(key: string): Promise<void> {
@@ -39,8 +39,8 @@ export class Mutex {
    * Unlock a key.
    *
    * @static
-   * @param {string} key
-   * @returns {Promise<void>}
+   * @param key -
+   *
    * @memberof Mutex
    */
   public static async unlock(key: string): Promise<void> {

--- a/sdk/storage/storage-blob/src/utils/RetriableReadableStream.ts
+++ b/sdk/storage/storage-blob/src/utils/RetriableReadableStream.ts
@@ -67,12 +67,12 @@ export class RetriableReadableStream extends Readable {
   /**
    * Creates an instance of RetriableReadableStream.
    *
-   * @param {NodeJS.ReadableStream} source The current ReadableStream returned from getter
-   * @param {ReadableStreamGetter} getter A method calling downloading request returning
+   * @param source - The current ReadableStream returned from getter
+   * @param getter - A method calling downloading request returning
    *                                      a new ReadableStream from specified offset
-   * @param {number} offset Offset position in original data source to read
-   * @param {number} count How much data in original data source to read
-   * @param {RetriableReadableStreamOptions} [options={}]
+   * @param offset - Offset position in original data source to read
+   * @param count - How much data in original data source to read
+   * @param options -
    * @memberof RetriableReadableStream
    */
   public constructor(

--- a/sdk/storage/storage-blob/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.browser.ts
@@ -5,8 +5,8 @@
  * Convert a Browser Blob object into ArrayBuffer.
  *
  * @export
- * @param {Blob} blob
- * @returns {Promise<ArrayBuffer>}
+ * @param blob -
+ *
  */
 export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
   const fileReader = new FileReader();
@@ -23,8 +23,8 @@ export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
  * Convert a Browser Blob object into string.
  *
  * @export
- * @param {Blob} blob
- * @returns {Promise<ArrayBuffer>}
+ * @param blob -
+ *
  */
 export async function blobToString(blob: Blob): Promise<string> {
   const fileReader = new FileReader();

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -69,8 +69,8 @@ import {
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata
  *
  * @export
- * @param {string} url
- * @returns {string}
+ * @param url -
+ *
  */
 export function escapeURLPath(url: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -132,8 +132,8 @@ export function getValueInConnString(
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export
- * @param {string} connectionString Connection string.
- * @returns {ConnectionString}  String key value pairs of the storage account's url and credentials.
+ * @param connectionString - Connection string.
+ * @returns String key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   let proxyUri = "";
@@ -215,8 +215,8 @@ export function extractConnectionStringParts(connectionString: string): Connecti
 /**
  * Internal escape method implemented Strategy Two mentioned in escapeURL() description.
  *
- * @param {string} text
- * @returns {string}
+ * @param text -
+ *
  */
 function escape(text: string): string {
   return encodeURIComponent(text)
@@ -231,9 +231,9 @@ function escape(text: string): string {
  * when URL path ends with a "/".
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name String to be appended to URL
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - String to be appended to URL
+ * @returnsAn updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -250,10 +250,10 @@ export function appendToURLPath(url: string, name: string): string {
  * will be replaced by name key. If not provide value, the parameter will be deleted.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name Parameter name
- * @param {string} [value] Parameter value
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - Parameter name
+ * @param value - Parameter value
+ * @returnsAn updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -265,9 +265,9 @@ export function setURLParameter(url: string, name: string, value?: string): stri
  * Get URL parameter by name.
  *
  * @export
- * @param {string} url
- * @param {string} name
- * @returns {(string | string[] | undefined)}
+ * @param url -
+ * @param name -
+ *
  */
 export function getURLParameter(url: string, name: string): string | string[] | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -278,8 +278,8 @@ export function getURLParameter(url: string, name: string): string | string[] | 
  * Set URL host.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} host New host string
+ * @param url - Source URL string
+ * @param host - New host string
  * @returns An updated URL string
  */
 export function setURLHost(url: string, host: string): string {
@@ -292,8 +292,8 @@ export function setURLHost(url: string, host: string): string {
  * Get URL path from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLPath(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -304,8 +304,8 @@ export function getURLPath(url: string): string | undefined {
  * Get URL scheme from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLScheme(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -316,8 +316,8 @@ export function getURLScheme(url: string): string | undefined {
  * Get URL path and query from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLPathAndQuery(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -339,8 +339,8 @@ export function getURLPathAndQuery(url: string): string | undefined {
  * Get URL query key value pairs from an URL string.
  *
  * @export
- * @param {string} url
- * @returns {{[key: string]: string}}
+ * @param url -
+ *
  */
 export function getURLQueries(url: string): { [key: string]: string } {
   let queryString = URLBuilder.parse(url).getQuery();
@@ -375,9 +375,9 @@ export function getURLQueries(url: string): { [key: string]: string } {
  * Append a string to URL query.
  *
  * @export
- * @param {string} url Source URL string.
- * @param {string} queryParts String to be appended to the URL query.
- * @returns {string} An updated URL string.
+ * @param url - Source URL string.
+ * @param queryParts - String to be appended to the URL query.
+ * @returnsAn updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -397,10 +397,10 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * Rounds a date off to seconds.
  *
  * @export
- * @param {Date} date
- * @param {boolean} [withMilliseconds=true] If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
+ * @param date -
+ * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns {string} Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -415,8 +415,8 @@ export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = tru
  * Base64 encode.
  *
  * @export
- * @param {string} content
- * @returns {string}
+ * @param content -
+ *
  */
 export function base64encode(content: string): string {
   return !isNode ? btoa(content) : Buffer.from(content).toString("base64");
@@ -426,8 +426,8 @@ export function base64encode(content: string): string {
  * Base64 decode.
  *
  * @export
- * @param {string} encodedString
- * @returns {string}
+ * @param encodedString -
+ *
  */
 export function base64decode(encodedString: string): string {
   return !isNode ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
@@ -437,8 +437,8 @@ export function base64decode(encodedString: string): string {
  * Generate a 64 bytes base64 block ID string.
  *
  * @export
- * @param {number} blockIndex
- * @returns {string}
+ * @param blockIndex -
+ *
  */
 export function generateBlockID(blockIDPrefix: string, blockIndex: number): string {
   // To generate a 64 bytes base64 string, source string should be 48
@@ -462,9 +462,9 @@ export function generateBlockID(blockIDPrefix: string, blockIndex: number): stri
  * Delay specified time interval.
  *
  * @export
- * @param {number} timeInMs
- * @param {AbortSignalLike} [aborter]
- * @param {Error} [abortError]
+ * @param timeInMs -
+ * @param aborter -
+ * @param abortError -
  */
 export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortError?: Error) {
   return new Promise<void>((resolve, reject) => {
@@ -495,10 +495,10 @@ export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortEr
  * String.prototype.padStart()
  *
  * @export
- * @param {string} currentString
- * @param {number} targetLength
- * @param {string} [padString=" "]
- * @returns {string}
+ * @param currentString -
+ * @param targetLength -
+ * @param [padString=" - "]
+ *
  */
 export function padStart(
   currentString: string,
@@ -550,9 +550,9 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
  * If two strings are equal when compared case insensitive.
  *
  * @export
- * @param {string} str1
- * @param {string} str2
- * @returns {boolean}
+ * @param str1 -
+ * @param str2 -
+ *
  */
 export function iEqual(str1: string, str2: string): boolean {
   return str1.toLocaleLowerCase() === str2.toLocaleLowerCase();
@@ -560,8 +560,8 @@ export function iEqual(str1: string, str2: string): boolean {
 
 /**
  * Extracts account name from the url
- * @param {string} url url to extract the account name from
- * @returns {string} with the account name
+ * @param url - url to extract the account name from
+ * @returnswith the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);
@@ -606,8 +606,8 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
  * Convert Tags to encoded string.
  *
  * @export
- * @param {Tags} tags
- * @returns {string | undefined}
+ * @param tags -
+ *
  */
 export function toBlobTagsString(tags?: Tags): string | undefined {
   if (tags === undefined) {
@@ -629,8 +629,8 @@ export function toBlobTagsString(tags?: Tags): string | undefined {
  * Convert Tags type to BlobTags.
  *
  * @export
- * @param {Tags} [tags]
- * @returns {(BlobTags | undefined)}
+ * @param tags -
+ *
  */
 export function toBlobTags(tags?: Tags): BlobTags | undefined {
   if (tags === undefined) {
@@ -657,8 +657,8 @@ export function toBlobTags(tags?: Tags): BlobTags | undefined {
  * Covert BlobTags to Tags type.
  *
  * @export
- * @param {BlobTags} [tags]
- * @returns {(Tags | undefined)}
+ * @param tags -
+ *
  */
 export function toTags(tags?: BlobTags): Tags | undefined {
   if (tags === undefined) {
@@ -676,8 +676,8 @@ export function toTags(tags?: BlobTags): Tags | undefined {
  * Convert BlobQueryTextConfiguration to QuerySerialization type.
  *
  * @export
- * @param {(BlobQueryJsonTextConfiguration | BlobQueryCsvTextConfiguration | BlobQueryArrowConfiguration)} [textConfiguration]
- * @returns {(QuerySerialization | undefined)}
+ * @param textConfiguration -
+ *
  */
 export function toQuerySerialization(
   textConfiguration?:
@@ -768,9 +768,9 @@ export function parseObjectReplicationRecord(
  * Attach a TokenCredential to an object.
  *
  * @export
- * @param {T} thing
- * @param {TokenCredential} credential
- * @returns {T}
+ * @param thing -
+ * @param credential -
+ *
  */
 export function attachCredential<T>(thing: T, credential: TokenCredential): T {
   (thing as any).credential = credential;

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -233,7 +233,7 @@ function escape(text: string): string {
  * @export
  * @param url - Source URL string
  * @param name - String to be appended to URL
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -253,7 +253,7 @@ export function appendToURLPath(url: string, name: string): string {
  * @param url - Source URL string
  * @param name - Parameter name
  * @param value - Parameter value
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -377,7 +377,7 @@ export function getURLQueries(url: string): { [key: string]: string } {
  * @export
  * @param url - Source URL string.
  * @param queryParts - String to be appended to the URL query.
- * @returnsAn updated URL string.
+ * @returns An updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -400,7 +400,7 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -561,7 +561,7 @@ export function iEqual(str1: string, str2: string): boolean {
 /**
  * Extracts account name from the url
  * @param url - url to extract the account name from
- * @returnswith the account name
+ * @returns with the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);

--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -69,7 +69,7 @@ export async function streamToBuffer(
  * @param stream - A Node.js Readable stream
  * @param buffer - Buffer to be filled, length must >= offset
  * @param encoding - Encoding of the Readable stream
- * @returnswith the count of bytes read.
+ * @returns with the count of bytes read.
  * @throws {RangeError} If buffer size is not big enough.
  */
 export async function streamToBuffer2(
@@ -113,7 +113,7 @@ export async function streamToBuffer2(
  * @export
  * @param stream - A Node.js Readable stream
  * @param encoding - Encoding of the Readable stream
- * @returnswith the count of bytes read.
+ * @returns with the count of bytes read.
  */
 export async function streamToBuffer3(
   readableStream: NodeJS.ReadableStream,

--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -8,12 +8,12 @@ import * as util from "util";
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {Buffer} buffer Buffer to be filled, length must >= offset
- * @param {number} offset From which position in the buffer to be filled, inclusive
- * @param {number} end To which position in the buffer to be filled, exclusive
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<void>}
+ * @param stream - A Node.js Readable stream
+ * @param buffer - Buffer to be filled, length must >= offset
+ * @param offset - From which position in the buffer to be filled, inclusive
+ * @param end - To which position in the buffer to be filled, exclusive
+ * @param encoding - Encoding of the Readable stream
+ *
  */
 export async function streamToBuffer(
   stream: NodeJS.ReadableStream,
@@ -66,10 +66,10 @@ export async function streamToBuffer(
  * Reads a readable stream into buffer entirely.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {Buffer} buffer Buffer to be filled, length must >= offset
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<number>} with the count of bytes read.
+ * @param stream - A Node.js Readable stream
+ * @param buffer - Buffer to be filled, length must >= offset
+ * @param encoding - Encoding of the Readable stream
+ * @returnswith the count of bytes read.
  * @throws {RangeError} If buffer size is not big enough.
  */
 export async function streamToBuffer2(
@@ -111,9 +111,9 @@ export async function streamToBuffer2(
  * Reads a readable stream into a buffer.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<Buffer>} with the count of bytes read.
+ * @param stream - A Node.js Readable stream
+ * @param encoding - Encoding of the Readable stream
+ * @returnswith the count of bytes read.
  */
 export async function streamToBuffer3(
   readableStream: NodeJS.ReadableStream,
@@ -137,9 +137,9 @@ export async function streamToBuffer3(
  * Writes the content of a readstream to a local file. Returns a Promise which is completed after the file handle is closed.
  *
  * @export
- * @param {NodeJS.ReadableStream} rs The read stream.
- * @param {string} file Destination file path.
- * @returns {Promise<void>}
+ * @param rs - The read stream.
+ * @param file - Destination file path.
+ *
  */
 export async function readStreamToLocalFile(
   rs: NodeJS.ReadableStream,

--- a/sdk/storage/storage-blob/test/utils/InjectorPolicy.ts
+++ b/sdk/storage/storage-blob/test/utils/InjectorPolicy.ts
@@ -23,8 +23,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of InjectorPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof InjectorPolicy
    */
   public constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, injector: Injector) {
@@ -35,8 +35,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof InjectorPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -96,7 +96,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returnsThe access token details.
+   * @returns The access token details.
    */
   async getToken(
     _scopes: string | string[],

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -84,7 +84,7 @@ export class SimpleTokenCredential implements TokenCredential {
 
   /**
    * Creates an instance of TokenCredential.
-   * @param {string} token
+   * @param token -
    */
   constructor(token: string, expiresOn?: Date) {
     this.token = token;
@@ -96,7 +96,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returns {AccessToken} The access token details.
+   * @returnsThe access token details.
    */
   async getToken(
     _scopes: string | string[],
@@ -155,8 +155,8 @@ export function isSuperSet(m1?: BlobMetadata, m2?: BlobMetadata): boolean {
  * Sleep for seconds.
  *
  * @export
- * @param {number} seconds
- * @returns {Promise<void>}
+ * @param seconds -
+ *
  */
 export function sleep(seconds: number): Promise<void> {
   return new Promise((resolve) => {
@@ -168,8 +168,8 @@ export function sleep(seconds: number): Promise<void> {
  * Generate a Uint8Array with specified byteLength and randome content.
  *
  * @export
- * @param {number} byteLength
- * @returns {Uint8Array}
+ * @param byteLength -
+ *
  */
 export function genearteRandomUint8Array(byteLength: number): Uint8Array {
   const uint8Arr = new Uint8Array(byteLength);

--- a/sdk/storage/storage-blob/test/utils/testutils.node.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.node.ts
@@ -8,9 +8,9 @@ import * as fs from "fs";
  * ReadableStream or the fs.WriteStream.
  *
  * @export
- * @param {NodeJS.ReadableStream} rs The read stream.
- * @param {string} file Destination file path.
- * @returns {Promise<void>}
+ * @param rs - The read stream.
+ * @param file - Destination file path.
+ *
  */
 export async function readStreamToLocalFileWithLogs(
   rs: NodeJS.ReadableStream,

--- a/sdk/storage/storage-common/src/BufferScheduler.ts
+++ b/sdk/storage/storage-common/src/BufferScheduler.ts
@@ -192,14 +192,14 @@ export class BufferScheduler {
   /**
    * Creates an instance of BufferScheduler.
    *
-   * @param {Readable} readable A Node.js Readable stream
-   * @param {number} bufferSize Buffer size of every maintained buffer
-   * @param {number} maxBuffers How many buffers can be allocated
-   * @param {OutgoingHandler} outgoingHandler An async function scheduled to be
+   * @param readable - A Node.js Readable stream
+   * @param bufferSize - Buffer size of every maintained buffer
+   * @param maxBuffers - How many buffers can be allocated
+   * @param outgoingHandler - An async function scheduled to be
    *                                          triggered when a buffer fully filled
    *                                          with stream data
-   * @param {number} concurrency Concurrency of executing outgoingHandlers (>0)
-   * @param {string} [encoding] [Optional] Encoding of Readable stream when it's a string stream
+   * @param concurrency - Concurrency of executing outgoingHandlers (>0)
+   * @param encoding - [Optional] Encoding of Readable stream when it's a string stream
    * @memberof BufferScheduler
    */
   constructor(
@@ -234,7 +234,7 @@ export class BufferScheduler {
    * Start the scheduler, will return error when stream of any of the outgoingHandlers
    * returns error.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof BufferScheduler
    */
   public async do(): Promise<void> {
@@ -289,7 +289,7 @@ export class BufferScheduler {
    * Insert a new data into unresolved array.
    *
    * @private
-   * @param {Buffer} data
+   * @param data -
    * @memberof BufferScheduler
    */
   private appendUnresolvedData(data: Buffer) {
@@ -302,7 +302,7 @@ export class BufferScheduler {
    * than blockSize when data in unresolvedDataArray is less than bufferSize.
    *
    * @private
-   * @returns {PooledBuffer}
+   *
    * @memberof BufferScheduler
    */
   private shiftBufferFromUnresolvedDataArray(buffer?: PooledBuffer): PooledBuffer {
@@ -324,7 +324,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returns {boolean} Return false when buffers in incoming are not enough, else true.
+   * @returnsReturn false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {
@@ -375,8 +375,8 @@ export class BufferScheduler {
    * Trigger a outgoing handler for a buffer shifted from outgoing.
    *
    * @private
-   * @param {Buffer} buffer
-   * @returns {Promise<any>}
+   * @param buffer -
+   *
    * @memberof BufferScheduler
    */
   private async triggerOutgoingHandler(buffer: PooledBuffer): Promise<any> {
@@ -405,7 +405,7 @@ export class BufferScheduler {
    * Return buffer used by outgoing handler into incoming.
    *
    * @private
-   * @param {Buffer} buffer
+   * @param buffer -
    * @memberof BufferScheduler
    */
   private reuseBuffer(buffer: PooledBuffer) {

--- a/sdk/storage/storage-common/src/BufferScheduler.ts
+++ b/sdk/storage/storage-common/src/BufferScheduler.ts
@@ -324,7 +324,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returnsReturn false when buffers in incoming are not enough, else true.
+   * @returns Return false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {

--- a/sdk/storage/storage-common/src/BuffersStream.ts
+++ b/sdk/storage/storage-common/src/BuffersStream.ts
@@ -46,8 +46,8 @@ export class BuffersStream extends Readable {
    * Creates an instance of BuffersStream that will emit the data
    * contained in the array of buffers.
    *
-   * @param {Buffer[]} buffers Array of buffers containing the data
-   * @param {number} byteLength The total length of data contained in the buffers
+   * @param buffers - Array of buffers containing the data
+   * @param byteLength - The total length of data contained in the buffers
    * @memberof BuffersStream
    */
   constructor(
@@ -73,7 +73,7 @@ export class BuffersStream extends Readable {
   /**
    * Internal _read() that will be called when the stream wants to pull more data in.
    *
-   * @param {number} size Optional. The size of data to be read
+   * @param size - Optional. The size of data to be read
    * @memberof BuffersStream
    */
   public _read(size?: number) {

--- a/sdk/storage/storage-common/src/PooledBuffer.ts
+++ b/sdk/storage/storage-common/src/PooledBuffer.ts
@@ -63,7 +63,7 @@ export class PooledBuffer {
    * Users may call the {@link PooledBuffer.fill} method to fill this
    * pooled buffer with data.
    *
-   * @param {number} capacity Total capacity of the internal buffers
+   * @param capacity - Total capacity of the internal buffers
    * @memberof PooledBuffer
    */
   constructor(capacity: number);
@@ -73,9 +73,9 @@ export class PooledBuffer {
    * Internal buffers are allocated and filled with data in the input buffers serially
    * with respect to the total length.
    *
-   * @param {number} capacity Total capacity of the internal buffers
-   * @param {Buffer[]} buffers Input buffers containing the data to be filled in the pooled buffer
-   * @param {number} totalLength Total length of the data to be filled in.
+   * @param capacity - Total capacity of the internal buffers
+   * @param buffers - Input buffers containing the data to be filled in the pooled buffer
+   * @param totalLength - Total length of the data to be filled in.
    * @memberof PooledBuffer
    */
   constructor(capacity: number, buffers: Buffer[], totalLength: number);
@@ -103,10 +103,10 @@ export class PooledBuffer {
    * with respect to the total length and the total capacity of the internal buffers.
    * Data copied will be shift out of the input buffers.
    *
-   * @param {Buffer[]} buffers Input buffers containing the data to be filled in the pooled buffer
-   * @param {number} totalLength Total length of the data to be filled in.
+   * @param buffers - Input buffers containing the data to be filled in the pooled buffer
+   * @param totalLength - Total length of the data to be filled in.
    *
-   * @returns {void}
+   *
    * @memberof PooledBuffer
    */
   public fill(buffers: Buffer[], totalLength: number) {
@@ -145,7 +145,7 @@ export class PooledBuffer {
   /**
    * Get the readable stream assembled from all the data in the internal buffers.
    *
-   * @returns {Readable}
+   *
    * @memberof PooledBuffer
    */
   public getReadableStream(): Readable {

--- a/sdk/storage/storage-datalake/src/dataLakeStorageClient.ts
+++ b/sdk/storage/storage-datalake/src/dataLakeStorageClient.ts
@@ -14,7 +14,6 @@ import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
 import { DataLakeStorageClientContext } from "./dataLakeStorageClientContext";
 
-
 class DataLakeStorageClient extends DataLakeStorageClientContext {
   // Operation groups
   filesystem: operations.FilesystemOperations;
@@ -24,9 +23,13 @@ class DataLakeStorageClient extends DataLakeStorageClientContext {
    * Initializes a new instance of the DataLakeStorageClient class.
    * @param credentials Credentials needed for the client to connect to Azure.
    * @param accountName The Azure Storage account name.
-   * @param [options] The parameter options
+   * @param options - The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, accountName: string, options?: Models.DataLakeStorageClientOptions) {
+  constructor(
+    credentials: msRest.ServiceClientCredentials,
+    accountName: string,
+    options?: Models.DataLakeStorageClientOptions
+  ) {
     super(credentials, accountName, options);
     this.filesystem = new operations.FilesystemOperations(this);
     this.path = new operations.PathOperations(this);

--- a/sdk/storage/storage-datalake/src/dataLakeStorageClientContext.ts
+++ b/sdk/storage/storage-datalake/src/dataLakeStorageClientContext.ts
@@ -25,44 +25,51 @@ export class DataLakeStorageClientContext extends msRestAzure.AzureServiceClient
    * Initializes a new instance of the DataLakeStorageClient class.
    * @param credentials Credentials needed for the client to connect to Azure.
    * @param accountName The Azure Storage account name.
-   * @param [options] The parameter options
+   * @param options - The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, accountName: string, options?: Models.DataLakeStorageClientOptions) {
+  constructor(
+    credentials: msRest.ServiceClientCredentials,
+    accountName: string,
+    options?: Models.DataLakeStorageClientOptions
+  ) {
     if (credentials == undefined) {
-      throw new Error('\'credentials\' cannot be null.');
+      throw new Error("'credentials' cannot be null.");
     }
     if (accountName == undefined) {
-      throw new Error('\'accountName\' cannot be null.');
+      throw new Error("'accountName' cannot be null.");
     }
 
     if (!options) {
       options = {};
     }
-    if(!options.userAgent) {
+    if (!options.userAgent) {
       const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
     super(credentials, options);
 
-    this.dnsSuffix = 'dfs.core.windows.net';
-    this.acceptLanguage = 'en-US';
+    this.dnsSuffix = "dfs.core.windows.net";
+    this.acceptLanguage = "en-US";
     this.longRunningOperationRetryTimeout = 30;
     this.baseUri = "https://{accountName}.{dnsSuffix}";
     this.requestContentType = "application/json; charset=utf-8";
     this.credentials = credentials;
     this.accountName = accountName;
 
-    if(options.xMsVersion !== null && options.xMsVersion !== undefined) {
+    if (options.xMsVersion !== null && options.xMsVersion !== undefined) {
       this.xMsVersion = options.xMsVersion;
     }
-    if(options.dnsSuffix !== null && options.dnsSuffix !== undefined) {
+    if (options.dnsSuffix !== null && options.dnsSuffix !== undefined) {
       this.dnsSuffix = options.dnsSuffix;
     }
-    if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
+    if (options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
       this.acceptLanguage = options.acceptLanguage;
     }
-    if(options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
+    if (
+      options.longRunningOperationRetryTimeout !== null &&
+      options.longRunningOperationRetryTimeout !== undefined
+    ) {
       this.longRunningOperationRetryTimeout = options.longRunningOperationRetryTimeout;
     }
   }

--- a/sdk/storage/storage-datalake/src/operations/filesystemOperations.ts
+++ b/sdk/storage/storage-datalake/src/operations/filesystemOperations.ts
@@ -20,7 +20,7 @@ export class FilesystemOperations {
 
   /**
    * Create a FilesystemOperations.
-   * @param {DataLakeStorageClientContext} client Reference to the service client.
+   * @param client - Reference to the service client.
    */
   constructor(client: DataLakeStorageClientContext) {
     this.client = client;
@@ -29,7 +29,7 @@ export class FilesystemOperations {
   /**
    * List filesystems and their properties in given account.
    * @summary List Filesystems
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.FilesystemListResponse>
    */
   list(options?: Models.FilesystemListOptionalParams): Promise<Models.FilesystemListResponse>;
@@ -41,14 +41,21 @@ export class FilesystemOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: Models.FilesystemListOptionalParams, callback: msRest.ServiceCallback<Models.FilesystemList>): void;
-  list(options?: Models.FilesystemListOptionalParams | msRest.ServiceCallback<Models.FilesystemList>, callback?: msRest.ServiceCallback<Models.FilesystemList>): Promise<Models.FilesystemListResponse> {
+  list(
+    options: Models.FilesystemListOptionalParams,
+    callback: msRest.ServiceCallback<Models.FilesystemList>
+  ): void;
+  list(
+    options?: Models.FilesystemListOptionalParams | msRest.ServiceCallback<Models.FilesystemList>,
+    callback?: msRest.ServiceCallback<Models.FilesystemList>
+  ): Promise<Models.FilesystemListResponse> {
     return this.client.sendOperationRequest(
       {
         options
       },
       listOperationSpec,
-      callback) as Promise<Models.FilesystemListResponse>;
+      callback
+    ) as Promise<Models.FilesystemListResponse>;
   }
 
   /**
@@ -59,10 +66,13 @@ export class FilesystemOperations {
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
    * are not permitted.  All letters must be lowercase.  The value must have between 3 and 63
    * characters.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.FilesystemCreateResponse>
    */
-  create(filesystem: string, options?: Models.FilesystemCreateOptionalParams): Promise<Models.FilesystemCreateResponse>;
+  create(
+    filesystem: string,
+    options?: Models.FilesystemCreateOptionalParams
+  ): Promise<Models.FilesystemCreateResponse>;
   /**
    * @param filesystem The filesystem identifier.  The value must start and end with a letter or
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
@@ -79,15 +89,24 @@ export class FilesystemOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(filesystem: string, options: Models.FilesystemCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(filesystem: string, options?: Models.FilesystemCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.FilesystemCreateResponse> {
+  create(
+    filesystem: string,
+    options: Models.FilesystemCreateOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  create(
+    filesystem: string,
+    options?: Models.FilesystemCreateOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.FilesystemCreateResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
         options
       },
       createOperationSpec,
-      callback) as Promise<Models.FilesystemCreateResponse>;
+      callback
+    ) as Promise<Models.FilesystemCreateResponse>;
   }
 
   /**
@@ -99,10 +118,13 @@ export class FilesystemOperations {
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
    * are not permitted.  All letters must be lowercase.  The value must have between 3 and 63
    * characters.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.FilesystemSetPropertiesResponse>
    */
-  setProperties(filesystem: string, options?: Models.FilesystemSetPropertiesOptionalParams): Promise<Models.FilesystemSetPropertiesResponse>;
+  setProperties(
+    filesystem: string,
+    options?: Models.FilesystemSetPropertiesOptionalParams
+  ): Promise<Models.FilesystemSetPropertiesResponse>;
   /**
    * @param filesystem The filesystem identifier.  The value must start and end with a letter or
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
@@ -119,15 +141,24 @@ export class FilesystemOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  setProperties(filesystem: string, options: Models.FilesystemSetPropertiesOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  setProperties(filesystem: string, options?: Models.FilesystemSetPropertiesOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.FilesystemSetPropertiesResponse> {
+  setProperties(
+    filesystem: string,
+    options: Models.FilesystemSetPropertiesOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  setProperties(
+    filesystem: string,
+    options?: Models.FilesystemSetPropertiesOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.FilesystemSetPropertiesResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
         options
       },
       setPropertiesOperationSpec,
-      callback) as Promise<Models.FilesystemSetPropertiesResponse>;
+      callback
+    ) as Promise<Models.FilesystemSetPropertiesResponse>;
   }
 
   /**
@@ -137,10 +168,13 @@ export class FilesystemOperations {
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
    * are not permitted.  All letters must be lowercase.  The value must have between 3 and 63
    * characters.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.FilesystemGetPropertiesResponse>
    */
-  getProperties(filesystem: string, options?: Models.FilesystemGetPropertiesOptionalParams): Promise<Models.FilesystemGetPropertiesResponse>;
+  getProperties(
+    filesystem: string,
+    options?: Models.FilesystemGetPropertiesOptionalParams
+  ): Promise<Models.FilesystemGetPropertiesResponse>;
   /**
    * @param filesystem The filesystem identifier.  The value must start and end with a letter or
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
@@ -157,15 +191,24 @@ export class FilesystemOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getProperties(filesystem: string, options: Models.FilesystemGetPropertiesOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  getProperties(filesystem: string, options?: Models.FilesystemGetPropertiesOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.FilesystemGetPropertiesResponse> {
+  getProperties(
+    filesystem: string,
+    options: Models.FilesystemGetPropertiesOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  getProperties(
+    filesystem: string,
+    options?: Models.FilesystemGetPropertiesOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.FilesystemGetPropertiesResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
         options
       },
       getPropertiesOperationSpec,
-      callback) as Promise<Models.FilesystemGetPropertiesResponse>;
+      callback
+    ) as Promise<Models.FilesystemGetPropertiesResponse>;
   }
 
   /**
@@ -183,10 +226,13 @@ export class FilesystemOperations {
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
    * are not permitted.  All letters must be lowercase.  The value must have between 3 and 63
    * characters.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.FilesystemDeleteResponse>
    */
-  deleteMethod(filesystem: string, options?: Models.FilesystemDeleteMethodOptionalParams): Promise<Models.FilesystemDeleteResponse>;
+  deleteMethod(
+    filesystem: string,
+    options?: Models.FilesystemDeleteMethodOptionalParams
+  ): Promise<Models.FilesystemDeleteResponse>;
   /**
    * @param filesystem The filesystem identifier.  The value must start and end with a letter or
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
@@ -203,15 +249,24 @@ export class FilesystemOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(filesystem: string, options: Models.FilesystemDeleteMethodOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(filesystem: string, options?: Models.FilesystemDeleteMethodOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.FilesystemDeleteResponse> {
+  deleteMethod(
+    filesystem: string,
+    options: Models.FilesystemDeleteMethodOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  deleteMethod(
+    filesystem: string,
+    options?: Models.FilesystemDeleteMethodOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.FilesystemDeleteResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
         options
       },
       deleteMethodOperationSpec,
-      callback) as Promise<Models.FilesystemDeleteResponse>;
+      callback
+    ) as Promise<Models.FilesystemDeleteResponse>;
   }
 }
 
@@ -219,10 +274,7 @@ export class FilesystemOperations {
 const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix],
   queryParameters: [
     Parameters.resource0,
     Parameters.prefix,
@@ -251,15 +303,8 @@ const listOperationSpec: msRest.OperationSpec = {
 const createOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "{filesystem}",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix,
-    Parameters.filesystem
-  ],
-  queryParameters: [
-    Parameters.resource1,
-    Parameters.timeout
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix, Parameters.filesystem],
+  queryParameters: [Parameters.resource1, Parameters.timeout],
   headerParameters: [
     Parameters.xMsProperties,
     Parameters.xMsClientRequestId,
@@ -281,15 +326,8 @@ const createOperationSpec: msRest.OperationSpec = {
 const setPropertiesOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
   path: "{filesystem}",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix,
-    Parameters.filesystem
-  ],
-  queryParameters: [
-    Parameters.resource1,
-    Parameters.timeout
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix, Parameters.filesystem],
+  queryParameters: [Parameters.resource1, Parameters.timeout],
   headerParameters: [
     Parameters.xMsProperties,
     Parameters.ifModifiedSince,
@@ -313,15 +351,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
 const getPropertiesOperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "{filesystem}",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix,
-    Parameters.filesystem
-  ],
-  queryParameters: [
-    Parameters.resource1,
-    Parameters.timeout
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix, Parameters.filesystem],
+  queryParameters: [Parameters.resource1, Parameters.timeout],
   headerParameters: [
     Parameters.xMsClientRequestId,
     Parameters.xMsDate,
@@ -342,15 +373,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
 const deleteMethodOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
   path: "{filesystem}",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix,
-    Parameters.filesystem
-  ],
-  queryParameters: [
-    Parameters.resource1,
-    Parameters.timeout
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix, Parameters.filesystem],
+  queryParameters: [Parameters.resource1, Parameters.timeout],
   headerParameters: [
     Parameters.ifModifiedSince,
     Parameters.ifUnmodifiedSince,

--- a/sdk/storage/storage-datalake/src/operations/pathOperations.ts
+++ b/sdk/storage/storage-datalake/src/operations/pathOperations.ts
@@ -20,7 +20,7 @@ export class PathOperations {
 
   /**
    * Create a PathOperations.
-   * @param {DataLakeStorageClientContext} client Reference to the service client.
+   * @param client - Reference to the service client.
    */
   constructor(client: DataLakeStorageClientContext) {
     this.client = client;
@@ -36,10 +36,14 @@ export class PathOperations {
    * number and must contain only letters, numbers, and the dash (-) character.  Consecutive dashes
    * are not permitted.  All letters must be lowercase.  The value must have between 3 and 63
    * characters.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathListResponse>
    */
-  list(recursive: boolean, filesystem: string, options?: Models.PathListOptionalParams): Promise<Models.PathListResponse>;
+  list(
+    recursive: boolean,
+    filesystem: string,
+    options?: Models.PathListOptionalParams
+  ): Promise<Models.PathListResponse>;
   /**
    * @param recursive If "true", all paths are listed; otherwise, only paths at the root of the
    * filesystem are listed.  If "directory" is specified, the list will only include paths that share
@@ -50,7 +54,11 @@ export class PathOperations {
    * characters.
    * @param callback The callback
    */
-  list(recursive: boolean, filesystem: string, callback: msRest.ServiceCallback<Models.PathList>): void;
+  list(
+    recursive: boolean,
+    filesystem: string,
+    callback: msRest.ServiceCallback<Models.PathList>
+  ): void;
   /**
    * @param recursive If "true", all paths are listed; otherwise, only paths at the root of the
    * filesystem are listed.  If "directory" is specified, the list will only include paths that share
@@ -62,8 +70,18 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(recursive: boolean, filesystem: string, options: Models.PathListOptionalParams, callback: msRest.ServiceCallback<Models.PathList>): void;
-  list(recursive: boolean, filesystem: string, options?: Models.PathListOptionalParams | msRest.ServiceCallback<Models.PathList>, callback?: msRest.ServiceCallback<Models.PathList>): Promise<Models.PathListResponse> {
+  list(
+    recursive: boolean,
+    filesystem: string,
+    options: Models.PathListOptionalParams,
+    callback: msRest.ServiceCallback<Models.PathList>
+  ): void;
+  list(
+    recursive: boolean,
+    filesystem: string,
+    options?: Models.PathListOptionalParams | msRest.ServiceCallback<Models.PathList>,
+    callback?: msRest.ServiceCallback<Models.PathList>
+  ): Promise<Models.PathListResponse> {
     return this.client.sendOperationRequest(
       {
         recursive,
@@ -71,7 +89,8 @@ export class PathOperations {
         options
       },
       listOperationSpec,
-      callback) as Promise<Models.PathListResponse>;
+      callback
+    ) as Promise<Models.PathListResponse>;
   }
 
   /**
@@ -84,10 +103,14 @@ export class PathOperations {
    * @summary Create File | Create Directory | Rename File | Rename Directory
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathCreateResponse>
    */
-  create(filesystem: string, path: string, options?: Models.PathCreateOptionalParams): Promise<Models.PathCreateResponse>;
+  create(
+    filesystem: string,
+    path: string,
+    options?: Models.PathCreateOptionalParams
+  ): Promise<Models.PathCreateResponse>;
   /**
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
@@ -100,8 +123,18 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(filesystem: string, path: string, options: Models.PathCreateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  create(filesystem: string, path: string, options?: Models.PathCreateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathCreateResponse> {
+  create(
+    filesystem: string,
+    path: string,
+    options: Models.PathCreateOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  create(
+    filesystem: string,
+    path: string,
+    options?: Models.PathCreateOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathCreateResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
@@ -109,7 +142,8 @@ export class PathOperations {
         options
       },
       createOperationSpec,
-      callback) as Promise<Models.PathCreateResponse>;
+      callback
+    ) as Promise<Models.PathCreateResponse>;
   }
 
   /**
@@ -129,10 +163,15 @@ export class PathOperations {
    * 'setAccessControl'
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathUpdateResponse>
    */
-  update(action: Models.PathUpdateAction, filesystem: string, path: string, options?: Models.PathUpdateOptionalParams): Promise<Models.PathUpdateResponse>;
+  update(
+    action: Models.PathUpdateAction,
+    filesystem: string,
+    path: string,
+    options?: Models.PathUpdateOptionalParams
+  ): Promise<Models.PathUpdateResponse>;
   /**
    * @param action The action must be "append" to upload data to be appended to a file, "flush" to
    * flush previously uploaded data to a file, "setProperties" to set the properties of a file or
@@ -146,7 +185,12 @@ export class PathOperations {
    * @param path The file or directory path.
    * @param callback The callback
    */
-  update(action: Models.PathUpdateAction, filesystem: string, path: string, callback: msRest.ServiceCallback<void>): void;
+  update(
+    action: Models.PathUpdateAction,
+    filesystem: string,
+    path: string,
+    callback: msRest.ServiceCallback<void>
+  ): void;
   /**
    * @param action The action must be "append" to upload data to be appended to a file, "flush" to
    * flush previously uploaded data to a file, "setProperties" to set the properties of a file or
@@ -161,8 +205,20 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  update(action: Models.PathUpdateAction, filesystem: string, path: string, options: Models.PathUpdateOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  update(action: Models.PathUpdateAction, filesystem: string, path: string, options?: Models.PathUpdateOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathUpdateResponse> {
+  update(
+    action: Models.PathUpdateAction,
+    filesystem: string,
+    path: string,
+    options: Models.PathUpdateOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  update(
+    action: Models.PathUpdateAction,
+    filesystem: string,
+    path: string,
+    options?: Models.PathUpdateOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         action,
@@ -171,7 +227,8 @@ export class PathOperations {
         options
       },
       updateOperationSpec,
-      callback) as Promise<Models.PathUpdateResponse>;
+      callback
+    ) as Promise<Models.PathUpdateResponse>;
   }
 
   /**
@@ -192,10 +249,15 @@ export class PathOperations {
    * 'acquire', 'break', 'change', 'renew', 'release'
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathLeaseResponse>
    */
-  lease(xMsLeaseAction: Models.PathLeaseAction, filesystem: string, path: string, options?: Models.PathLeaseOptionalParams): Promise<Models.PathLeaseResponse>;
+  lease(
+    xMsLeaseAction: Models.PathLeaseAction,
+    filesystem: string,
+    path: string,
+    options?: Models.PathLeaseOptionalParams
+  ): Promise<Models.PathLeaseResponse>;
   /**
    * @param xMsLeaseAction There are five lease actions: "acquire", "break", "change", "renew", and
    * "release". Use "acquire" and specify the "x-ms-proposed-lease-id" and "x-ms-lease-duration" to
@@ -211,7 +273,12 @@ export class PathOperations {
    * @param path The file or directory path.
    * @param callback The callback
    */
-  lease(xMsLeaseAction: Models.PathLeaseAction, filesystem: string, path: string, callback: msRest.ServiceCallback<void>): void;
+  lease(
+    xMsLeaseAction: Models.PathLeaseAction,
+    filesystem: string,
+    path: string,
+    callback: msRest.ServiceCallback<void>
+  ): void;
   /**
    * @param xMsLeaseAction There are five lease actions: "acquire", "break", "change", "renew", and
    * "release". Use "acquire" and specify the "x-ms-proposed-lease-id" and "x-ms-lease-duration" to
@@ -228,8 +295,20 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  lease(xMsLeaseAction: Models.PathLeaseAction, filesystem: string, path: string, options: Models.PathLeaseOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  lease(xMsLeaseAction: Models.PathLeaseAction, filesystem: string, path: string, options?: Models.PathLeaseOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathLeaseResponse> {
+  lease(
+    xMsLeaseAction: Models.PathLeaseAction,
+    filesystem: string,
+    path: string,
+    options: Models.PathLeaseOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  lease(
+    xMsLeaseAction: Models.PathLeaseAction,
+    filesystem: string,
+    path: string,
+    options?: Models.PathLeaseOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathLeaseResponse> {
     return this.client.sendOperationRequest(
       {
         xMsLeaseAction,
@@ -238,7 +317,8 @@ export class PathOperations {
         options
       },
       leaseOperationSpec,
-      callback) as Promise<Models.PathLeaseResponse>;
+      callback
+    ) as Promise<Models.PathLeaseResponse>;
   }
 
   /**
@@ -249,10 +329,14 @@ export class PathOperations {
    * @summary Read File
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathReadResponse>
    */
-  read(filesystem: string, path: string, options?: Models.PathReadOptionalParams): Promise<Models.PathReadResponse>;
+  read(
+    filesystem: string,
+    path: string,
+    options?: Models.PathReadOptionalParams
+  ): Promise<Models.PathReadResponse>;
   /**
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
@@ -265,8 +349,18 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  read(filesystem: string, path: string, options: Models.PathReadOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  read(filesystem: string, path: string, options?: Models.PathReadOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathReadResponse> {
+  read(
+    filesystem: string,
+    path: string,
+    options: Models.PathReadOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  read(
+    filesystem: string,
+    path: string,
+    options?: Models.PathReadOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathReadResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
@@ -274,7 +368,8 @@ export class PathOperations {
         options
       },
       readOperationSpec,
-      callback) as Promise<Models.PathReadResponse>;
+      callback
+    ) as Promise<Models.PathReadResponse>;
   }
 
   /**
@@ -286,10 +381,14 @@ export class PathOperations {
    * @summary Get Properties | Get Status | Get Access Control List
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathGetPropertiesResponse>
    */
-  getProperties(filesystem: string, path: string, options?: Models.PathGetPropertiesOptionalParams): Promise<Models.PathGetPropertiesResponse>;
+  getProperties(
+    filesystem: string,
+    path: string,
+    options?: Models.PathGetPropertiesOptionalParams
+  ): Promise<Models.PathGetPropertiesResponse>;
   /**
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
@@ -302,8 +401,18 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getProperties(filesystem: string, path: string, options: Models.PathGetPropertiesOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  getProperties(filesystem: string, path: string, options?: Models.PathGetPropertiesOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathGetPropertiesResponse> {
+  getProperties(
+    filesystem: string,
+    path: string,
+    options: Models.PathGetPropertiesOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  getProperties(
+    filesystem: string,
+    path: string,
+    options?: Models.PathGetPropertiesOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathGetPropertiesResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
@@ -311,7 +420,8 @@ export class PathOperations {
         options
       },
       getPropertiesOperationSpec,
-      callback) as Promise<Models.PathGetPropertiesResponse>;
+      callback
+    ) as Promise<Models.PathGetPropertiesResponse>;
   }
 
   /**
@@ -321,10 +431,14 @@ export class PathOperations {
    * @summary Delete File | Delete Directory
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
-   * @param [options] The optional parameters
+   * @param options - The optional parameters
    * @returns Promise<Models.PathDeleteResponse>
    */
-  deleteMethod(filesystem: string, path: string, options?: Models.PathDeleteMethodOptionalParams): Promise<Models.PathDeleteResponse>;
+  deleteMethod(
+    filesystem: string,
+    path: string,
+    options?: Models.PathDeleteMethodOptionalParams
+  ): Promise<Models.PathDeleteResponse>;
   /**
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
@@ -337,8 +451,18 @@ export class PathOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(filesystem: string, path: string, options: Models.PathDeleteMethodOptionalParams, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(filesystem: string, path: string, options?: Models.PathDeleteMethodOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.PathDeleteResponse> {
+  deleteMethod(
+    filesystem: string,
+    path: string,
+    options: Models.PathDeleteMethodOptionalParams,
+    callback: msRest.ServiceCallback<void>
+  ): void;
+  deleteMethod(
+    filesystem: string,
+    path: string,
+    options?: Models.PathDeleteMethodOptionalParams | msRest.ServiceCallback<void>,
+    callback?: msRest.ServiceCallback<void>
+  ): Promise<Models.PathDeleteResponse> {
     return this.client.sendOperationRequest(
       {
         filesystem,
@@ -346,7 +470,8 @@ export class PathOperations {
         options
       },
       deleteMethodOperationSpec,
-      callback) as Promise<Models.PathDeleteResponse>;
+      callback
+    ) as Promise<Models.PathDeleteResponse>;
   }
 }
 
@@ -355,11 +480,7 @@ const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "{filesystem}",
-  urlParameters: [
-    Parameters.accountName,
-    Parameters.dnsSuffix,
-    Parameters.filesystem
-  ],
+  urlParameters: [Parameters.accountName, Parameters.dnsSuffix, Parameters.filesystem],
   queryParameters: [
     Parameters.directory,
     Parameters.recursive0,
@@ -483,10 +604,7 @@ const updateOperationSpec: msRest.OperationSpec = {
     Parameters.acceptLanguage
   ],
   requestBody: {
-    parameterPath: [
-      "options",
-      "requestBody"
-    ],
+    parameterPath: ["options", "requestBody"],
     mapper: {
       serializedName: "requestBody",
       type: {
@@ -518,9 +636,7 @@ const leaseOperationSpec: msRest.OperationSpec = {
     Parameters.filesystem,
     Parameters.path
   ],
-  queryParameters: [
-    Parameters.timeout
-  ],
+  queryParameters: [Parameters.timeout],
   headerParameters: [
     Parameters.xMsLeaseAction,
     Parameters.xMsLeaseDuration,
@@ -562,9 +678,7 @@ const readOperationSpec: msRest.OperationSpec = {
     Parameters.filesystem,
     Parameters.path
   ],
-  queryParameters: [
-    Parameters.timeout
-  ],
+  queryParameters: [Parameters.timeout],
   headerParameters: [
     Parameters.range,
     Parameters.xMsLeaseId,
@@ -613,11 +727,7 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
     Parameters.filesystem,
     Parameters.path
   ],
-  queryParameters: [
-    Parameters.action1,
-    Parameters.upn,
-    Parameters.timeout
-  ],
+  queryParameters: [Parameters.action1, Parameters.upn, Parameters.timeout],
   headerParameters: [
     Parameters.xMsLeaseId,
     Parameters.ifMatch,
@@ -649,11 +759,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
     Parameters.filesystem,
     Parameters.path
   ],
-  queryParameters: [
-    Parameters.recursive1,
-    Parameters.continuation,
-    Parameters.timeout
-  ],
+  queryParameters: [Parameters.recursive1, Parameters.continuation, Parameters.timeout],
   headerParameters: [
     Parameters.xMsLeaseId,
     Parameters.ifMatch,

--- a/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
@@ -676,7 +676,7 @@ export class DataLakeFileSystemClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeFileSystemClient
    */
   public generateSasUrl(options: FileSystemGenerateSasUrlOptions): Promise<string> {

--- a/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
@@ -73,11 +73,11 @@ export class DataLakeFileSystemClient extends StorageClient {
   /**
    * Creates an instance of DataLakeFileSystemClient from url and credential.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake file system, such as
+   * @param url - A Client string pointing to Azure Storage data lake file system, such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem?sasString".
-   * @param {(StorageSharedKeyCredential | AnonymousCredential | TokenCredential)} [credential] Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof DataLakeFileSystemClient
    */
   constructor(
@@ -89,10 +89,10 @@ export class DataLakeFileSystemClient extends StorageClient {
   /**
    * Creates an instance of DataLakeFileSystemClient from url and pipeline.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake file system, such as
+   * @param url - A Client string pointing to Azure Storage data lake file system, such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof DataLakeFileSystemClient
    */
@@ -139,8 +139,8 @@ export class DataLakeFileSystemClient extends StorageClient {
   /**
    * Creates a {@link DataLakeDirectoryClient} object under current file system.
    *
-   * @param {string} directoryName
-   * @returns {DataLakeDirectoryClient}
+   * @param directoryName -
+   *
    * @memberof DataLakeFileSystemClient
    */
   public getDirectoryClient(directoryName: string): DataLakeDirectoryClient {
@@ -153,8 +153,8 @@ export class DataLakeFileSystemClient extends StorageClient {
   /**
    * Creates a {@link DataLakeFileClient} object under current file system.
    *
-   * @param {string} fileName
-   * @returns {DataLakeFileClient}
+   * @param fileName -
+   *
    * @memberof DataLakeFileSystemClient
    */
   public getFileClient(fileName: string): DataLakeFileClient {
@@ -167,8 +167,8 @@ export class DataLakeFileSystemClient extends StorageClient {
   /**
    * Get a {@link DataLakeLeaseClient} that manages leases on the file system.
    *
-   * @param {string} [proposeLeaseId] Optional. Initial proposed lease Id.
-   * @returns {DataLakeLeaseClient}
+   * @param proposeLeaseId - Optional. Initial proposed lease Id.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public getDataLakeLeaseClient(proposeLeaseId?: string): DataLakeLeaseClient {
@@ -181,8 +181,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    *
-   * @param {FileSystemCreateOptions} [options={}] Optional. Options when creating file system.
-   * @returns {Promise<FileSystemCreateResponse>}
+   * @param options - Optional. Options when creating file system.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async create(options: FileSystemCreateOptions = {}): Promise<FileSystemCreateResponse> {
@@ -213,8 +213,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    *
-   * @param {FileSystemCreateOptions} [options={}]
-   * @returns {Promise<FileSystemCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async createIfNotExists(
@@ -248,8 +248,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    * applications. Vice versa new file system with the same name might be added by other clients or
    * applications after this function completes.
    *
-   * @param {FileSystemExistsOptions} [options={}]
-   * @returns {Promise<boolean>}
+   * @param options -
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async exists(options: FileSystemExistsOptions = {}): Promise<boolean> {
@@ -278,8 +278,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container
    *
-   * @param {FileSystemDeleteOptions} [options={}] Optional. Options when deleting file system.
-   * @returns {Promise<FileSystemDeleteResponse>}
+   * @param options - Optional. Options when deleting file system.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async delete(options: FileSystemDeleteOptions = {}): Promise<FileSystemDeleteResponse> {
@@ -308,8 +308,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container
    *
-   * @param {FileSystemDeleteOptions} [options={}]
-   * @returns {Promise<FileSystemDeleteIfExistsResponse>}
+   * @param options -
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async deleteIfExists(
@@ -346,8 +346,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties
    *
-   * @param {FileSystemGetPropertiesOptions} [options={}] Optional. Options when getting file system properties.
-   * @returns {Promise<FileSystemGetPropertiesResponse>}
+   * @param options - Optional. Options when getting file system properties.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async getProperties(
@@ -392,10 +392,10 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-metadata
    *
-   * @param {Metadata} [metadata] Replace existing metadata with this value.
+   * @param metadata - Replace existing metadata with this value.
    *                              If no value provided the existing metadata will be removed.
-   * @param {FileSystemSetMetadataOptions} [options={}] Optional. Options when setting file system metadata.
-   * @returns {Promise<FileSystemSetMetadataResponse>}
+   * @param options - Optional. Options when setting file system metadata.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async setMetadata(
@@ -431,8 +431,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl
    *
-   * @param {FileSystemGetAccessPolicyOptions} [options={}] Optional. Options when getting file system access policy.
-   * @returns {Promise<FileSystemGetAccessPolicyResponse>}
+   * @param options - Optional. Options when getting file system access policy.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async getAccessPolicy(
@@ -479,10 +479,10 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-acl
    *
-   * @param {PublicAccessType} [access] Optional. The level of public access to data in the file system.
-   * @param {SignedIdentifier<AccessPolicy>[]} [fileSystemAcl] Optional. Array of elements each having a unique Id and details of the access policy.
-   * @param {FileSystemSetAccessPolicyOptions} [options={}] Optional. Options when setting file system access policy.
-   * @returns {Promise<FileSystemSetAccessPolicyResponse>}
+   * @param access - Optional. The level of public access to data in the file system.
+   * @param fileSystemAcl - Optional. Array of elements each having a unique Id and details of the access policy.
+   * @param options - Optional. Options when setting file system access policy.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public async setAccessPolicy(
@@ -583,8 +583,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/rest/api/storageservices/list-blobs
    *
-   * @param {ListPathsOptions} [options={}] Optional. Options when listing paths.
-   * @returns {PagedAsyncIterableIterator<Path, FileSystemListPathsResponse>}
+   * @param options - Optional. Options when listing paths.
+   *
    * @memberof DataLakeFileSystemClient
    */
   public listPaths(
@@ -675,8 +675,8 @@ export class DataLakeFileSystemClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {FileSystemGenerateSasUrlOptions} options Optional parameters.
-   * @returns {Promise<string>} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeFileSystemClient
    */
   public generateSasUrl(options: FileSystemGenerateSasUrlOptions): Promise<string> {

--- a/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
@@ -60,13 +60,13 @@ export class DataLakeServiceClient extends StorageClient {
    *
    * Creates an instance of DataLakeServiceClient from connection string.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof DataLakeServiceClient
    */
   public static fromConnectionString(connectionString: string, options?: StoragePipelineOptions) {
@@ -100,11 +100,11 @@ export class DataLakeServiceClient extends StorageClient {
   /**
    * Creates an instance of DataLakeServiceClient from url.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake service, such as
+   * @param url - A Client string pointing to Azure Storage data lake service, such as
    *                     "https://myaccount.dfs.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net?sasString".
-   * @param {(StorageSharedKeyCredential | AnonymousCredential | TokenCredential)} [credential] Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof DataLakeServiceClient
    */
   public constructor(
@@ -116,10 +116,10 @@ export class DataLakeServiceClient extends StorageClient {
   /**
    * Creates an instance of DataLakeServiceClient from url and pipeline.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake service, such as
+   * @param url - A Client string pointing to Azure Storage data lake service, such as
    *                     "https://myaccount.dfs.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof DataLakeServiceClient
    */
@@ -155,8 +155,8 @@ export class DataLakeServiceClient extends StorageClient {
   /**
    * Creates a {@link DataLakeFileSystemClient} object.
    *
-   * @param {string} fileSystemName File system name.
-   * @returns {DataLakeFileSystemClient}
+   * @param fileSystemName - File system name.
+   *
    * @memberof DataLakeServiceClient
    */
   public getFileSystemClient(fileSystemName: string): DataLakeFileSystemClient {
@@ -191,10 +191,10 @@ export class DataLakeServiceClient extends StorageClient {
    * ```
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key
    *
-   * @param {Date} startsOn The start time for the user delegation SAS. Must be within 7 days of the current time.
-   * @param {Date} expiresOn The end time for the user delegation SAS. Must be within 7 days of the current time.
-   * @param {ServiceGetUserDelegationKeyOptions} [options={}]
-   * @returns {Promise<ServiceGetUserDelegationKeyResponse>}
+   * @param startsOn - The start time for the user delegation SAS. Must be within 7 days of the current time.
+   * @param expiresOn - The end time for the user delegation SAS. Must be within 7 days of the current time.
+   * @param options -
+   *
    * @memberof DataLakeServiceClient
    */
   public async getUserDelegationKey(
@@ -298,8 +298,8 @@ export class DataLakeServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2
    *
-   * @param {ServiceListFileSystemsOptions} [options={}]
-   * @returns {PagedAsyncIterableIterator<FileSystemItem, ServiceListFileSystemsSegmentResponse>}
+   * @param options -
+   *
    * @memberof DataLakeServiceClient
    */
   public listFileSystems(
@@ -324,11 +324,11 @@ export class DataLakeServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas
    *
-   * @param {Date} expiresOn Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
-   * @param {AccountSASPermissions} [permissions=AccountSASPermissions.parse("r")] Specifies the list of permissions to be associated with the SAS.
-   * @param {string} [resourceTypes="sco"] Specifies the resource types associated with the shared access signature.
-   * @param {ServiceGenerateAccountSasUrlOptions} [options={}] Optional parameters.
-   * @returns {string} An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param expiresOn - Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
+   * @param permissions - Specifies the list of permissions to be associated with the SAS.
+   * @param resourceTypes - Specifies the resource types associated with the shared access signature.
+   * @param options - Optional parameters.
+   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeServiceClient
    */
   public generateAccountSasUrl(
@@ -365,9 +365,9 @@ export class DataLakeServiceClient extends StorageClient {
   /**
    * Renames an existing File System.
    *
-   * @param {string} sourceFileSystemName The name of the source File System.
-   * @param {string} destinationContainerName The new name of the File System.
-   * @param {ServiceRenameFileSystemOptions} [options] Options to configure File System Rename operation.
+   * @param sourceFileSystemName - The name of the source File System.
+   * @param destinationContainerName - The new name of the File System.
+   * @param options - Options to configure File System Rename operation.
    * @memberof DataLakeServiceClient
    */
   // @ts-ignore Need to hide this interface for now. Make it public and turn on the live tests for it when the service is ready.
@@ -414,9 +414,9 @@ export class DataLakeServiceClient extends StorageClient {
    * Restore a previously deleted File System.
    * This API is only functional if Container Soft Delete is enabled for the storage account.
    *
-   * @param {string} deletedFileSystemName The name of the source File System.
-   * @param {string} deleteFileSystemVersion The new name of the File System.
-   * @param {ServiceRenameFileSystemOptions} [options] Options to configure File System Restore operation.
+   * @param deletedFileSystemName - The name of the source File System.
+   * @param deleteFileSystemVersion - The new name of the File System.
+   * @param options - Options to configure File System Restore operation.
    * @memberof DataLakeServiceClient
    */
   public async undeleteFileSystem(

--- a/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
@@ -328,7 +328,7 @@ export class DataLakeServiceClient extends StorageClient {
    * @param permissions - Specifies the list of permissions to be associated with the SAS.
    * @param resourceTypes - Specifies the resource types associated with the shared access signature.
    * @param options - Optional parameters.
-   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -104,8 +104,8 @@ export class Pipeline extends BlobPipeline {
   /**
    * Creates an instance of Pipeline. Customize HTTPClient by implementing IHttpClient interface.
    *
-   * @param {RequestPolicyFactory[]} factories
-   * @param {PipelineOptions} [options={}]
+   * @param factories -
+   * @param options -
    * @memberof Pipeline
    */
   constructor(factories: RequestPolicyFactory[], options: PipelineOptions = {}) {
@@ -123,7 +123,7 @@ export class Pipeline extends BlobPipeline {
    * Transfer Pipeline object to ServiceClientOptions object which is required by
    * ServiceClient constructor.
    *
-   * @returns {ServiceClientOptions} The ServiceClientOptions object from this Pipeline.
+   * @returnsThe ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -180,9 +180,9 @@ export interface StoragePipelineOptions {
  * Creates a new Pipeline object with Credential provided.
  *
  * @export
- * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
- * @param {StoragePipelineOptions} [pipelineOptions] Optional. Options.
- * @returns {Pipeline} A new Pipeline object.
+ * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+ * @param pipelineOptions - Optional. Options.
+ * @returnsA new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
@@ -232,9 +232,9 @@ export function newPipeline(
  * Attach a TokenCredential to an object.
  *
  * @export
- * @param {T} thing
- * @param {TokenCredential} credential
- * @returns {T}
+ * @param thing -
+ * @param credential -
+ *
  */
 function attachCredential<T>(thing: T, credential: TokenCredential): T {
   (thing as any).credential = credential;

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -123,7 +123,7 @@ export class Pipeline extends BlobPipeline {
    * Transfer Pipeline object to ServiceClientOptions object which is required by
    * ServiceClient constructor.
    *
-   * @returnsThe ServiceClientOptions object from this Pipeline.
+   * @returns The ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -182,7 +182,7 @@ export interface StoragePipelineOptions {
  * @export
  * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
  * @param pipelineOptions - Optional. Options.
- * @returnsA new Pipeline object.
+ * @returns A new Pipeline object.
  */
 export function newPipeline(
   credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,

--- a/sdk/storage/storage-file-datalake/src/StorageBrowserPolicyFactory.ts
+++ b/sdk/storage/storage-file-datalake/src/StorageBrowserPolicyFactory.ts
@@ -16,9 +16,9 @@ export class StorageBrowserPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageBrowserPolicyFactory object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageBrowserPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageBrowserPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageBrowserPolicy {

--- a/sdk/storage/storage-file-datalake/src/StorageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/StorageClient.ts
@@ -101,8 +101,8 @@ export abstract class StorageClient {
 
   /**
    * Creates an instance of StorageClient.
-   * @param {string} url url to resource
-   * @param {Pipeline} pipeline request policy pipeline.
+   * @param url - url to resource
+   * @param pipeline - request policy pipeline.
    * @memberof StorageClient
    */
   protected constructor(url: string, pipeline: Pipeline) {

--- a/sdk/storage/storage-file-datalake/src/StorageRetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-datalake/src/StorageRetryPolicyFactory.ts
@@ -88,7 +88,7 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of StorageRetryPolicyFactory.
-   * @param {StorageRetryOptions} [retryOptions]
+   * @param retryOptions -
    * @memberof StorageRetryPolicyFactory
    */
   constructor(retryOptions?: StorageRetryOptions) {
@@ -98,9 +98,9 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageRetryPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageRetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageRetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy {

--- a/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
@@ -29,7 +29,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of TelemetryPolicyFactory.
-   * @param {UserAgentOptions} [telemetry]
+   * @param telemetry -
    * @memberof TelemetryPolicyFactory
    */
   constructor(telemetry?: UserAgentOptions) {
@@ -62,9 +62,9 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a TelemetryPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {TelemetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof TelemetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): TelemetryPolicy {

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -1154,7 +1154,7 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeDirectoryClient
    */
   public generateSasUrl(options: DirectoryGenerateSasUrlOptions): Promise<string> {
@@ -2003,7 +2003,7 @@ export class DataLakeFileClient extends DataLakePathClient {
    * @param offset - From which position of the file to download.
    * @param count - How much data to be downloaded. Will download to the end when passing undefined.
    * @param options - Options to read Data Lake file.
-   * @returnsThe response data for file read operation,
+   * @returns The response data for file read operation,
    *                                      but with readableStreamBody set to undefined since its
    *                                      content is already read and written into a local file
    *                                      at the specified path.
@@ -2158,7 +2158,7 @@ export class DataLakeFileClient extends DataLakePathClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeFileClient
    */
   public generateSasUrl(options: FileGenerateSasUrlOptions): Promise<string> {

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -128,12 +128,12 @@ export class DataLakePathClient extends StorageClient {
    * SetAccessControlRecursiveInternal operation sets the Access Control on a path and sub paths.
    *
    * @private
-   * @param {PathSetAccessControlRecursiveMode} mode Mode \"set\" sets POSIX access control rights on files and directories,
+   * @param mode - Mode \"set\" sets POSIX access control rights on files and directories,
    *                                                 Mode \"modify\" modifies one or more POSIX access control rights that pre-exist on files and directories,
    *                                                 Mode \"remove\" removes one or more POSIX access control rights that were present earlier on files and directories.
-   * @param {PathAccessControlItem[] | RemovePathAccessControlItem[]} acl The POSIX access control list for the file or directory.
-   * @param {PathChangeAccessControlRecursiveOptions} [options={}] Optional. Options
-   * @returns {Promise<PathChangeAccessControlRecursiveResponse>}
+   * @param acl - The POSIX access control list for the file or directory.
+   * @param options - Optional. Options
+   *
    * @memberof DataLakePathClient
    */
   private async setAccessControlRecursiveInternal(
@@ -225,11 +225,11 @@ export class DataLakePathClient extends StorageClient {
   /**
    * Creates an instance of DataLakePathClient from url and credential.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake path (directory or file), such as
+   * @param url - A Client string pointing to Azure Storage data lake path (directory or file), such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem/directory" or "https://myaccount.dfs.core.windows.net/filesystem/file".
    *                     You can append a SAS if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem/directory?sasString".
-   * @param {(StorageSharedKeyCredential | AnonymousCredential | TokenCredential)} [credential] Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof DataLakePathClient
    */
   public constructor(
@@ -241,10 +241,10 @@ export class DataLakePathClient extends StorageClient {
   /**
    * Creates an instance of DataLakePathClient from url and pipeline.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake path (directory or file), such as
+   * @param url - A Client string pointing to Azure Storage data lake path (directory or file), such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem/directory" or "https://myaccount.dfs.core.windows.net/filesystem/file".
    *                     You can append a SAS if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem/directory?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof DataLakePathClient
    */
@@ -302,7 +302,7 @@ export class DataLakePathClient extends StorageClient {
   /**
    * Convert current DataLakePathClient to DataLakeDirectoryClient if current path is a directory.
    *
-   * @returns {DataLakeDirectoryClient}
+   *
    * @memberof DataLakePathClient
    */
   public toDirectoryClient(): DataLakeDirectoryClient {
@@ -312,7 +312,7 @@ export class DataLakePathClient extends StorageClient {
   /**
    * Convert current DataLakePathClient to DataLakeFileClient if current path is a file.
    *
-   * @returns {DataLakeFileClient}
+   *
    * @memberof DataLakePathClient
    */
   public toFileClient(): DataLakeFileClient {
@@ -322,8 +322,8 @@ export class DataLakePathClient extends StorageClient {
   /**
    * Get a {@link DataLakeLeaseClient} that manages leases on the path (directory or file).
    *
-   * @param {string} [proposeLeaseId] Optional. Initial proposed lease Id.
-   * @returns {DataLakeLeaseClient}
+   * @param proposeLeaseId - Optional. Initial proposed lease Id.
+   *
    * @memberof DataLakePathClient
    */
   public getDataLakeLeaseClient(proposeLeaseId?: string): DataLakeLeaseClient {
@@ -335,9 +335,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceTypeModel} resourceType Resource type, "directory" or "file".
-   * @param {PathCreateOptions} [options={}] Optional. Options when creating path.
-   * @returns {Promise<PathCreateResponse>}
+   * @param resourceType - Resource type, "directory" or "file".
+   * @param options - Optional. Options when creating path.
+   *
    * @memberof DataLakePathClient
    */
   public async create(
@@ -371,9 +371,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceType} resourceType Resource type, "directory" or "file".
-   * @param {PathCreateOptions} [options={}]
-   * @returns {Promise<PathCreateIfNotExistsResponse>}
+   * @param resourceType - Resource type, "directory" or "file".
+   * @param options -
+   *
    * @memberof DataLakePathClient
    */
   public async createIfNotExists(
@@ -424,8 +424,8 @@ export class DataLakePathClient extends StorageClient {
    * applications. Vice versa new files might be added by other clients or applications after this
    * function completes.
    *
-   * @param {PathExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof DataLakePathClient
    */
   public async exists(options: PathExistsOptions = {}): Promise<boolean> {
@@ -451,9 +451,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete
    *
-   * @param {boolean} [recursive] Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
-   * @param {PathDeleteOptions} [options={}] Optional. Options when deleting path.
-   * @returns {Promise<PathDeleteResponse>}
+   * @param recursive - Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
+   * @param options - Optional. Options when deleting path.
+   *
    * @memberof DataLakePathClient
    */
   public async delete(
@@ -496,9 +496,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete
    *
-   * @param {boolean} [recursive] Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
-   * @param {PathDeleteOptions} [options={}]
-   * @returns {Promise<PathDeleteIfExistsResponse>}
+   * @param recursive - Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
+   * @param options -
+   *
    * @memberof DataLakePathClient
    */
   public async deleteIfExists(
@@ -546,8 +546,8 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties
    *
-   * @param {PathGetAccessControlOptions} [options={}] Optional. Options when getting file access control.
-   * @returns {Promise<PathGetAccessControlResponse>}
+   * @param options - Optional. Options when getting file access control.
+   *
    * @memberof DataLakePathClient
    */
   public async getAccessControl(
@@ -584,9 +584,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {PathAccessControlItem[]} acl The POSIX access control list for the file or directory.
-   * @param {PathSetAccessControlOptions} [options={}] Optional. Options when setting path access control.
-   * @returns {Promise<PathSetAccessControlResponse>}
+   * @param acl - The POSIX access control list for the file or directory.
+   * @param options - Optional. Options when setting path access control.
+   *
    * @memberof DataLakePathClient
    */
   public async setAccessControl(
@@ -622,9 +622,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {PathAccessControlItem[]} acl The POSIX access control list for the file or directory.
-   * @param {PathChangeAccessControlRecursiveOptions} [options={}] Optional. Options
-   * @returns {Promise<PathChangeAccessControlRecursiveResponse>}
+   * @param acl - The POSIX access control list for the file or directory.
+   * @param options - Optional. Options
+   *
    * @memberof DataLakePathClient
    */
   public async setAccessControlRecursive(
@@ -656,9 +656,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {PathAccessControlItem[]} acl The POSIX access control list for the file or directory.
-   * @param {PathChangeAccessControlRecursiveOptions} [options={}] Optional. Options
-   * @returns {Promise<PathChangeAccessControlRecursiveResponse>}
+   * @param acl - The POSIX access control list for the file or directory.
+   * @param options - Optional. Options
+   *
    * @memberof DataLakePathClient
    */
   public async updateAccessControlRecursive(
@@ -690,9 +690,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {RemovePathAccessControlItem[]} acl The POSIX access control list for the file or directory.
-   * @param {PathChangeAccessControlRecursiveOptions} [options={}] Optional. Options
-   * @returns {Promise<PathChangeAccessControlRecursiveResponse>}
+   * @param acl - The POSIX access control list for the file or directory.
+   * @param options - Optional. Options
+   *
    * @memberof DataLakePathClient
    */
   public async removeAccessControlRecursive(
@@ -724,9 +724,9 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {PathPermissions} permissions The POSIX access permissions for the file owner, the file owning group, and others.
-   * @param {PathSetPermissionsOptions} [options={}] Optional. Options when setting path permissions.
-   * @returns {Promise<PathSetPermissionsResponse>}
+   * @param permissions - The POSIX access permissions for the file owner, the file owning group, and others.
+   * @param options - Optional. Options when setting path permissions.
+   *
    * @memberof DataLakePathClient
    */
   public async setPermissions(
@@ -768,8 +768,8 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-properties
    *
-   * @param {PathGetPropertiesOptions} [options={}] Optional. Options when getting path properties.
-   * @returns {Promise<PathGetPropertiesResponse>}
+   * @param options - Optional. Options when getting path properties.
+   *
    * @memberof DataLakePathClient
    */
   public async getProperties(
@@ -803,9 +803,9 @@ export class DataLakePathClient extends StorageClient {
    * these blob HTTP headers without a value will be cleared.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
    *
-   * @param {PathHttpHeaders} httpHeaders
-   * @param {PathSetHttpHeadersOptions} [options={}]
-   * @returns {Promise<PathSetHttpHeadersResponse>}
+   * @param httpHeaders -
+   * @param options -
+   *
    * @memberof DataLakePathClient
    */
   public async setHttpHeaders(
@@ -850,10 +850,10 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-metadata
    *
-   * @param {Metadata} [metadata] Optional. Replace existing metadata with this value.
+   * @param metadata - Optional. Replace existing metadata with this value.
    *                              If no value provided the existing metadata will be removed.
-   * @param {PathSetMetadataOptions} [options={}] Optional. Options when setting path metadata.
-   * @returns {Promise<PathSetMetadataResponse>}
+   * @param options - Optional. Options when setting path metadata.
+   *
    * @memberof DataLakePathClient
    */
   public async setMetadata(
@@ -886,10 +886,10 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {string} destinationPath Destination directory path like "directory" or file path "directory/file".
+   * @param destinationPath - Destination directory path like "directory" or file path "directory/file".
    *                                 If the destinationPath is authenticated with SAS, add the SAS to the destination path like "directory/file?sasToken".
-   * @param {PathMoveOptions} [options] Optional. Options when moving directory or file.
-   * @returns {Promise<PathMoveResponse>}
+   * @param options - Optional. Options when moving directory or file.
+   *
    * @memberof DataLakePathClient
    */
   public async move(destinationPath: string, options?: PathMoveOptions): Promise<PathMoveResponse>;
@@ -899,11 +899,11 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {string} destinationFileSystem Destination file system like "filesystem".
-   * @param {string} destinationPath Destination directory path like "directory" or file path "directory/file"
+   * @param destinationFileSystem - Destination file system like "filesystem".
+   * @param destinationPath - Destination directory path like "directory" or file path "directory/file"
    *                                 If the destinationPath is authenticated with SAS, add the SAS to the destination path like "directory/file?sasToken".
-   * @param {PathMoveOptions} [options] Optional. Options when moving directory or file.
-   * @returns {Promise<PathMoveResponse>}
+   * @param options - Optional. Options when moving directory or file.
+   *
    * @memberof DataLakePathClient
    */
   public async move(
@@ -992,9 +992,9 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceTypeModel} resourceType Resource type, must be "directory" for DataLakeDirectoryClient.
-   * @param {PathCreateOptions} [options] Optional. Options when creating directory.
-   * @returns {Promise<PathCreateResponse>}
+   * @param resourceType - Resource type, must be "directory" for DataLakeDirectoryClient.
+   * @param options - Optional. Options when creating directory.
+   *
    * @memberof DataLakeDirectoryClient
    */
   public async create(
@@ -1007,8 +1007,8 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {DirectoryCreateOptions} [options] Optional. Options when creating directory.
-   * @returns {Promise<DirectoryCreateResponse>}
+   * @param options - Optional. Options when creating directory.
+   *
    * @memberof DataLakeDirectoryClient
    */
   public async create(options?: DirectoryCreateOptions): Promise<DirectoryCreateResponse>;
@@ -1057,9 +1057,9 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceType} resourceType Resource type, must be "directory" for DataLakeDirectoryClient.
-   * @param {PathCreateIfNotExistsOptions} [options]
-   * @returns {Promise<PathCreateIfNotExistsResponse>}
+   * @param resourceType - Resource type, must be "directory" for DataLakeDirectoryClient.
+   * @param options -
+   *
    * @memberof DataLakeDirectoryClient
    */
   public async createIfNotExists(
@@ -1072,8 +1072,8 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {DirectoryCreateIfNotExistsOptions} [options]
-   * @returns {Promise<DirectoryCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof DataLakeDirectoryClient
    */
   public async createIfNotExists(
@@ -1120,8 +1120,8 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
   /**
    * Creates a {@link DataLakeDirectoryClient} object under current directory.
    *
-   * @param {string} subdirectoryName Subdirectory name.
-   * @returns {DataLakeDirectoryClient}
+   * @param subdirectoryName - Subdirectory name.
+   *
    * @memberof DataLakeDirectoryClient
    */
   public getSubdirectoryClient(subdirectoryName: string): DataLakeDirectoryClient {
@@ -1134,8 +1134,8 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
   /**
    * Creates a {@link DataLakeFileClient} object under current directory.
    *
-   * @param {string} fileName
-   * @returns {DataLakeFileClient}
+   * @param fileName -
+   *
    * @memberof DataLakeDirectoryClient
    */
   public getFileClient(fileName: string): DataLakeFileClient {
@@ -1153,8 +1153,8 @@ export class DataLakeDirectoryClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {DirectoryGenerateSasUrlOptions} options Optional parameters.
-   * @returns {Promise<string>} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeDirectoryClient
    */
   public generateSasUrl(options: DirectoryGenerateSasUrlOptions): Promise<string> {
@@ -1218,11 +1218,11 @@ export class DataLakeFileClient extends DataLakePathClient {
   /**
    * Creates an instance of DataLakeFileClient from url and credential.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake file, such as
+   * @param url - A Client string pointing to Azure Storage data lake file, such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem/file".
    *                     You can append a SAS if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem/directory/file?sasString".
-   * @param {(StorageSharedKeyCredential | AnonymousCredential | TokenCredential)} [credential] Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof DataLakeFileClient
    */
   public constructor(
@@ -1234,10 +1234,10 @@ export class DataLakeFileClient extends DataLakePathClient {
   /**
    * Creates an instance of DataLakeFileClient from url and pipeline.
    *
-   * @param {string} url A Client string pointing to Azure Storage data lake file, such as
+   * @param url - A Client string pointing to Azure Storage data lake file, such as
    *                     "https://myaccount.dfs.core.windows.net/filesystem/file".
    *                     You can append a SAS if using AnonymousCredential, such as "https://myaccount.dfs.core.windows.net/filesystem/directory/file?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof DataLakeFileClient
    */
@@ -1278,9 +1278,9 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceTypeModel} resourceType Resource type, must be "file" for DataLakeFileClient.
-   * @param {PathCreateOptions} [options] Optional. Options when creating file.
-   * @returns {Promise<PathCreateResponse>}
+   * @param resourceType - Resource type, must be "file" for DataLakeFileClient.
+   * @param options - Optional. Options when creating file.
+   *
    * @memberof DataLakeFileClient
    */
   public async create(
@@ -1293,8 +1293,8 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {FileCreateOptions} [options] Optional. Options when creating file.
-   * @returns {Promise<FileCreateResponse>}
+   * @param options - Optional. Options when creating file.
+   *
    * @memberof DataLakeFileClient
    */
   public async create(options?: FileCreateOptions): Promise<FileCreateResponse>;
@@ -1340,9 +1340,9 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {PathResourceType} resourceType Resource type, must be "file" for DataLakeFileClient.
-   * @param {PathCreateIfNotExistsOptions} [options]
-   * @returns {Promise<PathCreateIfNotExistsResponse>}
+   * @param resourceType - Resource type, must be "file" for DataLakeFileClient.
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async createIfNotExists(
@@ -1355,8 +1355,8 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
-   * @param {FileCreateIfNotExistsOptions} [options] Optional. Options when creating file.
-   * @returns {Promise<FileCreateIfNotExistsResponse>}
+   * @param options - Optional. Options when creating file.
+   *
    * @memberof DataLakeFileClient
    */
   public async createIfNotExists(
@@ -1450,10 +1450,10 @@ export class DataLakeFileClient extends DataLakePathClient {
    * }
    * ```
    *
-   * @param {number} [offset=0] Optional. Offset to read file, default value is 0.
-   * @param {number} [count] Optional. How many bytes to read, default will read from offset to the end.
-   * @param {FileReadOptions} [options={}] Optional. Options when reading file.
-   * @returns {Promise<FileReadResponse>}
+   * @param offset - Optional. Offset to read file, default value is 0.
+   * @param count - Optional. How many bytes to read, default will read from offset to the end.
+   * @param options - Optional. Options when reading file.
+   *
    * @memberof DataLakeFileClient
    */
   public async read(
@@ -1496,11 +1496,11 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
    *
-   * @param {HttpRequestBody} body Content to be uploaded.
-   * @param {number} offset Append offset in bytes.
-   * @param {number} length Length of content to append in bytes.
-   * @param {FileAppendOptions} [options={}] Optional. Options when appending data.
-   * @returns {Promise<FileAppendResponse>}
+   * @param body - Content to be uploaded.
+   * @param offset - Append offset in bytes.
+   * @param length - Length of content to append in bytes.
+   * @param options - Optional. Options when appending data.
+   *
    * @memberof DataLakeFileClient
    */
   public async append(
@@ -1537,15 +1537,15 @@ export class DataLakeFileClient extends DataLakePathClient {
   /**
    * Flushes (writes) previously appended data to a file.
    *
-   * @param {number} position File position to flush.
+   * @param position - File position to flush.
    *                          This parameter allows the caller to upload data in parallel and control the order in which it is appended to the file.
    *                          It is required when uploading data to be appended to the file and when flushing previously uploaded data to the file.
    *                          The value must be the position where the data is to be appended. Uploaded data is not immediately flushed, or written,
    *                          to the file. To flush, the previously uploaded data must be contiguous, the position parameter must be specified and
    *                          equal to the length of the file after all data has been written, and there must not be a request entity body included
    *                          with the request.
-   * @param {FileFlushOptions} [options={}] Optional. Options when flushing data.
-   * @returns {Promise<FileFlushResponse>}
+   * @param options - Optional. Options when flushing data.
+   *
    * @memberof DataLakeFileClient
    */
   public async flush(position: number, options: FileFlushOptions = {}): Promise<FileFlushResponse> {
@@ -1578,9 +1578,9 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * Uploads a local file to a Data Lake file.
    *
-   * @param {string} filePath Full path of the local file
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {(Promise<FileUploadResponse>)}
+   * @param filePath - Full path of the local file
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async uploadFile(
@@ -1619,9 +1619,9 @@ export class DataLakeFileClient extends DataLakePathClient {
   /**
    * Uploads a Buffer(Node.js)/Blob/ArrayBuffer/ArrayBufferView to a File.
    *
-   * @param {Buffer | Blob | ArrayBuffer | ArrayBufferView} data Buffer(Node), Blob, ArrayBuffer or ArrayBufferView
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {Promise<FileUploadResponse>}
+   * @param data - Buffer(Node), Blob, ArrayBuffer or ArrayBufferView
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async upload(
@@ -1811,9 +1811,9 @@ export class DataLakeFileClient extends DataLakePathClient {
    * * Input stream highWaterMark is better to set a same value with options.chunkSize
    *   parameter, which will avoid Buffer.concat() operations.
    *
-   * @param {Readable} stream Node.js Readable stream.
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {Promise<FileUploadResponse>}
+   * @param stream - Node.js Readable stream.
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async uploadStream(
@@ -1906,11 +1906,11 @@ export class DataLakeFileClient extends DataLakePathClient {
    * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
    * consider {@link readToFile}.
    *
-   * @param {Buffer} buffer Buffer to be fill, must have length larger than count
-   * @param {number} offset From which position of the Data Lake file to read
-   * @param {number} [count] How much data to be read. Will read to the end when passing undefined
-   * @param {FileReadToBufferOptions} [options]
-   * @returns {Promise<Buffer>}
+   * @param buffer - Buffer to be fill, must have length larger than count
+   * @param offset - From which position of the Data Lake file to read
+   * @param count - How much data to be read. Will read to the end when passing undefined
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async readToBuffer(
@@ -1930,10 +1930,10 @@ export class DataLakeFileClient extends DataLakePathClient {
    * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
    * consider {@link readToFile}.
    *
-   * @param {number} offset From which position of the Data Lake file to read(in bytes)
-   * @param {number} [count] How much data(in bytes) to be read. Will read to the end when passing undefined
-   * @param {FileReadToBufferOptions} [options]
-   * @returns {Promise<Buffer>}
+   * @param offset - From which position of the Data Lake file to read(in bytes)
+   * @param count - How much data(in bytes) to be read. Will read to the end when passing undefined
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async readToBuffer(
@@ -1999,11 +1999,11 @@ export class DataLakeFileClient extends DataLakePathClient {
    * Fails if the the given file path already exits.
    * Offset and count are optional, pass 0 and undefined respectively to download the entire file.
    *
-   * @param {string} filePath
-   * @param {number} [offset] From which position of the file to download.
-   * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined.
-   * @param {FileReadOptions} [options] Options to read Data Lake file.
-   * @returns {Promise<FileReadResponse>} The response data for file read operation,
+   * @param filePath -
+   * @param offset - From which position of the file to download.
+   * @param count - How much data to be downloaded. Will download to the end when passing undefined.
+   * @param options - Options to read Data Lake file.
+   * @returnsThe response data for file read operation,
    *                                      but with readableStreamBody set to undefined since its
    *                                      content is already read and written into a local file
    *                                      at the specified path.
@@ -2060,9 +2060,9 @@ export class DataLakeFileClient extends DataLakePathClient {
    * }
    * ```
    *
-   * @param {string} query
-   * @param {FileQueryOptions} [options={}]
-   * @returns {Promise<FileReadResponse>}
+   * @param query -
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async query(query: string, options: FileQueryOptions = {}): Promise<FileReadResponse> {
@@ -2097,9 +2097,9 @@ export class DataLakeFileClient extends DataLakePathClient {
   /**
    * Sets an expiry time on a file, once that time is met the file is deleted.
    *
-   * @param {FileExpiryMode} mode
-   * @param {FileSetExpiryOptions} [options={}]
-   * @returns {Promise<FileSetExpiryResponse>}
+   * @param mode -
+   * @param options -
+   *
    * @memberof DataLakeFileClient
    */
   public async setExpiry(
@@ -2157,8 +2157,8 @@ export class DataLakeFileClient extends DataLakePathClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {FileGenerateSasUrlOptions} options Optional parameters.
-   * @returns {Promise<string>} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof DataLakeFileClient
    */
   public generateSasUrl(options: FileGenerateSasUrlOptions): Promise<string> {

--- a/sdk/storage/storage-file-datalake/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-file-datalake/src/credentials/AnonymousCredential.ts
@@ -20,9 +20,9 @@ export class AnonymousCredential extends Credential {
   /**
    * Creates an {@link AnonymousCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {AnonymousCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof AnonymousCredential
    */
   public create(

--- a/sdk/storage/storage-file-datalake/src/credentials/Credential.ts
+++ b/sdk/storage/storage-file-datalake/src/credentials/Credential.ts
@@ -16,9 +16,9 @@ export abstract class Credential implements RequestPolicyFactory {
   /**
    * Creates a RequestPolicy object.
    *
-   * @param {RequestPolicy} _nextPolicy
-   * @param {RequestPolicyOptions} _options
-   * @returns {RequestPolicy}
+   * @param _nextPolicy -
+   * @param _options -
+   *
    * @memberof Credential
    */
   public create(

--- a/sdk/storage/storage-file-datalake/src/credentials/StorageSharedKeyCredential.ts
+++ b/sdk/storage/storage-file-datalake/src/credentials/StorageSharedKeyCredential.ts
@@ -35,8 +35,8 @@ export class StorageSharedKeyCredential extends Credential {
 
   /**
    * Creates an instance of StorageSharedKeyCredential.
-   * @param {string} accountName
-   * @param {string} accountKey
+   * @param accountName -
+   * @param accountKey -
    * @memberof StorageSharedKeyCredential
    */
   constructor(accountName: string, accountKey: string) {
@@ -48,9 +48,9 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Creates a StorageSharedKeyCredentialPolicy object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageSharedKeyCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public create(
@@ -63,8 +63,8 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-file-datalake/src/credentials/UserDelegationKeyCredential.ts
+++ b/sdk/storage/storage-file-datalake/src/credentials/UserDelegationKeyCredential.ts
@@ -38,8 +38,8 @@ export class UserDelegationKeyCredential {
 
   /**
    * Creates an instance of UserDelegationKeyCredential.
-   * @param {string} accountName
-   * @param {UserDelegationKey} userDelegationKey
+   * @param accountName -
+   * @param userDelegationKey -
    * @memberof UserDelegationKeyCredential
    */
   constructor(accountName: string, userDelegationKey: UserDelegationKey) {
@@ -51,8 +51,8 @@ export class UserDelegationKeyCredential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof UserDelegationKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-file-datalake/src/policies/AnonymousCredentialPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/AnonymousCredentialPolicy.ts
@@ -16,8 +16,8 @@ import { CredentialPolicy } from "./CredentialPolicy";
 export class AnonymousCredentialPolicy extends CredentialPolicy {
   /**
    * Creates an instance of AnonymousCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof AnonymousCredentialPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {

--- a/sdk/storage/storage-file-datalake/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/CredentialPolicy.ts
@@ -16,8 +16,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -30,8 +30,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
    *
    * @protected
    * @abstract
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {

--- a/sdk/storage/storage-file-datalake/src/policies/StorageBrowserPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageBrowserPolicy.ts
@@ -29,8 +29,8 @@ import { setURLParameter } from "../utils/utils.common";
 export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of StorageBrowserPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof StorageBrowserPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -40,8 +40,8 @@ export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageBrowserPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-datalake/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageRetryPolicy.ts
@@ -21,7 +21,7 @@ import { logger } from "../log";
  * A factory method used to generated a RetryPolicy factory.
  *
  * @export
- * @param {StorageRetryOptions} retryOptions
+ * @param retryOptions -
  */
 export function NewRetryPolicyFactory(retryOptions?: StorageRetryOptions): RequestPolicyFactory {
   return {
@@ -79,9 +79,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of RetryPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageRetryOptions} [retryOptions=DEFAULT_RETRY_OPTIONS]
+   * @param nextPolicy -
+   * @param options -
+   * @param retryOptions -
    * @memberof StorageRetryPolicy
    */
   constructor(
@@ -131,8 +131,8 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageRetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -143,13 +143,13 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide and perform next retry. Won't mutate request parameter.
    *
    * @protected
-   * @param {WebResource} request
-   * @param {boolean} secondaryHas404  If attempt was against the secondary & it returned a StatusNotFound (404), then
+   * @param request -
+   * @param secondaryHas404 -  If attempt was against the secondary & it returned a StatusNotFound (404), then
    *                                   the resource was not found. This may be due to replication delay. So, in this
    *                                   case, we'll never try the secondary again for this operation.
-   * @param {number} attempt           How many retries has been attempted to performed, starting from 1, which includes
+   * @param attempt -           How many retries has been attempted to performed, starting from 1, which includes
    *                                   the attempt will be performed by this method call.
-   * @returns {Promise<HttpOperationResponse>}
+   *
    * @memberof StorageRetryPolicy
    */
   protected async attemptSendRequest(
@@ -202,11 +202,11 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide whether to retry according to last HTTP response and retry counters.
    *
    * @protected
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {HttpOperationResponse} [response]
-   * @param {RestError} [err]
-   * @returns {boolean}
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param response -
+   * @param err -
+   *
    * @memberof StorageRetryPolicy
    */
   protected shouldRetry(
@@ -280,9 +280,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Delay a calculated time between retries.
    *
    * @private
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {AbortSignalLike} [abortSignal]
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param abortSignal -
    * @memberof StorageRetryPolicy
    */
   private async delay(isPrimaryRetry: boolean, attempt: number, abortSignal?: AbortSignalLike) {

--- a/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -25,9 +25,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
 
   /**
    * Creates an instance of StorageSharedKeyCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageSharedKeyCredential} factory
+   * @param nextPolicy -
+   * @param options -
+   * @param factory -
    * @memberof StorageSharedKeyCredentialPolicy
    */
   constructor(
@@ -43,8 +43,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Signs request.
    *
    * @protected
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {
@@ -96,9 +96,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/authenticate-with-shared-key
    *
    * @private
-   * @param {WebResource} request
-   * @param {string} headerName
-   * @returns {string}
+   * @param request -
+   * @param headerName -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getHeaderValueToSign(request: WebResource, headerName: string): string {
@@ -130,8 +130,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    *    Construct the CanonicalizedHeaders string by concatenating all headers in this list into a single string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedHeadersString(request: WebResource): string {
@@ -165,8 +165,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Retrieves the webResource canonicalized resource string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedResourceString(request: WebResource): string {

--- a/sdk/storage/storage-file-datalake/src/policies/TelemetryPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/TelemetryPolicy.ts
@@ -30,9 +30,9 @@ export class TelemetryPolicy extends BaseRequestPolicy {
 
   /**
    * Creates an instance of TelemetryPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {string} telemetry
+   * @param nextPolicy -
+   * @param options -
+   * @param telemetry -
    * @memberof TelemetryPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, telemetry: string) {
@@ -43,8 +43,8 @@ export class TelemetryPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof TelemetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-datalake/src/sas/AccountSASPermissions.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/AccountSASPermissions.ts
@@ -18,8 +18,8 @@ export class AccountSASPermissions {
    * Parse initializes the AccountSASPermissions fields from a string.
    *
    * @static
-   * @param {string} permissions
-   * @returns {AccountSASPermissions}
+   * @param permissions -
+   *
    * @memberof AccountSASPermissions
    */
   public static parse(permissions: string): AccountSASPermissions {
@@ -132,7 +132,7 @@ export class AccountSASPermissions {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/AccountSASResourceTypes.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/AccountSASResourceTypes.ts
@@ -19,8 +19,8 @@ export class AccountSASResourceTypes {
    * Error if it encounters a character that does not correspond to a valid resource type.
    *
    * @static
-   * @param {string} resourceTypes
-   * @returns {AccountSASResourceTypes}
+   * @param resourceTypes -
+   *
    * @memberof AccountSASResourceTypes
    */
   public static parse(resourceTypes: string): AccountSASResourceTypes {
@@ -74,7 +74,7 @@ export class AccountSASResourceTypes {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASResourceTypes
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/AccountSASServices.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/AccountSASServices.ts
@@ -19,8 +19,8 @@ export class AccountSASServices {
    * Error if it encounters a character that does not correspond to a valid service.
    *
    * @static
-   * @param {string} services
-   * @returns {AccountSASServices}
+   * @param services -
+   *
    * @memberof AccountSASServices
    */
   public static parse(services: string): AccountSASServices {
@@ -83,7 +83,7 @@ export class AccountSASServices {
   /**
    * Converts the given services to a string.
    *
-   * @returns {string}
+   *
    * @memberof AccountSASServices
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/AccountSASSignatureValues.ts
@@ -105,9 +105,9 @@ export interface AccountSASSignatureValues {
  *
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
  *
- * @param {AccountSASSignatureValues} accountSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param accountSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  * @memberof AccountSASSignatureValues
  */
 export function generateAccountSASQueryParameters(

--- a/sdk/storage/storage-file-datalake/src/sas/DataLakeSASPermissions.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/DataLakeSASPermissions.ts
@@ -142,7 +142,7 @@ export class DataLakeSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returnsA string which represents the DataLakeSASPermissions
+   * @returns A string which represents the DataLakeSASPermissions
    * @memberof DataLakeSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/DataLakeSASPermissions.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/DataLakeSASPermissions.ts
@@ -19,8 +19,8 @@ export class DataLakeSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {DataLakeSASPermissions}
+   * @param permissions -
+   *
    * @memberof DataLakeSASPermissions
    */
   public static parse(permissions: string): DataLakeSASPermissions {
@@ -142,7 +142,7 @@ export class DataLakeSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returns {string} A string which represents the DataLakeSASPermissions
+   * @returnsA string which represents the DataLakeSASPermissions
    * @memberof DataLakeSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/DataLakeSASSignatureValues.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/DataLakeSASSignatureValues.ts
@@ -250,9 +250,9 @@ export interface DataLakeSASSignatureValues {
  * ```
  *
  * @export
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 export function generateDataLakeSASQueryParameters(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,
@@ -284,10 +284,10 @@ export function generateDataLakeSASQueryParameters(
  * ```
  *
  * @export
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {UserDelegationKey} userDelegationKey Return value of `blobServiceClient.getUserDelegationKey()`
- * @param {string} accountName
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param userDelegationKey - Return value of `blobServiceClient.getUserDelegationKey()`
+ * @param accountName -
+ *
  */
 export function generateDataLakeSASQueryParameters(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,
@@ -374,9 +374,9 @@ export function generateDataLakeSASQueryParameters(
  * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 function generateBlobSASQueryParameters20150405(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,
@@ -481,9 +481,9 @@ function generateBlobSASQueryParameters20150405(
  * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 function generateBlobSASQueryParameters20181109(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,
@@ -603,9 +603,9 @@ function generateBlobSASQueryParameters20181109(
  *
  * WARNING: identifier will be ignored, permissions and expiresOn are required.
  *
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {UserDelegationKeyCredential} userDelegationKeyCredential
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param userDelegationKeyCredential -
+ *
  */
 function generateBlobSASQueryParametersUDK20181109(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,
@@ -731,9 +731,9 @@ function generateBlobSASQueryParametersUDK20181109(
  *
  * WARNING: identifier will be ignored, permissions and expiresOn are required.
  *
- * @param {DataLakeSASSignatureValues} dataLakeSASSignatureValues
- * @param {UserDelegationKeyCredential} userDelegationKeyCredential
- * @returns {SASQueryParameters}
+ * @param dataLakeSASSignatureValues -
+ * @param userDelegationKeyCredential -
+ *
  */
 function generateBlobSASQueryParametersUDK20200210(
   dataLakeSASSignatureValues: DataLakeSASSignatureValues,

--- a/sdk/storage/storage-file-datalake/src/sas/DirectorySASPermissions.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/DirectorySASPermissions.ts
@@ -17,8 +17,8 @@ export class DirectorySASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {DirectorySASPermissions}
+   * @param permissions -
+   *
    * @memberof DirectorySASPermissions
    */
   public static parse(permissions: string) {
@@ -154,7 +154,7 @@ export class DirectorySASPermissions {
    * The order of the characters should be as specified here to ensure correctness.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @returns {string}
+   *
    * @memberof DirectorySASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/FileSystemSASPermissions.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/FileSystemSASPermissions.ts
@@ -17,8 +17,8 @@ export class FileSystemSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {FileSystemSASPermissions}
+   * @param permissions -
+   *
    * @memberof FileSystemSASPermissions
    */
   public static parse(permissions: string) {
@@ -154,7 +154,7 @@ export class FileSystemSASPermissions {
    * The order of the characters should be as specified here to ensure correctness.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @returns {string}
+   *
    * @memberof FileSystemSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-datalake/src/sas/SASQueryParameters.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/SASQueryParameters.ts
@@ -449,26 +449,26 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {string} [permissions] Representing the storage permissions
-   * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
-   * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
-   * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startsOn] Representing the start time for this SAS token
-   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
-   * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
-   * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
-   * @param {string} [resource] Representing the storage container or blob (only for Service SAS)
-   * @param {string} [cacheControl] Representing the cache-control header (only for Blob/File Service SAS)
-   * @param {string} [contentDisposition] Representing the content-disposition header (only for Blob/File Service SAS)
-   * @param {string} [contentEncoding] Representing the content-encoding header (only for Blob/File Service SAS)
-   * @param {string} [contentLanguage] Representing the content-language header (only for Blob/File Service SAS)
-   * @param {string} [contentType] Representing the content-type header (only for Blob/File Service SAS)
-   * @param {userDelegationKey} [userDelegationKey] Representing the user delegation key properties
-   * @param {string} [preauthorizedAgentObjectId] Representing the authorized AAD Object ID (only for User Delegation SAS)
-   * @param {string} [agentObjectId] Representing the unauthorized AAD Object ID (only for User Delegation SAS)
-   * @param {string} [correlationId] Representing the correlation ID (only for User Delegation SAS)
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param permissions - Representing the storage permissions
+   * @param services - Representing the storage services being accessed (only for Account SAS)
+   * @param resourceTypes - Representing the storage resource types being accessed (only for Account SAS)
+   * @param protocol - Representing the allowed HTTP protocol(s)
+   * @param startsOn - Representing the start time for this SAS token
+   * @param expiresOn - Representing the expiry time for this SAS token
+   * @param ipRange - Representing the range of valid IP addresses for this SAS token
+   * @param identifier - Representing the signed identifier (only for Service SAS)
+   * @param resource - Representing the storage container or blob (only for Service SAS)
+   * @param cacheControl - Representing the cache-control header (only for Blob/File Service SAS)
+   * @param contentDisposition - Representing the content-disposition header (only for Blob/File Service SAS)
+   * @param contentEncoding - Representing the content-encoding header (only for Blob/File Service SAS)
+   * @param contentLanguage - Representing the content-language header (only for Blob/File Service SAS)
+   * @param contentType - Representing the content-type header (only for Blob/File Service SAS)
+   * @param userDelegationKey - Representing the user delegation key properties
+   * @param preauthorizedAgentObjectId - Representing the authorized AAD Object ID (only for User Delegation SAS)
+   * @param agentObjectId - Representing the unauthorized AAD Object ID (only for User Delegation SAS)
+   * @param correlationId - Representing the correlation ID (only for User Delegation SAS)
    * @memberof SASQueryParameters
    */
   constructor(
@@ -498,9 +498,9 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {SASQueryParametersOptions} [options] Optional. Options to construct the SASQueryParameters.
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param options - Optional. Options to construct the SASQueryParameters.
    * @memberof SASQueryParameters
    */
   constructor(version: string, signature: string, options?: SASQueryParametersOptions);
@@ -595,7 +595,7 @@ export class SASQueryParameters {
   /**
    * Encodes all SAS query parameters into a string that can be appended to a URL.
    *
-   * @returns {string}
+   *
    * @memberof SASQueryParameters
    */
   public toString(): string {
@@ -738,10 +738,10 @@ export class SASQueryParameters {
    * A private helper method used to filter and append query key/value pairs into an array.
    *
    * @private
-   * @param {string[]} queries
-   * @param {string} key
-   * @param {string} [value]
-   * @returns {void}
+   * @param queries -
+   * @param key -
+   * @param value -
+   *
    * @memberof SASQueryParameters
    */
   private tryAppendQueryParameter(queries: string[], key: string, value?: string): void {

--- a/sdk/storage/storage-file-datalake/src/sas/SasIPRange.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/SasIPRange.ts
@@ -32,8 +32,8 @@ export interface SasIPRange {
  * "8.8.8.8" or "1.1.1.1-255.255.255.255"
  *
  * @export
- * @param {SasIPRange} ipRange
- * @returns {string}
+ * @param ipRange -
+ *
  */
 export function ipRangeToString(ipRange: SasIPRange): string {
   return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;

--- a/sdk/storage/storage-file-datalake/src/transforms.ts
+++ b/sdk/storage/storage-file-datalake/src/transforms.ts
@@ -34,8 +34,8 @@ import { base64encode } from "./utils/utils.common";
  * http://127.0.0.1:10000/abc               => http://127.0.0.1:10000/abc
  *
  * @export
- * @param {string} url
- * @returns {string}
+ * @param url -
+ *
  */
 export function toBlobEndpointUrl(url: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -69,8 +69,8 @@ export function toBlobEndpointUrl(url: string): string {
  * http://127.0.0.1:10000/abc               => http://127.0.0.1:10000/abc
  *
  * @export
- * @param {string} url
- * @returns {string}
+ * @param url -
+ *
  */
 export function toDfsEndpointUrl(url: string): string {
   const urlParsed = URLBuilder.parse(url);

--- a/sdk/storage/storage-file-datalake/src/utils/Batch.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/Batch.ts
@@ -94,7 +94,7 @@ export class Batch {
 
   /**
    * Creates an instance of Batch.
-   * @param {number} [concurrency=5]
+   * @param concurrency -
    * @memberof Batch
    */
   public constructor(concurrency: number = 5) {
@@ -108,7 +108,7 @@ export class Batch {
   /**
    * Add a operation into queue.
    *
-   * @param {Operation} operation
+   * @param operation -
    * @memberof Batch
    */
   public addOperation(operation: Operation): void {
@@ -128,7 +128,7 @@ export class Batch {
   /**
    * Start execute operations in the queue.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof Batch
    */
   public async do(): Promise<void> {
@@ -151,7 +151,7 @@ export class Batch {
    * Get next operation to be executed. Return null when reaching ends.
    *
    * @private
-   * @returns {(Operation | null)}
+   *
    * @memberof Batch
    */
   private nextOperation(): Operation | null {
@@ -166,7 +166,7 @@ export class Batch {
    * this method with do() is that do() wraps as an sync method.
    *
    * @private
-   * @returns {void}
+   *
    * @memberof Batch
    */
   private parallelExecute(): void {

--- a/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
@@ -331,7 +331,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returnsReturn false when buffers in incoming are not enough, else true.
+   * @returns Return false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {

--- a/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/BufferScheduler.ts
@@ -187,14 +187,14 @@ export class BufferScheduler {
   /**
    * Creates an instance of BufferScheduler.
    *
-   * @param {Readable} readable A Node.js Readable stream
-   * @param {number} bufferSize Buffer size of every maintained buffer
-   * @param {number} maxBuffers How many buffers can be allocated
-   * @param {OutgoingHandler} outgoingHandler An async function scheduled to be
+   * @param readable - A Node.js Readable stream
+   * @param bufferSize - Buffer size of every maintained buffer
+   * @param maxBuffers - How many buffers can be allocated
+   * @param outgoingHandler - An async function scheduled to be
    *                                          triggered when a buffer fully filled
    *                                          with stream data
-   * @param {number} concurrency Concurrency of executing outgoingHandlers (>0)
-   * @param {string} [encoding] [Optional] Encoding of Readable stream when it's a string stream
+   * @param concurrency - Concurrency of executing outgoingHandlers (>0)
+   * @param encoding - [Optional] Encoding of Readable stream when it's a string stream
    * @memberof BufferScheduler
    */
   constructor(
@@ -229,7 +229,7 @@ export class BufferScheduler {
    * Start the scheduler, will return error when stream of any of the outgoingHandlers
    * returns error.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof BufferScheduler
    */
   public async do(): Promise<void> {
@@ -283,7 +283,7 @@ export class BufferScheduler {
    * Insert a new data into unresolved array.
    *
    * @private
-   * @param {Buffer} data
+   * @param data -
    * @memberof BufferScheduler
    */
   private appendUnresolvedData(data: Buffer) {
@@ -296,7 +296,7 @@ export class BufferScheduler {
    * than blockSize when data in unresolvedDataArray is less than bufferSize.
    *
    * @private
-   * @returns {Buffer}
+   *
    * @memberof BufferScheduler
    */
   private shiftBufferFromUnresolvedDataArray(): Buffer {
@@ -331,7 +331,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returns {boolean} Return false when buffers in incoming are not enough, else true.
+   * @returnsReturn false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {
@@ -382,8 +382,8 @@ export class BufferScheduler {
    * Trigger a outgoing handler for a buffer shifted from outgoing.
    *
    * @private
-   * @param {Buffer} buffer
-   * @returns {Promise<any>}
+   * @param buffer -
+   *
    * @memberof BufferScheduler
    */
   private async triggerOutgoingHandler(buffer: Buffer): Promise<any> {
@@ -408,7 +408,7 @@ export class BufferScheduler {
    * Return buffer used by outgoing handler into incoming.
    *
    * @private
-   * @param {Buffer} buffer
+   * @param buffer -
    * @memberof BufferScheduler
    */
   private reuseBuffer(buffer: Buffer) {

--- a/sdk/storage/storage-file-datalake/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.browser.ts
@@ -5,8 +5,8 @@
  * Convert a Browser Blob object into ArrayBuffer.
  *
  * @export
- * @param {Blob} blob
- * @returns {Promise<ArrayBuffer>}
+ * @param blob -
+ *
  */
 export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
   const fileReader = new FileReader();
@@ -23,8 +23,8 @@ export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
  * Convert a Browser Blob object into string.
  *
  * @export
- * @param {Blob} blob
- * @returns {Promise<ArrayBuffer>}
+ * @param blob -
+ *
  */
 export async function blobToString(blob: Blob): Promise<string> {
   const fileReader = new FileReader();

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -220,7 +220,7 @@ function escape(text: string): string {
  * @export
  * @param url - Source URL string
  * @param name - String to be appended to URL
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -238,7 +238,7 @@ export function appendToURLPath(url: string, name: string): string {
  * @export
  * @param url - Source URL string.
  * @param queryParts - String to be appended to the URL query.
- * @returnsAn updated URL string.
+ * @returns An updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -262,7 +262,7 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * @param url - Source URL string
  * @param name - Parameter name
  * @param value - Parameter value
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -423,7 +423,7 @@ export function setURLQueries(url: string, queryString: string): string {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -584,7 +584,7 @@ export function iEqual(str1: string, str2: string): boolean {
 /**
  * Extracts account name from the blobEndpointUrl
  * @param blobEndpointUrl - blobEndpointUrl to extract the account name from
- * @returnsaccount name
+ * @returns account name
  */
 export function getAccountNameFromUrl(blobEndpointUrl: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(blobEndpointUrl);

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -56,8 +56,8 @@ import { DevelopmentConnectionString, HeaderConstants, UrlConstants } from "./co
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata
  *
  * @export
- * @param {string} url
- * @returns {string}
+ * @param url -
+ *
  */
 export function escapeURLPath(url: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -119,8 +119,8 @@ export function getValueInConnString(
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export
- * @param {string} connectionString Connection string.
- * @returns {ConnectionString}  String key value pairs of the storage account's url and credentials.
+ * @param connectionString - Connection string.
+ * @returns String key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   let proxyUri = "";
@@ -202,8 +202,8 @@ export function extractConnectionStringParts(connectionString: string): Connecti
 /**
  * Internal escape method implemented Strategy Two mentioned in escapeURL() description.
  *
- * @param {string} text
- * @returns {string}
+ * @param text -
+ *
  */
 function escape(text: string): string {
   return encodeURIComponent(text)
@@ -218,9 +218,9 @@ function escape(text: string): string {
  * when URL path ends with a "/".
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name String to be appended to URL
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - String to be appended to URL
+ * @returnsAn updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -236,9 +236,9 @@ export function appendToURLPath(url: string, name: string): string {
  * Append a string to URL query.
  *
  * @export
- * @param {string} url Source URL string.
- * @param {string} queryParts String to be appended to the URL query.
- * @returns {string} An updated URL string.
+ * @param url - Source URL string.
+ * @param queryParts - String to be appended to the URL query.
+ * @returnsAn updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -259,10 +259,10 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * will be replaced by name key. If not provide value, the parameter will be deleted.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name Parameter name
- * @param {string} [value] Parameter value
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - Parameter name
+ * @param value - Parameter value
+ * @returnsAn updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -274,9 +274,9 @@ export function setURLParameter(url: string, name: string, value?: string): stri
  * Get URL parameter by name.
  *
  * @export
- * @param {string} url
- * @param {string} name
- * @returns {(string | string[] | undefined)}
+ * @param url -
+ * @param name -
+ *
  */
 export function getURLParameter(url: string, name: string): string | string[] | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -287,8 +287,8 @@ export function getURLParameter(url: string, name: string): string | string[] | 
  * Set URL host.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} host New host string
+ * @param url - Source URL string
+ * @param host - New host string
  * @returns An updated URL string
  */
 export function setURLHost(url: string, host: string): string {
@@ -301,8 +301,8 @@ export function setURLHost(url: string, host: string): string {
  * Get URL path from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLPath(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -313,9 +313,9 @@ export function getURLPath(url: string): string | undefined {
  * Set URL path.
  *
  * @export
- * @param {string} url
- * @param {string} [path]
- * @returns {string}
+ * @param url -
+ * @param path -
+ *
  */
 export function setURLPath(url: string, path?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -327,8 +327,8 @@ export function setURLPath(url: string, path?: string): string {
  * Get URL scheme from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLScheme(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -339,8 +339,8 @@ export function getURLScheme(url: string): string | undefined {
  * Get URL path and query from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLPathAndQuery(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -362,8 +362,8 @@ export function getURLPathAndQuery(url: string): string | undefined {
  * Get URL query key value pairs from an URL string.
  *
  * @export
- * @param {string} url
- * @returns {{[key: string]: string}}
+ * @param url -
+ *
  */
 export function getURLQueries(url: string): { [key: string]: string } {
   let queryString = URLBuilder.parse(url).getQuery();
@@ -397,7 +397,7 @@ export function getURLQueries(url: string): { [key: string]: string } {
 /**
  * Get URL query string.
  *
- * @param {string} url
+ * @param url -
  */
 export function getURLQueryString(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -407,8 +407,8 @@ export function getURLQueryString(url: string): string | undefined {
 /**
  * Set URL query string.
  *
- * @param {string} url
- * @param {string} queryString
+ * @param url -
+ * @param queryString -
  */
 export function setURLQueries(url: string, queryString: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -420,10 +420,10 @@ export function setURLQueries(url: string, queryString: string): string {
  * Rounds a date off to seconds.
  *
  * @export
- * @param {Date} date
- * @param {boolean} [withMilliseconds=true] If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
+ * @param date -
+ * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns {string} Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -438,8 +438,8 @@ export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = tru
  * Base64 encode.
  *
  * @export
- * @param {string} content
- * @returns {string}
+ * @param content -
+ *
  */
 export function base64encode(content: string): string {
   return !isNode ? btoa(content) : Buffer.from(content).toString("base64");
@@ -449,8 +449,8 @@ export function base64encode(content: string): string {
  * Base64 decode.
  *
  * @export
- * @param {string} encodedString
- * @returns {string}
+ * @param encodedString -
+ *
  */
 export function base64decode(encodedString: string): string {
   return !isNode ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
@@ -460,8 +460,8 @@ export function base64decode(encodedString: string): string {
  * Generate a 64 bytes base64 block ID string.
  *
  * @export
- * @param {number} blockIndex
- * @returns {string}
+ * @param blockIndex -
+ *
  */
 export function generateBlockID(blockIDPrefix: string, blockIndex: number): string {
   // To generate a 64 bytes base64 string, source string should be 48
@@ -485,9 +485,9 @@ export function generateBlockID(blockIDPrefix: string, blockIndex: number): stri
  * Delay specified time interval.
  *
  * @export
- * @param {number} timeInMs
- * @param {AbortSignalLike} [aborter]
- * @param {Error} [abortError]
+ * @param timeInMs -
+ * @param aborter -
+ * @param abortError -
  */
 export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortError?: Error) {
   return new Promise<void>((resolve, reject) => {
@@ -518,10 +518,10 @@ export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortEr
  * String.prototype.padStart()
  *
  * @export
- * @param {string} currentString
- * @param {number} targetLength
- * @param {string} [padString=" "]
- * @returns {string}
+ * @param currentString -
+ * @param targetLength -
+ * @param [padString=" - "]
+ *
  */
 export function padStart(
   currentString: string,
@@ -573,9 +573,9 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
  * If two strings are equal when compared case insensitive.
  *
  * @export
- * @param {string} str1
- * @param {string} str2
- * @returns {boolean}
+ * @param str1 -
+ * @param str2 -
+ *
  */
 export function iEqual(str1: string, str2: string): boolean {
   return str1.toLocaleLowerCase() === str2.toLocaleLowerCase();
@@ -583,8 +583,8 @@ export function iEqual(str1: string, str2: string): boolean {
 
 /**
  * Extracts account name from the blobEndpointUrl
- * @param {string} blobEndpointUrl blobEndpointUrl to extract the account name from
- * @returns {string} account name
+ * @param blobEndpointUrl - blobEndpointUrl to extract the account name from
+ * @returnsaccount name
  */
 export function getAccountNameFromUrl(blobEndpointUrl: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(blobEndpointUrl);

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -9,12 +9,12 @@ import { isNode } from "@azure/core-http";
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {Buffer} buffer Buffer to be filled, length must >= offset
- * @param {number} offset From which position in the buffer to be filled, inclusive
- * @param {number} end To which position in the buffer to be filled, exclusive
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<void>}
+ * @param stream - A Node.js Readable stream
+ * @param buffer - Buffer to be filled, length must >= offset
+ * @param offset - From which position in the buffer to be filled, inclusive
+ * @param end - To which position in the buffer to be filled, exclusive
+ * @param encoding - Encoding of the Readable stream
+ *
  */
 export async function streamToBuffer(
   stream: NodeJS.ReadableStream,
@@ -67,10 +67,10 @@ export async function streamToBuffer(
  * Reads a readable stream into buffer entirely.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {Buffer} buffer Buffer to be filled, length must >= offset
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<number>} with the count of bytes read.
+ * @param stream - A Node.js Readable stream
+ * @param buffer - Buffer to be filled, length must >= offset
+ * @param encoding - Encoding of the Readable stream
+ * @returnswith the count of bytes read.
  * @throws {RangeError} If buffer size is not big enough.
  */
 export async function streamToBuffer2(

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -70,7 +70,7 @@ export async function streamToBuffer(
  * @param stream - A Node.js Readable stream
  * @param buffer - Buffer to be filled, length must >= offset
  * @param encoding - Encoding of the Readable stream
- * @returnswith the count of bytes read.
+ * @returns with the count of bytes read.
  * @throws {RangeError} If buffer size is not big enough.
  */
 export async function streamToBuffer2(

--- a/sdk/storage/storage-file-datalake/test/utils/InjectorPolicy.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/InjectorPolicy.ts
@@ -23,8 +23,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of InjectorPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof InjectorPolicy
    */
   public constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, injector: Injector) {
@@ -35,8 +35,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof InjectorPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
@@ -70,7 +70,7 @@ export class SimpleTokenCredential implements TokenCredential {
 
   /**
    * Creates an instance of TokenCredential.
-   * @param {string} token
+   * @param token -
    */
   constructor(token: string, expiresOn?: Date) {
     this.token = token;
@@ -82,7 +82,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returns {AccessToken} The access token details.
+   * @returnsThe access token details.
    */
   async getToken(
     _scopes: string | string[],

--- a/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
@@ -82,7 +82,7 @@ export class SimpleTokenCredential implements TokenCredential {
    *
    * @param _scopes Ignored since token is already known.
    * @param _options Ignored since token is already known.
-   * @returnsThe access token details.
+   * @returns The access token details.
    */
   async getToken(
     _scopes: string | string[],

--- a/sdk/storage/storage-file-datalake/test/utils/testutils.node.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/testutils.node.ts
@@ -8,9 +8,9 @@ import * as fs from "fs";
  * ReadableStream or the fs.WriteStream.
  *
  * @export
- * @param {NodeJS.ReadableStream} rs The read stream.
- * @param {string} file Destination file path.
- * @returns {Promise<void>}
+ * @param rs - The read stream.
+ * @param file - Destination file path.
+ *
  */
 export async function readStreamToLocalFileWithLogs(
   rs: NodeJS.ReadableStream,

--- a/sdk/storage/storage-file-share/src/AccountSASPermissions.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASPermissions.ts
@@ -18,8 +18,8 @@ export class AccountSASPermissions {
    * Parse initializes the AccountSASPermissions fields from a string.
    *
    * @static
-   * @param {string} permissions
-   * @returns {AccountSASPermissions}
+   * @param permissions -
+   *
    * @memberof AccountSASPermissions
    */
   public static parse(permissions: string): AccountSASPermissions {
@@ -132,7 +132,7 @@ export class AccountSASPermissions {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/AccountSASResourceTypes.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASResourceTypes.ts
@@ -19,8 +19,8 @@ export class AccountSASResourceTypes {
    * Error if it encounters a character that does not correspond to a valid resource type.
    *
    * @static
-   * @param {string} resourceTypes
-   * @returns {AccountSASResourceTypes}
+   * @param resourceTypes -
+   *
    * @memberof AccountSASResourceTypes
    */
   public static parse(resourceTypes: string): AccountSASResourceTypes {
@@ -74,7 +74,7 @@ export class AccountSASResourceTypes {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASResourceTypes
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/AccountSASServices.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASServices.ts
@@ -19,8 +19,8 @@ export class AccountSASServices {
    * Error if it encounters a character that does not correspond to a valid service.
    *
    * @static
-   * @param {string} services
-   * @returns {AccountSASServices}
+   * @param services -
+   *
    * @memberof AccountSASServices
    */
   public static parse(services: string): AccountSASServices {
@@ -83,7 +83,7 @@ export class AccountSASServices {
   /**
    * Converts the given services to a string.
    *
-   * @returns {string}
+   *
    * @memberof AccountSASServices
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
@@ -105,8 +105,8 @@ export interface AccountSASSignatureValues {
  *
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
  *
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param sharedKeyCredential -
+ *
  * @memberof AccountSASSignatureValues
  */
 export function generateAccountSASQueryParameters(

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -834,7 +834,7 @@ export class ShareClient extends StorageClient {
    * Provide "" will remove the snapshot and return a URL to the base share.
    *
    * @param snapshot - The snapshot timestamp.
-   * @returnsA new ShareClient object identical to the source but with the specified snapshot timestamp
+   * @returns A new ShareClient object identical to the source but with the specified snapshot timestamp
    * @memberof ShareClient
    */
   public withSnapshot(snapshot: string): ShareClient {
@@ -854,7 +854,7 @@ export class ShareClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
    *
    * @param options - Options to Share Create operation.
-   * @returnsResponse data for the Share Create operation.
+   * @returns Response data for the Share Create operation.
    * @memberof ShareClient
    */
   public async create(options: ShareCreateOptions = {}): Promise<ShareCreateResponse> {
@@ -927,7 +927,7 @@ export class ShareClient extends StorageClient {
    * Creates a {@link ShareDirectoryClient} object.
    *
    * @param directoryName A directory name
-   * @returnsThe ShareDirectoryClient object for the given directory name.
+   * @returns The ShareDirectoryClient object for the given directory name.
    * @memberof ShareClient
    */
   public getDirectoryClient(directoryName: string): ShareDirectoryClient {
@@ -955,7 +955,7 @@ export class ShareClient extends StorageClient {
    *
    * @param directoryName -
    * @param options - Options to Directory Create operation.
-   * @returnsDirectory creation response data and the corresponding directory client.
+   * @returns Directory creation response data and the corresponding directory client.
    * @memberof ShareClient
    */
   public async createDirectory(
@@ -994,7 +994,7 @@ export class ShareClient extends StorageClient {
    *
    * @param directoryName -
    * @param options - Options to Directory Delete operation.
-   * @returnsDirectory deletion response data.
+   * @returns Directory deletion response data.
    * @memberof ShareClient
    */
   public async deleteDirectory(
@@ -1027,7 +1027,7 @@ export class ShareClient extends StorageClient {
    * @param fileName -
    * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
    * @param options - Options to File Create operation.
-   * @returnsFile creation response data and the corresponding file client.
+   * @returns File creation response data and the corresponding file client.
    * @memberof ShareClient
    */
   public async createFile(
@@ -1149,7 +1149,7 @@ export class ShareClient extends StorageClient {
    * the `listShares` method of {@link ShareServiceClient} using the `includeMetadata` option, which
    * will retain their original casing.
    *
-   * @returnsResponse data for the Share Get Properties operation.
+   * @returns Response data for the Share Get Properties operation.
    * @memberof ShareClient
    */
   public async getProperties(
@@ -1183,7 +1183,7 @@ export class ShareClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
    *
    * @param options - Options to Share Delete operation.
-   * @returnsResponse data for the Share Delete operation.
+   * @returns Response data for the Share Delete operation.
    * @memberof ShareClient
    */
   public async delete(options: ShareDeleteMethodOptions = {}): Promise<ShareDeleteResponse> {
@@ -1257,7 +1257,7 @@ export class ShareClient extends StorageClient {
    *
    * @param metadata - If no metadata provided, all existing directory metadata will be removed.
    * @param option - Options to Share Set Metadata operation.
-   * @returnsResponse data for the Share Set Metadata operation.
+   * @returns Response data for the Share Set Metadata operation.
    * @memberof ShareClient
    */
   public async setMetadata(
@@ -1292,7 +1292,7 @@ export class ShareClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-acl
    *
    * @param option - Options to Share Get Access Policy operation.
-   * @returnsResponse data for the Share Get Access Policy operation.
+   * @returns Response data for the Share Get Access Policy operation.
    * @memberof ShareClient
    */
   public async getAccessPolicy(
@@ -1364,7 +1364,7 @@ export class ShareClient extends StorageClient {
    *
    * @param shareAcl - Array of signed identifiers, each having a unique Id and details of access policy.
    * @param option - Options to Share Set Access Policy operation.
-   * @returnsResponse data for the Share Set Access Policy operation.
+   * @returns Response data for the Share Set Access Policy operation.
    * @memberof ShareClient
    */
   public async setAccessPolicy(
@@ -1409,7 +1409,7 @@ export class ShareClient extends StorageClient {
    * Creates a read-only snapshot of a share.
    *
    * @param options - Options to Share Create Snapshot operation.
-   * @returnsResponse data for the Share Create Snapshot operation.
+   * @returns Response data for the Share Create Snapshot operation.
    * @memberof ShareClient
    */
   public async createSnapshot(
@@ -1440,7 +1440,7 @@ export class ShareClient extends StorageClient {
    *
    * @param quotaInGB - Specifies the maximum size of the share in gigabytes
    * @param option - Options to Share Set Quota operation.
-   * @returnsResponse data for the Share Get Quota operation.
+   * @returns Response data for the Share Get Quota operation.
    * @memberof ShareClient
    */
   public async setQuota(
@@ -1469,7 +1469,7 @@ export class ShareClient extends StorageClient {
    * Sets properties of the share.
    *
    * @param option - Options to Share Set Properties operation.
-   * @returnsResponse data for the Share Set Properties operation.
+   * @returns Response data for the Share Set Properties operation.
    * @memberof ShareClient
    */
   public async setProperties(
@@ -1497,7 +1497,7 @@ export class ShareClient extends StorageClient {
    * Retrieves statistics related to the share.
    *
    * @param option - Options to Share Get Statistics operation.
-   * @returnsResponse data for the Share Get Statistics operation.
+   * @returns Response data for the Share Get Statistics operation.
    * @memberof ShareClient
    */
   public async getStatistics(
@@ -1598,7 +1598,7 @@ export class ShareClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareClient
    */
   public generateSasUrl(options: ShareGenerateSasUrlOptions): string {
@@ -2084,7 +2084,7 @@ export class ShareDirectoryClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
    * @param options - Options to Directory Create operation.
-   * @returnsResponse data for the Directory  operation.
+   * @returns Response data for the Directory  operation.
    * @memberof ShareDirectoryClient
    */
   public async create(options: DirectoryCreateOptions = {}): Promise<DirectoryCreateResponse> {
@@ -2213,7 +2213,7 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a ShareDirectoryClient object for a sub directory.
    *
    * @param subDirectoryName A subdirectory name
-   * @returnsThe ShareDirectoryClient object for the given subdirectory name.
+   * @returns The ShareDirectoryClient object for the given subdirectory name.
    * @memberof ShareDirectoryClient
    *
    * Example usage:
@@ -2237,7 +2237,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param directoryName -
    * @param options - Options to Directory Create operation.
-   * @returnsDirectory create response data and the corresponding DirectoryClient instance.
+   * @returns Directory create response data and the corresponding DirectoryClient instance.
    * @memberof ShareDirectoryClient
    */
   public async createSubdirectory(
@@ -2279,7 +2279,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param directoryName -
    * @param options - Options to Directory Delete operation.
-   * @returnsDirectory deletion response data.
+   * @returns Directory deletion response data.
    * @memberof ShareDirectoryClient
    */
   public async deleteSubdirectory(
@@ -2314,7 +2314,7 @@ export class ShareDirectoryClient extends StorageClient {
    * @param fileName -
    * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
    * @param options - Options to File Create operation.
-   * @returnsFile creation response data and the corresponding file client.
+   * @returns File creation response data and the corresponding file client.
    * @memberof ShareDirectoryClient
    */
   public async createFile(
@@ -2363,7 +2363,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param fileName - Name of the file to delete
    * @param options - Options to File Delete operation.
-   * @returnsFile deletion response data.
+   * @returns File deletion response data.
    * @memberof ShareDirectoryClient
    */
   public async deleteFile(
@@ -2395,7 +2395,7 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a {@link ShareFileClient} object.
    *
    * @param fileName - A file name.
-   * @returnsA new ShareFileClient object for the given file name.
+   * @returns A new ShareFileClient object for the given file name.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -2466,7 +2466,7 @@ export class ShareDirectoryClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties
    *
    * @param options - Options to Directory Get Properties operation.
-   * @returnsResponse data for the Directory Get Properties operation.
+   * @returns Response data for the Directory Get Properties operation.
    * @memberof ShareDirectoryClient
    */
   public async getProperties(
@@ -2498,7 +2498,7 @@ export class ShareDirectoryClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
    * @param options - Options to Directory Delete operation.
-   * @returnsResponse data for the Directory Delete operation.
+   * @returns Response data for the Directory Delete operation.
    * @memberof ShareDirectoryClient
    */
   public async delete(options: DirectoryDeleteOptions = {}): Promise<DirectoryDeleteResponse> {
@@ -2575,7 +2575,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param metadata - If no metadata provided, all existing directory metadata will be removed
    * @param options - Options to Directory Set Metadata operation.
-   * @returnsResponse data for the Directory Set Metadata operation.
+   * @returns Response data for the Directory Set Metadata operation.
    * @memberof ShareDirectoryClient
    */
   public async setMetadata(
@@ -2639,7 +2639,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @private
    * @param options - Options to list files and directories operation.
-   * @returns& DirectoryItem>}
+   * @returns & DirectoryItem>}
    * @memberof ShareDirectoryClient
    */
   private async *listFilesAndDirectoriesItems(
@@ -2754,7 +2754,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param options - Options to list files and directories operation.
    * @memberof ShareDirectoryClient
-   * @returns, DirectoryListFilesAndDirectoriesSegmentResponse>}
+   * @returns , DirectoryListFilesAndDirectoriesSegmentResponse>}
    * An asyncIterableIterator that supports paging.
    */
   public listFilesAndDirectories(
@@ -2801,7 +2801,7 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @param marker - A string value that identifies the portion of the list to be returned with the next list operation.
    * @param options - Options to Directory List Files and Directories Segment operation.
-   * @returnsResponse data for the Directory List Files and Directories operation.
+   * @returns Response data for the Directory List Files and Directories operation.
    * @memberof ShareDirectoryClient
    */
   private async listFilesAndDirectoriesSegment(
@@ -4135,7 +4135,7 @@ export class ShareFileClient extends StorageClient {
    * Provide "" will remove the snapshot and return a URL to the base ShareFileClient.
    *
    * @param shareSnapshot - The share snapshot timestamp.
-   * @returnsA new ShareFileClient object identical to the source but with the specified share snapshot timestamp.
+   * @returns A new ShareFileClient object identical to the source but with the specified share snapshot timestamp.
    * @memberof ShareFileClient
    */
   public withShareSnapshot(shareSnapshot: string): ShareFileClient {
@@ -4155,7 +4155,7 @@ export class ShareFileClient extends StorageClient {
    *
    * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
    * @param options - Options to File Create operation.
-   * @returnsResponse data for the File Create  operation.
+   * @returns Response data for the File Create  operation.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -4226,7 +4226,7 @@ export class ShareFileClient extends StorageClient {
    * @param offset - From which position of the file to download, >= 0
    * @param count - How much data to be downloaded, > 0. Will download to the end when undefined
    * @param options - Options to File Download operation.
-   * @returnsResponse data for the File Download operation.
+   * @returns Response data for the File Download operation.
    * @memberof ShareFileClient
    *
    * Example usage (Node.js):
@@ -4408,7 +4408,7 @@ export class ShareFileClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-properties
    *
    * @param options - Options to File Get Properties operation.
-   * @returnsResponse data for the File Get Properties operation.
+   * @returns Response data for the File Get Properties operation.
    * @memberof ShareFileClient
    */
   public async getProperties(
@@ -4495,7 +4495,7 @@ export class ShareFileClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
    * @param options - Options to File Delete operation.
-   * @returnsResponse data for the File Delete operation.
+   * @returns Response data for the File Delete operation.
    * @memberof ShareFileClient
    */
   public async delete(options: FileDeleteOptions = {}): Promise<FileDeleteResponse> {
@@ -4586,7 +4586,7 @@ export class ShareFileClient extends StorageClient {
    * @param FileHttpHeaders - File HTTP headers like Content-Type.
    *                                             Provide undefined will remove existing HTTP headers.
    * @param options - Options to File Set HTTP Headers operation.
-   * @returnsResponse data for the File Set HTTP Headers operation.
+   * @returns Response data for the File Set HTTP Headers operation.
    * @memberof ShareFileClient
    */
   public async setHttpHeaders(
@@ -4633,7 +4633,7 @@ export class ShareFileClient extends StorageClient {
    *                        If the specified byte value is less than the current size of the file,
    *                        then all ranges above the specified byte value are cleared.
    * @param options - Options to File Resize operation.
-   * @returnsResponse data for the File Set HTTP Headers operation.
+   * @returns Response data for the File Set HTTP Headers operation.
    * @memberof ShareFileClient
    */
   public async resize(
@@ -4681,7 +4681,7 @@ export class ShareFileClient extends StorageClient {
    *
    * @param metadata - If no metadata provided, all existing directory metadata will be removed
    * @param options - Options to File Set Metadata operation.
-   * @returnsResponse data for the File Set Metadata operation.
+   * @returns Response data for the File Set Metadata operation.
    * @memberof ShareFileClient
    */
   public async setMetadata(
@@ -4718,7 +4718,7 @@ export class ShareFileClient extends StorageClient {
    * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
    * @param options - Options to File Upload Range operation.
-   * @returnsResponse data for the File Upload Range operation.
+   * @returns Response data for the File Upload Range operation.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -5555,7 +5555,7 @@ export class ShareFileClient extends StorageClient {
    * @param offset - From which position of the block blob to download.
    * @param count - How much data to be downloaded. Will download to the end when passing undefined.
    * @param options - Options to Blob download options.
-   * @returnsThe response data for blob download operation,
+   * @returns The response data for blob download operation,
    *                                                 but with readableStreamBody set to undefined since its
    *                                                 content is already read and written into a local file
    *                                                 at the specified path.
@@ -5866,7 +5866,7 @@ export class ShareFileClient extends StorageClient {
    * Get a {@link ShareLeaseClient} that manages leases on the file.
    *
    * @param proposeLeaseId - Initial proposed lease Id.
-   * @returnsA new ShareLeaseClient object for managing leases on the file.
+   * @returns A new ShareLeaseClient object for managing leases on the file.
    * @memberof ShareFileClient
    */
   public getShareLeaseClient(proposeLeaseId?: string) {
@@ -5882,7 +5882,7 @@ export class ShareFileClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareFileClient
    */
   public generateSasUrl(options: FileGenerateSasUrlOptions): string {
@@ -6049,7 +6049,7 @@ export class ShareLeaseClient {
    *
    * @param duration - Specifies the duration of lease in seconds. For file, the only allowed value is -1 for a lease that never expires. For share, must be -1 or between 15 to 60.
    * @param options - Options for the lease management operation.
-   * @returnsResponse data for acquire lease operation.
+   * @returns Response data for acquire lease operation.
    * @memberof ShareLeaseClient
    */
   public async acquireLease(
@@ -6083,7 +6083,7 @@ export class ShareLeaseClient {
    *
    * @param proposedLeaseId - the proposed new lease Id.
    * @param options - Options for the lease management operation.
-   * @returnsResponse data for change lease operation.
+   * @returns Response data for change lease operation.
    * @memberof ShareLeaseClient
    */
   public async changeLease(
@@ -6118,7 +6118,7 @@ export class ShareLeaseClient {
    * immediately acquire a lease.
    *
    * @param options - Options for the lease management operation.
-   * @returnsResponse data for release lease operation.
+   * @returns Response data for release lease operation.
    * @memberof ShareLeaseClient
    */
   public async releaseLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -6146,7 +6146,7 @@ export class ShareLeaseClient {
    * To force end the lease.
    *
    * @param options - Options for the lease management operation.
-   * @returnsResponse data for break lease operation.
+   * @returns Response data for break lease operation.
    * @memberof ShareLeaseClient
    */
   public async breakLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -6173,7 +6173,7 @@ export class ShareLeaseClient {
    * When you renew a lease, the lease duration clock resets.
    *
    * @param options - Options for the lease management operation.
-   * @returnsResponse data for renew lease operation.
+   * @returns Response data for renew lease operation.
    * @memberof ShareLeaseClient
    */
   public async renewLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -736,38 +736,38 @@ export class ShareClient extends StorageClient {
   }
 
   /**
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} name Share name.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param name - Share name.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ShareClient
    */
   constructor(connectionString: string, name: string, options?: StoragePipelineOptions);
   /**
    * Creates an instance of ShareClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file share, such as
+   * @param url - A URL string pointing to Azure Storage file share, such as
    *                     "https://myaccount.file.core.windows.net/share". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/share?sasString".
-   * @param {Credential} [credential] Such as AnonymousCredential or StorageSharedKeyCredential.
+   * @param credential - Such as AnonymousCredential or StorageSharedKeyCredential.
    *                                  If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ShareClient
    */
   constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
   /**
    * Creates an instance of ShareClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file share, such as
+   * @param url - A URL string pointing to Azure Storage file share, such as
    *                     "https://myaccount.file.core.windows.net/share". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/share?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof ShareClient
    */
@@ -833,8 +833,8 @@ export class ShareClient extends StorageClient {
    * Creates a new ShareClient object identical to the source but with the specified snapshot timestamp.
    * Provide "" will remove the snapshot and return a URL to the base share.
    *
-   * @param {string} snapshot The snapshot timestamp.
-   * @returns {ShareClient} A new ShareClient object identical to the source but with the specified snapshot timestamp
+   * @param snapshot - The snapshot timestamp.
+   * @returnsA new ShareClient object identical to the source but with the specified snapshot timestamp
    * @memberof ShareClient
    */
   public withSnapshot(snapshot: string): ShareClient {
@@ -853,8 +853,8 @@ export class ShareClient extends StorageClient {
    * the same name already exists, the operation fails.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
    *
-   * @param {ShareCreateOptions} [options] Options to Share Create operation.
-   * @returns {Promise<ShareCreateResponse>} Response data for the Share Create operation.
+   * @param options - Options to Share Create operation.
+   * @returnsResponse data for the Share Create operation.
    * @memberof ShareClient
    */
   public async create(options: ShareCreateOptions = {}): Promise<ShareCreateResponse> {
@@ -881,8 +881,8 @@ export class ShareClient extends StorageClient {
    * the same name already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
    *
-   * @param {ShareCreateOptions} [options]
-   * @returns {Promise<ShareCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof ShareClient
    */
   public async createIfNotExists(
@@ -927,7 +927,7 @@ export class ShareClient extends StorageClient {
    * Creates a {@link ShareDirectoryClient} object.
    *
    * @param directoryName A directory name
-   * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given directory name.
+   * @returnsThe ShareDirectoryClient object for the given directory name.
    * @memberof ShareClient
    */
   public getDirectoryClient(directoryName: string): ShareDirectoryClient {
@@ -953,9 +953,9 @@ export class ShareClient extends StorageClient {
    * Creates a new subdirectory under this share.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
-   * @param {string} directoryName
-   * @param {DirectoryCreateOptions} [options] Options to Directory Create operation.
-   * @returns {Promise<{ directoryClient: ShareDirectoryClient, directoryCreateResponse: DirectoryCreateResponse }>} Directory creation response data and the corresponding directory client.
+   * @param directoryName -
+   * @param options - Options to Directory Create operation.
+   * @returnsDirectory creation response data and the corresponding directory client.
    * @memberof ShareClient
    */
   public async createDirectory(
@@ -992,9 +992,9 @@ export class ShareClient extends StorageClient {
    * Note that the directory must be empty before it can be deleted.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
-   * @param {string} directoryName
-   * @param {DirectoryDeleteOptions} [options] Options to Directory Delete operation.
-   * @returns {Promise<DirectoryDeleteResponse>} Directory deletion response data.
+   * @param directoryName -
+   * @param options - Options to Directory Delete operation.
+   * @returnsDirectory deletion response data.
    * @memberof ShareClient
    */
   public async deleteDirectory(
@@ -1024,10 +1024,10 @@ export class ShareClient extends StorageClient {
    * Note it only initializes the file with no content.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
    *
-   * @param {string} fileName
-   * @param {number} size Specifies the maximum size in bytes for the file, up to 4 TB.
-   * @param {FileCreateOptions} [options] Options to File Create operation.
-   * @returns {Promise<{ fileClient: ShareFileClient, fileCreateResponse: FileCreateResponse }>} File creation response data and the corresponding file client.
+   * @param fileName -
+   * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
+   * @param options - Options to File Create operation.
+   * @returnsFile creation response data and the corresponding file client.
    * @memberof ShareClient
    */
   public async createFile(
@@ -1073,9 +1073,9 @@ export class ShareClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
-   * @param {string} directoryName
-   * @param {string} fileName
-   * @param {FileDeleteOptions} [options] Options to File Delete operation.
+   * @param directoryName -
+   * @param fileName -
+   * @param options - Options to File Delete operation.
    * @returns Promise<FileDeleteResponse> File Delete response data.
    * @memberof ShareClient
    */
@@ -1109,8 +1109,8 @@ export class ShareClient extends StorageClient {
    * applications. Vice versa new shares might be added by other clients or applications after this
    * function completes.
    *
-   * @param {ShareExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof ShareClient
    */
   public async exists(options: ShareExistsOptions = {}): Promise<boolean> {
@@ -1149,7 +1149,7 @@ export class ShareClient extends StorageClient {
    * the `listShares` method of {@link ShareServiceClient} using the `includeMetadata` option, which
    * will retain their original casing.
    *
-   * @returns {Promise<ShareGetPropertiesResponse>} Response data for the Share Get Properties operation.
+   * @returnsResponse data for the Share Get Properties operation.
    * @memberof ShareClient
    */
   public async getProperties(
@@ -1182,8 +1182,8 @@ export class ShareClient extends StorageClient {
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
    *
-   * @param {ShareDeleteMethodOptions} [options] Options to Share Delete operation.
-   * @returns {Promise<ShareDeleteResponse>} Response data for the Share Delete operation.
+   * @param options - Options to Share Delete operation.
+   * @returnsResponse data for the Share Delete operation.
    * @memberof ShareClient
    */
   public async delete(options: ShareDeleteMethodOptions = {}): Promise<ShareDeleteResponse> {
@@ -1209,8 +1209,8 @@ export class ShareClient extends StorageClient {
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
    *
-   * @param {ShareDeleteMethodOptions} [options]
-   * @returns {Promise<ShareDeleteIfExistsResponse>}
+   * @param options -
+   *
    * @memberof ShareClient
    */
   public async deleteIfExists(
@@ -1255,9 +1255,9 @@ export class ShareClient extends StorageClient {
    * metadata will be removed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-metadata
    *
-   * @param {Metadata} [metadata] If no metadata provided, all existing directory metadata will be removed.
-   * @param {ShareSetMetadataOptions} [option] Options to Share Set Metadata operation.
-   * @returns {Promise<ShareSetMetadataResponse>} Response data for the Share Set Metadata operation.
+   * @param metadata - If no metadata provided, all existing directory metadata will be removed.
+   * @param option - Options to Share Set Metadata operation.
+   * @returnsResponse data for the Share Set Metadata operation.
    * @memberof ShareClient
    */
   public async setMetadata(
@@ -1291,8 +1291,8 @@ export class ShareClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-acl
    *
-   * @param {ShareGetAccessPolicyOptions} [option] Options to Share Get Access Policy operation.
-   * @returns {Promise<ShareGetAccessPolicyResponse>} Response data for the Share Get Access Policy operation.
+   * @param option - Options to Share Get Access Policy operation.
+   * @returnsResponse data for the Share Get Access Policy operation.
    * @memberof ShareClient
    */
   public async getAccessPolicy(
@@ -1362,9 +1362,9 @@ export class ShareClient extends StorageClient {
    * fail with status code 403 (Forbidden), until the access policy becomes active.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-acl
    *
-   * @param {SignedIdentifier[]} [shareAcl] Array of signed identifiers, each having a unique Id and details of access policy.
-   * @param {ShareSetAccessPolicyOptions} [option] Options to Share Set Access Policy operation.
-   * @returns {Promise<ShareSetAccessPolicyResponse>} Response data for the Share Set Access Policy operation.
+   * @param shareAcl - Array of signed identifiers, each having a unique Id and details of access policy.
+   * @param option - Options to Share Set Access Policy operation.
+   * @returnsResponse data for the Share Set Access Policy operation.
    * @memberof ShareClient
    */
   public async setAccessPolicy(
@@ -1408,8 +1408,8 @@ export class ShareClient extends StorageClient {
   /**
    * Creates a read-only snapshot of a share.
    *
-   * @param {ShareCreateSnapshotOptions} [options={}] Options to Share Create Snapshot operation.
-   * @returns {Promise<ShareCreateSnapshotResponse>} Response data for the Share Create Snapshot operation.
+   * @param options - Options to Share Create Snapshot operation.
+   * @returnsResponse data for the Share Create Snapshot operation.
    * @memberof ShareClient
    */
   public async createSnapshot(
@@ -1438,9 +1438,9 @@ export class ShareClient extends StorageClient {
    *
    * @deprecated Use {@link ShareClient.setProperties} instead.
    *
-   * @param {number} quotaInGB Specifies the maximum size of the share in gigabytes
-   * @param {ShareSetQuotaOptions} [option] Options to Share Set Quota operation.
-   * @returns {Promise<ShareSetQuotaResponse>} Response data for the Share Get Quota operation.
+   * @param quotaInGB - Specifies the maximum size of the share in gigabytes
+   * @param option - Options to Share Set Quota operation.
+   * @returnsResponse data for the Share Get Quota operation.
    * @memberof ShareClient
    */
   public async setQuota(
@@ -1468,8 +1468,8 @@ export class ShareClient extends StorageClient {
   /**
    * Sets properties of the share.
    *
-   * @param {ShareSetPropertiesOptions} [option] Options to Share Set Properties operation.
-   * @returns {Promise<ShareSetPropertiesResponse>} Response data for the Share Set Properties operation.
+   * @param option - Options to Share Set Properties operation.
+   * @returnsResponse data for the Share Set Properties operation.
    * @memberof ShareClient
    */
   public async setProperties(
@@ -1496,8 +1496,8 @@ export class ShareClient extends StorageClient {
   /**
    * Retrieves statistics related to the share.
    *
-   * @param {ShareGetStatisticsOptions} [option] Options to Share Get Statistics operation.
-   * @returns {Promise<ShareGetStatisticsResponse>} Response data for the Share Get Statistics operation.
+   * @param option - Options to Share Get Statistics operation.
+   * @returnsResponse data for the Share Get Statistics operation.
    * @memberof ShareClient
    */
   public async getStatistics(
@@ -1528,7 +1528,7 @@ export class ShareClient extends StorageClient {
    * The created security descriptor can be used for the files/directories in the share.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-permission
    *
-   * @param {ShareCreatePermissionOptions} [options] Options to Share Create Permission operation.
+   * @param options - Options to Share Create Permission operation.
    * @param filePermission File permission described in the SDDL
    */
   public async createPermission(
@@ -1565,7 +1565,7 @@ export class ShareClient extends StorageClient {
    * which indicates a security descriptor.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-permission
    *
-   * @param {ShareGetPermissionOptions} [options] Options to Share Create Permission operation.
+   * @param options - Options to Share Create Permission operation.
    * @param filePermissionKey File permission key which indicates the security descriptor of the permission.
    */
   public async getPermission(
@@ -1597,8 +1597,8 @@ export class ShareClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {ShareGenerateSasUrlOptions} options Optional parameters.
-   * @returns {string} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareClient
    */
   public generateSasUrl(options: ShareGenerateSasUrlOptions): string {
@@ -2025,7 +2025,7 @@ export class ShareDirectoryClient extends StorageClient {
   /**
    * Creates an instance of DirectoryClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file directory, such as
+   * @param url - A URL string pointing to Azure Storage file directory, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory?sasString".
@@ -2033,16 +2033,16 @@ export class ShareDirectoryClient extends StorageClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a directory name includes %, directory name must be encoded in the URL.
    *                     Such as a directory named "mydir%", the URL should be "https://myaccount.file.core.windows.net/myshare/mydir%25".
-   * @param {Credential} [credential] Such as AnonymousCredential or StorageSharedKeyCredential.
+   * @param credential - Such as AnonymousCredential or StorageSharedKeyCredential.
    *                                  If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ShareDirectoryClient
    */
   constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
   /**
    * Creates an instance of DirectoryClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file directory, such as
+   * @param url - A URL string pointing to Azure Storage file directory, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory?sasString".
@@ -2050,7 +2050,7 @@ export class ShareDirectoryClient extends StorageClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a directory name includes %, directory name must be encoded in the URL.
    *                     Such as a directory named "mydir%", the URL should be "https://myaccount.file.core.windows.net/myshare/mydir%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof ShareDirectoryClient
    */
@@ -2083,8 +2083,8 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a new directory under the specified share or parent directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
-   * @param {DirectoryCreateOptions} [options] Options to Directory Create operation.
-   * @returns {Promise<DirectoryCreateResponse>} Response data for the Directory  operation.
+   * @param options - Options to Directory Create operation.
+   * @returnsResponse data for the Directory  operation.
    * @memberof ShareDirectoryClient
    */
   public async create(options: DirectoryCreateOptions = {}): Promise<DirectoryCreateResponse> {
@@ -2126,8 +2126,8 @@ export class ShareDirectoryClient extends StorageClient {
    * If the directory already exists, it is not modified.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
-   * @param {DirectoryCreateOptions} [options]
-   * @returns {Promise<DirectoryCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   public async createIfNotExists(
@@ -2172,9 +2172,9 @@ export class ShareDirectoryClient extends StorageClient {
    * Sets properties on the directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-properties
    *
-   * @param {properties} [DirectoryProperties] Directory properties. If no values are provided,
+   * @param DirectoryProperties - Directory properties. If no values are provided,
    *                                            existing values will be preserved.
-   * @returns {Promise<DirectorySetPropertiesResponse>}
+   *
    * @memberof ShareDirectoryClient
    */
   public async setProperties(
@@ -2213,7 +2213,7 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a ShareDirectoryClient object for a sub directory.
    *
    * @param subDirectoryName A subdirectory name
-   * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given subdirectory name.
+   * @returnsThe ShareDirectoryClient object for the given subdirectory name.
    * @memberof ShareDirectoryClient
    *
    * Example usage:
@@ -2235,9 +2235,9 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a new subdirectory under this directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
-   * @param {string} directoryName
-   * @param {DirectoryCreateOptions} [options] Options to Directory Create operation.
-   * @returns {Promise<{ directoryClient: ShareDirectoryClient; directoryCreateResponse: DirectoryCreateResponse; }>} Directory create response data and the corresponding DirectoryClient instance.
+   * @param directoryName -
+   * @param options - Options to Directory Create operation.
+   * @returnsDirectory create response data and the corresponding DirectoryClient instance.
    * @memberof ShareDirectoryClient
    */
   public async createSubdirectory(
@@ -2277,9 +2277,9 @@ export class ShareDirectoryClient extends StorageClient {
    * Note that the directory must be empty before it can be deleted.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
-   * @param {string} directoryName
-   * @param {DirectoryDeleteOptions} [options] Options to Directory Delete operation.
-   * @returns {DirectoryDeleteResponse} Directory deletion response data.
+   * @param directoryName -
+   * @param options - Options to Directory Delete operation.
+   * @returnsDirectory deletion response data.
    * @memberof ShareDirectoryClient
    */
   public async deleteSubdirectory(
@@ -2311,10 +2311,10 @@ export class ShareDirectoryClient extends StorageClient {
    * Creates a new file or replaces a file under this directory. Note it only initializes the file with no content.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
    *
-   * @param {string} fileName
-   * @param {number} size Specifies the maximum size in bytes for the file, up to 4 TB.
-   * @param {FileCreateOptions} [options] Options to File Create operation.
-   * @returns {Promise<{ fileClient: ShareFileClient, fileCreateResponse: FileCreateResponse }>} File creation response data and the corresponding file client.
+   * @param fileName -
+   * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
+   * @param options - Options to File Create operation.
+   * @returnsFile creation response data and the corresponding file client.
    * @memberof ShareDirectoryClient
    */
   public async createFile(
@@ -2361,9 +2361,9 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
-   * @param {string} fileName Name of the file to delete
-   * @param {FileDeleteOptions} [options] Options to File Delete operation.
-   * @returns {Promise<FileDeleteResponse>} File deletion response data.
+   * @param fileName - Name of the file to delete
+   * @param options - Options to File Delete operation.
+   * @returnsFile deletion response data.
    * @memberof ShareDirectoryClient
    */
   public async deleteFile(
@@ -2394,8 +2394,8 @@ export class ShareDirectoryClient extends StorageClient {
   /**
    * Creates a {@link ShareFileClient} object.
    *
-   * @param {string} fileName A file name.
-   * @returns {ShareFileClient} A new ShareFileClient object for the given file name.
+   * @param fileName - A file name.
+   * @returnsA new ShareFileClient object for the given file name.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -2426,8 +2426,8 @@ export class ShareDirectoryClient extends StorageClient {
    * applications. Vice versa new directories might be added by other clients or applications after this
    * function completes.
    *
-   * @param {DirectoryExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof ShareDirectoryClient
    */
   public async exists(options: DirectoryExistsOptions = {}): Promise<boolean> {
@@ -2465,8 +2465,8 @@ export class ShareDirectoryClient extends StorageClient {
    * subdirectories.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties
    *
-   * @param {DirectoryGetPropertiesOptions} [options] Options to Directory Get Properties operation.
-   * @returns {Promise<DirectoryGetPropertiesResponse>} Response data for the Directory Get Properties operation.
+   * @param options - Options to Directory Get Properties operation.
+   * @returnsResponse data for the Directory Get Properties operation.
    * @memberof ShareDirectoryClient
    */
   public async getProperties(
@@ -2497,8 +2497,8 @@ export class ShareDirectoryClient extends StorageClient {
    * deleted.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
-   * @param {DirectoryDeleteOptions} [options] Options to Directory Delete operation.
-   * @returns {Promise<DirectoryDeleteResponse>} Response data for the Directory Delete operation.
+   * @param options - Options to Directory Delete operation.
+   * @returnsResponse data for the Directory Delete operation.
    * @memberof ShareDirectoryClient
    */
   public async delete(options: DirectoryDeleteOptions = {}): Promise<DirectoryDeleteResponse> {
@@ -2524,8 +2524,8 @@ export class ShareDirectoryClient extends StorageClient {
    * deleted.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
-   * @param {DirectoryDeleteOptions} [options]
-   * @returns {Promise<DirectoryDeleteIfExistsResponse>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   public async deleteIfExists(
@@ -2573,9 +2573,9 @@ export class ShareDirectoryClient extends StorageClient {
    * Updates user defined metadata for the specified directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-metadata
    *
-   * @param {Metadata} [metadata] If no metadata provided, all existing directory metadata will be removed
-   * @param {DirectorySetMetadataOptions} [options] Options to Directory Set Metadata operation.
-   * @returns {Promise<DirectorySetMetadataResponse>} Response data for the Directory Set Metadata operation.
+   * @param metadata - If no metadata provided, all existing directory metadata will be removed
+   * @param options - Options to Directory Set Metadata operation.
+   * @returnsResponse data for the Directory Set Metadata operation.
    * @memberof ShareDirectoryClient
    */
   public async setMetadata(
@@ -2607,15 +2607,15 @@ export class ShareDirectoryClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link DirectoryListFilesAndDirectoriesSegmentResponse} objects
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list of files and directories to be returned with the next listing operation. The
    *                          operation returns the ContinuationToken value within the response body if the
    *                          listing operation did not return all files and directories remaining to be listed
    *                          with the current page. The ContinuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {DirectoryListFilesAndDirectoriesSegmentOptions} [options] Options to list files and directories operation.
-   * @returns {AsyncIterableIterator<DirectoryListFilesAndDirectoriesSegmentResponse>}
+   * @param options - Options to list files and directories operation.
+   *
    * @memberof ShareDirectoryClient
    */
   private async *iterateFilesAndDirectoriesSegments(
@@ -2638,8 +2638,8 @@ export class ShareDirectoryClient extends StorageClient {
    * Returns an AsyncIterableIterator for file and directory items
    *
    * @private
-   * @param {DirectoryListFilesAndDirectoriesSegmentOptions} [options] Options to list files and directories operation.
-   * @returns {AsyncIterableIterator<{ kind: "file" } & FileItem | { kind: "directory" } & DirectoryItem>}
+   * @param options - Options to list files and directories operation.
+   * @returns& DirectoryItem>}
    * @memberof ShareDirectoryClient
    */
   private async *listFilesAndDirectoriesItems(
@@ -2752,9 +2752,9 @@ export class ShareDirectoryClient extends StorageClient {
    * }
    * ```
    *
-   * @param {DirectoryListFilesAndDirectoriesOptions} [options] Options to list files and directories operation.
+   * @param options - Options to list files and directories operation.
    * @memberof ShareDirectoryClient
-   * @returns {PagedAsyncIterableIterator<{ kind: "file" } & FileItem | { kind: "directory" } , DirectoryListFilesAndDirectoriesSegmentResponse>}
+   * @returns, DirectoryListFilesAndDirectoriesSegmentResponse>}
    * An asyncIterableIterator that supports paging.
    */
   public listFilesAndDirectories(
@@ -2799,9 +2799,9 @@ export class ShareDirectoryClient extends StorageClient {
    * contents only for a single level of the directory hierarchy.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files
    *
-   * @param {string} [marker] A string value that identifies the portion of the list to be returned with the next list operation.
-   * @param {DirectoryListFilesAndDirectoriesSegmentOptions} [options] Options to Directory List Files and Directories Segment operation.
-   * @returns {Promise<DirectoryListFilesAndDirectoriesSegmentResponse>} Response data for the Directory List Files and Directories operation.
+   * @param marker - A string value that identifies the portion of the list to be returned with the next list operation.
+   * @param options - Options to Directory List Files and Directories Segment operation.
+   * @returnsResponse data for the Directory List Files and Directories operation.
    * @memberof ShareDirectoryClient
    */
   private async listFilesAndDirectoriesSegment(
@@ -2838,13 +2838,13 @@ export class ShareDirectoryClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link DirectoryListHandlesResponse}
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of the list to be
+   * @param marker - A string value that identifies the portion of the list to be
    *                          returned with the next list handles operation. The operation returns a
    *                          marker value within the response body if the list returned was not complete.
    *                          The marker value may then be used in a subsequent call to request the next
    *                          set of list items.
-   * @param {DirectoryListHandlesSegmentOptions} [options] Options to list handles operation.
-   * @returns {AsyncIterableIterator<DirectoryListHandlesResponse>}
+   * @param options - Options to list handles operation.
+   *
    * @memberof ShareDirectoryClient
    */
   private async *iterateHandleSegments(
@@ -2865,8 +2865,8 @@ export class ShareDirectoryClient extends StorageClient {
    * Returns an AsyncIterableIterator for handles
    *
    * @private
-   * @param {DirectoryListHandlesSegmentOptions} [options] Options to list handles operation.
-   * @returns {AsyncIterableIterator<HandleItem>}
+   * @param options - Options to list handles operation.
+   *
    * @memberof ShareDirectoryClient
    */
   private async *listHandleItems(
@@ -2954,9 +2954,9 @@ export class ShareDirectoryClient extends StorageClient {
    * }
    * ```
    *
-   * @param {DirectoryListHandlesOptions} [options] Options to list handles operation.
+   * @param options - Options to list handles operation.
    * @memberof ShareDirectoryClient
-   * @returns {PagedAsyncIterableIterator<HandleItem, DirectoryListHandlesResponse>}
+   *
    * An asyncIterableIterator that supports paging.
    */
   public listHandles(
@@ -2993,13 +2993,13 @@ export class ShareDirectoryClient extends StorageClient {
    * Lists handles for a directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles
    *
-   * @param {string} [marker] Optional. A string value that identifies the portion of the list to be
+   * @param marker - Optional. A string value that identifies the portion of the list to be
    *                          returned with the next list handles operation. The operation returns a
    *                          marker value within the response body if the list returned was not complete.
    *                          The marker value may then be used in a subsequent call to request the next
    *                          set of list items.
-   * @param {DirectoryListHandlesSegmentOptions} [options={}]
-   * @returns {Promise<DirectoryListHandlesResponse>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   private async listHandlesSegment(
@@ -3039,13 +3039,13 @@ export class ShareDirectoryClient extends StorageClient {
    * Force close all handles for a directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {string} [marker] Optional. A string value that identifies the position of handles that will
+   * @param marker - Optional. A string value that identifies the position of handles that will
    *                          be closed with the next force close handles operation.
    *                          The operation returns a marker value within the response
    *                          body if there are more handles to close. The marker value
    *                          may then be used in a subsequent call to close the next set of handles.
-   * @param {DirectoryForceCloseHandlesSegmentOptions} [options={}]
-   * @returns {Promise<DirectoryForceCloseHandlesResponse>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   private async forceCloseHandlesSegment(
@@ -3082,8 +3082,8 @@ export class ShareDirectoryClient extends StorageClient {
    * Force close all handles for a directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {DirectoryForceCloseHandlesSegmentOptions} [options={}]
-   * @returns {Promise<CloseHandlesInfo>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   public async forceCloseAllHandles(
@@ -3124,12 +3124,12 @@ export class ShareDirectoryClient extends StorageClient {
    * Force close a specific handle for a directory.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {Aborter} aborter Create a new Aborter instance with Aborter.none or Aborter.timeout(),
+   * @param aborter - Create a new Aborter instance with Aborter.none or Aborter.timeout(),
    *                          goto documents of Aborter for more examples about request cancellation
-   * @param {string} handleId Specific handle ID, cannot be asterisk "*".
+   * @param handleId - Specific handle ID, cannot be asterisk "*".
    *                          Use forceCloseHandlesSegment() to close all handles.
-   * @param {DirectoryForceCloseHandlesOptions} [options={}]
-   * @returns {Promise<DirectoryForceCloseHandlesResponse>}
+   * @param options -
+   *
    * @memberof ShareDirectoryClient
    */
   public async forceCloseHandle(
@@ -4076,7 +4076,7 @@ export class ShareFileClient extends StorageClient {
   /**
    * Creates an instance of ShareFileClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file, such as
+   * @param url - A URL string pointing to Azure Storage file, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory/file". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory/file?sasString".
@@ -4084,16 +4084,16 @@ export class ShareFileClient extends StorageClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a file or directory name includes %, file or directory name must be encoded in the URL.
    *                     Such as a file named "myfile%", the URL should be "https://myaccount.file.core.windows.net/myshare/mydirectory/myfile%25".
-   * @param {Credential} [credential] Such as AnonymousCredential or StorageSharedKeyCredential.
+   * @param credential - Such as AnonymousCredential or StorageSharedKeyCredential.
    *                                  If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ShareFileClient
    */
   constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
   /**
    * Creates an instance of ShareFileClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file, such as
+   * @param url - A URL string pointing to Azure Storage file, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory/file". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.file.core.windows.net/myshare/mydirectory/file?sasString".
@@ -4101,7 +4101,7 @@ export class ShareFileClient extends StorageClient {
    *                     Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    *                     However, if a file or directory name includes %, file or directory name must be encoded in the URL.
    *                     Such as a file named "myfile%", the URL should be "https://myaccount.file.core.windows.net/myshare/mydirectory/myfile%25".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof ShareFileClient
    */
@@ -4134,8 +4134,8 @@ export class ShareFileClient extends StorageClient {
    * Creates a new ShareFileClient object identical to the source but with the specified share snapshot timestamp.
    * Provide "" will remove the snapshot and return a URL to the base ShareFileClient.
    *
-   * @param {string} shareSnapshot The share snapshot timestamp.
-   * @returns {ShareFileClient} A new ShareFileClient object identical to the source but with the specified share snapshot timestamp.
+   * @param shareSnapshot - The share snapshot timestamp.
+   * @returnsA new ShareFileClient object identical to the source but with the specified share snapshot timestamp.
    * @memberof ShareFileClient
    */
   public withShareSnapshot(shareSnapshot: string): ShareFileClient {
@@ -4153,9 +4153,9 @@ export class ShareFileClient extends StorageClient {
    * Creates a new file or replaces a file. Note it only initializes the file with no content.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
    *
-   * @param {number} size Specifies the maximum size in bytes for the file, up to 4 TB.
-   * @param {FileCreateOptions} [options] Options to File Create operation.
-   * @returns {Promise<FileCreateResponse>} Response data for the File Create  operation.
+   * @param size - Specifies the maximum size in bytes for the file, up to 4 TB.
+   * @param options - Options to File Create operation.
+   * @returnsResponse data for the File Create  operation.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -4223,10 +4223,10 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file
    *
-   * @param {number} [offset] From which position of the file to download, >= 0
-   * @param {number} [count] How much data to be downloaded, > 0. Will download to the end when undefined
-   * @param {FileDownloadOptions} [options] Options to File Download operation.
-   * @returns {Promise<FileDownloadResponse>} Response data for the File Download operation.
+   * @param offset - From which position of the file to download, >= 0
+   * @param count - How much data to be downloaded, > 0. Will download to the end when undefined
+   * @param options - Options to File Download operation.
+   * @returnsResponse data for the File Download operation.
    * @memberof ShareFileClient
    *
    * Example usage (Node.js):
@@ -4369,8 +4369,8 @@ export class ShareFileClient extends StorageClient {
    * applications. Vice versa new files might be added by other clients or applications after this
    * function completes.
    *
-   * @param {FileExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof ShareFileClient
    */
   public async exists(options: FileExistsOptions = {}): Promise<boolean> {
@@ -4407,8 +4407,8 @@ export class ShareFileClient extends StorageClient {
    * for the file. It does not return the content of the file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-properties
    *
-   * @param {FileGetPropertiesOptions} [options] Options to File Get Properties operation.
-   * @returns {Promise<FileGetPropertiesResponse>} Response data for the File Get Properties operation.
+   * @param options - Options to File Get Properties operation.
+   * @returnsResponse data for the File Get Properties operation.
    * @memberof ShareFileClient
    */
   public async getProperties(
@@ -4439,11 +4439,11 @@ export class ShareFileClient extends StorageClient {
    * Sets properties on the file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
    *
-   * @param {FileProperties} [properties] File properties. For file HTTP headers(e.g. Content-Type),
+   * @param properties - File properties. For file HTTP headers(e.g. Content-Type),
    *                                       if no values are provided, existing HTTP headers will be removed.
    *                                       For other file properties(e.g. fileAttributes), if no values are provided,
    *                                       existing values will be preserved.
-   * @returns {Promise<SetPropertiesResponse>}
+   *
    * @memberof ShareFileClient
    */
   public async setProperties(properties: FileProperties = {}): Promise<SetPropertiesResponse> {
@@ -4494,8 +4494,8 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
-   * @param {FileDeleteOptions} [options] Options to File Delete operation.
-   * @returns {Promise<FileDeleteResponse>} Response data for the File Delete operation.
+   * @param options - Options to File Delete operation.
+   * @returnsResponse data for the File Delete operation.
    * @memberof ShareFileClient
    */
   public async delete(options: FileDeleteOptions = {}): Promise<FileDeleteResponse> {
@@ -4531,8 +4531,8 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
-   * @param {FileDeleteOptions} [options]
-   * @returns {Promise<FileDeleteIfExistsResponse>}
+   * @param options -
+   *
    * @memberof ShareFileClient
    */
   public async deleteIfExists(
@@ -4583,10 +4583,10 @@ export class ShareFileClient extends StorageClient {
    * these file HTTP headers without a value will be cleared.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
    *
-   * @param {fileHttpHeaders} [FileHttpHeaders] File HTTP headers like Content-Type.
+   * @param FileHttpHeaders - File HTTP headers like Content-Type.
    *                                             Provide undefined will remove existing HTTP headers.
-   * @param {FileSetHttpHeadersOptions} [options] Options to File Set HTTP Headers operation.
-   * @returns {Promise<FileSetHTTPHeadersResponse>} Response data for the File Set HTTP Headers operation.
+   * @param options - Options to File Set HTTP Headers operation.
+   * @returnsResponse data for the File Set HTTP Headers operation.
    * @memberof ShareFileClient
    */
   public async setHttpHeaders(
@@ -4629,11 +4629,11 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
    *
-   * @param {number} length Resizes a file to the specified size in bytes.
+   * @param length - Resizes a file to the specified size in bytes.
    *                        If the specified byte value is less than the current size of the file,
    *                        then all ranges above the specified byte value are cleared.
-   * @param {FileResizeOptions} [options] Options to File Resize operation.
-   * @returns {Promise<FileSetHTTPHeadersResponse>} Response data for the File Set HTTP Headers operation.
+   * @param options - Options to File Resize operation.
+   * @returnsResponse data for the File Set HTTP Headers operation.
    * @memberof ShareFileClient
    */
   public async resize(
@@ -4679,9 +4679,9 @@ export class ShareFileClient extends StorageClient {
    * metadata will be removed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-metadata
    *
-   * @param {Metadata} [metadata] If no metadata provided, all existing directory metadata will be removed
-   * @param {FileSetMetadataOptions} [options] Options to File Set Metadata operation.
-   * @returns {Promise<FileSetMetadataResponse>} Response data for the File Set Metadata operation.
+   * @param metadata - If no metadata provided, all existing directory metadata will be removed
+   * @param options - Options to File Set Metadata operation.
+   * @returnsResponse data for the File Set Metadata operation.
    * @memberof ShareFileClient
    */
   public async setMetadata(
@@ -4712,13 +4712,13 @@ export class ShareFileClient extends StorageClient {
    * It won't change the size, properties or metadata of the file.
    * Both the start and count of the range must be specified. The range can be up to 4 MB in size.
    *
-   * @param {HttpRequestBody} body Blob, string, ArrayBuffer, ArrayBufferView or a function
+   * @param body - Blob, string, ArrayBuffer, ArrayBufferView or a function
    *                               which returns a new Readable stream whose offset is from data source beginning.
-   * @param {number} offset Offset position of the destination Azure File to upload.
-   * @param {number} contentLength Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
+   * @param offset - Offset position of the destination Azure File to upload.
+   * @param contentLength - Length of body in bytes. Use Buffer.byteLength() to calculate body length for a
    *                               string including non non-Base64/Hex-encoded characters.
-   * @param {FileUploadRangeOptions} [options={}] Options to File Upload Range operation.
-   * @returns {Promise<FileUploadRangeResponse>} Response data for the File Upload Range operation.
+   * @param options - Options to File Upload Range operation.
+   * @returnsResponse data for the File Upload Range operation.
    * @memberof ShareFileClient
    *
    * Example usage:
@@ -4783,12 +4783,12 @@ export class ShareFileClient extends StorageClient {
    * Upload a range of bytes to a file where the contents are read from a another file's URL.
    * The range can be up to 4 MB in size.
    *
-   * @param {string} sourceURL Specify a URL to the copy source, Shared Access Signature(SAS) maybe needed for authentication.
-   * @param {number} sourceOffset The source offset to copy from. Pass 0 to copy from the beginning of source file.
-   * @param {number} destOffset Offset of destination file.
-   * @param {number} count Number of bytes to be uploaded from source file.
-   * @param {FileUploadRangeFromURLOptions} [options={}] Options to configure File - Upload Range from URL operation.
-   * @returns {Promise<FileUploadRangeFromURLResponse>}
+   * @param sourceURL - Specify a URL to the copy source, Shared Access Signature(SAS) maybe needed for authentication.
+   * @param sourceOffset - The source offset to copy from. Pass 0 to copy from the beginning of source file.
+   * @param destOffset - Offset of destination file.
+   * @param count - Number of bytes to be uploaded from source file.
+   * @param options - Options to configure File - Upload Range from URL operation.
+   *
    * @memberof FileURL
    */
   public async uploadRangeFromURL(
@@ -4837,10 +4837,10 @@ export class ShareFileClient extends StorageClient {
    * Clears the specified range and
    * releases the space used in storage for that range.
    *
-   * @param {number} offset
-   * @param {number} contentLength
-   * @param {FileClearRangeOptions} [options] Options to File Clear Range operation.
-   * @returns {Promise<FileUploadRangeResponse>}
+   * @param offset -
+   * @param contentLength -
+   * @param options - Options to File Clear Range operation.
+   *
    * @memberof ShareFileClient
    */
   public async clearRange(
@@ -4878,8 +4878,8 @@ export class ShareFileClient extends StorageClient {
   /**
    * Returns the list of valid ranges for a file.
    *
-   * @param {FileGetRangeListOptions} [options] Options to File Get range List operation.
-   * @returns {Promise<FileGetRangeListResponse>}
+   * @param options - Options to File Get range List operation.
+   *
    * @memberof ShareFileClient
    */
   public async getRangeList(
@@ -4920,9 +4920,9 @@ export class ShareFileClient extends StorageClient {
   /**
    * Returns the list of ranges that differ between a previous share snapshot and this file.
    *
-   * @param {string} [prevShareSnapshot] The previous snapshot parameter is an opaque DateTime value that specifies the previous share snapshot to compare with.
-   * @param {FileGetRangeListOptions} [options]
-   * @returns {Promise<FileGetRangeListDiffResponse>}
+   * @param prevShareSnapshot - The previous snapshot parameter is an opaque DateTime value that specifies the previous share snapshot to compare with.
+   * @param options -
+   *
    * @memberof ShareFileClient
    */
   public async getRangeListDiff(
@@ -4954,15 +4954,15 @@ export class ShareFileClient extends StorageClient {
   /**
    * Copies a blob or file to a destination file within the storage account.
    *
-   * @param {string} copySource Specifies the URL of the source file or blob, up to 2 KB in length.
+   * @param copySource - Specifies the URL of the source file or blob, up to 2 KB in length.
    * To copy a file to another file within the same storage account, you may use Shared Key to
    * authenticate the source file. If you are copying a file from another storage account, or if you
    * are copying a blob from the same storage account or another storage account, then you must
    * authenticate the source file or blob using a shared access signature. If the source is a public
    * blob, no authentication is required to perform the copy operation. A file in a share snapshot
    * can also be specified as a copy source.
-   * @param {FileStartCopyOptions} [options] Options to File Start Copy operation.
-   * @returns {Promise<FileStartCopyResponse>}
+   * @param options - Options to File Start Copy operation.
+   *
    * @memberof ShareFileClient
    */
   public async startCopyFromURL(
@@ -4999,9 +4999,9 @@ export class ShareFileClient extends StorageClient {
    * metadata.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-file
    *
-   * @param {string} copyId Id of the Copy File operation to abort.
-   * @param {FileAbortCopyFromURLOptions} [options] Options to File Abort Copy From URL operation.
-   * @returns {Promise<FileAbortCopyResponse>}
+   * @param copyId - Id of the Copy File operation to abort.
+   * @param options - Options to File Abort Copy From URL operation.
+   *
    * @memberof ShareFileClient
    */
   public async abortCopyFromURL(
@@ -5034,9 +5034,9 @@ export class ShareFileClient extends StorageClient {
   /**
    * Creates a new Azure File or replaces an existing Azure File, and then uploads a Buffer(Node)/Blob/ArrayBuffer/ArrayBufferView to it.
    *
-   * @param {Buffer | Blob | ArrayBuffer | ArrayBufferView} data Buffer(Node), Blob, ArrayBuffer or ArrayBufferView
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {Promise<void>}
+   * @param data - Buffer(Node), Blob, ArrayBuffer or ArrayBufferView
+   * @param options -
+   *
    */
   public async uploadData(
     data: Buffer | Blob | ArrayBuffer | ArrayBufferView,
@@ -5088,10 +5088,10 @@ export class ShareFileClient extends StorageClient {
    * Uploads a browser Blob object to an Azure file. Requires a blobFactory as the data source,
    * which need to return a Blob object with the offset and size provided.
    *
-   * @param {(offset: number, size: number) => Blob} blobFactory
-   * @param {number} size
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {Promise<void>}
+   * @param blobFactory -
+   * @param size -
+   * @param options -
+   *
    */
   async uploadSeekableBlob(
     blobFactory: (offset: number, size: number) => Blob,
@@ -5123,10 +5123,10 @@ export class ShareFileClient extends StorageClient {
    *
    * Creates a new Azure File or replaces an existing Azure File, and then uploads a local file to it.
    *
-   * @param {string} filePath Full path of local file
-   * @param {ShareFileClient} fileClient ShareFileClient
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {(Promise<void>)}
+   * @param filePath - Full path of local file
+   * @param fileClient - ShareFileClient
+   * @param options -
+   *
    */
   public async uploadFile(
     filePath: string,
@@ -5166,12 +5166,12 @@ export class ShareFileClient extends StorageClient {
    * is the offset in the Azure file to be uploaded.
    *
    * @export
-   * @param {(offset: number) => NodeJS.ReadableStream} streamFactory Returns a Node.js Readable stream starting
+   * @param streamFactory - Returns a Node.js Readable stream starting
    *                                                                  from the offset defined
-   * @param {number} size Size of the Azure file
-   * @param {ShareFileClient} fileClient ShareFileClient
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {(Promise<void>)}
+   * @param size - Size of the Azure file
+   * @param fileClient - ShareFileClient
+   * @param options -
+   *
    */
   async uploadResetableStream(
     streamFactory: (offset: number, count?: number) => NodeJS.ReadableStream,
@@ -5203,11 +5203,11 @@ export class ShareFileClient extends StorageClient {
 
   /**
    *
-   * @param {(offset: number, count: number) => HttpRequestBody} bodyFactory
-   * @param {number} size Size of the Azure file
-   * @param {ShareFileClient} fileClient ShareFileClient
-   * @param {FileParallelUploadOptions} [options]
-   * @returns {(Promise<void>)}
+   * @param bodyFactory -
+   * @param size - Size of the Azure file
+   * @param fileClient - ShareFileClient
+   * @param options -
+   *
    */
   private async uploadSeekableInternal(
     bodyFactory: (offset: number, count: number) => HttpRequestBody,
@@ -5291,11 +5291,11 @@ export class ShareFileClient extends StorageClient {
    * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
    * consider {@link downloadToFile}.
    *
-   * @param {Buffer} buffer Buffer to be fill, must have length larger than count
-   * @param {number} offset From which position of the Azure File to download
-   * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined
-   * @param {FileDownloadToBufferOptions} [options]
-   * @returns {Promise<Buffer>}
+   * @param buffer - Buffer to be fill, must have length larger than count
+   * @param offset - From which position of the Azure File to download
+   * @param count - How much data to be downloaded. Will download to the end when passing undefined
+   * @param options -
+   *
    */
   public async downloadToBuffer(
     buffer: Buffer,
@@ -5314,10 +5314,10 @@ export class ShareFileClient extends StorageClient {
    * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
    * consider {@link downloadToFile}.
    *
-   * @param {number} offset From which position of the Azure file to download
-   * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined
-   * @param {FileDownloadToBufferOptions} [options]
-   * @returns {Promise<Buffer>}
+   * @param offset - From which position of the Azure file to download
+   * @param count - How much data to be downloaded. Will download to the end when passing undefined
+   * @param options -
+   *
    */
   public async downloadToBuffer(
     offset?: number,
@@ -5458,15 +5458,15 @@ export class ShareFileClient extends StorageClient {
    * * Input stream highWaterMark is better to set a same value with bufferSize
    *   parameter, which will avoid Buffer.concat() operations.
    *
-   * @param {Readable} stream Node.js Readable stream. Must be less or equal than file size.
-   * @param {number} size Size of file to be created. Maximum size allowed is 4 TB.
+   * @param stream - Node.js Readable stream. Must be less or equal than file size.
+   * @param size - Size of file to be created. Maximum size allowed is 4 TB.
    *                      If this value is larger than stream size, there will be empty bytes in file tail.
-   * @param {number} bufferSize Size of every buffer allocated in bytes, also the chunk/range size during
+   * @param bufferSize - Size of every buffer allocated in bytes, also the chunk/range size during
    *                            the uploaded file. Size must be > 0 and <= 4 * 1024 * 1024 (4MB)
-   * @param {number} maxBuffers Max buffers will allocate during uploading, positive correlation
+   * @param maxBuffers - Max buffers will allocate during uploading, positive correlation
    *                            with max uploading concurrency
-   * @param {FileUploadStreamOptions} [options]
-   * @returns {Promise<void>}
+   * @param options -
+   *
    */
   public async uploadStream(
     stream: Readable,
@@ -5551,11 +5551,11 @@ export class ShareFileClient extends StorageClient {
    * Fails if the the given file path already exits.
    * Offset and count are optional, pass 0 and undefined respectively to download the entire blob.
    *
-   * @param {string} filePath
-   * @param {number} [offset] From which position of the block blob to download.
-   * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined.
-   * @param {BlobDownloadOptions} [options] Options to Blob download options.
-   * @returns {Promise<FileDownloadResponse>} The response data for blob download operation,
+   * @param filePath -
+   * @param offset - From which position of the block blob to download.
+   * @param count - How much data to be downloaded. Will download to the end when passing undefined.
+   * @param options - Options to Blob download options.
+   * @returnsThe response data for blob download operation,
    *                                                 but with readableStreamBody set to undefined since its
    *                                                 content is already read and written into a local file
    *                                                 at the specified path.
@@ -5598,13 +5598,13 @@ export class ShareFileClient extends StorageClient {
    * Lists handles for a file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles
    *
-   * @param {string} [marker] Optional. A string value that identifies the portion of the list to be
+   * @param marker - Optional. A string value that identifies the portion of the list to be
    *                          returned with the next list handles operation. The operation returns a
    *                          marker value within the response body if the list returned was not complete.
    *                          The marker value may then be used in a subsequent call to request the next
    *                          set of list items.
-   * @param {FileListHandlesSegmentOptions} [options={}]
-   * @returns {Promise<FileListHandlesResponse>}
+   * @param options -
+   *
    * @memberof FileURL
    */
   private async listHandlesSegment(
@@ -5645,13 +5645,13 @@ export class ShareFileClient extends StorageClient {
    * Returns an AsyncIterableIterator for FileListHandlesResponse
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of the list to be
+   * @param marker - A string value that identifies the portion of the list to be
    *                          returned with the next list handles operation. The operation returns a
    *                          marker value within the response body if the list returned was not complete.
    *                          The marker value may then be used in a subsequent call to request the next
    *                          set of list items.
-   * @param {FileListHandlesSegmentOptions} [options] Options to list handles operation.
-   * @returns {AsyncIterableIterator<FileListHandlesResponse>}
+   * @param options - Options to list handles operation.
+   *
    * @memberof ShareFileClient
    */
   private async *iterateHandleSegments(
@@ -5672,8 +5672,8 @@ export class ShareFileClient extends StorageClient {
    * Returns an AsyncIterableIterator for handles
    *
    * @private
-   * @param {FileListHandlesSegmentOptions} [options] Options to list handles operation.
-   * @returns {AsyncIterableIterator<HandleItem>}
+   * @param options - Options to list handles operation.
+   *
    * @memberof ShareFileClient
    */
   private async *listHandleItems(
@@ -5695,9 +5695,9 @@ export class ShareFileClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the handles in pages.
    *
-   * @param {FileListHandlesOptions} [options] Options to list handles operation.
+   * @param options - Options to list handles operation.
    * @memberof ShareFileClient
-   * @returns {PagedAsyncIterableIterator<HandleItem, FileListHandlesResponse>}
+   *
    * An asyncIterableIterator that supports paging.
    */
   public listHandles(
@@ -5734,13 +5734,13 @@ export class ShareFileClient extends StorageClient {
    * Force close all handles for a file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {string} [marker] Optional. A string value that identifies the position of handles that will
+   * @param marker - Optional. A string value that identifies the position of handles that will
    *                          be closed with the next force close handles operation.
    *                          The operation returns a marker value within the response
    *                          body if there are more handles to close. The marker value
    *                          may then be used in a subsequent call to close the next set of handles.
-   * @param {FileForceCloseHandlesOptions} [options] Options to force close handles operation.
-   * @returns {Promise<FileForceCloseHandlesResponse>}
+   * @param options - Options to force close handles operation.
+   *
    * @memberof ShareFileClient
    */
   private async forceCloseHandlesSegment(
@@ -5777,8 +5777,8 @@ export class ShareFileClient extends StorageClient {
    * Force close all handles for a file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {FileForceCloseHandlesOptions} [options] Options to force close handles operation.
-   * @returns {Promise<CloseHandlesInfo>}
+   * @param options - Options to force close handles operation.
+   *
    * @memberof ShareFileClient
    */
   public async forceCloseAllHandles(
@@ -5822,10 +5822,10 @@ export class ShareFileClient extends StorageClient {
    * Force close a specific handle for a file.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles
    *
-   * @param {string} handleId Specific handle ID, cannot be asterisk "*".
+   * @param handleId - Specific handle ID, cannot be asterisk "*".
    *                          Use forceCloseAllHandles() to close all handles.
    * @param FileForceCloseHandlesOptions} [options] Options to force close handles operation.
-   * @returns {Promise<FileForceCloseHandlesResponse>}
+   *
    * @memberof ShareFileClient
    */
   public async forceCloseHandle(
@@ -5865,8 +5865,8 @@ export class ShareFileClient extends StorageClient {
   /**
    * Get a {@link ShareLeaseClient} that manages leases on the file.
    *
-   * @param {string} [proposeLeaseId] Initial proposed lease Id.
-   * @returns {ShareLeaseClient} A new ShareLeaseClient object for managing leases on the file.
+   * @param proposeLeaseId - Initial proposed lease Id.
+   * @returnsA new ShareLeaseClient object for managing leases on the file.
    * @memberof ShareFileClient
    */
   public getShareLeaseClient(proposeLeaseId?: string) {
@@ -5881,8 +5881,8 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {FileGenerateSasUrlOptions} options Optional parameters.
-   * @returns {string} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareFileClient
    */
   public generateSasUrl(options: FileGenerateSasUrlOptions): string {
@@ -6018,8 +6018,8 @@ export class ShareLeaseClient {
 
   /**
    * Creates an instance of ShareLeaseClient.
-   * @param {ShareFileClient} client The client to make the lease operation requests.
-   * @param {string} leaseId Initial proposed lease id.
+   * @param client - The client to make the lease operation requests.
+   * @param leaseId - Initial proposed lease id.
    * @memberof ShareLeaseClient
    */
   constructor(client: ShareFileClient, leaseId?: string) {
@@ -6047,9 +6047,9 @@ export class ShareLeaseClient {
   /**
    * Establishes and manages a lock on a file, share or share snapshot for write and delete operations.
    *
-   * @param {number} duration Specifies the duration of lease in seconds. For file, the only allowed value is -1 for a lease that never expires. For share, must be -1 or between 15 to 60.
-   * @param {LeaseOperationOptions} [options={}] Options for the lease management operation.
-   * @returns {Promise<LeaseOperationResponse>} Response data for acquire lease operation.
+   * @param duration - Specifies the duration of lease in seconds. For file, the only allowed value is -1 for a lease that never expires. For share, must be -1 or between 15 to 60.
+   * @param options - Options for the lease management operation.
+   * @returnsResponse data for acquire lease operation.
    * @memberof ShareLeaseClient
    */
   public async acquireLease(
@@ -6081,9 +6081,9 @@ export class ShareLeaseClient {
   /**
    * To change the ID of an existing lease.
    *
-   * @param {string} proposedLeaseId the proposed new lease Id.
-   * @param {LeaseOperationOptions} [options={}] Options for the lease management operation.
-   * @returns {Promise<LeaseOperationResponse>} Response data for change lease operation.
+   * @param proposedLeaseId - the proposed new lease Id.
+   * @param options - Options for the lease management operation.
+   * @returnsResponse data for change lease operation.
    * @memberof ShareLeaseClient
    */
   public async changeLease(
@@ -6117,8 +6117,8 @@ export class ShareLeaseClient {
    * To free the lease if it is no longer needed so that another client may
    * immediately acquire a lease.
    *
-   * @param {LeaseOperationOptions} [options={}] Options for the lease management operation.
-   * @returns {Promise<LeaseOperationResponse>} Response data for release lease operation.
+   * @param options - Options for the lease management operation.
+   * @returnsResponse data for release lease operation.
    * @memberof ShareLeaseClient
    */
   public async releaseLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -6145,8 +6145,8 @@ export class ShareLeaseClient {
   /**
    * To force end the lease.
    *
-   * @param {LeaseOperationOptions} [options={}] Options for the lease management operation.
-   * @returns {Promise<LeaseOperationResponse>} Response data for break lease operation.
+   * @param options - Options for the lease management operation.
+   * @returnsResponse data for break lease operation.
    * @memberof ShareLeaseClient
    */
   public async breakLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
@@ -6172,8 +6172,8 @@ export class ShareLeaseClient {
    * Note that the lease may be renewed even if it has expired as long as the share has not been leased again since the expiration of that lease.
    * When you renew a lease, the lease duration clock resets.
    *
-   * @param {LeaseOperationOptions} [options={}] Options for the lease management operation.
-   * @returns {Promise<LeaseOperationResponse>} Response data for renew lease operation.
+   * @param options - Options for the lease management operation.
+   * @returnsResponse data for renew lease operation.
    * @memberof ShareLeaseClient
    */
   public async renewLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {

--- a/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
+++ b/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
@@ -471,11 +471,11 @@ export class FileDownloadResponse implements FileDownloadResponseModel {
   /**
    * Creates an instance of FileDownloadResponse.
    *
-   * @param {FileDownloadResponseModel} originalResponse
-   * @param {ReadableStreamGetter} getter
-   * @param {number} offset
-   * @param {number} count
-   * @param {RetriableReadableStreamOptions} [options={}]
+   * @param originalResponse -
+   * @param getter -
+   * @param offset -
+   * @param count -
+   * @param options -
    * @memberof FileDownloadResponse
    */
   public constructor(

--- a/sdk/storage/storage-file-share/src/FileSASPermissions.ts
+++ b/sdk/storage/storage-file-share/src/FileSASPermissions.ts
@@ -19,8 +19,8 @@ export class FileSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {FileSASPermissions}
+   * @param permissions -
+   *
    * @memberof FileSASPermissions
    */
   public static parse(permissions: string): FileSASPermissions {
@@ -84,7 +84,7 @@ export class FileSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returns {string} A string which represents the FileSASPermissions
+   * @returnsA string which represents the FileSASPermissions
    * @memberof FileSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/FileSASPermissions.ts
+++ b/sdk/storage/storage-file-share/src/FileSASPermissions.ts
@@ -84,7 +84,7 @@ export class FileSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returnsA string which represents the FileSASPermissions
+   * @returns A string which represents the FileSASPermissions
    * @memberof FileSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/FileSASSignatureValues.ts
+++ b/sdk/storage/storage-file-share/src/FileSASSignatureValues.ts
@@ -150,9 +150,9 @@ export interface FileSASSignatureValues {
  * this constructor.
  *
  * @export
- * @param {FileSASSignatureValues} fileSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param fileSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 export function generateFileSASQueryParameters(
   fileSASSignatureValues: FileSASSignatureValues,

--- a/sdk/storage/storage-file-share/src/FileSystemAttributes.ts
+++ b/sdk/storage/storage-file-share/src/FileSystemAttributes.ts
@@ -11,8 +11,8 @@ export class FileSystemAttributes {
    * Error if it encounters a string that does not correspond to a valid attributes.
    *
    * @static
-   * @param {string} fileAttributes The value of header x-ms-file-attributes.
-   * @returns {FileSystemAttributes}
+   * @param fileAttributes - The value of header x-ms-file-attributes.
+   *
    * @memberof FileSystemAttributes
    */
   public static parse(fileAttributes: string): FileSystemAttributes {
@@ -148,7 +148,7 @@ export class FileSystemAttributes {
   /**
    * Converts the given attributes to a string.
    *
-   * @returns {string} A string which represents the FileSystemAttributes
+   * @returnsA string which represents the FileSystemAttributes
    * @memberof FileSystemAttributes
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/FileSystemAttributes.ts
+++ b/sdk/storage/storage-file-share/src/FileSystemAttributes.ts
@@ -148,7 +148,7 @@ export class FileSystemAttributes {
   /**
    * Converts the given attributes to a string.
    *
-   * @returnsA string which represents the FileSystemAttributes
+   * @returns A string which represents the FileSystemAttributes
    * @memberof FileSystemAttributes
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -116,7 +116,7 @@ export class Pipeline {
    * Transfer Pipeline object to ServiceClientOptions object which required by
    * ServiceClient constructor.
    *
-   * @returnsThe ServiceClientOptions object from this Pipeline.
+   * @returns The ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -174,7 +174,7 @@ export interface StoragePipelineOptions {
  * @static
  * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential.
  * @param pipelineOptions - Optional. Options.
- * @returnsA new Pipeline object.
+ * @returns A new Pipeline object.
  * @memberof Pipeline
  */
 export function newPipeline(

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -98,8 +98,8 @@ export class Pipeline {
   /**
    * Creates an instance of Pipeline. Customize HTTPClient by implementing IHttpClient interface.
    *
-   * @param {RequestPolicyFactory[]} factories
-   * @param {PipelineOptions} [options={}]
+   * @param factories -
+   * @param options -
    * @memberof Pipeline
    */
   constructor(factories: RequestPolicyFactory[], options: PipelineOptions = {}) {
@@ -116,7 +116,7 @@ export class Pipeline {
    * Transfer Pipeline object to ServiceClientOptions object which required by
    * ServiceClient constructor.
    *
-   * @returns {ServiceClientOptions} The ServiceClientOptions object from this Pipeline.
+   * @returnsThe ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -172,9 +172,9 @@ export interface StoragePipelineOptions {
  * Creates a new {@link Pipeline} object with {@link Credential} provided.
  *
  * @static
- * @param {Credential} credential Such as AnonymousCredential, StorageSharedKeyCredential.
- * @param {StoragePipelineOptions} [pipelineOptions] Optional. Options.
- * @returns {Pipeline} A new Pipeline object.
+ * @param credential - Such as AnonymousCredential, StorageSharedKeyCredential.
+ * @param pipelineOptions - Optional. Options.
+ * @returnsA new Pipeline object.
  * @memberof Pipeline
  */
 export function newPipeline(

--- a/sdk/storage/storage-file-share/src/Range.ts
+++ b/sdk/storage/storage-file-share/src/Range.ts
@@ -33,8 +33,8 @@ export interface Range {
  * "bytes=255-" or "bytes=0-511"
  *
  * @export
- * @param {Range} range A range of byte positions.
- * @returns {string} The string representation for the byte range.
+ * @param range - A range of byte positions.
+ * @returnsThe string representation for the byte range.
  */
 export function rangeToString(range: Range): string {
   if (range.offset < 0) {

--- a/sdk/storage/storage-file-share/src/Range.ts
+++ b/sdk/storage/storage-file-share/src/Range.ts
@@ -34,7 +34,7 @@ export interface Range {
  *
  * @export
  * @param range - A range of byte positions.
- * @returnsThe string representation for the byte range.
+ * @returns The string representation for the byte range.
  */
 export function rangeToString(range: Range): string {
   if (range.offset < 0) {

--- a/sdk/storage/storage-file-share/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-file-share/src/SASQueryParameters.ts
@@ -190,22 +190,22 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {string} [permissions] Representing the storage permissions
-   * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
-   * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
-   * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startsOn] Representing the start time for this SAS token
-   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
-   * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
-   * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
-   * @param {string} [resource] Representing the storage container or blob (only for Service SAS)
-   * @param {string} [cacheControl] Representing the cache-control header (only for Blob/File Service SAS)
-   * @param {string} [contentDisposition] Representing the content-disposition header (only for Blob/File Service SAS)
-   * @param {string} [contentEncoding] Representing the content-encoding header (only for Blob/File Service SAS)
-   * @param {string} [contentLanguage] Representing the content-language header (only for Blob/File Service SAS)
-   * @param {string} [contentType] Representing the content-type header (only for Blob/File Service SAS)
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param permissions - Representing the storage permissions
+   * @param services - Representing the storage services being accessed (only for Account SAS)
+   * @param resourceTypes - Representing the storage resource types being accessed (only for Account SAS)
+   * @param protocol - Representing the allowed HTTP protocol(s)
+   * @param startsOn - Representing the start time for this SAS token
+   * @param expiresOn - Representing the expiry time for this SAS token
+   * @param ipRange - Representing the range of valid IP addresses for this SAS token
+   * @param identifier - Representing the signed identifier (only for Service SAS)
+   * @param resource - Representing the storage container or blob (only for Service SAS)
+   * @param cacheControl - Representing the cache-control header (only for Blob/File Service SAS)
+   * @param contentDisposition - Representing the content-disposition header (only for Blob/File Service SAS)
+   * @param contentEncoding - Representing the content-encoding header (only for Blob/File Service SAS)
+   * @param contentLanguage - Representing the content-language header (only for Blob/File Service SAS)
+   * @param contentType - Representing the content-type header (only for Blob/File Service SAS)
    * @memberof SASQueryParameters
    */
   constructor(
@@ -247,7 +247,7 @@ export class SASQueryParameters {
   /**
    * Encodes all SAS query parameters into a string that can be appended to a URL.
    *
-   * @returns {string}
+   *
    * @memberof SASQueryParameters
    */
   public toString(): string {
@@ -342,10 +342,10 @@ export class SASQueryParameters {
    * A private helper method used to filter and append query key/value pairs into an array.
    *
    * @private
-   * @param {string[]} queries
-   * @param {string} key
-   * @param {string} [value]
-   * @returns {void}
+   * @param queries -
+   * @param key -
+   * @param value -
+   *
    * @memberof SASQueryParameters
    */
   private tryAppendQueryParameter(queries: string[], key: string, value?: string): void {

--- a/sdk/storage/storage-file-share/src/SasIPRange.ts
+++ b/sdk/storage/storage-file-share/src/SasIPRange.ts
@@ -33,7 +33,7 @@ export interface SasIPRange {
  *
  * @export
  * @param ipRange - A range of IP addresses.
- * @returnsstring representation of the IP range.
+ * @returns string representation of the IP range.
  */
 export function ipRangeToString(ipRange: SasIPRange): string {
   return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;

--- a/sdk/storage/storage-file-share/src/SasIPRange.ts
+++ b/sdk/storage/storage-file-share/src/SasIPRange.ts
@@ -32,8 +32,8 @@ export interface SasIPRange {
  * "8.8.8.8" or "1.1.1.1-255.255.255.255"
  *
  * @export
- * @param {SasIPRange} ipRange A range of IP addresses.
- * @returns {string} string representation of the IP range.
+ * @param ipRange - A range of IP addresses.
+ * @returnsstring representation of the IP range.
  */
 export function ipRangeToString(ipRange: SasIPRange): string {
   return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;

--- a/sdk/storage/storage-file-share/src/ShareSASPermissions.ts
+++ b/sdk/storage/storage-file-share/src/ShareSASPermissions.ts
@@ -17,7 +17,7 @@ export class ShareSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
+   * @param permissions -
    * @memberof ShareSASPermissions
    */
   public static parse(permissions: string) {
@@ -95,7 +95,7 @@ export class ShareSASPermissions {
    * The order of the characters should be as specified here to ensure correctness.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @returns {string}
+   *
    * @memberof ShareSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -318,7 +318,7 @@ export class ShareServiceClient extends StorageClient {
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
    * @param options - Options to configure the HTTP pipeline.
-   * @returnsA new ShareServiceClient from the given connection string.
+   * @returns A new ShareServiceClient from the given connection string.
    * @memberof ShareServiceClient
    */
   public static fromConnectionString(
@@ -393,7 +393,7 @@ export class ShareServiceClient extends StorageClient {
    * Creates a ShareClient object.
    *
    * @param shareName Name of a share.
-   * @returnsThe ShareClient object for the given share name.
+   * @returns The ShareClient object for the given share name.
    * @memberof ShareServiceClient
    *
    * Example usage:
@@ -413,7 +413,7 @@ export class ShareServiceClient extends StorageClient {
    *
    * @param shareName -
    * @param options -
-   * @returnsShare creation response and the corresponding share client.
+   * @returns Share creation response and the corresponding share client.
    * @memberof ShareServiceClient
    */
   public async createShare(
@@ -450,7 +450,7 @@ export class ShareServiceClient extends StorageClient {
    *
    * @param shareName -
    * @param options -
-   * @returnsShare deletion response and the corresponding share client.
+   * @returns Share deletion response and the corresponding share client.
    * @memberof ShareServiceClient
    */
   public async deleteShare(
@@ -484,7 +484,7 @@ export class ShareServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties}
    *
    * @param options - Options to Get Properties operation.
-   * @returnsResponse data for the Get Properties operation.
+   * @returns Response data for the Get Properties operation.
    * @memberof ShareServiceClient
    */
   public async getProperties(
@@ -517,7 +517,7 @@ export class ShareServiceClient extends StorageClient {
    *
    * @param properties -
    * @param options - Options to Set Properties operation.
-   * @returnsResponse data for the Set Properties operation.
+   * @returns Response data for the Set Properties operation.
    * @memberof ShareServiceClient
    */
   public async setProperties(
@@ -734,7 +734,7 @@ export class ShareServiceClient extends StorageClient {
    *                          request the next set of list items. The marker value is opaque to the
    *                          client.
    * @param options - Options to List Shares Segment operation.
-   * @returnsResponse data for the List Shares Segment operation.
+   * @returns Response data for the List Shares Segment operation.
    * @memberof ShareServiceClient
    */
   private async listSharesSegment(
@@ -785,7 +785,7 @@ export class ShareServiceClient extends StorageClient {
    * @param deletedShareName The name of the previously deleted share.
    * @param deletedShareVersion The version of the previously deleted share.
    * @param options - Options to Share undelete operation.
-   * @returnsRestored share.
+   * @returns Restored share.
    * @memberof ShareServiceClient
    */
   public async undeleteShare(
@@ -829,7 +829,7 @@ export class ShareServiceClient extends StorageClient {
    * @param permissions - Specifies the list of permissions to be associated with the SAS.
    * @param resourceTypes - Specifies the resource types associated with the shared access signature.
    * @param options - Optional parameters.
-   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -311,14 +311,14 @@ export class ShareServiceClient extends StorageClient {
    *
    * Creates an instance of ShareServiceClient from connection string.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
-   * @returns {ShareServiceClient} A new ShareServiceClient from the given connection string.
+   * @param options - Options to configure the HTTP pipeline.
+   * @returnsA new ShareServiceClient from the given connection string.
    * @memberof ShareServiceClient
    */
   public static fromConnectionString(
@@ -350,22 +350,22 @@ export class ShareServiceClient extends StorageClient {
   /**
    * Creates an instance of ShareServiceClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file service, such as
+   * @param url - A URL string pointing to Azure Storage file service, such as
    *                     "https://myaccount.file.core.windows.net". You can Append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.file.core.windows.net?sasString".
-   * @param {Credential} [credential] Such as AnonymousCredential or StorageSharedKeyCredential.
+   * @param credential - Such as AnonymousCredential or StorageSharedKeyCredential.
    *                                  If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    * @memberof ShareServiceClient
    */
   constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
   /**
    * Creates an instance of ShareServiceClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage file service, such as
+   * @param url - A URL string pointing to Azure Storage file service, such as
    *                     "https://myaccount.file.core.windows.net". You can Append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.file.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof ShareServiceClient
    */
@@ -393,7 +393,7 @@ export class ShareServiceClient extends StorageClient {
    * Creates a ShareClient object.
    *
    * @param shareName Name of a share.
-   * @returns {ShareClient} The ShareClient object for the given share name.
+   * @returnsThe ShareClient object for the given share name.
    * @memberof ShareServiceClient
    *
    * Example usage:
@@ -411,9 +411,9 @@ export class ShareServiceClient extends StorageClient {
   /**
    * Creates a Share.
    *
-   * @param {string} shareName
-   * @param {ShareCreateOptions} [options]
-   * @returns {Promise<{ shareCreateResponse: ShareCreateResponse, shareClient: ShareClient }>} Share creation response and the corresponding share client.
+   * @param shareName -
+   * @param options -
+   * @returnsShare creation response and the corresponding share client.
    * @memberof ShareServiceClient
    */
   public async createShare(
@@ -448,9 +448,9 @@ export class ShareServiceClient extends StorageClient {
   /**
    * Deletes a Share.
    *
-   * @param {string} shareName
-   * @param {ShareDeleteMethodOptions} [options]
-   * @returns {Promise<ShareDeleteResponse>} Share deletion response and the corresponding share client.
+   * @param shareName -
+   * @param options -
+   * @returnsShare deletion response and the corresponding share client.
    * @memberof ShareServiceClient
    */
   public async deleteShare(
@@ -483,8 +483,8 @@ export class ShareServiceClient extends StorageClient {
    * for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties}
    *
-   * @param {ServiceGetPropertiesOptions} [options={}] Options to Get Properties operation.
-   * @returns {Promise<ServiceGetPropertiesResponse>} Response data for the Get Properties operation.
+   * @param options - Options to Get Properties operation.
+   * @returnsResponse data for the Get Properties operation.
    * @memberof ShareServiceClient
    */
   public async getProperties(
@@ -515,9 +515,9 @@ export class ShareServiceClient extends StorageClient {
    * for Storage Analytics, CORS (Cross-Origin Resource Sharing) rules and soft delete settings.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-service-properties}
    *
-   * @param {FileServiceProperties} properties
-   * @param {ServiceSetPropertiesOptions} [options={}] Options to Set Properties operation.
-   * @returns {Promise<ServiceSetPropertiesResponse>} Response data for the Set Properties operation.
+   * @param properties -
+   * @param options - Options to Set Properties operation.
+   * @returnsResponse data for the Set Properties operation.
    * @memberof ShareServiceClient
    */
   public async setProperties(
@@ -548,15 +548,15 @@ export class ShareServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link ServiceListSharesSegmentResponse} objects
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list of shares to be returned with the next listing operation. The
    *                          operation returns the ContinuationToken value within the response body if the
    *                          listing operation did not return all shares remaining to be listed
    *                          with the current page. The ContinuationToken value can be used as the value for
    *                          the marker parameter in a subsequent call to request the next page of list
    *                          items. The marker value is opaque to the client.
-   * @param {ServiceListSharesSegmentOptions} [options] Options to list shares operation.
-   * @returns {AsyncIterableIterator<ServiceListSharesSegmentResponse>}
+   * @param options - Options to list shares operation.
+   *
    * @memberof ShareServiceClient
    */
   private async *listSegments(
@@ -579,8 +579,8 @@ export class ShareServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for share items
    *
    * @private
-   * @param {ServiceListSharesSegmentOptions} [options] Options to list shares operation.
-   * @returns {AsyncIterableIterator<ServiceListSharesSegmentResponse>}
+   * @param options - Options to list shares operation.
+   *
    * @memberof ShareServiceClient
    */
   private async *listItems(
@@ -668,9 +668,9 @@ export class ShareServiceClient extends StorageClient {
    * }
    * ```
    *
-   * @param {ServiceListSharesOptions} [options] Options to list shares operation.
+   * @param options - Options to list shares operation.
    * @memberof ShareServiceClient
-   * @returns {PagedAsyncIterableIterator<ShareItem, ServiceListSharesSegmentResponse>}
+   *
    * An asyncIterableIterator that supports paging.
    */
   public listShares(
@@ -727,14 +727,14 @@ export class ShareServiceClient extends StorageClient {
    * Gets the properties of a storage account's File service, including properties for Storage
    * Analytics metrics and CORS (Cross-Origin Resource Sharing) rules.
    *
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                          the list to be returned with the next list operation. The operation
    *                          returns a marker value within the response body if the list returned was
    *                          not complete. The marker value may then be used in a subsequent call to
    *                          request the next set of list items. The marker value is opaque to the
    *                          client.
-   * @param {ServiceListSharesSegmentOptions} [options={}] Options to List Shares Segment operation.
-   * @returns {Promise<ServiceListSharesSegmentResponse>} Response data for the List Shares Segment operation.
+   * @param options - Options to List Shares Segment operation.
+   * @returnsResponse data for the List Shares Segment operation.
    * @memberof ShareServiceClient
    */
   private async listSharesSegment(
@@ -784,8 +784,8 @@ export class ShareServiceClient extends StorageClient {
    *
    * @param deletedShareName The name of the previously deleted share.
    * @param deletedShareVersion The version of the previously deleted share.
-   * @param {ShareUndeleteOptions} [options] Options to Share undelete operation.
-   * @returns {Promise<ShareClient>} Restored share.
+   * @param options - Options to Share undelete operation.
+   * @returnsRestored share.
    * @memberof ShareServiceClient
    */
   public async undeleteShare(
@@ -825,11 +825,11 @@ export class ShareServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas
    *
-   * @param {Date} expiresOn Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
-   * @param {AccountSASPermissions} [permissions=AccountSASPermissions.parse("r")] Specifies the list of permissions to be associated with the SAS.
-   * @param {string} [resourceTypes="sco"] Specifies the resource types associated with the shared access signature.
-   * @param {ServiceGenerateAccountSasUrlOptions} [options={}] Optional parameters.
-   * @returns {string} An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param expiresOn - Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
+   * @param permissions - Specifies the list of permissions to be associated with the SAS.
+   * @param resourceTypes - Specifies the resource types associated with the shared access signature.
+   * @param options - Optional parameters.
+   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof ShareServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-file-share/src/StorageBrowserPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/StorageBrowserPolicyFactory.ts
@@ -16,9 +16,9 @@ export class StorageBrowserPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageBrowserPolicyFactory object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageBrowserPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageBrowserPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageBrowserPolicy {

--- a/sdk/storage/storage-file-share/src/StorageClient.ts
+++ b/sdk/storage/storage-file-share/src/StorageClient.ts
@@ -67,8 +67,8 @@ export abstract class StorageClient {
 
   /**
    * Creates an instance of StorageClient.
-   * @param {string} url
-   * @param {Pipeline} pipeline
+   * @param url -
+   * @param pipeline -
    * @memberof StorageClient
    */
   protected constructor(url: string, pipeline: Pipeline) {

--- a/sdk/storage/storage-file-share/src/StorageRetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/StorageRetryPolicyFactory.ts
@@ -77,7 +77,7 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of StorageRetryPolicyFactory.
-   * @param {StorageRetryOptions} [retryOptions]
+   * @param retryOptions -
    * @memberof StorageRetryPolicyFactory
    */
   constructor(retryOptions?: StorageRetryOptions) {
@@ -86,9 +86,9 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates a StorageRetryPolicy object.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageRetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageRetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy {

--- a/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
@@ -29,7 +29,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of TelemetryPolicyFactory.
-   * @param {UserAgentOptions} [telemetry]
+   * @param telemetry -
    * @memberof TelemetryPolicyFactory
    */
   constructor(telemetry?: UserAgentOptions) {
@@ -62,9 +62,9 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a {@link RequestPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {TelemetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof TelemetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): TelemetryPolicy {

--- a/sdk/storage/storage-file-share/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-file-share/src/credentials/AnonymousCredential.ts
@@ -20,9 +20,9 @@ export class AnonymousCredential extends Credential {
   /**
    * Creates an {@link AnonymousCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {AnonymousCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof AnonymousCredential
    */
   public create(

--- a/sdk/storage/storage-file-share/src/credentials/Credential.ts
+++ b/sdk/storage/storage-file-share/src/credentials/Credential.ts
@@ -16,9 +16,9 @@ export abstract class Credential implements RequestPolicyFactory {
   /**
    * Creates a RequestPolicy object.
    *
-   * @param {RequestPolicy} _nextPolicy
-   * @param {RequestPolicyOptions} _options
-   * @returns {RequestPolicy}
+   * @param _nextPolicy -
+   * @param _options -
+   *
    * @memberof Credential
    */
   public create(

--- a/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.ts
+++ b/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.ts
@@ -35,8 +35,8 @@ export class StorageSharedKeyCredential extends Credential {
 
   /**
    * Creates an instance of StorageSharedKeyCredential.
-   * @param {string} accountName
-   * @param {string} accountKey
+   * @param accountName -
+   * @param accountKey -
    * @memberof StorageSharedKeyCredential
    */
   constructor(accountName: string, accountKey: string) {
@@ -48,9 +48,9 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Creates a {@link StorageSharedKeyCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageSharedKeyCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public create(
@@ -63,8 +63,8 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-file-share/src/models.ts
+++ b/sdk/storage/storage-file-share/src/models.ts
@@ -190,8 +190,8 @@ export interface ShareProtocols {
  * Convert protocols from joined string to ShareProtocols.
  *
  * @export
- * @param {string} protocolsString
- * @returns {ShareProtocols}
+ * @param protocolsString -
+ *
  */
 export function toShareProtocols(protocolsString?: string): ShareProtocols | undefined {
   if (protocolsString === undefined) {
@@ -214,8 +214,8 @@ export function toShareProtocols(protocolsString?: string): ShareProtocols | und
  * Convert ShareProtocols to joined string.
  *
  * @export
- * @param {ShareProtocols} protocols
- * @returns {string | undefined}
+ * @param protocols -
+ *
  */
 export function toShareProtocolsString(protocols: ShareProtocols = {}): string | undefined {
   let protocolStr = undefined;

--- a/sdk/storage/storage-file-share/src/policies/AnonymousCredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/AnonymousCredentialPolicy.ts
@@ -16,8 +16,8 @@ import { CredentialPolicy } from "./CredentialPolicy";
 export class AnonymousCredentialPolicy extends CredentialPolicy {
   /**
    * Creates an instance of AnonymousCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof AnonymousCredentialPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {

--- a/sdk/storage/storage-file-share/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/CredentialPolicy.ts
@@ -16,8 +16,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -30,8 +30,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
    *
    * @protected
    * @abstract
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {

--- a/sdk/storage/storage-file-share/src/policies/StorageBrowserPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageBrowserPolicy.ts
@@ -30,8 +30,8 @@ import { setURLParameter } from "../utils/utils.common";
 export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of StorageBrowserPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof StorageBrowserPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -41,8 +41,8 @@ export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageBrowserPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
@@ -23,7 +23,7 @@ import { logger } from "../log";
  * A factory method used to generated a RetryPolicy factory.
  *
  * @export
- * @param {StorageRetryOptions} retryOptions
+ * @param retryOptions -
  */
 export function NewStorageRetryPolicyFactory(
   retryOptions?: StorageRetryOptions
@@ -82,9 +82,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of RetryPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageRetryOptions} [retryOptions=DEFAULT_RETRY_OPTIONS]
+   * @param nextPolicy -
+   * @param options -
+   * @param retryOptions -
    * @memberof StorageRetryPolicy
    */
   constructor(
@@ -130,8 +130,8 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageRetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -142,14 +142,14 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide and perform next retry. Won't mutate request parameter.
    *
    * @protected
-   * @param {WebResource} request
-   * @param {HttpOperationResponse} response
-   * @param {boolean} secondaryHas404  If attempt was against the secondary & it returned a StatusNotFound (404), then
+   * @param request -
+   * @param response -
+   * @param secondaryHas404 -  If attempt was against the secondary & it returned a StatusNotFound (404), then
    *                                   the resource was not found. This may be due to replication delay. So, in this
    *                                   case, we'll never try the secondary again for this operation.
-   * @param {number} attempt           How many retries has been attempted to performed, starting from 1, which includes
+   * @param attempt -           How many retries has been attempted to performed, starting from 1, which includes
    *                                   the attempt will be performed by this method call.
-   * @returns {Promise<HttpOperationResponse>}
+   *
    * @memberof StorageRetryPolicy
    */
   protected async attemptSendRequest(
@@ -194,11 +194,11 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide whether to retry according to last HTTP response and retry counters.
    *
    * @protected
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {HttpOperationResponse} [response]
-   * @param {RestError} [err]
-   * @returns {boolean}
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param response -
+   * @param err -
+   *
    * @memberof StorageRetryPolicy
    */
   protected shouldRetry(
@@ -272,9 +272,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Delay a calculated time between retries.
    *
    * @private
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {AbortSignalLike} [abortSignal]
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param abortSignal -
    * @memberof StorageRetryPolicy
    */
   private async delay(isPrimaryRetry: boolean, attempt: number, abortSignal?: AbortSignalLike) {

--- a/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -25,9 +25,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
 
   /**
    * Creates an instance of StorageSharedKeyCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageSharedKeyCredential} factory
+   * @param nextPolicy -
+   * @param options -
+   * @param factory -
    * @memberof StorageSharedKeyCredentialPolicy
    */
   constructor(
@@ -43,8 +43,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Signs request.
    *
    * @protected
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {
@@ -91,9 +91,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/authenticate-with-shared-key
    *
    * @private
-   * @param {WebResource} request
-   * @param {string} headerName
-   * @returns {string}
+   * @param request -
+   * @param headerName -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getHeaderValueToSign(request: WebResource, headerName: string): string {
@@ -125,8 +125,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    *    Construct the CanonicalizedHeaders string by concatenating all headers in this list into a single string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedHeadersString(request: WebResource): string {
@@ -160,8 +160,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Retrieves the webResource canonicalized resource string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedResourceString(request: WebResource): string {

--- a/sdk/storage/storage-file-share/src/policies/TelemetryPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/TelemetryPolicy.ts
@@ -30,9 +30,9 @@ export class TelemetryPolicy extends BaseRequestPolicy {
 
   /**
    * Creates an instance of TelemetryPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {TelemetryOptions} [telemetry]
+   * @param nextPolicy -
+   * @param options -
+   * @param telemetry -
    * @memberof TelemetryPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, telemetry: string) {
@@ -43,8 +43,8 @@ export class TelemetryPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof TelemetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-share/src/utils/Batch.ts
+++ b/sdk/storage/storage-file-share/src/utils/Batch.ts
@@ -94,7 +94,7 @@ export class Batch {
 
   /**
    * Creates an instance of Batch.
-   * @param {number} [concurrency=5]
+   * @param concurrency -
    * @memberof Batch
    */
   public constructor(concurrency: number = 5) {
@@ -108,7 +108,7 @@ export class Batch {
   /**
    * Add a operation into queue.
    *
-   * @param {Operation} operation
+   * @param operation -
    * @memberof Batch
    */
   public addOperation(operation: Operation): void {
@@ -128,7 +128,7 @@ export class Batch {
   /**
    * Start execute operations in the queue.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof Batch
    */
   public async do(): Promise<void> {
@@ -152,7 +152,7 @@ export class Batch {
    * Get next operation to be executed. Return null when reaching ends.
    *
    * @private
-   * @returns {(Operation | null)}
+   *
    * @memberof Batch
    */
   private nextOperation(): Operation | null {
@@ -167,7 +167,7 @@ export class Batch {
    * this method with do() is that do() wraps as an sync method.
    *
    * @private
-   * @returns {void}
+   *
    * @memberof Batch
    */
   private parallelExecute(): void {

--- a/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
@@ -331,7 +331,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returnsReturn false when buffers in incoming are not enough, else true.
+   * @returns Return false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {

--- a/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
+++ b/sdk/storage/storage-file-share/src/utils/BufferScheduler.ts
@@ -187,14 +187,14 @@ export class BufferScheduler {
   /**
    * Creates an instance of BufferScheduler.
    *
-   * @param {Readable} readable A Node.js Readable stream
-   * @param {number} bufferSize Buffer size of every maintained buffer
-   * @param {number} maxBuffers How many buffers can be allocated
-   * @param {OutgoingHandler} outgoingHandler An async function scheduled to be
+   * @param readable - A Node.js Readable stream
+   * @param bufferSize - Buffer size of every maintained buffer
+   * @param maxBuffers - How many buffers can be allocated
+   * @param outgoingHandler - An async function scheduled to be
    *                                          triggered when a buffer fully filled
    *                                          with stream data
-   * @param {number} concurrency Concurrency of executing outgoingHandlers (>0)
-   * @param {string} [encoding] [Optional] Encoding of Readable stream when it's a string stream
+   * @param concurrency - Concurrency of executing outgoingHandlers (>0)
+   * @param encoding - [Optional] Encoding of Readable stream when it's a string stream
    * @memberof BufferScheduler
    */
   constructor(
@@ -229,7 +229,7 @@ export class BufferScheduler {
    * Start the scheduler, will return error when stream of any of the outgoingHandlers
    * returns error.
    *
-   * @returns {Promise<void>}
+   *
    * @memberof BufferScheduler
    */
   public async do(): Promise<void> {
@@ -283,7 +283,7 @@ export class BufferScheduler {
    * Insert a new data into unresolved array.
    *
    * @private
-   * @param {Buffer} data
+   * @param data -
    * @memberof BufferScheduler
    */
   private appendUnresolvedData(data: Buffer) {
@@ -296,7 +296,7 @@ export class BufferScheduler {
    * than blockSize when data in unresolvedDataArray is less than bufferSize.
    *
    * @private
-   * @returns {Buffer}
+   *
    * @memberof BufferScheduler
    */
   private shiftBufferFromUnresolvedDataArray(): Buffer {
@@ -331,7 +331,7 @@ export class BufferScheduler {
    * Return false when available buffers in incoming are not enough, else true.
    *
    * @private
-   * @returns {boolean} Return false when buffers in incoming are not enough, else true.
+   * @returnsReturn false when buffers in incoming are not enough, else true.
    * @memberof BufferScheduler
    */
   private resolveData(): boolean {
@@ -382,8 +382,8 @@ export class BufferScheduler {
    * Trigger a outgoing handler for a buffer shifted from outgoing.
    *
    * @private
-   * @param {Buffer} buffer
-   * @returns {Promise<any>}
+   * @param buffer -
+   *
    * @memberof BufferScheduler
    */
   private async triggerOutgoingHandler(buffer: Buffer): Promise<any> {
@@ -408,7 +408,7 @@ export class BufferScheduler {
    * Return buffer used by outgoing handler into incoming.
    *
    * @private
-   * @param {Buffer} buffer
+   * @param buffer -
    * @memberof BufferScheduler
    */
   private reuseBuffer(buffer: Buffer) {

--- a/sdk/storage/storage-file-share/src/utils/RetriableReadableStream.ts
+++ b/sdk/storage/storage-file-share/src/utils/RetriableReadableStream.ts
@@ -69,12 +69,12 @@ export class RetriableReadableStream extends Readable {
   /**
    * Creates an instance of RetriableReadableStream.
    *
-   * @param {NodeJS.ReadableStream} source The current ReadableStream returned from getter
-   * @param {ReadableStreamGetter} getter A method calling downloading request returning
+   * @param source - The current ReadableStream returned from getter
+   * @param getter - A method calling downloading request returning
    *                                      a new ReadableStream from specified offset
-   * @param {number} offset Offset position in original data source to read
-   * @param {number} count How much data in original data source to read
-   * @param {RetriableReadableStreamOptions} [options={}]
+   * @param offset - Offset position in original data source to read
+   * @param count - How much data in original data source to read
+   * @param options -
    * @memberof RetriableReadableStream
    */
   public constructor(

--- a/sdk/storage/storage-file-share/src/utils/utils.browser.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.browser.ts
@@ -5,8 +5,8 @@
  * Convert a Browser Blob object into ArrayBuffer.
  *
  * @export
- * @param {Blob} blob
- * @returns {Promise<ArrayBuffer>}
+ * @param blob -
+ *
  */
 export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
   const fileReader = new FileReader();

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -103,7 +103,7 @@ function getValueInConnString(
  *
  * @export
  * @param connectionString - Connection string.
- * @returnsString key value pairs of the storage account's url and credentials.
+ * @returns String key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   // Matching FileEndpoint in the Account connection string
@@ -193,7 +193,7 @@ function escape(text: string): string {
  * @export
  * @param url - Source URL string
  * @param name - String to be appended to URL
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -211,7 +211,7 @@ export function appendToURLPath(url: string, name: string): string {
  * @export
  * @param url - Source URL string.
  * @param queryParts - String to be appended to the URL query.
- * @returnsAn updated URL string.
+ * @returns An updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -235,7 +235,7 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * @param url - Source URL string
  * @param name - Parameter name
  * @param value - Parameter value
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -323,7 +323,7 @@ export function getURLQueries(url: string): { [key: string]: string } {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -448,7 +448,7 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
 /**
  * Extracts account name from the url
  * @param url - url to extract the account name from
- * @returnswith the account name
+ * @returns with the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -56,8 +56,8 @@ import { HeaderConstants, URLConstants } from "./constants";
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata
  *
  * @export
- * @param {string} url
- * @returns {string}
+ * @param url -
+ *
  */
 export function escapeURLPath(url: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -102,8 +102,8 @@ function getValueInConnString(
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export
- * @param {string} connectionString Connection string.
- * @returns {ConnectionString} String key value pairs of the storage account's url and credentials.
+ * @param connectionString - Connection string.
+ * @returnsString key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   // Matching FileEndpoint in the Account connection string
@@ -175,8 +175,8 @@ export function extractConnectionStringParts(connectionString: string): Connecti
 /**
  * Internal escape method implemented Strategy Two mentioned in escapeURL() description.
  *
- * @param {string} text
- * @returns {string}
+ * @param text -
+ *
  */
 function escape(text: string): string {
   return encodeURIComponent(text)
@@ -191,9 +191,9 @@ function escape(text: string): string {
  * when URL path ends with a "/".
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name String to be appended to URL
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - String to be appended to URL
+ * @returnsAn updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -209,9 +209,9 @@ export function appendToURLPath(url: string, name: string): string {
  * Append a string to URL query.
  *
  * @export
- * @param {string} url Source URL string.
- * @param {string} queryParts String to be appended to the URL query.
- * @returns {string} An updated URL string.
+ * @param url - Source URL string.
+ * @param queryParts - String to be appended to the URL query.
+ * @returnsAn updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -232,10 +232,10 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * will be replaced by name key. If not provide value, the parameter will be deleted.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name Parameter name
- * @param {string} [value] Parameter value
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - Parameter name
+ * @param value - Parameter value
+ * @returnsAn updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -247,9 +247,9 @@ export function setURLParameter(url: string, name: string, value?: string): stri
  * Get URL parameter by name.
  *
  * @export
- * @param {string} url
- * @param {string} name
- * @returns {(string | string[] | undefined)}
+ * @param url -
+ * @param name -
+ *
  */
 export function getURLParameter(url: string, name: string): string | string[] | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -260,8 +260,8 @@ export function getURLParameter(url: string, name: string): string | string[] | 
  * Set URL host.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} host New host string
+ * @param url - Source URL string
+ * @param host - New host string
  * @returns An updated URL string
  */
 export function setURLHost(url: string, host: string): string {
@@ -274,8 +274,8 @@ export function setURLHost(url: string, host: string): string {
  * Get URL path from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)}
+ * @param url - Source URL string
+ *
  */
 export function getURLPath(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -286,8 +286,8 @@ export function getURLPath(url: string): string | undefined {
  * Get URL query key value pairs from an URL string.
  *
  * @export
- * @param {string} url
- * @returns {{[key: string]: string}}
+ * @param url -
+ *
  */
 export function getURLQueries(url: string): { [key: string]: string } {
   let queryString = URLBuilder.parse(url).getQuery();
@@ -320,10 +320,10 @@ export function getURLQueries(url: string): { [key: string]: string } {
  * Rounds a date off to seconds.
  *
  * @export
- * @param {Date} date
- * @param {boolean} [withMilliseconds=true] If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
+ * @param date -
+ * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns {string} Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -338,8 +338,8 @@ export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = tru
  * Base64 encode.
  *
  * @export
- * @param {string} content
- * @returns {string}
+ * @param content -
+ *
  */
 export function base64encode(content: string): string {
   return !isNode ? btoa(content) : Buffer.from(content).toString("base64");
@@ -349,8 +349,8 @@ export function base64encode(content: string): string {
  * Base64 decode.
  *
  * @export
- * @param {string} encodedString
- * @returns {string}
+ * @param encodedString -
+ *
  */
 export function base64decode(encodedString: string): string {
   return !isNode ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
@@ -360,9 +360,9 @@ export function base64decode(encodedString: string): string {
  * Delay specified time interval.
  *
  * @export
- * @param {number} timeInMs
- * @param {AbortSignalLike} [aborter]
- * @param {Error} [abortError]
+ * @param timeInMs -
+ * @param aborter -
+ * @param abortError -
  */
 export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortError?: Error) {
   return new Promise<void>((resolve, reject) => {
@@ -393,10 +393,10 @@ export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortEr
  * String.prototype.padStart()
  *
  * @export
- * @param {string} currentString
- * @param {number} targetLength
- * @param {string} [padString=" "]
- * @returns {string}
+ * @param currentString -
+ * @param targetLength -
+ * @param [padString=" - "]
+ *
  */
 export function padStart(
   currentString: string,
@@ -447,8 +447,8 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
 
 /**
  * Extracts account name from the url
- * @param {string} url url to extract the account name from
- * @returns {string} with the account name
+ * @param url - url to extract the account name from
+ * @returnswith the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);

--- a/sdk/storage/storage-file-share/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.node.ts
@@ -8,12 +8,12 @@ import * as util from "util";
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
  *
  * @export
- * @param {NodeJS.ReadableStream} stream A Node.js Readable stream
- * @param {Buffer} buffer Buffer to be filled, length must >= offset
- * @param {number} offset From which position in the buffer to be filled, inclusive
- * @param {number} end To which position in the buffer to be filled, exclusive
- * @param {string} [encoding] Encoding of the Readable stream
- * @returns {Promise<void>}
+ * @param stream - A Node.js Readable stream
+ * @param buffer - Buffer to be filled, length must >= offset
+ * @param offset - From which position in the buffer to be filled, inclusive
+ * @param end - To which position in the buffer to be filled, exclusive
+ * @param encoding - Encoding of the Readable stream
+ *
  */
 export async function streamToBuffer(
   stream: NodeJS.ReadableStream,
@@ -68,9 +68,9 @@ export async function streamToBuffer(
  * Writes the content of a readstream to a local file. Returns a Promise which is completed after the file handle is closed.
  *
  * @export
- * @param {NodeJS.ReadableStream} rs The read stream.
- * @param {string} file Destination file path.
- * @returns {Promise<void>}
+ * @param rs - The read stream.
+ * @param file - Destination file path.
+ *
  */
 export async function readStreamToLocalFile(
   rs: NodeJS.ReadableStream,

--- a/sdk/storage/storage-file-share/test/utils/InjectorPolicy.ts
+++ b/sdk/storage/storage-file-share/test/utils/InjectorPolicy.ts
@@ -23,8 +23,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of InjectorPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof InjectorPolicy
    */
   public constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, injector: Injector) {
@@ -35,8 +35,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof InjectorPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-share/test/utils/MockPolicy.ts
+++ b/sdk/storage/storage-file-share/test/utils/MockPolicy.ts
@@ -17,8 +17,8 @@ export class MockPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of MockPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof MockPolicy
    */
   public constructor(
@@ -33,8 +33,8 @@ export class MockPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof InjectorPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-file-share/test/utils/testutils.node.ts
+++ b/sdk/storage/storage-file-share/test/utils/testutils.node.ts
@@ -8,9 +8,9 @@ import * as fs from "fs";
  * ReadableStream or the fs.WriteStream.
  *
  * @export
- * @param {NodeJS.ReadableStream} rs The read stream.
- * @param {string} file Destination file path.
- * @returns {Promise<void>}
+ * @param rs - The read stream.
+ * @param file - Destination file path.
+ *
  */
 export async function readStreamToLocalFileWithLogs(
   rs: NodeJS.ReadableStream,

--- a/sdk/storage/storage-internal-avro/src/AvroParser.ts
+++ b/sdk/storage/storage-internal-avro/src/AvroParser.ts
@@ -28,10 +28,10 @@ export class AvroParser {
    * Reads a fixed number of bytes from the stream.
    *
    * @static
-   * @param {AvroReadable} [stream]
-   * @param {number} [length]
-   * @param {AvroParserReadOptions} [options={}]
-   * @returns {Promise<Uint8Array>}
+   * @param stream -
+   * @param length -
+   * @param options -
+   *
    * @memberof AvroParser
    */
   public static async readFixedBytes(
@@ -50,9 +50,9 @@ export class AvroParser {
    * Reads a single byte from the stream.
    *
    * @static
-   * @param {AvroReadable} [stream]
-   * @param {AvroParserReadOptions} [options={}]
-   * @returns {Promise<number>}
+   * @param stream -
+   * @param options -
+   *
    * @memberof AvroParser
    */
   private static async readByte(

--- a/sdk/storage/storage-queue/src/AccountSASPermissions.ts
+++ b/sdk/storage/storage-queue/src/AccountSASPermissions.ts
@@ -18,8 +18,8 @@ export class AccountSASPermissions {
    * Parse initializes the AccountSASPermissions fields from a string.
    *
    * @static
-   * @param {string} permissions
-   * @returns {AccountSASPermissions}
+   * @param permissions -
+   *
    * @memberof AccountSASPermissions
    */
   public static parse(permissions: string): AccountSASPermissions {
@@ -132,7 +132,7 @@ export class AccountSASPermissions {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-queue/src/AccountSASResourceTypes.ts
+++ b/sdk/storage/storage-queue/src/AccountSASResourceTypes.ts
@@ -19,8 +19,8 @@ export class AccountSASResourceTypes {
    * Error if it encounters a character that does not correspond to a valid resource type.
    *
    * @static
-   * @param {string} resourceTypes
-   * @returns {AccountSASResourceTypes}
+   * @param resourceTypes -
+   *
    * @memberof AccountSASResourceTypes
    */
   public static parse(resourceTypes: string): AccountSASResourceTypes {
@@ -74,7 +74,7 @@ export class AccountSASResourceTypes {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
    *
-   * @returns {string}
+   *
    * @memberof AccountSASResourceTypes
    */
   public toString(): string {

--- a/sdk/storage/storage-queue/src/AccountSASServices.ts
+++ b/sdk/storage/storage-queue/src/AccountSASServices.ts
@@ -19,8 +19,8 @@ export class AccountSASServices {
    * Error if it encounters a character that does not correspond to a valid service.
    *
    * @static
-   * @param {string} services
-   * @returns {AccountSASServices}
+   * @param services -
+   *
    * @memberof AccountSASServices
    */
   public static parse(services: string): AccountSASServices {
@@ -83,7 +83,7 @@ export class AccountSASServices {
   /**
    * Converts the given services to a string.
    *
-   * @returns {string}
+   *
    * @memberof AccountSASServices
    */
   public toString(): string {

--- a/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
@@ -105,9 +105,9 @@ export interface AccountSASSignatureValues {
  *
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
  *
- * @param {AccountSASSignatureValues} accountSASSignatureValues SAS Signature values of the account
- * @param {StorageSharedKeyCredential} sharedKeyCredential Shared key credential.
- * @returns {SASQueryParameters}
+ * @param accountSASSignatureValues - SAS Signature values of the account
+ * @param sharedKeyCredential - Shared key credential.
+ *
  * @memberof AccountSASSignatureValues
  */
 export function generateAccountSASQueryParameters(

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -119,7 +119,7 @@ export class Pipeline {
    * Transfers Pipeline object to ServiceClientOptions object which required by
    * ServiceClient constructor.
    *
-   * @returnsThe ServiceClientOptions object from this Pipeline.
+   * @returns The ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -178,7 +178,7 @@ export interface StoragePipelineOptions {
  * @static
  * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
  * @param pipelineOptions - Options.
- * @returnsA new Pipeline object.
+ * @returns A new Pipeline object.
  * @memberof Pipeline
  */
 export function newPipeline(

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -101,8 +101,8 @@ export class Pipeline {
   /**
    * Creates an instance of Pipeline. Customize HTTPClient by implementing IHttpClient interface.
    *
-   * @param {RequestPolicyFactory[]} factories
-   * @param {PipelineOptions} [options={}]
+   * @param factories -
+   * @param options -
    * @memberof Pipeline
    */
   constructor(factories: RequestPolicyFactory[], options: PipelineOptions = {}) {
@@ -119,7 +119,7 @@ export class Pipeline {
    * Transfers Pipeline object to ServiceClientOptions object which required by
    * ServiceClient constructor.
    *
-   * @returns {ServiceClientOptions} The ServiceClientOptions object from this Pipeline.
+   * @returnsThe ServiceClientOptions object from this Pipeline.
    * @memberof Pipeline
    */
   public toServiceClientOptions(): ServiceClientOptions {
@@ -176,9 +176,9 @@ export interface StoragePipelineOptions {
  * Creates a new Pipeline object with Credential provided.
  *
  * @static
- * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
- * @param {StoragePipelineOptions} [pipelineOptions] Options.
- * @returns {Pipeline} A new Pipeline object.
+ * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+ * @param pipelineOptions - Options.
+ * @returnsA new Pipeline object.
  * @memberof Pipeline
  */
 export function newPipeline(

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -570,26 +570,26 @@ export class QueueClient extends StorageClient {
   /**
    * Creates an instance of QueueClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} queueName Queue name.
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param queueName - Queue name.
+   * @param options - Options to configure the HTTP pipeline.
    * @memberof QueueClient
    */
   constructor(connectionString: string, queueName: string, options?: StoragePipelineOptions);
   /**
    * Creates an instance of QueueClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage queue, such as
+   * @param url - A URL string pointing to Azure Storage queue, such as
    *                     "https://myaccount.queue.core.windows.net/myqueue". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.queue.core.windows.net/myqueue?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Options to configure the HTTP pipeline.
    * @memberof QueueClient
    */
   constructor(
@@ -600,11 +600,11 @@ export class QueueClient extends StorageClient {
   /**
    * Creates an instance of QueueClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage queue, such as
+   * @param url - A URL string pointing to Azure Storage queue, such as
    *                     "https://myaccount.queue.core.windows.net/myqueue". You can
    *                     append a SAS if using AnonymousCredential, such as
    *                     "https://myaccount.queue.core.windows.net/myqueue?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof QueueClient
    */
@@ -701,8 +701,8 @@ export class QueueClient extends StorageClient {
    * Creates a new queue under the specified account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4
    *
-   * @param {QueueCreateOptions} [options] Options to Queue create operation.
-   * @returns {Promise<QueueCreateResponse>} Response data for the Queue create operation.
+   * @param options - Options to Queue create operation.
+   * @returnsResponse data for the Queue create operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -736,8 +736,8 @@ export class QueueClient extends StorageClient {
    * If the queue already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4
    *
-   * @param {QueueCreateOptions} [options]
-   * @returns {Promise<QueueCreateIfNotExistsResponse>}
+   * @param options -
+   *
    * @memberof QueueClient
    */
   public async createIfNotExists(
@@ -793,8 +793,8 @@ export class QueueClient extends StorageClient {
    * Deletes the specified queue permanently if it exists.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3
    *
-   * @param {QueueDeleteOptions} [options]
-   * @returns {Promise<QueueDeleteIfExistsResponse>}
+   * @param options -
+   *
    * @memberof QueueClient
    */
   public async deleteIfExists(
@@ -836,8 +836,8 @@ export class QueueClient extends StorageClient {
    * Deletes the specified queue permanently.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3
    *
-   * @param {QueueDeleteOptions} [options] Options to Queue delete operation.
-   * @returns {Promise<QueueDeleteResponse>} Response data for the Queue delete operation.
+   * @param options - Options to Queue delete operation.
+   * @returnsResponse data for the Queue delete operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -874,8 +874,8 @@ export class QueueClient extends StorageClient {
    * applications. Vice versa new queues might be added by other clients or applications after this
    * function completes.
    *
-   * @param {QueueExistsOptions} [options] options to Exists operation.
-   * @returns {Promise<boolean>}
+   * @param options - options to Exists operation.
+   *
    * @memberof QueueClient
    */
   public async exists(options: QueueExistsOptions = {}): Promise<boolean> {
@@ -914,8 +914,8 @@ export class QueueClient extends StorageClient {
    * the `listQueues` method of {@link QueueServiceClient} using the `includeMetadata` option, which
    * will retain their original casing.
    *
-   * @param {QueueGetPropertiesOptions} [options] Options to Queue get properties operation.
-   * @returns {Promise<QueueGetPropertiesResponse>} Response data for the Queue get properties operation.
+   * @param options - Options to Queue get properties operation.
+   * @returnsResponse data for the Queue get properties operation.
    * @memberof QueueClient
    */
   public async getProperties(
@@ -945,9 +945,9 @@ export class QueueClient extends StorageClient {
    * metadata will be removed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-metadata
    *
-   * @param {Metadata} [metadata] If no metadata provided, all existing metadata will be removed.
-   * @param {QueueSetMetadataOptions} [options] Options to Queue set metadata operation.
-   * @returns {Promise<QueueSetMetadataResponse>} Response data for the Queue set metadata operation.
+   * @param metadata - If no metadata provided, all existing metadata will be removed.
+   * @param options - Options to Queue set metadata operation.
+   * @returnsResponse data for the Queue set metadata operation.
    * @memberof QueueClient
    */
   public async setMetadata(
@@ -980,8 +980,8 @@ export class QueueClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-acl
    *
-   * @param {QueueGetAccessPolicyOptions} [options] Options to Queue get access policy operation.
-   * @returns {Promise<QueueGetAccessPolicyResponse>} Response data for the Queue get access policy operation.
+   * @param options - Options to Queue get access policy operation.
+   * @returnsResponse data for the Queue get access policy operation.
    * @memberof QueueClient
    */
   public async getAccessPolicy(
@@ -1042,9 +1042,9 @@ export class QueueClient extends StorageClient {
    * Sets stored access policies for the queue that may be used with Shared Access Signatures.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl
    *
-   * @param {SignedIdentifier[]} [queueAcl]
-   * @param {QueueSetAccessPolicyOptions} [options] Options to Queue set access policy operation.
-   * @returns {Promise<QueueSetAccessPolicyResponse>} Response data for the Queue set access policy operation.
+   * @param queueAcl -
+   * @param options - Options to Queue set access policy operation.
+   * @returnsResponse data for the Queue set access policy operation.
    * @memberof QueueClient
    */
   public async setAccessPolicy(
@@ -1089,8 +1089,8 @@ export class QueueClient extends StorageClient {
    * Clear deletes all messages from a queue.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages
    *
-   * @param {QueueClearMessagesOptions} [options] Options to clear messages operation.
-   * @returns {Promise<QueueClearMessagesResponse>} Response data for the clear messages operation.
+   * @param options - Options to clear messages operation.
+   * @returnsResponse data for the clear messages operation.
    * @memberof QueueClient
    */
   public async clearMessages(
@@ -1120,9 +1120,9 @@ export class QueueClient extends StorageClient {
    * To include markup in the message, the contents of the message must either be XML-escaped or Base64-encode.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-message
    *
-   * @param {string} messageText Text of the message to send
-   * @param {QueueSendMessageOptions} [options] Options to send messages operation.
-   * @returns {Promise<QueueSendMessageResponse>} Response data for the send messages operation.
+   * @param messageText - Text of the message to send
+   * @param options - Options to send messages operation.
+   * @returnsResponse data for the send messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1180,8 +1180,8 @@ export class QueueClient extends StorageClient {
    * receiveMessages retrieves one or more messages from the front of the queue.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages
    *
-   * @param {QueueReceiveMessageOptions} [options] Options to receive messages operation.
-   * @returns {Promise<QueueReceiveMessageResponse>} Response data for the receive messages operation.
+   * @param options - Options to receive messages operation.
+   * @returnsResponse data for the receive messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1243,8 +1243,8 @@ export class QueueClient extends StorageClient {
    * peekMessages retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages
    *
-   * @param {QueuePeekMessagesOptions} [options] Options to peek messages operation.
-   * @returns {QueuePeekMessagesResponse>} Response data for the peek messages operation.
+   * @param options - Options to peek messages operation.
+   * @returnsResponse data for the peek messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1295,10 +1295,10 @@ export class QueueClient extends StorageClient {
    * deleteMessage permanently removes the specified message from its queue.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2
    *
-   * @param {string} messageId Id of the message.
-   * @param {string} popReceipt A valid pop receipt value returned from an earlier call to the receive messages or update message operation.
-   * @param {QueueDeleteMessageOptions} [options] Options to delete message operation.
-   * @returns {Promise<QueueDeleteMessageResponse>} Response data for the delete message operation.
+   * @param messageId - Id of the message.
+   * @param popReceipt - A valid pop receipt value returned from an earlier call to the receive messages or update message operation.
+   * @param options - Options to delete message operation.
+   * @returnsResponse data for the delete message operation.
    * @memberof QueueClient
    */
   public async deleteMessage(
@@ -1329,16 +1329,16 @@ export class QueueClient extends StorageClient {
    * To include markup in the message, the contents of the message must either be XML-escaped or Base64-encode.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/update-message
    *
-   * @param {string} messageId Id of the message
-   * @param {string} popReceipt A valid pop receipt value returned from an earlier call to the receive messages or update message operation.
-   * @param {string} message Message to update. If this parameter is undefined, then the content of the message won't be updated.
-   * @param {number} visibilityTimeout Specifies the new visibility timeout value, in seconds,
+   * @param messageId - Id of the message
+   * @param popReceipt - A valid pop receipt value returned from an earlier call to the receive messages or update message operation.
+   * @param message - Message to update. If this parameter is undefined, then the content of the message won't be updated.
+   * @param visibilityTimeout - Specifies the new visibility timeout value, in seconds,
    *                                   relative to server time. The new value must be larger than or equal to 0,
    *                                   and cannot be larger than 7 days. The visibility timeout of a message cannot
    *                                   be set to a value later than the expiry time.
    *                                   A message can be updated until it has been deleted or has expired.
-   * @param {QueueUpdateMessageOptions} [options] Options to update message operation.
-   * @returns {Promise<QueueUpdateMessageResponse>} Response data for the update message operation.
+   * @param options - Options to update message operation.
+   * @returnsResponse data for the update message operation.
    * @memberof QueueClient
    */
   public async updateMessage(
@@ -1415,8 +1415,8 @@ export class QueueClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
-   * @param {QueueGenerateSasUrlOptions} options Optional parameters.
-   * @returns {string} The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param options - Optional parameters.
+   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof QueueClient
    */
   public generateSasUrl(options: QueueGenerateSasUrlOptions): string {

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -702,7 +702,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4
    *
    * @param options - Options to Queue create operation.
-   * @returnsResponse data for the Queue create operation.
+   * @returns Response data for the Queue create operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -837,7 +837,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3
    *
    * @param options - Options to Queue delete operation.
-   * @returnsResponse data for the Queue delete operation.
+   * @returns Response data for the Queue delete operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -915,7 +915,7 @@ export class QueueClient extends StorageClient {
    * will retain their original casing.
    *
    * @param options - Options to Queue get properties operation.
-   * @returnsResponse data for the Queue get properties operation.
+   * @returns Response data for the Queue get properties operation.
    * @memberof QueueClient
    */
   public async getProperties(
@@ -947,7 +947,7 @@ export class QueueClient extends StorageClient {
    *
    * @param metadata - If no metadata provided, all existing metadata will be removed.
    * @param options - Options to Queue set metadata operation.
-   * @returnsResponse data for the Queue set metadata operation.
+   * @returns Response data for the Queue set metadata operation.
    * @memberof QueueClient
    */
   public async setMetadata(
@@ -981,7 +981,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-acl
    *
    * @param options - Options to Queue get access policy operation.
-   * @returnsResponse data for the Queue get access policy operation.
+   * @returns Response data for the Queue get access policy operation.
    * @memberof QueueClient
    */
   public async getAccessPolicy(
@@ -1044,7 +1044,7 @@ export class QueueClient extends StorageClient {
    *
    * @param queueAcl -
    * @param options - Options to Queue set access policy operation.
-   * @returnsResponse data for the Queue set access policy operation.
+   * @returns Response data for the Queue set access policy operation.
    * @memberof QueueClient
    */
   public async setAccessPolicy(
@@ -1090,7 +1090,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages
    *
    * @param options - Options to clear messages operation.
-   * @returnsResponse data for the clear messages operation.
+   * @returns Response data for the clear messages operation.
    * @memberof QueueClient
    */
   public async clearMessages(
@@ -1122,7 +1122,7 @@ export class QueueClient extends StorageClient {
    *
    * @param messageText - Text of the message to send
    * @param options - Options to send messages operation.
-   * @returnsResponse data for the send messages operation.
+   * @returns Response data for the send messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1181,7 +1181,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages
    *
    * @param options - Options to receive messages operation.
-   * @returnsResponse data for the receive messages operation.
+   * @returns Response data for the receive messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1244,7 +1244,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages
    *
    * @param options - Options to peek messages operation.
-   * @returnsResponse data for the peek messages operation.
+   * @returns Response data for the peek messages operation.
    * @memberof QueueClient
    *
    * Example usage:
@@ -1298,7 +1298,7 @@ export class QueueClient extends StorageClient {
    * @param messageId - Id of the message.
    * @param popReceipt - A valid pop receipt value returned from an earlier call to the receive messages or update message operation.
    * @param options - Options to delete message operation.
-   * @returnsResponse data for the delete message operation.
+   * @returns Response data for the delete message operation.
    * @memberof QueueClient
    */
   public async deleteMessage(
@@ -1338,7 +1338,7 @@ export class QueueClient extends StorageClient {
    *                                   be set to a value later than the expiry time.
    *                                   A message can be updated until it has been deleted or has expired.
    * @param options - Options to update message operation.
-   * @returnsResponse data for the update message operation.
+   * @returns Response data for the update message operation.
    * @memberof QueueClient
    */
   public async updateMessage(
@@ -1416,7 +1416,7 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
    *
    * @param options - Optional parameters.
-   * @returnsThe SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns The SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof QueueClient
    */
   public generateSasUrl(options: QueueGenerateSasUrlOptions): string {

--- a/sdk/storage/storage-queue/src/QueueSASPermissions.ts
+++ b/sdk/storage/storage-queue/src/QueueSASPermissions.ts
@@ -84,7 +84,7 @@ export class QueueSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returnsA string which represents the QueueSASPermissions
+   * @returns A string which represents the QueueSASPermissions
    * @memberof QueueSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-queue/src/QueueSASPermissions.ts
+++ b/sdk/storage/storage-queue/src/QueueSASPermissions.ts
@@ -19,8 +19,8 @@ export class QueueSASPermissions {
    * Error if it encounters a character that does not correspond to a valid permission.
    *
    * @static
-   * @param {string} permissions
-   * @returns {QueueSASPermissions}
+   * @param permissions -
+   *
    * @memberof QueueSASPermissions
    */
   public static parse(permissions: string): QueueSASPermissions {
@@ -84,7 +84,7 @@ export class QueueSASPermissions {
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
-   * @returns {string} A string which represents the QueueSASPermissions
+   * @returnsA string which represents the QueueSASPermissions
    * @memberof QueueSASPermissions
    */
   public toString(): string {

--- a/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
@@ -101,9 +101,9 @@ export interface QueueSASSignatureValues {
  * this constructor.
  *
  * @export
- * @param {QueueSASSignatureValues} queueSASSignatureValues
- * @param {StorageSharedKeyCredential} sharedKeyCredential
- * @returns {SASQueryParameters}
+ * @param queueSASSignatureValues -
+ * @param sharedKeyCredential -
+ *
  */
 export function generateQueueSASQueryParameters(
   queueSASSignatureValues: QueueSASSignatureValues,

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -218,7 +218,7 @@ export class QueueServiceClient extends StorageClient {
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
    * @param options - Options to configure the HTTP pipeline.
-   * @returnsA new QueueServiceClient object from the given connection string.
+   * @returns A new QueueServiceClient object from the given connection string.
    * @memberof QueueServiceClient
    */
   public static fromConnectionString(
@@ -344,7 +344,7 @@ export class QueueServiceClient extends StorageClient {
    * Creates a {@link QueueClient} object.
    *
    * @param queueName -
-   * @returnsa new QueueClient
+   * @returns a new QueueClient
    * @memberof QueueServiceClient
    *
    * Example usage:
@@ -370,7 +370,7 @@ export class QueueServiceClient extends StorageClient {
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
    * @param options - Options to list queues operation.
-   * @returnsResponse data for the list queues segment operation.
+   * @returns Response data for the list queues segment operation.
    * @memberof QueueServiceClient
    */
   private async listQueuesSegment(
@@ -536,7 +536,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * @param options - Options to list queues operation.
    * @memberof QueueServiceClient
-   * @returnsAn asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listQueues(
     options: ServiceListQueuesOptions = {}
@@ -583,7 +583,7 @@ export class QueueServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties
    *
    * @param options - Options to get properties operation.
-   * @returnsResponse data including the queue service properties.
+   * @returns Response data including the queue service properties.
    * @memberof QueueServiceClient
    */
   public async getProperties(
@@ -616,7 +616,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * @param properties -
    * @param options - Options to set properties operation.
-   * @returnsResponse data for the Set Properties operation.
+   * @returns Response data for the Set Properties operation.
    * @memberof QueueServiceClient
    */
   public async setProperties(
@@ -650,7 +650,7 @@ export class QueueServiceClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats
    *
    * @param options - Options to get statistics operation.
-   * @returnsResponse data for get statistics the operation.
+   * @returns Response data for get statistics the operation.
    * @memberof QueueServiceClient
    */
   public async getStatistics(
@@ -682,7 +682,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * @param queueName - name of the queue to create
    * @param options - Options to Queue create operation.
-   * @returnsResponse data for the Queue create operation.
+   * @returns Response data for the Queue create operation.
    * @memberof QueueServiceClient
    */
   public async createQueue(
@@ -715,7 +715,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * @param queueName - name of the queue to delete.
    * @param options - Options to Queue delete operation.
-   * @returnsResponse data for the Queue delete operation.
+   * @returns Response data for the Queue delete operation.
    * @memberof QueueServiceClient
    */
   public async deleteQueue(
@@ -754,7 +754,7 @@ export class QueueServiceClient extends StorageClient {
    * @param permissions - Specifies the list of permissions to be associated with the SAS.
    * @param resourceTypes - Specifies the resource types associated with the shared access signature.
    * @param options - Optional parameters.
-   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @returns An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof QueueServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -211,14 +211,14 @@ export class QueueServiceClient extends StorageClient {
   /**
    * Creates an instance of QueueServiceClient.
    *
-   * @param {string} connectionString Account connection string or a SAS connection string of an Azure storage account.
+   * @param connectionString - Account connection string or a SAS connection string of an Azure storage account.
    *                                  [ Note - Account connection string can only be used in NODE.JS runtime. ]
    *                                  Account connection string example -
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
-   * @returns {QueueServiceClient} A new QueueServiceClient object from the given connection string.
+   * @param options - Options to configure the HTTP pipeline.
+   * @returnsA new QueueServiceClient object from the given connection string.
    * @memberof QueueServiceClient
    */
   public static fromConnectionString(
@@ -261,11 +261,11 @@ export class QueueServiceClient extends StorageClient {
   /**
    * Creates an instance of QueueServiceClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage queue service, such as
+   * @param url - A URL string pointing to Azure Storage queue service, such as
    *                     "https://myaccount.queue.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.queue.core.windows.net?sasString".
-   * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
-   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param credential -  Such as AnonymousCredential, StorageSharedKeyCredential or any credential from the @azure/identity package to authenticate requests to the service. You can also provide an object that implements the TokenCredential interface. If not specified, AnonymousCredential is used.
+   * @param options - Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    *
    * Example using DefaultAzureCredential from `@azure/identity`:
@@ -306,10 +306,10 @@ export class QueueServiceClient extends StorageClient {
   /**
    * Creates an instance of QueueServiceClient.
    *
-   * @param {string} url A URL string pointing to Azure Storage queue service, such as
+   * @param url - A URL string pointing to Azure Storage queue service, such as
    *                     "https://myaccount.queue.core.windows.net". You can append a SAS
    *                     if using AnonymousCredential, such as "https://myaccount.queue.core.windows.net?sasString".
-   * @param {Pipeline} pipeline Call newPipeline() to create a default
+   * @param pipeline - Call newPipeline() to create a default
    *                            pipeline, or provide a customized pipeline.
    * @memberof QueueServiceClient
    */
@@ -343,8 +343,8 @@ export class QueueServiceClient extends StorageClient {
   /**
    * Creates a {@link QueueClient} object.
    *
-   * @param {string} queueName
-   * @returns {QueueClient} a new QueueClient
+   * @param queueName -
+   * @returnsa new QueueClient
    * @memberof QueueServiceClient
    *
    * Example usage:
@@ -362,15 +362,15 @@ export class QueueServiceClient extends StorageClient {
    * Returns a list of the queues under the specified account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-queues1
    *
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                        the list of queues to be returned with the next listing operation. The
    *                        operation returns the continuationToken value within the response body if the
    *                        listing operation did not return all queues remaining to be listed
    *                        with the current page. The continuationToken value can be used as the value for
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
-   * @param {ServiceListQueuesSegmentOptions} [options] Options to list queues operation.
-   * @returns {Promise<ServiceListQueuesSegmentResponse>} Response data for the list queues segment operation.
+   * @param options - Options to list queues operation.
+   * @returnsResponse data for the list queues segment operation.
    * @memberof QueueServiceClient
    */
   private async listQueuesSegment(
@@ -410,15 +410,15 @@ export class QueueServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link ServiceListQueuesSegmentResponse} objects
    *
    * @private
-   * @param {string} [marker] A string value that identifies the portion of
+   * @param marker - A string value that identifies the portion of
    *                        the list of queues to be returned with the next listing operation. The
    *                        operation returns the continuationToken value within the response body if the
    *                        listing operation did not return all queues remaining to be listed
    *                        with the current page. The continuationToken value can be used as the value for
    *                        the marker parameter in a subsequent call to request the next page of list
    *                        items. The marker value is opaque to the client.
-   * @param {ServiceListQueuesSegmentOptions} [options] Options to list queues operation.
-   * @returns {AsyncIterableIterator<ServiceListQueuesSegmentResponse>}
+   * @param options - Options to list queues operation.
+   *
    * @memberof QueueServiceClient
    */
   private async *listSegments(
@@ -441,8 +441,8 @@ export class QueueServiceClient extends StorageClient {
    * Returns an AsyncIterableIterator for {@link QueueItem} objects
    *
    * @private
-   * @param {ServiceListQueuesSegmentOptions} [options] Options to list queues operation.
-   * @returns {AsyncIterableIterator<QueueItem>}
+   * @param options - Options to list queues operation.
+   *
    * @memberof QueueServiceClient
    */
   private async *listItems(
@@ -534,9 +534,9 @@ export class QueueServiceClient extends StorageClient {
    * }
    * ```
    *
-   * @param {ServiceListQueuesOptions} [options] Options to list queues operation.
+   * @param options - Options to list queues operation.
    * @memberof QueueServiceClient
-   * @returns {PagedAsyncIterableIterator<QueueItem, ServiceListQueuesSegmentResponse>} An asyncIterableIterator that supports paging.
+   * @returnsAn asyncIterableIterator that supports paging.
    */
   public listQueues(
     options: ServiceListQueuesOptions = {}
@@ -582,8 +582,8 @@ export class QueueServiceClient extends StorageClient {
    * for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties
    *
-   * @param {ServiceGetPropertiesOptions} [options] Options to get properties operation.
-   * @returns {Promise<ServiceGetPropertiesResponse>} Response data including the queue service properties.
+   * @param options - Options to get properties operation.
+   * @returnsResponse data including the queue service properties.
    * @memberof QueueServiceClient
    */
   public async getProperties(
@@ -614,9 +614,9 @@ export class QueueServiceClient extends StorageClient {
    * for Storage Analytics, CORS (Cross-Origin Resource Sharing) rules and soft delete settings.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-service-properties
    *
-   * @param {QueueServiceProperties} properties
-   * @param {ServiceGetPropertiesOptions} [options] Options to set properties operation.
-   * @returns {Promise<ServiceSetPropertiesResponse>} Response data for the Set Properties operation.
+   * @param properties -
+   * @param options - Options to set properties operation.
+   * @returnsResponse data for the Set Properties operation.
    * @memberof QueueServiceClient
    */
   public async setProperties(
@@ -649,8 +649,8 @@ export class QueueServiceClient extends StorageClient {
    * replication is enabled for the storage account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats
    *
-   * @param {ServiceGetStatisticsOptions} [options] Options to get statistics operation.
-   * @returns {Promise<ServiceGetStatisticsResponse>} Response data for get statistics the operation.
+   * @param options - Options to get statistics operation.
+   * @returnsResponse data for get statistics the operation.
    * @memberof QueueServiceClient
    */
   public async getStatistics(
@@ -680,9 +680,9 @@ export class QueueServiceClient extends StorageClient {
    * Creates a new queue under the specified account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4
    *
-   * @param {string} queueName name of the queue to create
-   * @param {QueueCreateOptions} [options] Options to Queue create operation.
-   * @returns {Promise<QueueCreateResponse>} Response data for the Queue create operation.
+   * @param queueName - name of the queue to create
+   * @param options - Options to Queue create operation.
+   * @returnsResponse data for the Queue create operation.
    * @memberof QueueServiceClient
    */
   public async createQueue(
@@ -713,9 +713,9 @@ export class QueueServiceClient extends StorageClient {
    * Deletes the specified queue permanently.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3
    *
-   * @param {string} queueName name of the queue to delete.
-   * @param {QueueDeleteOptions} [options] Options to Queue delete operation.
-   * @returns {Promise<QueueDeleteResponse>} Response data for the Queue delete operation.
+   * @param queueName - name of the queue to delete.
+   * @param options - Options to Queue delete operation.
+   * @returnsResponse data for the Queue delete operation.
    * @memberof QueueServiceClient
    */
   public async deleteQueue(
@@ -750,11 +750,11 @@ export class QueueServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas
    *
-   * @param {Date} expiresOn Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
-   * @param {AccountSASPermissions} [permissions=AccountSASPermissions.parse("r")] Specifies the list of permissions to be associated with the SAS.
-   * @param {string} [resourceTypes="sco"] Specifies the resource types associated with the shared access signature.
-   * @param {ServiceGenerateAccountSasUrlOptions} [options={}] Optional parameters.
-   * @returns {string} An account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
+   * @param expiresOn - Optional. The time at which the shared access signature becomes invalid. Default to an hour later if not specified.
+   * @param permissions - Specifies the list of permissions to be associated with the SAS.
+   * @param resourceTypes - Specifies the resource types associated with the shared access signature.
+   * @param options - Optional parameters.
+   * @returnsAn account SAS URI consisting of the URI to the resource represented by this client, followed by the generated SAS token.
    * @memberof QueueServiceClient
    */
   public generateAccountSasUrl(

--- a/sdk/storage/storage-queue/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-queue/src/SASQueryParameters.ts
@@ -149,17 +149,17 @@ export class SASQueryParameters {
   /**
    * Creates an instance of SASQueryParameters.
    *
-   * @param {string} version Representing the storage version
-   * @param {string} signature Representing the signature for the SAS token
-   * @param {string} [permissions] Representing the storage permissions
-   * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
-   * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
-   * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startsOn] Representing the start time for this SAS token
-   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
-   * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
-   * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
-   * @param {string} [resource] Representing the storage queue (only for Service SAS)
+   * @param version - Representing the storage version
+   * @param signature - Representing the signature for the SAS token
+   * @param permissions - Representing the storage permissions
+   * @param services - Representing the storage services being accessed (only for Account SAS)
+   * @param resourceTypes - Representing the storage resource types being accessed (only for Account SAS)
+   * @param protocol - Representing the allowed HTTP protocol(s)
+   * @param startsOn - Representing the start time for this SAS token
+   * @param expiresOn - Representing the expiry time for this SAS token
+   * @param ipRange - Representing the range of valid IP addresses for this SAS token
+   * @param identifier - Representing the signed identifier (only for Service SAS)
+   * @param resource - Representing the storage queue (only for Service SAS)
    */
   constructor(
     version: string,
@@ -190,7 +190,7 @@ export class SASQueryParameters {
   /**
    * Encodes all SAS query parameters into a string that can be appended to a URL.
    *
-   * @returns {string}
+   *
    * @memberof SASQueryParameters
    */
   public toString(): string {
@@ -253,10 +253,10 @@ export class SASQueryParameters {
    * A private helper method used to filter and append query key/value pairs into an array.
    *
    * @private
-   * @param {string[]} queries
-   * @param {string} key
-   * @param {string} [value]
-   * @returns {void}
+   * @param queries -
+   * @param key -
+   * @param value -
+   *
    * @memberof SASQueryParameters
    */
   private tryAppendQueryParameter(queries: string[], key: string, value?: string): void {

--- a/sdk/storage/storage-queue/src/SasIPRange.ts
+++ b/sdk/storage/storage-queue/src/SasIPRange.ts
@@ -32,8 +32,8 @@ export interface SasIPRange {
  * "8.8.8.8" or "1.1.1.1-255.255.255.255"
  *
  * @export
- * @param {SasIPRange} ipRange
- * @returns {string}
+ * @param ipRange -
+ *
  */
 export function ipRangeToString(ipRange: SasIPRange): string {
   return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;

--- a/sdk/storage/storage-queue/src/StorageBrowserPolicyFactory.ts
+++ b/sdk/storage/storage-queue/src/StorageBrowserPolicyFactory.ts
@@ -16,9 +16,9 @@ export class StorageBrowserPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a StorageBrowserPolicyFactory object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageBrowserPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageBrowserPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageBrowserPolicy {

--- a/sdk/storage/storage-queue/src/StorageClient.ts
+++ b/sdk/storage/storage-queue/src/StorageClient.ts
@@ -69,8 +69,8 @@ export abstract class StorageClient {
 
   /**
    * Creates an instance of StorageClient.
-   * @param {string} url
-   * @param {Pipeline} pipeline
+   * @param url -
+   * @param pipeline -
    * @memberof StorageClient
    */
   protected constructor(url: string, pipeline: Pipeline) {

--- a/sdk/storage/storage-queue/src/StorageRetryPolicyFactory.ts
+++ b/sdk/storage/storage-queue/src/StorageRetryPolicyFactory.ts
@@ -87,7 +87,7 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of StorageRetryPolicyFactory.
-   * @param {StorageRetryOptions} [retryOptions]
+   * @param retryOptions -
    * @memberof StorageRetryPolicyFactory
    */
   constructor(retryOptions?: StorageRetryOptions) {
@@ -97,9 +97,9 @@ export class StorageRetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a {@link StorageRetryPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageRetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageRetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): StorageRetryPolicy {

--- a/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
@@ -29,7 +29,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of TelemetryPolicyFactory.
-   * @param {UserAgentOptions} [telemetry]
+   * @param telemetry -
    * @memberof TelemetryPolicyFactory
    */
   constructor(telemetry?: UserAgentOptions) {
@@ -62,9 +62,9 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
   /**
    * Creates a {@link TelemetryPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {TelemetryPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof TelemetryPolicyFactory
    */
   public create(nextPolicy: RequestPolicy, options: RequestPolicyOptions): TelemetryPolicy {

--- a/sdk/storage/storage-queue/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-queue/src/credentials/AnonymousCredential.ts
@@ -20,9 +20,9 @@ export class AnonymousCredential extends Credential {
   /**
    * Creates an {@link AnonymousCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {AnonymousCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof AnonymousCredential
    */
   public create(

--- a/sdk/storage/storage-queue/src/credentials/Credential.ts
+++ b/sdk/storage/storage-queue/src/credentials/Credential.ts
@@ -16,9 +16,9 @@ export abstract class Credential implements RequestPolicyFactory {
   /**
    * Creates a RequestPolicy object.
    *
-   * @param {RequestPolicy} _nextPolicy
-   * @param {RequestPolicyOptions} _options
-   * @returns {RequestPolicy}
+   * @param _nextPolicy -
+   * @param _options -
+   *
    * @memberof Credential
    */
   public create(

--- a/sdk/storage/storage-queue/src/credentials/StorageSharedKeyCredential.ts
+++ b/sdk/storage/storage-queue/src/credentials/StorageSharedKeyCredential.ts
@@ -35,8 +35,8 @@ export class StorageSharedKeyCredential extends Credential {
 
   /**
    * Creates an instance of StorageSharedKeyCredential.
-   * @param {string} accountName
-   * @param {string} accountKey
+   * @param accountName -
+   * @param accountKey -
    * @memberof StorageSharedKeyCredential
    */
   constructor(accountName: string, accountKey: string) {
@@ -48,9 +48,9 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Creates a {@link StorageSharedKeyCredentialPolicy} object.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @returns {StorageSharedKeyCredentialPolicy}
+   * @param nextPolicy -
+   * @param options -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public create(
@@ -63,8 +63,8 @@ export class StorageSharedKeyCredential extends Credential {
   /**
    * Generates a hash signature for an HTTP request or for a SAS.
    *
-   * @param {string} stringToSign
-   * @returns {string}
+   * @param stringToSign -
+   *
    * @memberof StorageSharedKeyCredential
    */
   public computeHMACSHA256(stringToSign: string): string {

--- a/sdk/storage/storage-queue/src/policies/AnonymousCredentialPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/AnonymousCredentialPolicy.ts
@@ -16,8 +16,8 @@ import { CredentialPolicy } from "./CredentialPolicy";
 export class AnonymousCredentialPolicy extends CredentialPolicy {
   /**
    * Creates an instance of AnonymousCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof AnonymousCredentialPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {

--- a/sdk/storage/storage-queue/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/CredentialPolicy.ts
@@ -16,8 +16,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -30,8 +30,8 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
    *
    * @protected
    * @abstract
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof CredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {

--- a/sdk/storage/storage-queue/src/policies/StorageBrowserPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageBrowserPolicy.ts
@@ -30,8 +30,8 @@ import { setURLParameter } from "../utils/utils.common";
 export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of StorageBrowserPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof StorageBrowserPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
@@ -41,8 +41,8 @@ export class StorageBrowserPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageBrowserPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
@@ -23,8 +23,8 @@ import { logger } from "../log";
  * A factory method used to generated a RetryPolicy factory.
  *
  * @export
- * @param {StorageRetryOptions} retryOptions
- * @returns {RequestPolicyFactory}
+ * @param retryOptions -
+ *
  */
 export function NewRetryPolicyFactory(retryOptions?: StorageRetryOptions): RequestPolicyFactory {
   return {
@@ -82,9 +82,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of RetryPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {RetryOptions} [retryOptions=DEFAULT_RETRY_OPTIONS]
+   * @param nextPolicy -
+   * @param options -
+   * @param retryOptions -
    * @memberof StorageRetryPolicy
    */
   constructor(
@@ -134,8 +134,8 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof StorageRetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -146,14 +146,14 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide and perform next retry. Won't mutate request parameter.
    *
    * @protected
-   * @param {WebResource} request
-   * @param {HttpOperationResponse} response
-   * @param {boolean} secondaryHas404  If attempt was against the secondary & it returned a StatusNotFound (404), then
+   * @param request -
+   * @param response -
+   * @param secondaryHas404 -  If attempt was against the secondary & it returned a StatusNotFound (404), then
    *                                   the resource was not found. This may be due to replication delay. So, in this
    *                                   case, we'll never try the secondary again for this operation.
-   * @param {number} attempt           How many retries has been attempted to performed, starting from 1, which includes
+   * @param attempt -           How many retries has been attempted to performed, starting from 1, which includes
    *                                   the attempt will be performed by this method call.
-   * @returns {Promise<HttpOperationResponse>}
+   *
    * @memberof StorageRetryPolicy
    */
   protected async attemptSendRequest(
@@ -204,11 +204,11 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Decide whether to retry according to last HTTP response and retry counters.
    *
    * @protected
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {HttpOperationResponse} [response]
-   * @param {RestError} [err]
-   * @returns {boolean}
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param response -
+   * @param err -
+   *
    * @memberof StorageRetryPolicy
    */
   protected shouldRetry(
@@ -282,9 +282,9 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Delay a calculated time between retries.
    *
    * @private
-   * @param {boolean} isPrimaryRetry
-   * @param {number} attempt
-   * @param {AbortSignalLike} [abortSignal]
+   * @param isPrimaryRetry -
+   * @param attempt -
+   * @param abortSignal -
    * @memberof StorageRetryPolicy
    */
   private async delay(isPrimaryRetry: boolean, attempt: number, abortSignal?: AbortSignalLike) {

--- a/sdk/storage/storage-queue/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -25,9 +25,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
 
   /**
    * Creates an instance of StorageSharedKeyCredentialPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {StorageSharedKeyCredential} factory
+   * @param nextPolicy -
+   * @param options -
+   * @param factory -
    * @memberof StorageSharedKeyCredentialPolicy
    */
   constructor(
@@ -43,8 +43,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Signs request.
    *
    * @protected
-   * @param {WebResource} request
-   * @returns {WebResource}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   protected signRequest(request: WebResource): WebResource {
@@ -91,9 +91,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/authenticate-with-shared-key
    *
    * @private
-   * @param {WebResource} request
-   * @param {string} headerName
-   * @returns {string}
+   * @param request -
+   * @param headerName -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getHeaderValueToSign(request: WebResource, headerName: string): string {
@@ -125,8 +125,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    *    Construct the CanonicalizedHeaders string by concatenating all headers in this list into a single string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedHeadersString(request: WebResource): string {
@@ -160,8 +160,8 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
    * Retrieves the webResource canonicalized resource string.
    *
    * @private
-   * @param {WebResource} request
-   * @returns {string}
+   * @param request -
+   *
    * @memberof StorageSharedKeyCredentialPolicy
    */
   private getCanonicalizedResourceString(request: WebResource): string {

--- a/sdk/storage/storage-queue/src/policies/TelemetryPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/TelemetryPolicy.ts
@@ -30,9 +30,9 @@ export class TelemetryPolicy extends BaseRequestPolicy {
 
   /**
    * Creates an instance of TelemetryPolicy.
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
-   * @param {string} telemetry
+   * @param nextPolicy -
+   * @param options -
+   * @param telemetry -
    * @memberof TelemetryPolicy
    */
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, telemetry: string) {
@@ -43,8 +43,8 @@ export class TelemetryPolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof TelemetryPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -6,8 +6,8 @@ import { getTracer, SpanOptions, OperationTracingOptions } from "@azure/core-tra
 
 /**
  * Creates a span using the global tracer.
- * @param {string} operationName The name of the operation being performed.
- * @param {SpanOptions} options The options for the underlying http request.
+ * @param operationName - The name of the operation being performed.
+ * @param options - The options for the underlying http request.
  */
 export function createSpan(
   operationName: string,

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -13,7 +13,7 @@ import { Pipeline } from "../Pipeline";
  * @export
  * @param url - Source URL string
  * @param name - String to be appended to URL
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -33,7 +33,7 @@ export function appendToURLPath(url: string, name: string): string {
  * @param url - Source URL string
  * @param name - Parameter name
  * @param value - Parameter value
- * @returnsAn updated URL string
+ * @returns An updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -47,7 +47,7 @@ export function setURLParameter(url: string, name: string, value?: string): stri
  * @export
  * @param url - URL string
  * @param name - Parameter name
- * @returnsParameter value(s) for the given parameter name.
+ * @returns Parameter value(s) for the given parameter name.
  */
 export function getURLParameter(url: string, name: string): string | string[] | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -73,7 +73,7 @@ export function setURLHost(url: string, host: string): string {
  *
  * @export
  * @param url - Source URL string
- * @returnsThe path part of the given URL string.
+ * @returns The path part of the given URL string.
  */
 export function getURLPath(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -85,7 +85,7 @@ export function getURLPath(url: string): string | undefined {
  *
  * @export
  * @param url -
- * @returnsquery key value string pairs from the given URL string.
+ * @returns query key value string pairs from the given URL string.
  */
 export function getURLQueries(url: string): { [key: string]: string } {
   let queryString = URLBuilder.parse(url).getQuery();
@@ -145,7 +145,7 @@ function getProxyUriFromDevConnString(connectionString: string): string {
  *
  * @param connectionString - Account connection string.
  * @param argument - property to get value from the connection string.
- * @returnsValue of the property specified in argument.
+ * @returns Value of the property specified in argument.
  */
 export function getValueInConnString(
   connectionString: string,
@@ -171,7 +171,7 @@ export function getValueInConnString(
  *
  * @export
  * @param connectionString - Connection string.
- * @returnsString key value pairs of the storage account's url and credentials.
+ * @returns String key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   let proxyUri = "";
@@ -257,7 +257,7 @@ export function extractConnectionStringParts(connectionString: string): Connecti
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -336,7 +336,7 @@ export function padStart(
 /**
  * Sanitizes a url by removing the Signature parameter
  * @param url - to sanitize
- * @returnssanitized string
+ * @returns sanitized string
  */
 export function sanitizeURL(url: string): string {
   let safeURL: string = url;
@@ -350,7 +350,7 @@ export function sanitizeURL(url: string): string {
 /**
  * Sanitize headers by removing sensitive values such as AUTHORIZATION and X_MS_COPY_SOURCE
  * @param originalHeader - original headers
- * @returnssanitized headers
+ * @returns sanitized headers
  */
 export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
   const headers: HttpHeaders = new HttpHeaders();
@@ -370,7 +370,7 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
 /**
  * Extracts account name from the url
  * @param url - url to extract the account name from
- * @returnswith the account name
+ * @returns with the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);
@@ -415,7 +415,7 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
  * Gets a new StorageClientContext
  * @param url - Url used for the StorageClientContext
  * @param pipeline - a pipeline containing HTTP request policies
- * @returnsnew StorageClientContext
+ * @returns new StorageClientContext
  */
 export function getStorageClientContext(url: string, pipeline: Pipeline): StorageClientContext {
   const storageClientContext = new StorageClientContext(url, pipeline.toServiceClientOptions());
@@ -431,7 +431,7 @@ export function getStorageClientContext(url: string, pipeline: Pipeline): Storag
  * @export
  * @param url - Source URL string.
  * @param queryParts - String to be appended to the URL query.
- * @returnsAn updated URL string.
+ * @returns An updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -11,9 +11,9 @@ import { Pipeline } from "../Pipeline";
  * when URL path ends with a "/".
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name String to be appended to URL
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - String to be appended to URL
+ * @returnsAn updated URL string
  */
 export function appendToURLPath(url: string, name: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -30,10 +30,10 @@ export function appendToURLPath(url: string, name: string): string {
  * will be replaced by name key. If not provide value, the parameter will be deleted.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} name Parameter name
- * @param {string} [value] Parameter value
- * @returns {string} An updated URL string
+ * @param url - Source URL string
+ * @param name - Parameter name
+ * @param value - Parameter value
+ * @returnsAn updated URL string
  */
 export function setURLParameter(url: string, name: string, value?: string): string {
   const urlParsed = URLBuilder.parse(url);
@@ -45,9 +45,9 @@ export function setURLParameter(url: string, name: string, value?: string): stri
  * Get URL parameter by name.
  *
  * @export
- * @param {string} url URL string
- * @param {string} name Parameter name
- * @returns {(string | string[] | undefined)} Parameter value(s) for the given parameter name.
+ * @param url - URL string
+ * @param name - Parameter name
+ * @returnsParameter value(s) for the given parameter name.
  */
 export function getURLParameter(url: string, name: string): string | string[] | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -58,8 +58,8 @@ export function getURLParameter(url: string, name: string): string | string[] | 
  * Set URL host.
  *
  * @export
- * @param {string} url Source URL string
- * @param {string} host New host string
+ * @param url - Source URL string
+ * @param host - New host string
  * @returns An updated URL string
  */
 export function setURLHost(url: string, host: string): string {
@@ -72,8 +72,8 @@ export function setURLHost(url: string, host: string): string {
  * Gets URL path from an URL string.
  *
  * @export
- * @param {string} url Source URL string
- * @returns {(string | undefined)} The path part of the given URL string.
+ * @param url - Source URL string
+ * @returnsThe path part of the given URL string.
  */
 export function getURLPath(url: string): string | undefined {
   const urlParsed = URLBuilder.parse(url);
@@ -84,8 +84,8 @@ export function getURLPath(url: string): string | undefined {
  * Gets URL query key value pairs from an URL string.
  *
  * @export
- * @param {string} url
- * @returns {{[key: string]: string}} query key value string pairs from the given URL string.
+ * @param url -
+ * @returnsquery key value string pairs from the given URL string.
  */
 export function getURLQueries(url: string): { [key: string]: string } {
   let queryString = URLBuilder.parse(url).getQuery();
@@ -143,9 +143,9 @@ function getProxyUriFromDevConnString(connectionString: string): string {
 
 /**
  *
- * @param {string} connectionString Account connection string.
- * @param {string} argument property to get value from the connection string.
- * @returns {string} Value of the property specified in argument.
+ * @param connectionString - Account connection string.
+ * @param argument - property to get value from the connection string.
+ * @returnsValue of the property specified in argument.
  */
 export function getValueInConnString(
   connectionString: string,
@@ -170,8 +170,8 @@ export function getValueInConnString(
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export
- * @param {string} connectionString Connection string.
- * @returns {ConnectionString} String key value pairs of the storage account's url and credentials.
+ * @param connectionString - Connection string.
+ * @returnsString key value pairs of the storage account's url and credentials.
  */
 export function extractConnectionStringParts(connectionString: string): ConnectionString {
   let proxyUri = "";
@@ -254,10 +254,10 @@ export function extractConnectionStringParts(connectionString: string): Connecti
  * Rounds a date off to seconds.
  *
  * @export
- * @param {Date} date
- * @param {boolean} [withMilliseconds=true] If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
+ * @param date -
+ * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns {string} Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returnsDate string in ISO8061 format, with or without 7 milliseconds component
  */
 export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
@@ -272,9 +272,9 @@ export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = tru
  * Delay specified time interval.
  *
  * @export
- * @param {number} timeInMs
- * @param {AbortSignalLike} [aborter]
- * @param {Error} [abortError]
+ * @param timeInMs -
+ * @param aborter -
+ * @param abortError -
  */
 export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortError?: Error) {
   return new Promise<void>((resolve, reject) => {
@@ -305,10 +305,10 @@ export async function delay(timeInMs: number, aborter?: AbortSignalLike, abortEr
  * String.prototype.padStart()
  *
  * @export
- * @param {string} currentString
- * @param {number} targetLength
- * @param {string} [padString=" "]
- * @returns {string}
+ * @param currentString -
+ * @param targetLength -
+ * @param [padString=" - "]
+ *
  */
 export function padStart(
   currentString: string,
@@ -335,8 +335,8 @@ export function padStart(
 
 /**
  * Sanitizes a url by removing the Signature parameter
- * @param {string} url to sanitize
- * @returns {string} sanitized string
+ * @param url - to sanitize
+ * @returnssanitized string
  */
 export function sanitizeURL(url: string): string {
   let safeURL: string = url;
@@ -349,8 +349,8 @@ export function sanitizeURL(url: string): string {
 
 /**
  * Sanitize headers by removing sensitive values such as AUTHORIZATION and X_MS_COPY_SOURCE
- * @param {HttpHeaders} originalHeader original headers
- * @returns {HttpHeaders} sanitized headers
+ * @param originalHeader - original headers
+ * @returnssanitized headers
  */
 export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
   const headers: HttpHeaders = new HttpHeaders();
@@ -369,8 +369,8 @@ export function sanitizeHeaders(originalHeader: HttpHeaders): HttpHeaders {
 
 /**
  * Extracts account name from the url
- * @param {string} url url to extract the account name from
- * @returns {string} with the account name
+ * @param url - url to extract the account name from
+ * @returnswith the account name
  */
 export function getAccountNameFromUrl(url: string): string {
   const parsedUrl: URLBuilder = URLBuilder.parse(url);
@@ -413,9 +413,9 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
 
 /**
  * Gets a new StorageClientContext
- * @param {string} url Url used for the StorageClientContext
- * @param {url} pipeline a pipeline containing HTTP request policies
- * @returns {StorageClientContext} new StorageClientContext
+ * @param url - Url used for the StorageClientContext
+ * @param pipeline - a pipeline containing HTTP request policies
+ * @returnsnew StorageClientContext
  */
 export function getStorageClientContext(url: string, pipeline: Pipeline): StorageClientContext {
   const storageClientContext = new StorageClientContext(url, pipeline.toServiceClientOptions());
@@ -429,9 +429,9 @@ export function getStorageClientContext(url: string, pipeline: Pipeline): Storag
  * Append a string to URL query.
  *
  * @export
- * @param {string} url Source URL string.
- * @param {string} queryParts String to be appended to the URL query.
- * @returns {string} An updated URL string.
+ * @param url - Source URL string.
+ * @param queryParts - String to be appended to the URL query.
+ * @returnsAn updated URL string.
  */
 export function appendToURLQuery(url: string, queryParts: string): string {
   const urlParsed = URLBuilder.parse(url);

--- a/sdk/storage/storage-queue/test/utils/InjectorPolicy.ts
+++ b/sdk/storage/storage-queue/test/utils/InjectorPolicy.ts
@@ -23,8 +23,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Creates an instance of InjectorPolicy.
    *
-   * @param {RequestPolicy} nextPolicy
-   * @param {RequestPolicyOptions} options
+   * @param nextPolicy -
+   * @param options -
    * @memberof InjectorPolicy
    */
   public constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, injector: Injector) {
@@ -35,8 +35,8 @@ export class InjectorPolicy extends BaseRequestPolicy {
   /**
    * Sends request.
    *
-   * @param {WebResource} request
-   * @returns {Promise<HttpOperationResponse>}
+   * @param request -
+   *
    * @memberof InjectorPolicy
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {


### PR DESCRIPTION
This PR updates the usage of `@param` and `@returns` tag to follow TSDoc. Related to #12956

This will need a follow up from the Storage team to update the docs for all the parameters that only have been annotated with the `@param` tag, but have no description