### PR TITLE
[core-https] Remove unused parameter

### DIFF
--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -137,7 +137,6 @@ export interface Pipeline {
 
 // @public
 export interface PipelineOptions {
-    httpsClient?: HttpsClient;
     proxyOptions?: ProxySettings;
     redirectOptions?: RedirectPolicyOptions;
     retryOptions?: ExponentialRetryPolicyOptions;

--- a/sdk/core/core-https/src/pipeline.ts
+++ b/sdk/core/core-https/src/pipeline.ts
@@ -398,12 +398,6 @@ export function createEmptyPipeline(): Pipeline {
  */
 export interface PipelineOptions {
   /**
-   * The HttpsClient implementation to use for outgoing HTTP requests.
-   * Defaults to DefaultHttpsClient.
-   */
-  httpsClient?: HttpsClient;
-
-  /**
    * Options that control how to retry failed requests.
    */
   retryOptions?: ExponentialRetryPolicyOptions;


### PR DESCRIPTION
@deyaaeldeen pointed out that `httpsClient` doesn't get used in `PipelineOptions` today, since Pipelines are not strongly coupled to their `HttpsClient` (sendRequest takes it as an argument instead.)

This is great, but does clutter our story slightly for using `PipelineOptions` as the base of what client packages extend for providing additional convenience parameters. You can still absolutely pass a custom `httpsClient`, but that is now exclusively done through `ServiceClientOptions`.

I think this is one of those weird places where we did things two different ways previously. Thoughts? 