### PR TITLE
[Event Hubs] Fix remaining TSDoc linting errors

### DIFF
--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -10,7 +10,6 @@ import { isObjectWithProperties } from "./util/typeGuards";
 /**
  * The default data transformer that will be used by the Azure SDK.
  * @internal
- * @ingore
  */
 export const defaultDataTransformer = {
   /**

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -226,6 +226,7 @@ export function toRheaMessage(data: EventData, partitionKey?: string): RheaMessa
  *       propertyName: "property value"
  *    }
  * }
+ * ```
  */
 export interface EventData {
   /**

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -91,7 +91,7 @@ export interface EventDataBatch {
    * The maximum size of the batch, in bytes. The `tryAdd` function on the batch will return `false`
    * if the event being added causes the size of the batch to exceed this limit. Use the `createBatch()` method on
    * the `EventHubProducerClient` to set the maxSizeInBytes.
-   * @readonly.
+   * @readonly
    */
   readonly maxSizeInBytes: number;
 

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -420,7 +420,7 @@ export class EventHubConsumerClient {
    * @param options - Configures the way events are received.
    * Most common are `maxBatchSize` and `maxWaitTimeInSeconds` that control the flow of
    * events to the handler provided to receive events as well as the start position. For example,
-   * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }
+   * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }`
    */
   subscribe(handlers: SubscriptionEventHandlers, options?: SubscribeOptions): Subscription; // #1
   /**
@@ -447,7 +447,7 @@ export class EventHubConsumerClient {
    * @param options - Configures the way events are received.
    * Most common are `maxBatchSize` and `maxWaitTimeInSeconds` that control the flow of
    * events to the handler provided to receive events as well as the start position. For example,
-   * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }
+   * `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }`
    */
 
   subscribe(

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -162,7 +162,7 @@ export interface SubscriptionEventHandlers {
 
 /**
  * Options to configure the `subscribe` method on the `EventHubConsumerClient`.
- * For example, `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }
+ * For example, `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }`
  */
 export interface SubscribeOptions {
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -658,7 +658,6 @@ export class EventHubReceiver extends LinkEntity {
    * @param abortSignal - An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
-   * @returns Promise<ReceivedEventData[]>.
    * @throws AbortError if the operation is cancelled via the abortSignal.
    * @throws MessagingError if an error is encountered while receiving a message.
    * @throws Error if the underlying connection or receiver has been closed.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -598,7 +598,6 @@ export class EventHubSender extends LinkEntity {
    * Creates a new sender to the given event hub, and optionally to a given partition if it is
    * not present in the context or returns the one present in the context.
    * @hidden
-   * @static
    * @param partitionId - Partition ID to which it will send event data.
    */
   static create(context: ConnectionContext, partitionId?: string): EventHubSender {

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -5,7 +5,7 @@ import { createClientLogger } from "@azure/logger";
 import { isObjectWithProperties } from "./util/typeGuards";
 
 /**
- * The @azure/logger configuration for this package.
+ * The `@azure/logger` configuration for this package.
  * This will output logs using the `azure:event-hubs` namespace prefix.
  */
 export const logger = createClientLogger("event-hubs");

--- a/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
+++ b/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
@@ -9,8 +9,8 @@ import { parseConnectionString } from "@azure/core-amqp";
 export interface EventHubConnectionStringProperties {
   /**
    * The fully qualified Event Hub namespace extracted from the "Endpoint" in the
-   * connection string. This is likely to be similar to "{yournamespace}.servicebus.windows.net".
-   * This is typically used to construct the EventHub{Producer|Consumer}Client.
+   * connection string. This is likely to be similar to "\{yournamespace\}.servicebus.windows.net".
+   * This is typically used to construct an EventHubProducerClient or an EventHubConsumerClient.
    */
   fullyQualifiedNamespace: string;
   /**
@@ -45,7 +45,7 @@ export interface EventHubConnectionStringProperties {
 
 /**
  * Parses given connection string into the different properties applicable to Azure Event Hubs.
- * The properties are useful to then construct an EventHub{Producer|Consumer}Client.
+ * The properties are useful to then construct an EventHubProducerClient or an EventHubConsumerClient.
  * @param connectionString - The connection string associated with the Shared Access Policy created
  * for the Event Hubs namespace.
  */

--- a/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
+++ b/sdk/eventhub/event-hubs/src/util/connectionStringUtils.ts
@@ -9,7 +9,7 @@ import { parseConnectionString } from "@azure/core-amqp";
 export interface EventHubConnectionStringProperties {
   /**
    * The fully qualified Event Hub namespace extracted from the "Endpoint" in the
-   * connection string. This is likely to be similar to "\{yournamespace\}.servicebus.windows.net".
+   * connection string. This is likely to be similar to `{yournamespace}.servicebus.windows.net`.
    * This is typically used to construct an EventHubProducerClient or an EventHubConsumerClient.
    */
   fullyQualifiedNamespace: string;


### PR DESCRIPTION
This PR fixes the remaining TSDoc related linting errors in Event Hubs, thereby reducing the number of total linter problems from 70 to 38. Related to #12953 and #10777

@chradek Of the 38, errors are 18 and warnings are 20. Handing over the rest to your capable hands!