### PR TITLE
[core-amqp] fix remaining eslint errors

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -48,7 +48,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o core-amqp-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -55,7 +55,7 @@
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
     "test": "npm run test:node && npm run test:browser",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register -t 50000 --reporter ../../../common/tools/mocha-multi-reporter.js ./test/**/*.spec.ts",
+    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register -t 50000 --reporter ../../../common/tools/mocha-multi-reporter.js ./test/*.spec.ts ./test/node/*.spec.ts",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },
@@ -101,6 +101,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^8.0.0",
     "@types/sinon": "^9.0.4",
+    "@types/ws": "^7.2.4",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -393,7 +393,7 @@ export enum ErrorNameConditionMapper {
 export function isMessagingError(error: Error | MessagingError): error is MessagingError;
 
 // @public
-export function isSystemError(err: any): err is NetworkSystemError;
+export function isSystemError(err: unknown): err is NetworkSystemError;
 
 // @public
 export const logger: import("@azure/logger").AzureLogger;

--- a/sdk/core/core-amqp/rollup.base.config.js
+++ b/sdk/core/core-amqp/rollup.base.config.js
@@ -62,7 +62,7 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = "dist-esm/test/**/*.spec.js";
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
@@ -138,7 +138,7 @@ export function browserConfig(test = false) {
   };
 
   if (test) {
-    baseConfig.input = "dist-esm/test/**/*.spec.js";
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/browser/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "test-browser/index.js";
 

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -101,6 +101,7 @@ export interface CreateConnectionContextBaseParameters {
   operationTimeoutInMs?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- renaming constant would be a breaking change.
 export const ConnectionContextBase = {
   /**
    * Creates the base connection context.

--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -170,13 +170,13 @@ export const ConnectionContextBase = {
       config: parameters.config,
       refreshConnection() {
         const newConnection = new Connection(connectionOptions);
-        const connectionLock = `${Constants.establishConnection}-${generate_uuid()}`;
+        const newConnectionLock = `${Constants.establishConnection}-${generate_uuid()}`;
         this.wasConnectionCloseCalled = false;
-        this.connectionLock = connectionLock;
+        this.connectionLock = newConnectionLock;
         this.negotiateClaimLock = `${Constants.negotiateClaim} - ${generate_uuid()}`;
         this.connection = newConnection;
         this.connectionId = newConnection.id;
-        this.cbsSession = new CbsClient(newConnection, connectionLock);
+        this.cbsSession = new CbsClient(newConnection, newConnectionLock);
       }
     };
 

--- a/sdk/core/core-amqp/src/amqpAnnotatedMessage.ts
+++ b/sdk/core/core-amqp/src/amqpAnnotatedMessage.ts
@@ -43,6 +43,7 @@ export interface AmqpAnnotatedMessage {
 /**
  * Describes the operations that can be performed on(or to get) the AmqpAnnotatedMessage.
  */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- renaming constant would be a breaking change.
 export const AmqpAnnotatedMessage = {
   /**
    * Takes RheaMessage(`Message` type from "rhea") and returns it in the AmqpAnnotatedMessage format.

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -3,6 +3,7 @@
 
 import { parseConnectionString } from "../util/utils";
 import { WebSocketImpl } from "rhea-promise";
+import { isDefined } from "../util/typeGuards";
 
 /**
  * Describes the options that can be provided while creating a connection config.
@@ -147,7 +148,7 @@ export const ConnectionConfig = {
     if (options.isEntityPathRequired && !config.entityPath) {
       throw new TypeError("Missing 'entityPath' in configuration");
     }
-    if (config.entityPath != null) {
+    if (isDefined(config.entityPath)) {
       config.entityPath = String(config.entityPath);
     }
 

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -147,7 +147,7 @@ export const ConnectionConfig = {
     if (options.isEntityPathRequired && !config.entityPath) {
       throw new TypeError("Missing 'entityPath' in configuration");
     }
-    if (config.entityPath != undefined) {
+    if (config.entityPath != null) {
       config.entityPath = String(config.entityPath);
     }
 

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -82,6 +82,7 @@ export interface ConnectionConfig {
 /**
  * Describes the ConnectionConfig module
  */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- renaming constant would be a breaking change.
 export const ConnectionConfig = {
   /**
    * Creates the connection config.

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -4,6 +4,7 @@
 
 import { AmqpError, AmqpResponseStatusCode, isAmqpError as rheaIsAmqpError } from "rhea-promise";
 import { isNode, isNumber, isString } from "../src/util/utils";
+import { isObjectWithProperties } from "./util/typeGuards";
 
 /**
  * Maps the conditions to the numeric AMQP Response status codes.
@@ -582,8 +583,8 @@ export enum SystemErrorConditionMapper {
  * Checks whether the provided error is a node.js SystemError.
  * @param err - An object that may contain error information.
  */
-export function isSystemError(err: any): err is NetworkSystemError {
-  if (!err) {
+export function isSystemError(err: unknown): err is NetworkSystemError {
+  if (!isObjectWithProperties(err, ["code", "syscall", "errno"])) {
     return false;
   }
 

--- a/sdk/core/core-amqp/src/log.ts
+++ b/sdk/core/core-amqp/src/log.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { createClientLogger } from "@azure/logger";
+import { isObjectWithProperties } from "./util/typeGuards";
 
 /**
  * The \@azure/logger configuration for this package.
@@ -14,8 +15,8 @@ export const logger = createClientLogger("core-amqp");
  * @param error - Error containing a stack trace.
  * @hidden
  */
-export function logErrorStackTrace(error: any): void {
-  if (error && error.stack) {
+export function logErrorStackTrace(error: unknown): void {
+  if (isObjectWithProperties(error, ["stack"])) {
     logger.verbose(error.stack);
   }
 }

--- a/sdk/core/core-amqp/src/messageHeader.ts
+++ b/sdk/core/core-amqp/src/messageHeader.ts
@@ -37,6 +37,7 @@ export interface AmqpMessageHeader {
 /**
  * Describes the operations that can be performed on the message header.
  */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- renaming constant would be a breaking change.
 export const AmqpMessageHeader = {
   /**
    * Converts MessageHeader to RheaMessageHeader.

--- a/sdk/core/core-amqp/src/messageProperties.ts
+++ b/sdk/core/core-amqp/src/messageProperties.ts
@@ -69,6 +69,7 @@ export interface AmqpMessageProperties {
 /**
  * Describes the operations that can be performed on the amqp message properties.
  */
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- renaming constant would be a breaking change.
 export const AmqpMessageProperties = {
   /**
    * Converts MessageProperties to RheaMessageProperties.

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -18,6 +18,7 @@ import {
 } from "rhea-promise";
 import { ConditionStatusMapper, translate } from "./errors";
 import { logErrorStackTrace, logger } from "./log";
+import { isDefined } from "./util/typeGuards";
 
 /**
  * Describes the options that can be specified while sending a request.
@@ -134,7 +135,7 @@ export class RequestResponseLink implements ReqResLink {
 
       const onAbort = (): void => {
         // safe to clear the timeout if it hasn't already occurred.
-        if (timer != null) {
+        if (isDefined(timer)) {
           clearTimeout(timer);
         }
         aborter!.removeEventListener("abort", onAbort);
@@ -172,7 +173,7 @@ export class RequestResponseLink implements ReqResLink {
         reject: reject,
         cleanupBeforeResolveOrReject: () => {
           if (aborter) aborter.removeEventListener("abort", onAbort);
-          if (timer != null) {
+          if (isDefined(timer)) {
             clearTimeout(timer);
           }
         }

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -247,8 +247,9 @@ type NormalizedInfo = {
  *
  * Handle different variations of property names in responses emitted by EventHubs and ServiceBus.
  */
-export const getCodeDescriptionAndError = (props: any): NormalizedInfo => {
-  if (!props) props = {};
+export const getCodeDescriptionAndError = (
+  props: { [key: string]: string | number | undefined } = {}
+): NormalizedInfo => {
   return {
     statusCode: (props[Constants.statusCode] || props.statusCode) as number,
     statusDescription: (props[Constants.statusDescription] || props.statusDescription) as string,

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -114,6 +114,8 @@ export class RequestResponseLink implements ReqResLink {
     }
 
     return new Promise<RheaMessage>((resolve: any, reject: any) => {
+      let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+
       const rejectOnAbort = (): void => {
         this._responsesMap.delete(request.message_id as string);
         const address = this.receiver.address || "address";
@@ -132,7 +134,9 @@ export class RequestResponseLink implements ReqResLink {
 
       const onAbort = (): void => {
         // safe to clear the timeout if it hasn't already occurred.
-        clearTimeout(timer);
+        if (timer != null) {
+          clearTimeout(timer);
+        }
         aborter!.removeEventListener("abort", onAbort);
 
         rejectOnAbort();
@@ -147,7 +151,7 @@ export class RequestResponseLink implements ReqResLink {
         aborter.addEventListener("abort", onAbort);
       }
 
-      const timer = setTimeout(() => {
+      timer = setTimeout(() => {
         this._responsesMap.delete(request.message_id as string);
         if (aborter) {
           aborter.removeEventListener("abort", onAbort);
@@ -168,7 +172,9 @@ export class RequestResponseLink implements ReqResLink {
         reject: reject,
         cleanupBeforeResolveOrReject: () => {
           if (aborter) aborter.removeEventListener("abort", onAbort);
-          clearTimeout(timer);
+          if (timer != null) {
+            clearTimeout(timer);
+          }
         }
       });
 

--- a/sdk/core/core-amqp/src/util/typeGuards.ts
+++ b/sdk/core/core-amqp/src/util/typeGuards.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Helper TypeGuard that checks if something is defined or not.
+ * @param thing - Anything
+ * @internal
+ */
+export function isDefined<T>(thing: T | undefined | null): thing is T {
+  return typeof thing !== "undefined" && thing !== null;
+}
+
+/**
+ * Helper TypeGuard that checks if the input is an object with the specified properties.
+ * @param thing - Anything.
+ * @param properties - The name of the properties that should appear in the object.
+ * @internal
+ */
+export function isObjectWithProperties<Thing extends unknown, PropertyName extends string>(
+  thing: Thing,
+  properties: PropertyName[]
+): thing is Thing & Record<PropertyName, unknown> {
+  if (!isDefined(thing) || typeof thing !== "object") {
+    return false;
+  }
+
+  for (const property of properties) {
+    if (!objectHasProperty(thing, property)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Helper TypeGuard that checks if the input is an object with the specified property.
+ * @param thing - Any object.
+ * @param property - The name of the property that should appear in the object.
+ * @internal
+ */
+export function objectHasProperty<Thing extends unknown, PropertyName extends string>(
+  thing: Thing,
+  property: PropertyName
+): thing is Thing & Record<PropertyName, unknown> {
+  if (!(property in thing)) {
+    return false;
+  }
+
+  return true;
+}

--- a/sdk/core/core-amqp/src/util/typeGuards.ts
+++ b/sdk/core/core-amqp/src/util/typeGuards.ts
@@ -12,6 +12,7 @@ export function isDefined<T>(thing: T | undefined | null): thing is T {
 
 /**
  * Helper TypeGuard that checks if the input is an object with the specified properties.
+ * Note: The properties may be inherited.
  * @param thing - Anything.
  * @param properties - The name of the properties that should appear in the object.
  * @internal
@@ -35,6 +36,7 @@ export function isObjectWithProperties<Thing extends unknown, PropertyName exten
 
 /**
  * Helper TypeGuard that checks if the input is an object with the specified property.
+ * Note: The property may be inherited.
  * @param thing - Any object.
  * @param property - The name of the property that should appear in the object.
  * @internal

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -69,11 +69,11 @@ export type ParsedOutput<T> = { [P in keyof T]: T[P] };
  *
  * Connection strings have the following syntax:
  *
- * ConnectionString ::= Part { ";" Part } [ ";" ] [ WhiteSpace ]
+ * ConnectionString ::= `Part { ";" Part } [ ";" ] [ WhiteSpace ]`
  * Part             ::= [ PartLiteral [ "=" PartLiteral ] ]
  * PartLiteral      ::= [ WhiteSpace ] Literal [ WhiteSpace ]
  * Literal          ::= ? any sequence of characters except ; or = or WhiteSpace ?
- * WhiteSpace       ::= ? all whitespace characters including \r and \n ?
+ * WhiteSpace       ::= ? all whitespace characters including `\r` and `\n` ?
  *
  * @param connectionString - The connection string to be parsed.
  * @returns ParsedOutput<T>.

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -157,7 +157,7 @@ export class Timeout {
     return Promise.race([wrappedPromise, timer]);
   }
 
-  private _promiseFinally<T>(promise: Promise<T>, fn: Function): Promise<T> {
+  private _promiseFinally<T>(promise: Promise<T>, fn: (...args: any[]) => void): Promise<T> {
     const success = (result: T): T => {
       fn();
       return result;

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -4,6 +4,7 @@
 import AsyncLock from "async-lock";
 import { AbortError, AbortSignalLike } from "@azure/abort-controller";
 import { WebSocketImpl } from "rhea-promise";
+import { isDefined } from "./typeGuards";
 
 export { AsyncLock };
 /**
@@ -209,7 +210,7 @@ export function delay<T>(
     };
 
     onAborted = (): void => {
-      if (timer != null) {
+      if (isDefined(timer)) {
         clearTimeout(timer);
       }
       removeListeners();

--- a/sdk/core/core-amqp/test/browser/websockets.spec.ts
+++ b/sdk/core/core-amqp/test/browser/websockets.spec.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+const should = chai.should();
+import { ConnectionConfig, ConnectionContextBase } from "../../src";
+
+describe("ConnectionContextBase (browser)", function() {
+  it("should default to using a websocket", async () => {
+    const host = "hostname.servicebus.windows.net";
+    const connectionString = `Endpoint=sb://${host}/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep`;
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+
+    config.webSocketEndpointPath = "ws";
+
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+
+    should.exist(context);
+    should.equal(context.connection["options"]["webSocketOptions"]?.url, `wss://${host}:443/ws`);
+  });
+});

--- a/sdk/core/core-amqp/test/context.spec.ts
+++ b/sdk/core/core-amqp/test/context.spec.ts
@@ -5,7 +5,6 @@ import * as chai from "chai";
 const should = chai.should();
 import { CbsClient, ConnectionConfig, ConnectionContextBase } from "../src";
 import { Connection } from "rhea-promise";
-import { isNode } from "../src/util/utils";
 
 describe("ConnectionContextBase", function() {
   it("should be created with required parameters", function(done) {
@@ -249,50 +248,6 @@ describe("ConnectionContextBase", function() {
     );
     context.cbsSession.should.instanceOf(CbsClient);
   });
-
-  if (isNode) {
-    it("should accept a websocket constructor in Node", async () => {
-      const connectionString =
-        "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
-      const path = "mypath";
-      const config = ConnectionConfig.create(connectionString, path);
-
-      config.webSocket = require("ws");
-      config.webSocketEndpointPath = "/ws";
-
-      const context = ConnectionContextBase.create({
-        config: config,
-        connectionProperties: {
-          product: "MSJSClient",
-          userAgent: "/js-amqp-client",
-          version: "1.0.0"
-        }
-      });
-
-      should.exist(context);
-    });
-  } else {
-    it("should default to using a websocket in the browser", async () => {
-      const connectionString =
-        "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
-      const path = "mypath";
-      const config = ConnectionConfig.create(connectionString, path);
-
-      config.webSocketEndpointPath = "/ws";
-
-      const context = ConnectionContextBase.create({
-        config: config,
-        connectionProperties: {
-          product: "MSJSClient",
-          userAgent: "/js-amqp-client",
-          version: "1.0.0"
-        }
-      });
-
-      should.exist(context);
-      should.exist(context.connection.options.connection_details);
-    });
-  }
 
   it("Throws error if user-agent string length is greater than 512 characters", function(done) {
     const connectionString =

--- a/sdk/core/core-amqp/test/node/websockets.spec.ts
+++ b/sdk/core/core-amqp/test/node/websockets.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+const should = chai.should();
+import { ConnectionConfig, ConnectionContextBase } from "../../src";
+import ws from "ws";
+
+describe("ConnectionContextBase (node.js)", function() {
+  it("should accept a websocket constructor", async () => {
+    const host = "hostname.servicebus.windows.net";
+    const connectionString = `Endpoint=sb://${host}/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep`;
+    const path = "mypath";
+    const config = ConnectionConfig.create(connectionString, path);
+
+    config.webSocket = ws;
+    config.webSocketEndpointPath = "ws";
+
+    const context = ConnectionContextBase.create({
+      config: config,
+      connectionProperties: {
+        product: "MSJSClient",
+        userAgent: "/js-amqp-client",
+        version: "1.0.0"
+      }
+    });
+
+    should.exist(context);
+    should.equal(context.connection["options"]["webSocketOptions"]?.url, `wss://${host}:443/ws`);
+  });
+});


### PR DESCRIPTION
Fixes #10775 

Brings existing 19 issues down to 0 and makes lint errors fail CI.

Notable: I had to pull the websockets test out into separate browser and node.js files. This was because previously, we were using `require` to conditionally pull in the `ws` dependency for node.js, but the linter wants us to stop usage of `require`. There are dynamic `import` statements but not with es6 modules (it requires es2020 I believe). Separating the test by runtime let me use ES2015 imports to import `ws` just in node.js.