### PR TITLE
[Digital Twins] Fix linting errors in test files

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testComponents.spec.ts
@@ -13,7 +13,7 @@ const MODEL_ID = "dtmi:samples:DTComponentTestsModel;1";
 const COMPONENT_ID = "dtmi:samples:DTComponentTestsComponent;1";
 const DIGITAL_TWIN_ID = "DTComponentTestsTempTwin";
 
-const component = {
+const testComponent = {
   "@id": COMPONENT_ID,
   "@type": "Interface",
   "@context": "dtmi:dtdl:context;2",
@@ -32,7 +32,7 @@ const component = {
   ]
 };
 
-const model = {
+const testModel = {
   "@id": MODEL_ID,
   "@type": "Interface",
   "@context": "dtmi:dtdl:context;2",
@@ -81,7 +81,7 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     await recorder.stop();
   });
 
-  async function deleteModels() {
+  async function deleteModels(): Promise<void> {
     try {
       await client.deleteModel(MODEL_ID);
     } catch (Exception) {}
@@ -91,23 +91,23 @@ describe("DigitalTwins Components - read, update and delete operations", () => {
     } catch (Exception) {}
   }
 
-  async function createModel() {
-    const simpleModels = [component, model];
+  async function createModel(): Promise<void> {
+    const simpleModels = [testComponent, testModel];
     await client.createModels(simpleModels);
   }
 
-  async function setUpModels() {
+  async function setUpModels(): Promise<void> {
     await deleteModels();
     await createModel();
   }
 
-  async function deleteDigitalTwin(digitalTwinId: string) {
+  async function deleteDigitalTwin(digitalTwinId: string): Promise<void> {
     try {
       await client.deleteDigitalTwin(digitalTwinId);
     } catch (Exception) {}
   }
 
-  async function createDigitalTwin(digitalTwinId: string) {
+  async function createDigitalTwin(digitalTwinId: string): Promise<void> {
     await deleteDigitalTwin(digitalTwinId);
     await client.upsertDigitalTwin(digitalTwinId, JSON.stringify(temporary_twin));
   }

--- a/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testDigitalTwins.spec.ts
@@ -49,29 +49,29 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
     await recorder.stop();
   });
 
-  async function deleteModels() {
+  async function deleteModels(): Promise<void> {
     try {
       await client.deleteModel(BUILDING_MODEL_ID);
     } catch (Exception) {}
   }
 
-  async function createModel() {
+  async function createModel(): Promise<void> {
     const simpleModel = [dtdl_model_building];
     await client.createModels(simpleModel);
   }
 
-  async function setUpModels() {
+  async function setUpModels(): Promise<void> {
     await deleteModels();
     await createModel();
   }
 
-  async function deleteDigitalTwin(digitalTwinId: string) {
+  async function deleteDigitalTwin(digitalTwinId: string): Promise<void> {
     try {
       await client.deleteDigitalTwin(digitalTwinId);
     } catch (Exception) {}
   }
 
-  async function deleteDigitalTwins() {
+  async function deleteDigitalTwins(): Promise<void> {
     try {
       const queryResult = client.queryTwins("SELECT * FROM digitaltwins");
       for await (const item of queryResult) {
@@ -865,7 +865,7 @@ describe("DigitalTwins - create, read, update, delete and telemetry operations",
       const query = "SELECT * FROM digitaltwins";
       const queryResult = client.queryTwins(query);
       for await (const item of queryResult) {
-        if (item.$dtId == digitalTwinId) {
+        if (item.$dtId === digitalTwinId) {
           twinFound = true;
           break;
         }

--- a/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testModels.spec.ts
@@ -13,7 +13,7 @@ const should = chai.should();
 const MODEL_ID = "dtmi:samples:DTModelTestsModel;1";
 const COMPONENT_ID = "dtmi:samples:DTModelTestsComponent;1";
 
-const component = {
+const testComponent = {
   "@id": COMPONENT_ID,
   "@type": "Interface",
   "@context": "dtmi:dtdl:context;2",
@@ -32,7 +32,7 @@ const component = {
   ]
 };
 
-const model = {
+const testModel = {
   "@id": MODEL_ID,
   "@type": "Interface",
   "@context": "dtmi:dtdl:context;2",
@@ -70,7 +70,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     await recorder.stop();
   });
 
-  async function deleteModels() {
+  async function deleteModels(): Promise<void> {
     try {
       await client.deleteModel(MODEL_ID);
     } catch (Exception) {}
@@ -80,12 +80,12 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     } catch (Exception) {}
   }
 
-  async function createModel() {
-    const simpleModels = [component, model];
+  async function createModel(): Promise<void> {
+    const simpleModels = [testComponent, testModel];
     await client.createModels(simpleModels);
   }
 
-  async function setUpModels() {
+  async function setUpModels(): Promise<void> {
     await deleteModels();
     await createModel();
   }
@@ -107,14 +107,18 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     await deleteModels();
 
     try {
-      const models = await client.createModels([component, model]);
+      const models = await client.createModels([testComponent, testModel]);
       assert.equal(models.length, 2, "Unexpected result from createModels().");
       assert.equal(
         models[0].id,
-        component["@id"],
+        testComponent["@id"],
         "Unexpected component in result from createModels()."
       );
-      assert.equal(models[1].id, model["@id"], "Unexpected model in result from createModels().");
+      assert.equal(
+        models[1].id,
+        testModel["@id"],
+        "Unexpected model in result from createModels()."
+      );
     } finally {
       await deleteModels();
     }
@@ -125,7 +129,7 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
 
     let errorWasThrown = false;
     try {
-      await client.createModels([component, model]);
+      await client.createModels([testComponent, testModel]);
     } catch (error) {
       errorWasThrown = true;
       assert.include(error.message, `Some of the model ids already exist`);
@@ -217,7 +221,11 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
 
     try {
       const model = await client.getModel(COMPONENT_ID);
-      assert.equal(model.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
     } finally {
       await deleteModels();
     }
@@ -228,7 +236,11 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
 
     try {
       const model = await client.getModel(COMPONENT_ID, true);
-      assert.equal(model.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
     } finally {
       await deleteModels();
     }
@@ -260,10 +272,10 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
       let modelModelFound = false;
       let count = 0;
       for await (const model of models) {
-        if (model.id == COMPONENT_ID) {
+        if (model.id === COMPONENT_ID) {
           componentModelFound = true;
         }
-        if (model.id == MODEL_ID) {
+        if (model.id === MODEL_ID) {
           modelModelFound = true;
         }
         count++;
@@ -286,10 +298,10 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
       let modelModelFound = false;
       let count = 0;
       for await (const model of models) {
-        if (model.id == COMPONENT_ID) {
+        if (model.id === COMPONENT_ID) {
           componentModelFound = true;
         }
-        if (model.id == MODEL_ID) {
+        if (model.id === MODEL_ID) {
           modelModelFound = true;
         }
         count++;
@@ -306,15 +318,23 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     await deleteModels();
 
     try {
-      await client.createModels([component]);
+      await client.createModels([testComponent]);
 
       const model1 = await client.getModel(COMPONENT_ID);
-      assert.equal(model1.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model1.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
       assert.equal(model1.decommissioned, false, "Unexpected result from getModel().");
 
       await client.decomissionModel(COMPONENT_ID);
       const model2 = await client.getModel(COMPONENT_ID);
-      assert.equal(model2.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model2.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
       assert.equal(model2.decommissioned, true, "Unexpected result from getModel().");
     } finally {
       await deleteModels();
@@ -344,20 +364,32 @@ describe("DigitalTwins Models - create, read, list, delete operations", () => {
     await deleteModels();
 
     try {
-      await client.createModels([component]);
+      await client.createModels([testComponent]);
 
       const model1 = await client.getModel(COMPONENT_ID);
-      assert.equal(model1.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model1.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
       assert.equal(model1.decommissioned, false, "Unexpected result from getModel().");
 
       await client.decomissionModel(COMPONENT_ID);
       const model2 = await client.getModel(COMPONENT_ID);
-      assert.equal(model2.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model2.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
       assert.equal(model2.decommissioned, true, "Unexpected result from getModel().");
 
       await client.decomissionModel(COMPONENT_ID);
       const model3 = await client.getModel(COMPONENT_ID);
-      assert.equal(model3.id, component["@id"], "Unexpected component in result from getModel().");
+      assert.equal(
+        model3.id,
+        testComponent["@id"],
+        "Unexpected component in result from getModel()."
+      );
       assert.equal(model3.decommissioned, true, "Unexpected result from getModel().");
     } finally {
       await deleteModels();

--- a/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/public/testRelationships.spec.ts
@@ -94,7 +94,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await recorder.stop();
   });
 
-  async function deleteModels() {
+  async function deleteModels(): Promise<void> {
     try {
       await client.deleteModel(BUILDING_MODEL_ID);
     } catch (Exception) {}
@@ -108,17 +108,17 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     } catch (Exception) {}
   }
 
-  async function createModel() {
+  async function createModel(): Promise<void> {
     const simpleModels = [dtdl_model_building, dtdl_model_floor, dtdl_model_room];
     await client.createModels(simpleModels);
   }
 
-  async function setUpModels() {
+  async function setUpModels(): Promise<void> {
     await deleteModels();
     await createModel();
   }
 
-  async function deleteDigitalTwins() {
+  async function deleteDigitalTwins(): Promise<void> {
     try {
       await client.deleteDigitalTwin(BUILDING_DIGITAL_TWIN_ID);
     } catch (Exception) {}
@@ -130,7 +130,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     } catch (Exception) {}
   }
 
-  async function createDigitalTwins() {
+  async function createDigitalTwins(): Promise<void> {
     const buildingTwin = {
       $metadata: {
         $model: BUILDING_MODEL_ID
@@ -157,7 +157,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
     await client.upsertDigitalTwin(ROOM_DIGITAL_TWIN_ID, JSON.stringify(roomTwin));
   }
 
-  async function setUpDigitalTwins() {
+  async function setUpDigitalTwins(): Promise<void> {
     await deleteDigitalTwins();
     await createDigitalTwins();
   }
@@ -1024,7 +1024,7 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
         errorWasThrown = true;
         assert.include(
           error.message,
-          `The target location specified by path segment \'isAccessDoorRestricted\' was not found`
+          `The target location specified by path segment 'isAccessDoorRestricted' was not found`
         );
         should.equal(errorWasThrown, true, "Error was not thrown");
       }
@@ -1219,8 +1219,8 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       let relationshipFound = false;
       let count = 0;
       const relationships = client.listRelationships(BUILDING_DIGITAL_TWIN_ID);
-      for await (const relationship of relationships) {
-        if (relationship.$relationshipId == relationshipId) {
+      for await (const relationshipFromList of relationships) {
+        if (relationshipFromList.$relationshipId === relationshipId) {
           relationshipFound = true;
         }
         count++;
@@ -1278,13 +1278,13 @@ describe("DigitalTwins Relationships - create, read, list, delete operations", (
       let relationshipFound = false;
       let count = 0;
       const relationships = client.listIncomingRelationships(BUILDING_DIGITAL_TWIN_ID);
-      for await (const relationship of relationships) {
-        if (relationship.relationshipId == relationshipId) {
+      for await (const relationshipFromList of relationships) {
+        if (relationshipFromList.relationshipId === relationshipId) {
           relationshipFound = true;
         }
         count++;
       }
-      assert.equal(count == 0, true, "Unexpected count result from listRelationships().");
+      assert.equal(count === 0, true, "Unexpected count result from listRelationships().");
       assert.equal(relationshipFound, false, "Unexpected result from listRelationships().");
     } finally {
       try {

--- a/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
+++ b/sdk/digitaltwins/digital-twins-core/test/utils/testAuthentication.ts
@@ -7,7 +7,7 @@ import { env, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorde
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 
-export async function authenticate(that: any): Promise<any> {
+export async function authenticate(that: Mocha.Context): Promise<any> {
   const keySuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {


### PR DESCRIPTION
This brings down the linter errors in the digital twins package from 84 to 42, mainly focusing on the below kinds
- variable shadowing
- functions with no return types
- == vs ===
Related to #13733