### PR TITLE
Added @azure/template to its own samples' dependencies.

### DIFF
--- a/sdk/template/template/samples/javascript/package.json
+++ b/sdk/template/template/samples/javascript/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template",
   "sideEffects": false,
   "dependencies": {
+    "@azure/template": "dev",
     "@azure/identity": "latest",
     "dotenv": "^8.2.0"
   }

--- a/sdk/template/template/samples/typescript/package.json
+++ b/sdk/template/template/samples/typescript/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template",
   "sideEffects": false,
   "dependencies": {
+    "@azure/template": "dev",
     "@azure/identity": "latest",
     "dotenv": "^8.2.0"
   },


### PR DESCRIPTION
This should help resolve the issues we're seeing with Smoke Tests. There's some magic there that only installs packages that are listed as a dependency somewhere in a package.json, and I had forgotten to add those here.

We'll also need to publish a new dev version of @azure/template, which I'll do manually once this is merged and then set up a nightly cycle for it (CC @mikeharder).