### PR TITLE
[Text Analytics] Update relatedEntities to be an array

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -225,7 +225,8 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
 export interface HealthcareEntity extends Entity {
     dataSources: EntityDataSource[];
     isNegated: boolean;
-    relatedEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
+    // Warning: (ae-forgotten-export) The symbol "RelatedHealthcareEntity" needs to be exported by the entry point index.d.ts
+    relatedEntities: RelatedHealthcareEntity[];
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -225,7 +225,6 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
 export interface HealthcareEntity extends Entity {
     dataSources: EntityDataSource[];
     isNegated: boolean;
-    // Warning: (ae-forgotten-export) The symbol "RelatedHealthcareEntity" needs to be exported by the entry point index.d.ts
     relatedEntities: RelatedHealthcareEntity[];
 }
 
@@ -430,6 +429,12 @@ export interface RecognizePiiEntitiesResultArray extends Array<RecognizePiiEntit
 export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessResult {
     readonly entities: PiiEntity[];
     redactedText: string;
+}
+
+// @public
+export interface RelatedHealthcareEntity {
+    relatedEntity: HealthcareEntity;
+    relationType: HealthcareEntityRelationType;
 }
 
 // @public (undocumented)

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
@@ -43,11 +43,13 @@ async function main() {
       for (const entity of result.entities) {
         console.log(
           `\t- Entity ${entity.text} of type ${entity.category} ${
-            entity.relatedEntities.size > 0 ? "and it is related to the following entities" : ""
+            entity.relatedEntities.length > 0 ? "and it is related to the following entities" : ""
           }`
         );
         for (const edge of entity.relatedEntities) {
-          console.log(`\t\t- ${edge[0].text} with the relationship being ${edge[1]}`);
+          console.log(
+            `\t\t- ${edge.relatedEntity.text} with the relationship being ${edge.relationType}`
+          );
         }
         if (entity.dataSources.length > 0) {
           console.log("\t and it can be referenced in the following data sources:");

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcareEntities.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcareEntities.ts
@@ -44,11 +44,13 @@ export async function main() {
       for (const entity of result.entities) {
         console.log(
           `\t- Entity ${entity.text} of type ${entity.category} ${
-            entity.relatedEntities.size > 0 ? "and it is related to the following entities" : ""
+            entity.relatedEntities.length > 0 ? "and it is related to the following entities" : ""
           }`
         );
         for (const edge of entity.relatedEntities) {
-          console.log(`\t\t- ${edge[0].text} with the relationship being ${edge[1]}`);
+          console.log(
+            `\t\t- ${edge.relatedEntity.text} with the relationship being ${edge.relationType}`
+          );
         }
         if (entity.dataSources.length > 0) {
           console.log("\t and it can be referenced in the following data sources:");

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
@@ -90,6 +90,20 @@ export interface EntityDataSource {
 }
 
 /**
+ * A related healthcare entity along with the type of the healthcare relation.
+ */
+export interface RelatedHealthcareEntity {
+  /**
+   * A related healthcare entity that is the target of a healthcare relation.
+   */
+  relatedEntity: HealthcareEntity;
+  /**
+   * The type of the healthcare relation.
+   */
+  relationType: HealthcareEntityRelationType;
+}
+
+/**
  * A healthcare entity represented as a node in a directed graph where the edges are
  * a particular type of relationship between the source and target nodes.
  */
@@ -107,7 +121,7 @@ export interface HealthcareEntity extends Entity {
    * relationship where the current entity is the source and the entities in
    * the map are the target.
    */
-  relatedEntities: Map<HealthcareEntity, HealthcareEntityRelationType>;
+  relatedEntities: RelatedHealthcareEntity[];
 }
 
 /**
@@ -190,7 +204,7 @@ function makeHealthcareEntitiesWithoutNeighbors(
       links?.map(({ dataSource, id }): EntityDataSource => ({ name: dataSource, entityId: id })) ??
       [],
     // initialize the neighbors map to be filled later.
-    relatedEntities: new Map()
+    relatedEntities: []
   };
 }
 
@@ -214,9 +228,9 @@ function makeHealthcareEntitiesGraph(
     const sourceEntity = entities[sourceIndex];
     const targetEntity = entities[targetIndex];
     if (isHealthcareEntityRelationType(relationType)) {
-      sourceEntity.relatedEntities.set(targetEntity, relationType);
+      sourceEntity.relatedEntities.push({ relatedEntity: targetEntity, relationType });
       if (relation.bidirectional) {
-        targetEntity.relatedEntities.set(sourceEntity, relationType);
+        targetEntity.relatedEntities.push({ relatedEntity: sourceEntity, relationType });
       }
     } else {
       throw new Error(`Unrecognized healthcare entity relation type: ${relationType}`);

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -84,7 +84,8 @@ export {
   AnalyzeHealthcareEntitiesErrorResult,
   HealthcareEntity,
   EntityDataSource,
-  HealthcareEntityRelationType
+  HealthcareEntityRelationType,
+  RelatedHealthcareEntity
 } from "./analyzeHealthcareEntitiesResult";
 export {
   PagedAnalyzeBatchActionsResult,


### PR DESCRIPTION
I was preparing for the text analytics release today and found that I get this error when I compile samples using TS 3.6.5:
```
src/beginAnalyzeHealthcareEntities.ts:50:28 - error TS2569: Type 'Map<HealthcareEntity, HealthcareEntityRelationType>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.

50         for (const edge of entity.relatedEntities) {
```

~I did not expect that the `Map` type is not supported by older TS versions. In this PR, I change the type of `relatedEntities` to be an array of objects instead. This is diverging from other languages which use maps. I am not sure if we should give up on supporting older versions of TS to be consistent with other languages or should we do this? Let me know what do you think.~

EDIT: I investigated this further and Map is supported in ES6 only so thankfully this has nothing to do with the TS version. However, without this change, customers will have to use ES6.