### PR TITLE
Remove canary check for OpenTelemetry versions

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
@@ -1,6 +1,6 @@
 const execa = require("execa");
 
-const versions = ["latest", "canary"];
+const versions = ["latest"];
 
 const packageJson = require("./package.json");
 const packages = [


### PR DESCRIPTION
OT API keeps getting breaking changes, remoting canary check until OT code is stable, this is causing build issues

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=731707&view=results