### PR TITLE
[Service Bus] Fix return tag to follow TSDoc

### DIFF
--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -547,7 +547,7 @@ export namespace ConnectionContext {
    * Once closed,
    * - the clients created by this ServiceBusClient cannot be used to send/receive messages anymore.
    * - this ServiceBusClient cannot be used to create any new queues/topics/subscriptions clients.
-   * @returns {Promise<any>}
+   *
    */
   export async function close(context: ConnectionContext): Promise<void> {
     const logPrefix = `[${context.connectionId}]`;

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -547,7 +547,6 @@ export namespace ConnectionContext {
    * Once closed,
    * - the clients created by this ServiceBusClient cannot be used to send/receive messages anymore.
    * - this ServiceBusClient cannot be used to create any new queues/topics/subscriptions clients.
-   *
    */
   export async function close(context: ConnectionContext): Promise<void> {
     const logPrefix = `[${context.connectionId}]`;

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -78,7 +78,6 @@ export class BatchingReceiver extends MessageReceiver {
   /**
    * To be called when connection is disconnected to gracefully close ongoing receive request.
    * @param connectionError - The connection error if any.
-   * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(connectionError?: AmqpError | Error): Promise<void> {
     await this.closeLink();
@@ -100,7 +99,7 @@ export class BatchingReceiver extends MessageReceiver {
    * @param maxTimeAfterFirstMessageInMs - The total amount of time to wait after the first message
    * has been received. Defaults to 1 second.
    * If this time elapses before the `maxMessageCount` is reached, then messages collected till then will be returned to the user.
-   * @returns {Promise<ServiceBusMessageImpl[]>} A promise that resolves with an array of Message objects.
+   * @returns A promise that resolves with an array of Message objects.
    */
   async receive(
     maxMessageCount: number,

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -186,7 +186,6 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Determines whether the AMQP link is open. If open then returns true else returns false.
-   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this._link ? this._link.isOpen() : false;
@@ -365,7 +364,6 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   /**
    * Negotiates the cbs claim for the ClientEntity.
    * @param setTokenRenewal - Set the token renewal timer. Default false.
-   * @returns Promise<void>
    */
   private async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {
     this._logger.verbose(`${this._logPrefix} negotiateclaim() has been called`);
@@ -468,7 +466,6 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
   /**
    * Ensures that the token is renewed within the predefined renewal margin.
-   * @returns {void}
    */
   private _ensureTokenRenewal(): void {
     if (!this._tokenTimeout) {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -349,7 +349,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Closes the AMQP management session to the ServiceBus namespace for this client,
    * returning a promise that will be resolved when disconnection is completed.
-   * @returns Promise<void>
    */
   async close(): Promise<void> {
     try {
@@ -380,7 +379,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * also fetch even Deferred messages (but not Deadlettered message).
    *
    * @param messageCount - The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedSBMessage[]>
    */
   async peek(
     messageCount: number,
@@ -406,7 +404,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param sessionId - The sessionId from which messages need to be peeked.
    * @param messageCount - The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedMessageInfo[]>
    */
   async peekMessagesBySession(
     sessionId: string,
@@ -428,7 +425,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param fromSequenceNumber - The sequence number from where to read the message.
    * @param messageCount - The number of messages to retrieve. Default value `1`.
    * @param sessionId - The sessionId from which messages need to be peeked.
-   * @returns Promise<ReceivedMessageInfo[]>
    */
   async peekBySequenceNumber(
     fromSequenceNumber: Long,
@@ -527,7 +523,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param lockToken - Lock token of the message
    * @param options - Options that can be set while sending the request.
-   * @returns Promise<Date> New lock token expiry date and time in UTC format.
+   * @returns New lock token expiry date and time in UTC format.
    */
   async renewLock(lockToken: string, options?: SendManagementRequestOptions): Promise<Date> {
     throwErrorIfConnectionClosed(this._context);
@@ -579,7 +575,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
    * @param messages - An array of messages that needs to be scheduled.
-   * @returns Promise<number> The sequence numbers of messages that were scheduled.
+   * @returns The sequence numbers of messages that were scheduled.
    */
   async scheduleMessages(
     scheduledEnqueueTimeUtc: Date,
@@ -672,7 +668,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   /**
    * Cancels an array of messages that were scheduled.
    * @param sequenceNumbers - An Array of sequence numbers of the message to be cancelled.
-   * @returns Promise<void>
    */
   async cancelScheduledMessages(
     sequenceNumbers: Long[],
@@ -739,9 +734,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param sequenceNumbers - A list containing the sequence numbers to receive.
    * @param receiveMode - The mode in which the receiver was created.
-   * @returns Promise<ServiceBusMessage[]>
-   * - Returns a list of messages identified by the given sequenceNumbers.
-   * - Returns an empty list if no messages are found.
+   * @returns a list of messages identified by the given sequenceNumbers or an empty list if no messages are found.
    * - Throws an error if the messages have not been deferred.
    */
   async receiveDeferredMessages(
@@ -833,8 +826,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param lockTokens - Message lock tokens to update disposition status.
    * @param dispositionStatus - The disposition status to be set
    * @param options - Optional parameters that can be provided while updating the disposition status.
-   *
-   * @returns Promise<void>
    */
   async updateDispositionStatus(
     lockToken: string,
@@ -901,7 +892,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param sessionId - Id of the session for which the lock needs to be renewed
    * @param options - Options that can be set while sending the request.
-   * @returns Promise<Date> New lock token expiry date and time in UTC format.
+   * @returns New lock token expiry date and time in UTC format.
    */
   async renewSessionLock(
     sessionId: string,
@@ -951,7 +942,6 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    *
    * @param sessionId - The session for which the state needs to be set
    * @param state - The state that needs to be set.
-   * @returns Promise<void>
    */
   async setSessionState(
     sessionId: string,
@@ -995,7 +985,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * Gets the state of the specified session.
    *
    * @param sessionId - The session for which the state needs to be retrieved.
-   * @returns Promise<any> The state of that session
+   * @returns The state of that session
    */
   async getSessionState(
     sessionId: string,
@@ -1040,7 +1030,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * @param lastUpdateTime - Filter to include only sessions updated after a given time.
    * @param skip - The number of sessions to skip
    * @param top - Maximum numer of sessions.
-   * @returns Promise<string[]> A list of session ids.
+   * @returns A list of session ids.
    */
   async listMessageSessions(
     skip: number,
@@ -1095,7 +1085,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
 
   /**
    * Get all the rules on the Subscription.
-   * @returns Promise<RuleDescription[]> A list of rules.
+   * @returns A list of rules.
    */
   async getRules(
     options?: OperationOptionsBase & SendManagementRequestOptions

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -158,7 +158,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    *
    * @param encodedMessage - The encoded message to be sent to ServiceBus.
    * @param sendBatch - Boolean indicating whether the encoded message represents a batch of messages or not
-   * @returns Promise<Delivery>
    */
   private _trySend(
     encodedMessage: Buffer,
@@ -320,7 +319,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
   /**
    * Closes the rhea link.
    * To be called when connection is disconnected, onAmqpClose and onSessionClose events.
-   * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(): Promise<void> {
     // Clears the token renewal timer. Closes the link and its session if they are open.
@@ -330,7 +328,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
 
   /**
    * Determines whether the AMQP sender link is open. If open then returns true else returns false.
-   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this.link == null ? false : this.link.isOpen();
@@ -348,7 +345,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * Sends the given message, with the given options on this link
    *
    * @param data - Message to send. Will be sent as UTF8-encoded JSON string.
-   * @returns {Promise<void>}
    */
   async send(data: ServiceBusMessage, options?: OperationOptionsBase): Promise<void> {
     throwErrorIfConnectionClosed(this._context);
@@ -390,7 +386,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    * of the envelope (batch message).
    * @param inputMessages - An array of Message objects to be sent in a
    * Batch message.
-   * @returns {Promise<void>}
    */
   async sendMessages(
     inputMessages: ServiceBusMessage[],
@@ -476,7 +471,6 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
    *     retryOptions: { maxRetries: 5; timeoutInMs: 10 }
    * }
    * ```
-   * @returns {Promise<number>}
    */
   async getMaxMessageSize(
     options: {

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -448,7 +448,6 @@ export class StreamingReceiver extends MessageReceiver {
   /**
    * Will reconnect the receiver link if necessary.
    * @param receiverError - The receiver error or connection error, if any.
-   * @returns {Promise<void>} Promise<void>.
    */
   async onDetached(receiverError?: AmqpError | Error): Promise<void> {
     logger.verbose(`${this.logPrefix} onDetached: reinitializing link.`);

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -87,7 +87,7 @@ export interface ServiceBusReceiver {
    * @param options - A set of options to control the receive operation.
    * - `maxWaitTimeInMs`: The maximum time to wait for the first message before returning an empty array if no messages are available.
    * - `abortSignal`: The signal to use to abort the ongoing operation.
-   * @returns Promise<ServiceBusReceivedMessage[]> A promise that resolves with an array of messages.
+   * @returns A promise that resolves with an array of messages.
    * @throws Error if the underlying connection, client or receiver is closed.
    * @throws Error if current receiver is already in state of receiving messages.
    * @throws `ServiceBusError` if the service returns an error while receiving messages.
@@ -101,9 +101,7 @@ export interface ServiceBusReceiver {
    * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
    * @param sequenceNumbers - The sequence number or an array of sequence numbers for the messages that need to be received.
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns {Promise<ServiceBusMessage[]>}
-   * - Returns a list of messages identified by the given sequenceNumbers.
-   * - Returns an empty list if no messages are found.
+   * @returns A list of messages identified by the given sequenceNumbers or an empty list if no messages are found.
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while receiving deferred messages.
    */
@@ -164,8 +162,6 @@ export interface ServiceBusReceiver {
    * in this mode.
    * @throws Error with name `ServiceUnavailableError` if Service Bus does not acknowledge the request to settle
    * the message in time. The message may or may not have been settled successfully.
-   *
-   * @returns Promise<void>.
    */
   completeMessage(message: ServiceBusReceivedMessage): Promise<void>;
   /**
@@ -189,8 +185,6 @@ export interface ServiceBusReceiver {
    * the message in time. The message may or may not have been settled successfully.
    *
    * @param propertiesToModify - The properties of the message to modify while abandoning the message.
-   *
-   * @returns Promise<void>.
    */
   abandonMessage(
     message: ServiceBusReceivedMessage,
@@ -217,8 +211,6 @@ export interface ServiceBusReceiver {
    * the message in time. The message may or may not have been settled successfully.
    *
    * @param propertiesToModify - The properties of the message to modify while deferring the message
-   *
-   * @returns Promise<void>
    */
   deferMessage(
     message: ServiceBusReceivedMessage,
@@ -246,8 +238,6 @@ export interface ServiceBusReceiver {
    *
    * @param options - The DeadLetter options that can be provided while
    * rejecting the message.
-   *
-   * @returns Promise<void>
    */
   deadLetterMessage(
     message: ServiceBusReceivedMessage,
@@ -261,7 +251,7 @@ export interface ServiceBusReceiver {
    * before its lock expires, then the message lands back in the Queue/Subscription for the next
    * receive operation.
    *
-   * @returns Promise<Date> - New lock token expiry date and time in UTC format.
+   * @returns New lock token expiry date and time in UTC format.
    * @throws Error if the underlying connection, client or receiver is closed.
    * @throws ServiceBusError if the service returns an error while renewing message lock.
    */
@@ -354,7 +344,6 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
    * be concurrently processed. You can also provide a timeout in milliseconds to denote the
    * amount of time to wait for a new message before closing the receiver.
    *
-   * @returns void
    * @throws Error if the underlying connection or receiver is closed.
    * @throws Error if current receiver is already in state of receiving messages.
    * @throws ServiceBusError if the service returns an error while receiving messages. These are bubbled up to be handled by user provided `onError` handler.

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -89,7 +89,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * Gets the state of the Session. For more on session states, see
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns {Promise<any>} The state of that session
+   * @returns The state of that session
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while retrieving session state.
    */
@@ -103,7 +103,6 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while setting the session state.
    *
-   * @returns {Promise<void>}
    */
   setSessionState(state: any, options?: OperationOptionsBase): Promise<void>;
 }
@@ -204,7 +203,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * will land back in the Queue/Subscription with their delivery count incremented.
    *
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns Promise<Date> - New lock token expiry date and time in UTC format.
+   * @returns New lock token expiry date and time in UTC format.
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while renewing session lock.
    */
@@ -267,7 +266,7 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * Gets the state of the Session. For more on session states, see
    * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns Promise<any> The state of that session
+   * @returns The state of that session
    * @throws Error if the underlying connection or receiver is closed.
    * @throws `ServiceBusError` if the service returns an error while retrieving session state.
    */
@@ -461,7 +460,6 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
    * also provide a timeout in milliseconds to denote the amount of time to wait for a new message
    * before closing the receiver.
    *
-   * @returns void
    * @throws Error if the underlying connection or receiver is closed.
    * @throws Error if the receiver is already in state of receiving messages.
    * @throws `ServiceBusError` if the service returns an error while receiving messages. These are bubbled up to be handled by user provided `onError` handler.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -42,7 +42,6 @@ export interface ServiceBusSender {
    * @param messages - A single message or an array of messages or a batch of messages created via the createBatch()
    * method to send.
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns Promise<void>
    * @throws `ServiceBusError` with the code `MessageSizeExceeded` if the provided messages do not fit in a single `ServiceBusMessageBatch`.
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws `ServiceBusError` if the service returns an error while sending messages to the service.
@@ -58,7 +57,6 @@ export interface ServiceBusSender {
    * @param options - Configures the behavior of the batch.
    * - `maxSizeInBytes`: The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
    *
-   * @returns {Promise<ServiceBusMessageBatch>}
    * @throws `ServiceBusError` if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.
    */
@@ -88,7 +86,7 @@ export interface ServiceBusSender {
    * @param messages - Message or an array of messages that need to be scheduled.
    * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled.
+   * @returns The sequence numbers of messages that were scheduled.
    * You will need the sequence number if you intend to cancel the scheduling of the messages.
    * Save the `Long` type as-is in your application without converting to number. Since JavaScript
    * only supports 53 bit numbers, converting the `Long` to number will cause loss in precision.
@@ -105,7 +103,6 @@ export interface ServiceBusSender {
    * Cancels multiple messages that were scheduled to appear on a ServiceBus Queue/Subscription.
    * @param sequenceNumbers - Sequence number or an array of sequence numbers of the messages to be cancelled.
    * @param options - Options bag to pass an abort signal or tracing options.
-   * @returns Promise<void>
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws `ServiceBusError` if the service returns an error while canceling scheduled messages.
    */
@@ -122,7 +119,6 @@ export interface ServiceBusSender {
    * Once closed, the sender cannot be used for any further operations.
    * Use the `createSender` function on the QueueClient or TopicClient to instantiate a new Sender
    *
-   * @returns {Promise<void>}
    */
   close(): Promise<void>;
 }

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -450,10 +450,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     QueueProperties,
-   *     EntitiesResponse<QueueProperties>,
-   *   >} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listQueues(
     options?: OperationOptions
@@ -556,10 +553,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the queues in pages.
    *
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     QueueRuntimeProperties,
-   *     EntitiesResponse<QueueRuntimeProperties>,
-   *   >} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listQueuesRuntimeProperties(
     options?: OperationOptions
@@ -932,10 +926,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list the topics in pages.
    *
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     TopicProperties,
-   *     EntitiesResponse<TopicProperties>,
-   *   >} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listTopics(
     options?: OperationOptions
@@ -1038,11 +1029,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    * .byPage() returns an async iterable iterator to list runtime info of the topics in pages.
    *
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     TopicRuntimeProperties,
-   *     EntitiesResponse<TopicRuntimeProperties>,
-
-   *   >} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listTopicsRuntimeProperties(
     options?: OperationOptions
@@ -1433,10 +1420,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the subscriptions in pages.
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     SubscriptionProperties,
-   *     EntitiesResponse<SubscriptionProperties>
-   *   >} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listSubscriptions(
     topicName: string,
@@ -1550,11 +1534,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list runtime info of subscriptions in pages.
    *
-   * @returns {PagedAsyncIterableIterator<
-   *     SubscriptionRuntimeProperties,
-   *     EntitiesResponse<SubscriptionRuntimeProperties>,
-
-   *   >}  An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listSubscriptionsRuntimeProperties(
     topicName: string,
@@ -1959,7 +1939,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
    *
    * .byPage() returns an async iterable iterator to list the rules in pages.
    *
-   * @returns {PagedAsyncIterableIterator<RuleProperties, EntitiesResponse<RuleProperties>>} An asyncIterableIterator that supports paging.
+   * @returns An asyncIterableIterator that supports paging.
    */
   public listRules(
     topicName: string,

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -165,7 +165,6 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * @param annotations - The message annotations to set on the batch.
    * @param applicationProperties - The application properties to set on the batch.
    * @param messageProperties - The message properties to set on the batch.
-   * @returns {Buffer}
    */
   private _generateBatch(
     encodedMessages: Buffer[],

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -581,8 +581,6 @@ export class MessageSession extends LinkEntity<Receiver> {
    * @param options - Options to control whether messages should be automatically completed. You can
    * also provide a timeout in milliseconds to denote the amount of time to wait for a new message
    * before closing the receiver.
-   *
-   * @returns void
    */
   subscribe(onMessage: OnMessage, onError: OnError, options: SubscribeOptions): void {
     if (!options) options = {};
@@ -742,7 +740,7 @@ export class MessageSession extends LinkEntity<Receiver> {
    * @param maxMessageCount - The maximum number of messages to receive from Queue/Subscription.
    * @param maxWaitTimeInMs - The total wait time in milliseconds until which the receiver will attempt to receive specified number of messages.
    * If this time elapses before the `maxMessageCount` is reached, then messages collected till then will be returned to the user.
-   * @returns Promise<ServiceBusMessage[]> A promise that resolves with an array of Message objects.
+   * @returns A promise that resolves with an array of Message objects.
    */
   async receiveMessages(
     maxMessageCount: number,

--- a/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
+++ b/sdk/servicebus/service-bus/src/util/atomXmlHelper.ts
@@ -299,7 +299,6 @@ function parseFeedResult(feed: any): object[] & { nextLink?: string } {
 
 /**
  * @internal
- * @returns {statusCode is keyof typeof Constants.HttpResponseCodes}
  */
 function isKnownResponseCode(
   statusCode: number

--- a/sdk/servicebus/service-bus/src/util/crypto.browser.ts
+++ b/sdk/servicebus/service-bus/src/util/crypto.browser.ts
@@ -6,7 +6,6 @@
 
 /**
  * @internal
- * @returns {Promise<string>}
  */
 export async function generateKey(secret: string, stringToSign: string): Promise<string> {
   const key = await window.crypto.subtle.importKey(
@@ -41,7 +40,7 @@ function convertToUint8Array(value: string): Uint8Array {
  * Encodes a byte array in base64 format.
  * @param value - the Uint8Aray to encode
  * @internal
- * @returns {string}
+ *
  */
 function encodeByteArray(value: Uint8Array): string {
   let str = "";

--- a/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
+++ b/sdk/servicebus/service-bus/src/util/sasServiceClientCredentials.ts
@@ -38,7 +38,7 @@ export class SasServiceClientCredentials implements ServiceClientCredentials {
    * Signs a request with the Authentication header.
    *
    * @param webResource - The WebResource to be signed.
-   * @returns {Promise<WebResource>} The signed request object.
+   * @returns The signed request object.
    */
   async signRequest(webResource: WebResource): Promise<WebResource> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -42,7 +42,7 @@ export function getUniqueName(name: string): string {
  * different byte order. This is the order of bytes needed to make Service Bus recognize the token.
  *
  * @param lockToken - The lock token whose bytes need to be reorded.
- * @returns Buffer - Buffer representing reordered bytes.
+ * @returns Buffer representing reordered bytes.
  */
 export function reorderLockToken(lockTokenBytes: Buffer): Buffer {
   if (!lockTokenBytes || !Buffer.isBuffer(lockTokenBytes)) {
@@ -106,7 +106,7 @@ export function calculateRenewAfterDuration(lockedUntilUtc: Date): number {
  *   - Thus, we `divide` the value by `10000` to convert it to JS Date ticks.
  *
  * @param buf - Input as a Buffer
- * @returns Date The JS Date object.
+ * @returns The JS Date object.
  */
 export function convertTicksToDate(buf: number[]): Date {
   const epochMicroDiff: number = 621355968000000000;
@@ -543,7 +543,6 @@ export const StandardAbortMessage = "The operation was aborted.";
  * @param abortSignal - The abortSignal associated with containing operation.
  * @param abortErrorMsg - The abort error message associated with containing operation.
  * @param value - The value to be resolved with after a timeout of t milliseconds.
- * @returns {Promise<T>} - Resolved promise
  *
  * @internal
  */
@@ -632,8 +631,6 @@ export const libInfo: string = `azsdk-js-azureservicebus/${Constants.packageJson
 /**
  * @internal
  * Returns the formatted prefix by removing the spaces, by appending the libInfo.
- *
- * @returns {string}
  */
 export function formatUserAgentPrefix(prefix?: string): string {
   let userAgentPrefix = `${(prefix || "").replace(" ", "")}`;
@@ -644,7 +641,6 @@ export function formatUserAgentPrefix(prefix?: string): string {
 /**
  * @internal
  * Helper method which returns `HttpResponse` from an object of shape `HttpOperationResponse`.
- * @returns {HttpResponse}
  */
 export const getHttpResponseOnly = ({
   request,

--- a/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
@@ -178,8 +178,6 @@ export async function recreateSubscription(
 
 /**
  * Utility that verifies the message count of an entity.
- *
- * @returns {Promise<void>}
  */
 export async function verifyMessageCount(
   expectedMessageCount: number,


### PR DESCRIPTION
This PR fixes over 90 linter errors around the `@returns` tag in Service Bus. Related to #10781

- Remove the type info in the `@returns` tag as this is redundant. TS tooling can figure out the typing info without needing us to have it add it here
- Remove the entire tag if it was not adding any information other than the type