### PR TITLE
[Text Analytics] Minor refactorings and fix tags

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -538,9 +538,6 @@ export interface TextAnalyticsOperationOptions extends OperationOptions {
 export type TextAnalyticsOperationStatus = "notStarted" | "running" | "succeeded" | "failed" | "rejected" | "cancelled" | "cancelling" | "partiallyCompleted" | "partiallySucceeded";
 
 // @public
-export type TextAnalyticsResult = TextAnalyticsSuccessResult | TextAnalyticsErrorResult;
-
-// @public
 export interface TextAnalyticsSuccessResult {
     readonly error?: undefined;
     readonly id: string;

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -326,10 +326,7 @@ function makeRecognizeCategorizedEntitiesActionResult(
     if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
       const recognizeEntitiesResults = makeRecognizeCategorizedEntitiesResultArray(
         documents,
-        actionResults?.documents,
-        actionResults?.errors,
-        actionResults?.modelVersion,
-        actionResults?.statistics
+        actionResults
       );
       return [
         ...actions,
@@ -403,13 +400,7 @@ function makeExtractKeyPhrasesActionResult(
   ): ExtractKeyPhrasesActionSuccessResult[] {
     const { results: actionResults, lastUpdateDateTime } = task;
     if (actionResults.documents.length !== 0 || actionResults.errors.length !== 0) {
-      const extractKeyPhrasesResults = makeExtractKeyPhrasesResultArray(
-        documents,
-        actionResults?.documents,
-        actionResults?.errors,
-        actionResults?.modelVersion,
-        actionResults?.statistics
-      );
+      const extractKeyPhrasesResults = makeExtractKeyPhrasesResultArray(documents, actionResults);
       return [
         ...actions,
         {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
@@ -7,9 +7,11 @@ import {
   Entity,
   HealthcareRelation,
   TextDocumentBatchStatistics,
-  HealthcareEntity as GeneratedHealthcareEntity
+  HealthcareEntity as GeneratedHealthcareEntity,
+  TextAnalyticsError
 } from "./generated/models";
 import {
+  makeTextAnalyticsErrorResult,
   makeTextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
   TextAnalyticsSuccessResult
@@ -44,7 +46,6 @@ export type HealthcareEntityRelationType =
  * a type predicate for the healthcare entity relation type
  * @param relation - a healthcare entity relation type
  * @internal
- * @hidden
  */
 function isHealthcareEntityRelationType(
   relation: string
@@ -172,7 +173,6 @@ export interface PagedAnalyzeHealthcareEntitiesResult
  * Creates a user-friendly healthcare entity represented as a node in a graph
  * @param entity - the healthcare entity returned by the service
  * @internal
- * @hidden
  */
 function makeHealthcareEntitiesWithoutNeighbors(
   entity: GeneratedHealthcareEntity
@@ -201,7 +201,6 @@ function makeHealthcareEntitiesWithoutNeighbors(
  * @param relations - relationship information between pairs of healthcare entities
  *                  - using JSON pointers
  * @internal
- * @hidden
  */
 function makeHealthcareEntitiesGraph(
   entities: HealthcareEntity[],
@@ -228,7 +227,6 @@ function makeHealthcareEntitiesGraph(
  * Creates a healthcare entity in the convenience layer from the one sent by the service.
  * @param document - incoming results sent by the service for a particular document
  * @internal
- * @hidden
  */
 export function makeHealthcareEntitiesResult(
   document: DocumentHealthcareEntities
@@ -240,4 +238,14 @@ export function makeHealthcareEntitiesResult(
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     entities: newEntities
   };
+}
+
+/**
+ * @internal
+ */
+export function makeHealthcareEntitiesErrorResult(
+  id: string,
+  error: TextAnalyticsError
+): AnalyzeHealthcareEntitiesErrorResult {
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -140,8 +140,12 @@ export interface MinedOpinion {
  */
 export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult;
 
+/**
+ * @param document - A document result coming from the service.
+ * @internal
+ */
 export function makeAnalyzeSentimentResult(
-  document: DocumentSentiment
+  result: DocumentSentiment
 ): AnalyzeSentimentSuccessResult {
   const {
     id,
@@ -150,15 +154,18 @@ export function makeAnalyzeSentimentResult(
     sentenceSentiments: sentences,
     warnings,
     statistics
-  } = document;
+  } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     sentiment,
     confidenceScores,
-    sentences: sentences.map((sentence) => convertGeneratedSentenceSentiment(sentence, document))
+    sentences: sentences.map((sentence) => convertGeneratedSentenceSentiment(sentence, result))
   };
 }
 
+/**
+ * @internal
+ */
 export function makeAnalyzeSentimentErrorResult(
   id: string,
   error: TextAnalyticsError
@@ -173,10 +180,11 @@ export function makeAnalyzeSentimentErrorResult(
  * @param sentence - The sentence sentiment object to be converted.
  * @param response - The entire response returned by the service.
  * @returns The user-friendly sentence sentiment object.
+ * @internal
  */
 function convertGeneratedSentenceSentiment(
   sentence: GeneratedSentenceSentiment,
-  document: DocumentSentiment
+  result: DocumentSentiment
 ): SentenceSentiment {
   return {
     confidenceScores: sentence.confidenceScores,
@@ -196,7 +204,7 @@ function convertGeneratedSentenceSentiment(
             },
             opinions: aspect.relations
               .filter((relation) => relation.relationType === "opinion")
-              .map((relation) => convertAspectRelationToOpinionSentiment(relation, document))
+              .map((relation) => convertAspectRelationToOpinionSentiment(relation, result))
           })
         )
       : []
@@ -211,15 +219,16 @@ function convertGeneratedSentenceSentiment(
  * @param aspectRelation - The aspect relation object to be converted.
  * @param response - The entire response returned by the service.
  * @returns The user-friendly opinion sentiment object.
+ * @internal
  */
 function convertAspectRelationToOpinionSentiment(
   aspectRelation: AspectRelation,
-  document: DocumentSentiment
+  result: DocumentSentiment
 ): OpinionSentiment {
   const opinionPtr = aspectRelation.ref;
   const opinionIndex: OpinionIndex = parseOpinionIndex(opinionPtr);
   const opinion: SentenceOpinion | undefined =
-    document.sentenceSentiments?.[opinionIndex.sentence].opinions?.[opinionIndex.opinion];
+    result.sentenceSentiments?.[opinionIndex.sentence].opinions?.[opinionIndex.opinion];
   if (opinion !== undefined) {
     return opinion;
   } else {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResultArray.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResultArray.ts
@@ -4,14 +4,14 @@
 import {
   TextDocumentBatchStatistics,
   TextDocumentInput,
-  GeneratedClientSentimentResponse
+  SentimentResponse
 } from "./generated/models";
 import {
   AnalyzeSentimentResult,
-  makeAnalyzeSentimentResult,
-  makeAnalyzeSentimentErrorResult
+  makeAnalyzeSentimentErrorResult,
+  makeAnalyzeSentimentResult
 } from "./analyzeSentimentResult";
-import { sortResponseIdObjects } from "./util";
+import { combineSuccessfulAndErroneousDocumentsWithStatisticsAndModelVersion } from "./textAnalyticsResult";
 
 /**
  * Array of `AnalyzeSentimentResult` objects corresponding to a batch of input documents, and
@@ -31,27 +31,17 @@ export interface AnalyzeSentimentResultArray extends Array<AnalyzeSentimentResul
   modelVersion: string;
 }
 
+/**
+ * @internal
+ */
 export function makeAnalyzeSentimentResultArray(
   input: TextDocumentInput[],
-  response: GeneratedClientSentimentResponse
+  response: SentimentResponse
 ): AnalyzeSentimentResultArray {
-  const { documents, errors, modelVersion, statistics } = response;
-  const unsortedResult = documents
-    .map(
-      (document): AnalyzeSentimentResult => {
-        return makeAnalyzeSentimentResult(document);
-      }
-    )
-    .concat(
-      errors.map(
-        (error): AnalyzeSentimentResult => {
-          return makeAnalyzeSentimentErrorResult(error.id, error.error);
-        }
-      )
-    );
-  const result = sortResponseIdObjects(input, unsortedResult);
-  return Object.assign(result, {
-    statistics,
-    modelVersion
-  });
+  return combineSuccessfulAndErroneousDocumentsWithStatisticsAndModelVersion(
+    input,
+    response,
+    makeAnalyzeSentimentResult,
+    makeAnalyzeSentimentErrorResult
+  );
 }

--- a/sdk/textanalytics/ai-text-analytics/src/azureKeyCredentialPolicy.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/azureKeyCredentialPolicy.ts
@@ -16,6 +16,7 @@ const API_KEY_HEADER_NAME = "Ocp-Apim-Subscription-Key";
 /**
  * Create an HTTP pipeline policy to authenticate a request
  * using an `AzureKeyCredential` for Text Analytics
+ * @internal
  */
 export function createTextAnalyticsAzureKeyCredentialPolicy(
   credential: KeyCredential
@@ -30,6 +31,7 @@ export function createTextAnalyticsAzureKeyCredentialPolicy(
 /**
  * A concrete implementation of an AzureKeyCredential policy
  * using the appropriate header for TextAnalytics
+ * @internal
  */
 class TextAnalyticsAzureKeyCredentialPolicy extends BaseRequestPolicy {
   private credential: KeyCredential;

--- a/sdk/textanalytics/ai-text-analytics/src/constants.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/constants.ts
@@ -1,4 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @internal
+ */
 export const SDK_VERSION: string = "5.1.0-beta.5";

--- a/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
@@ -7,12 +7,7 @@ import {
   TextAnalyticsErrorResult,
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
-import {
-  DetectedLanguage,
-  TextDocumentStatistics,
-  TextAnalyticsError,
-  TextAnalyticsWarning
-} from "./generated/models";
+import { DetectedLanguage, TextAnalyticsError, DocumentLanguage } from "./generated/models";
 
 /**
  * The result of the detect language operation on a single document.
@@ -35,18 +30,20 @@ export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult 
  */
 export type DetectLanguageErrorResult = TextAnalyticsErrorResult;
 
-export function makeDetectLanguageResult(
-  id: string,
-  detectedLanguage: DetectedLanguage,
-  warnings: TextAnalyticsWarning[],
-  statistics?: TextDocumentStatistics
-): DetectLanguageSuccessResult {
+/**
+ * @internal
+ */
+export function makeDetectLanguageResult(response: DocumentLanguage): DetectLanguageSuccessResult {
+  const { id, warnings, statistics, detectedLanguage } = response;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     primaryLanguage: detectedLanguage
   };
 }
 
+/**
+ * @internal
+ */
 export function makeDetectLanguageErrorResult(
   id: string,
   error: TextAnalyticsError

--- a/sdk/textanalytics/ai-text-analytics/src/extractKeyPhrasesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/extractKeyPhrasesResult.ts
@@ -7,11 +7,7 @@ import {
   TextAnalyticsErrorResult,
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
-import {
-  TextDocumentStatistics,
-  TextAnalyticsError,
-  TextAnalyticsWarning
-} from "./generated/models";
+import { TextAnalyticsError, DocumentKeyPhrases } from "./generated/models";
 
 /**
  * The result of the extract key phrases operation on a single document.
@@ -35,18 +31,22 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
  */
 export type ExtractKeyPhrasesErrorResult = TextAnalyticsErrorResult;
 
+/**
+ * @internal
+ */
 export function makeExtractKeyPhrasesResult(
-  id: string,
-  keyPhrases: string[],
-  warnings: TextAnalyticsWarning[],
-  statistics?: TextDocumentStatistics
+  result: DocumentKeyPhrases
 ): ExtractKeyPhrasesSuccessResult {
+  const { id, warnings, statistics, keyPhrases } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     keyPhrases
   };
 }
 
+/**
+ * @internal
+ */
 export function makeExtractKeyPhrasesErrorResult(
   id: string,
   error: TextAnalyticsError

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
@@ -37,7 +37,7 @@ import {
   GeneratedClientSentimentResponse
 } from "./models";
 
-/** @hidden */
+/** @internal */
 export class GeneratedClient extends GeneratedClientContext {
   /**
    * Initializes a new instance of the GeneratedClient class.

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -12,7 +12,7 @@ import { GeneratedClientOptionalParams } from "./models";
 const packageName = "@azure/ai-text-analytics";
 const packageVersion = "5.1.0-beta.5";
 
-/** @hidden */
+/** @internal */
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;
 

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -103,7 +103,6 @@ export {
   ExtractKeyPhrasesActionSuccessResult
 } from "./analyzeBatchActionsResult";
 export {
-  TextAnalyticsResult,
   ErrorCode,
   TextAnalyticsError,
   TextAnalyticsErrorResult,

--- a/sdk/textanalytics/ai-text-analytics/src/logger.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/logger.ts
@@ -4,6 +4,7 @@
 import { createClientLogger } from "@azure/logger";
 
 /**
- * The \@azure/logger configuration for this package.
+ * The `@azure/logger` configuration for this package.
+ * @internal
  */
 export const logger = createClientLogger("ai-text-analytics");

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -30,6 +30,9 @@ import { createSpan } from "../../tracing";
 import { logger } from "../../logger";
 export { State };
 
+/**
+ * @internal
+ */
 interface AnalyzeResultsWithPagination {
   result: AnalyzeBatchActionsResult;
   top?: number;
@@ -37,7 +40,7 @@ interface AnalyzeResultsWithPagination {
 }
 
 /**
- * The metadata for beginAnalyzeBatchActionsoperations.
+ * The metadata for beginAnalyzeBatchActions operations.
  */
 export interface AnalyzeBatchActionsOperationMetadata extends OperationMetadata {
   /**
@@ -58,6 +61,9 @@ export interface AnalyzeBatchActionsOperationMetadata extends OperationMetadata 
   displayName?: string;
 }
 
+/**
+ * @internal
+ */
 interface AnalyzeBatchActionsOperationStatus {
   done: boolean;
   /**
@@ -69,6 +75,9 @@ interface AnalyzeBatchActionsOperationStatus {
   operationMetdata?: AnalyzeBatchActionsOperationMetadata;
 }
 
+/**
+ * @internal
+ */
 interface BeginAnalyzeInternalOptions extends OperationOptions {
   displayName?: string;
 }
@@ -105,6 +114,7 @@ export interface AnalyzeBatchActionsOperationState
 /**
  * Class that represents a poller that waits for results of the analyze
  * operation.
+ * @internal
  */
 export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperation<
   AnalyzeBatchActionsOperationState,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
@@ -12,6 +12,9 @@ import {
   AnalyzeBatchActionsOperationState
 } from "./operation";
 
+/**
+ * @internal
+ */
 export interface AnalyzeBatchActionsPollerOptions extends AnalysisPollerOptions {
   actions: GeneratedActions;
   readonly displayName?: string;
@@ -19,7 +22,7 @@ export interface AnalyzeBatchActionsPollerOptions extends AnalysisPollerOptions 
 }
 
 /**
- * Result type of the Analyze Long-Running-Operation (LRO)
+ * Result type of the Begin Analyze Batch Actions Long-Running-Operation (LRO).
  */
 export type AnalyzeBatchActionsPollerLike = PollerLike<
   AnalyzeBatchActionsOperationState,
@@ -27,7 +30,8 @@ export type AnalyzeBatchActionsPollerLike = PollerLike<
 >;
 
 /**
- * Class that represents a poller that waits for the analyze results.
+ * Class that represents a poller that waits for the analyze batch actions results.
+ * @internal
  */
 export class BeginAnalyzeBatchActionsPoller extends AnalysisPoller<
   AnalyzeBatchActionsOperationState,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -19,7 +19,8 @@ import {
   AnalyzeHealthcareEntitiesResultArray,
   PagedAsyncIterableAnalyzeHealthcareEntitiesResult,
   PagedAnalyzeHealthcareEntitiesResult,
-  makeHealthcareEntitiesResult
+  makeHealthcareEntitiesResult,
+  makeHealthcareEntitiesErrorResult
 } from "../../analyzeHealthcareEntitiesResult";
 import { PageSettings } from "@azure/core-paging";
 import {
@@ -37,12 +38,18 @@ import { createSpan } from "../../tracing";
 import { TextAnalyticsOperationOptions } from "../../textAnalyticsOperationOptions";
 export { State };
 
+/**
+ * @internal
+ */
 interface AnalyzeHealthcareEntitiesResultWithPagination {
   result: AnalyzeHealthcareEntitiesResultArray;
   top?: number;
   skip?: number;
 }
 
+/**
+ * @internal
+ */
 interface HealthcareJobStatus {
   done: boolean;
   /**
@@ -59,6 +66,9 @@ interface HealthcareJobStatus {
   operationMetdata?: OperationMetadata;
 }
 
+/**
+ * @internal
+ */
 interface BeginAnalyzeHealthcareInternalOptions extends OperationOptions {
   /**
    * This value indicates which model will be used for scoring. If a model-version is
@@ -76,7 +86,7 @@ interface BeginAnalyzeHealthcareInternalOptions extends OperationOptions {
 }
 
 /**
- * Options for the begin analyze healthcare operation.
+ * Options for the begin analyze healthcare entities operation.
  */
 export interface BeginAnalyzeHealthcareEntitiesOptions extends TextAnalyticsOperationOptions {
   /**
@@ -101,6 +111,7 @@ export interface AnalyzeHealthcareOperationState
 
 /**
  * Class that represents a poller that waits for the healthcare results.
+ * @internal
  */
 export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation<
   AnalyzeHealthcareOperationState,
@@ -192,7 +203,8 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
         const result = processAndCombineSuccessfulAndErroneousDocuments(
           this.documents,
           response.results,
-          makeHealthcareEntitiesResult
+          makeHealthcareEntitiesResult,
+          makeHealthcareEntitiesErrorResult
         );
         return response.nextLink
           ? { result, ...nextLinkToTopAndSkip(response.nextLink) }

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
@@ -12,6 +12,9 @@ import {
   AnalyzeHealthcareOperationState
 } from "./operation";
 
+/**
+ * @internal
+ */
 export interface HealthcarePollerOptions extends AnalysisPollerOptions {
   readonly modelVersion?: string;
   readonly includeStatistics?: boolean;
@@ -28,6 +31,7 @@ export type AnalyzeHealthcareEntitiesPollerLike = PollerLike<
 
 /**
  * Class that represents a poller that waits for the healthcare results.
+ * @internal
  */
 export class BeginAnalyzeHealthcarePoller extends AnalysisPoller<
   AnalyzeHealthcareOperationState,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
@@ -8,6 +8,7 @@ import { State, TextDocumentInput } from "../generated/models";
 
 /**
  * Common parameters to a Poller.
+ * @internal
  */
 export interface AnalysisPollerOptions {
   readonly client: GeneratedClient;
@@ -52,6 +53,7 @@ export interface AnalysisPollOperationState<TResult>
 
 /**
  * Common properties and methods of analysis Pollers.
+ * @internal
  */
 export abstract class AnalysisPoller<TState, TResult> extends Poller<TState, TResult> {
   /**
@@ -69,6 +71,7 @@ export abstract class AnalysisPoller<TState, TResult> extends Poller<TState, TRe
 
 /**
  * Common properties and methods of polling operations.
+ * @internal
  */
 export abstract class AnalysisPollOperation<TState, TResult>
   implements PollOperation<TState, TResult> {

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
@@ -7,12 +7,7 @@ import {
   TextAnalyticsErrorResult,
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
-import {
-  Entity,
-  TextDocumentStatistics,
-  TextAnalyticsError,
-  TextAnalyticsWarning
-} from "./generated/models";
+import { Entity, TextAnalyticsError, DocumentEntities } from "./generated/models";
 
 /**
  * An entity from text analysis with information about its categorical
@@ -43,18 +38,22 @@ export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalytics
  */
 export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;
 
+/**
+ * @internal
+ */
 export function makeRecognizeCategorizedEntitiesResult(
-  id: string,
-  entities: CategorizedEntity[],
-  warnings: TextAnalyticsWarning[],
-  statistics?: TextDocumentStatistics
+  result: DocumentEntities
 ): RecognizeCategorizedEntitiesSuccessResult {
+  const { entities, statistics, warnings, id } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     entities
   };
 }
 
+/**
+ * @internal
+ */
 export function makeRecognizeCategorizedEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeLinkedEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeLinkedEntitiesResult.ts
@@ -7,12 +7,7 @@ import {
   TextAnalyticsErrorResult,
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
-import {
-  TextDocumentStatistics,
-  TextAnalyticsError,
-  LinkedEntity,
-  TextAnalyticsWarning
-} from "./generated/models";
+import { TextAnalyticsError, LinkedEntity, DocumentLinkedEntities } from "./generated/models";
 
 /**
  * The result of the recognize linked entities operation on a single document.
@@ -37,18 +32,22 @@ export interface RecognizeLinkedEntitiesSuccessResult extends TextAnalyticsSucce
  */
 export type RecognizeLinkedEntitiesErrorResult = TextAnalyticsErrorResult;
 
+/**
+ * @internal
+ */
 export function makeRecognizeLinkedEntitiesResult(
-  id: string,
-  entities: LinkedEntity[],
-  warnings: TextAnalyticsWarning[],
-  statistics?: TextDocumentStatistics
+  result: DocumentLinkedEntities
 ): RecognizeLinkedEntitiesSuccessResult {
+  const { statistics, id, warnings, entities } = result;
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     entities
   };
 }
 
+/**
+ * @internal
+ */
 export function makeRecognizeLinkedEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError

--- a/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
@@ -7,7 +7,7 @@ import {
   TextAnalyticsErrorResult,
   makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
-import { Entity, TextAnalyticsError } from "./generated/models";
+import { Entity, PiiDocumentEntities, TextAnalyticsError } from "./generated/models";
 
 /**
  * An entity from PII recognition with information about the kind of PII
@@ -42,8 +42,11 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
  */
 export type RecognizePiiEntitiesErrorResult = TextAnalyticsErrorResult;
 
+/**
+ * @internal
+ */
 export function makeRecognizePiiEntitiesResult(
-  document: RecognizePiiEntitiesSuccessResult
+  document: PiiDocumentEntities
 ): RecognizePiiEntitiesSuccessResult {
   const { id, entities, warnings, statistics, redactedText } = document;
   return {
@@ -53,6 +56,9 @@ export function makeRecognizePiiEntitiesResult(
   };
 }
 
+/**
+ * @internal
+ */
 export function makeRecognizePiiEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError

--- a/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResultArray.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResultArray.ts
@@ -7,7 +7,7 @@ import {
   makeRecognizePiiEntitiesResult,
   makeRecognizePiiEntitiesErrorResult
 } from "./recognizePiiEntitiesResult";
-import { sortResponseIdObjects } from "./util";
+import { combineSuccessfulAndErroneousDocumentsWithStatisticsAndModelVersion } from "./textAnalyticsResult";
 
 /**
  * Collection of `RecognizePiiEntitiesResult` objects corresponding to a batch of input documents, and
@@ -27,27 +27,17 @@ export interface RecognizePiiEntitiesResultArray extends Array<RecognizePiiEntit
   modelVersion: string;
 }
 
+/**
+ * @internal
+ */
 export function makeRecognizePiiEntitiesResultArray(
   input: TextDocumentInput[],
   response: PiiResult
 ): RecognizePiiEntitiesResultArray {
-  const { documents, errors, statistics, modelVersion } = response;
-  const unsortedResult = documents
-    .map(
-      (document): RecognizePiiEntitiesResult => {
-        return makeRecognizePiiEntitiesResult(document);
-      }
-    )
-    .concat(
-      errors.map(
-        (error): RecognizePiiEntitiesResult => {
-          return makeRecognizePiiEntitiesErrorResult(error.id, error.error);
-        }
-      )
-    );
-  const result = sortResponseIdObjects(input, unsortedResult);
-  return Object.assign(result, {
-    statistics,
-    modelVersion
-  });
+  return combineSuccessfulAndErroneousDocumentsWithStatisticsAndModelVersion(
+    input,
+    response,
+    makeRecognizePiiEntitiesResult,
+    makeRecognizePiiEntitiesErrorResult
+  );
 }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -407,13 +407,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(finalOptions)
       );
 
-      return makeDetectLanguageResultArray(
-        realInputs,
-        result.documents,
-        result.errors,
-        result.modelVersion,
-        result.statistics
-      );
+      return makeDetectLanguageResultArray(realInputs, result);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -498,13 +492,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(addStrEncodingParam(finalOptions))
       );
 
-      return makeRecognizeCategorizedEntitiesResultArray(
-        realInputs,
-        result.documents,
-        result.errors,
-        result.modelVersion,
-        result.statistics
-      );
+      return makeRecognizeCategorizedEntitiesResultArray(realInputs, result);
     } catch (e) {
       /**
        * This special logic handles REST exception with code
@@ -669,13 +657,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(finalOptions)
       );
 
-      return makeExtractKeyPhrasesResultArray(
-        realInputs,
-        result.documents,
-        result.errors,
-        result.modelVersion,
-        result.statistics
-      );
+      return makeExtractKeyPhrasesResultArray(realInputs, result);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -831,13 +813,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(addStrEncodingParam(finalOptions))
       );
 
-      return makeRecognizeLinkedEntitiesResultArray(
-        realInputs,
-        result.documents,
-        result.errors,
-        result.modelVersion,
-        result.statistics
-      );
+      return makeRecognizeLinkedEntitiesResultArray(realInputs, result);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -981,6 +957,9 @@ export class TextAnalyticsClient {
   }
 }
 
+/**
+ * @internal
+ */
 function addEncodingParamToAnalyzeInput(actions: TextAnalyticsActions): GeneratedActions {
   return {
     entityRecognitionPiiTasks: actions.recognizePiiEntitiesActions
@@ -997,6 +976,9 @@ function isStringArray(documents: any[]): documents is string[] {
   return typeof documents[0] === "string";
 }
 
+/**
+ * @internal
+ */
 function convertToDetectLanguageInput(
   inputs: string[],
   countryHint: string
@@ -1015,6 +997,9 @@ function convertToDetectLanguageInput(
   );
 }
 
+/**
+ * @internal
+ */
 function convertToTextDocumentInput(inputs: string[], language: string): TextDocumentInput[] {
   return inputs.map(
     (text: string, index): TextDocumentInput => {
@@ -1031,7 +1016,6 @@ function convertToTextDocumentInput(inputs: string[], language: string): TextDoc
  * Creates the options the service expects for the analyze sentiment API from the user friendly ones.
  * @param params - the user friendly parameters
  * @internal
- * @hidden
  */
 function makeAnalyzeSentimentOptionsModel(
   params: AnalyzeSentimentOptions
@@ -1051,7 +1035,6 @@ function makeAnalyzeSentimentOptionsModel(
  * Creates the options the service expects for the recognize pii entities API from the user friendly ones.
  * @param params - the user friendly parameters
  * @internal
- * @hidden
  */
 function makePiiEntitiesOptionsModel(
   params: RecognizePiiEntitiesOptions

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -6,6 +6,9 @@ import { URL, URLSearchParams } from "./utils/url";
 import { logger } from "./logger";
 import { StringIndexType as GeneratedStringIndexType } from "./generated";
 
+/**
+ * @internal
+ */
 export interface IdObject {
   id: string;
 }
@@ -44,12 +47,18 @@ export function sortResponseIdObjects<T extends IdObject, U extends IdObject>(
   return result;
 }
 
+/**
+ * @internal
+ */
 export interface OpinionIndex {
   document: number;
   sentence: number;
   opinion: number;
 }
 
+/**
+ * @internal
+ */
 export function parseOpinionIndex(pointer: string): OpinionIndex {
   const regex = new RegExp(/#\/documents\/(\d+)\/sentences\/(\d+)\/opinions\/(\d+)/);
   const res = regex.exec(pointer);
@@ -69,7 +78,6 @@ export function parseOpinionIndex(pointer: string): OpinionIndex {
  * Parses the index of the healthcare entity from a JSON pointer.
  * @param pointer - a JSON pointer representing an entity
  * @internal
- * @hidden
  */
 export function parseHealthcareEntityIndex(pointer: string): number {
   const regex = new RegExp(/#\/results\/documents\/(\d+)\/entities\/(\d+)/);
@@ -88,6 +96,9 @@ const jsEncodingUnit = "Utf16CodeUnit";
  */
 export type StringIndexType = "TextElements_v8" | "UnicodeCodePoint" | "Utf16CodeUnit";
 
+/**
+ * @internal
+ */
 export function addStrEncodingParam<Options extends { stringIndexType?: StringIndexType }>(
   options: Options
 ): Options & { stringIndexType: StringIndexType } {
@@ -98,7 +109,6 @@ export function addStrEncodingParam<Options extends { stringIndexType?: StringIn
  * Set the stringIndexType property with default if it does not exist in x.
  * @param options - operation options bag that has a {@link StringIndexType}
  * @internal
- * @hidden
  */
 export function setStrEncodingParam<X extends { stringIndexType?: GeneratedStringIndexType }>(
   x: X
@@ -106,15 +116,24 @@ export function setStrEncodingParam<X extends { stringIndexType?: GeneratedStrin
   return { ...x, stringIndexType: x.stringIndexType || jsEncodingUnit };
 }
 
+/**
+ * @internal
+ */
 export function AddParamsToTask<X>(action: X): { parameters?: X } {
   return { parameters: action };
 }
 
+/**
+ * @internal
+ */
 export interface PageParam {
   top: number;
   skip: number;
 }
 
+/**
+ * @internal
+ */
 export function nextLinkToTopAndSkip(nextLink: string): PageParam {
   const url = new URL(nextLink);
   const searchParams = new URLSearchParams(url.searchParams);
@@ -136,6 +155,9 @@ export function nextLinkToTopAndSkip(nextLink: string): PageParam {
   };
 }
 
+/**
+ * @internal
+ */
 export function getOperationId(operationLocation: string): string {
   const lastSlashIndex = operationLocation.lastIndexOf("/");
   return operationLocation.substring(lastSlashIndex + 1);

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -14,7 +14,7 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/25616b92ccaec6c8bd3dd51f1312243bca88fe2d/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.3/TextAnalytics.json
 add-credentials: false
-package-version: 5.1.0-beta.4
+package-version: 5.1.0-beta.5
 v3: true
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.2"

--- a/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/internal/collections.spec.ts
@@ -62,7 +62,6 @@ describe("SentimentResultArray", () => {
           }
         }
       ],
-      _response: {} as any,
       modelVersion: ""
     });
 
@@ -88,9 +87,8 @@ describe("DetectLanguageResultArray", () => {
         text: "test3"
       }
     ];
-    const result = makeDetectLanguageResultArray(
-      input,
-      [
+    const result = makeDetectLanguageResultArray(input, {
+      documents: [
         {
           id: "A",
           detectedLanguage: {
@@ -110,7 +108,7 @@ describe("DetectLanguageResultArray", () => {
           warnings: []
         }
       ],
-      [
+      errors: [
         {
           id: "B",
           error: {
@@ -119,8 +117,8 @@ describe("DetectLanguageResultArray", () => {
           }
         }
       ],
-      ""
-    );
+      modelVersion: ""
+    });
 
     const inputOrder = input.map((item) => item.id);
     const outputOrder = result.map((item) => item.id);
@@ -144,9 +142,8 @@ describe("ExtractKeyPhrasesResultArray", () => {
         text: "test3"
       }
     ];
-    const result = makeExtractKeyPhrasesResultArray(
-      input,
-      [
+    const result = makeExtractKeyPhrasesResultArray(input, {
+      documents: [
         {
           id: "A",
           keyPhrases: ["test", "test2"],
@@ -158,7 +155,7 @@ describe("ExtractKeyPhrasesResultArray", () => {
           warnings: []
         }
       ],
-      [
+      errors: [
         {
           id: "B",
           error: {
@@ -167,8 +164,8 @@ describe("ExtractKeyPhrasesResultArray", () => {
           }
         }
       ],
-      ""
-    );
+      modelVersion: ""
+    });
 
     const inputOrder = input.map((item) => item.id);
     const outputOrder = result.map((item) => item.id);
@@ -192,9 +189,8 @@ describe("RecognizeCategorizedEntitiesResultArray", () => {
         text: "test3"
       }
     ];
-    const result = makeRecognizeCategorizedEntitiesResultArray(
-      input,
-      [
+    const result = makeRecognizeCategorizedEntitiesResultArray(input, {
+      documents: [
         {
           id: "A",
           entities: [
@@ -223,7 +219,7 @@ describe("RecognizeCategorizedEntitiesResultArray", () => {
           warnings: []
         }
       ],
-      [
+      errors: [
         {
           id: "B",
           error: {
@@ -232,8 +228,8 @@ describe("RecognizeCategorizedEntitiesResultArray", () => {
           }
         }
       ],
-      ""
-    );
+      modelVersion: ""
+    });
 
     const inputOrder = input.map((item) => item.id);
     const outputOrder = result.map((item) => item.id);
@@ -257,9 +253,8 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
         text: "test3"
       }
     ];
-    const result = makeRecognizeLinkedEntitiesResultArray(
-      input,
-      [
+    const result = makeRecognizeLinkedEntitiesResultArray(input, {
+      documents: [
         {
           id: "A",
           entities: [
@@ -303,7 +298,7 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
           warnings: []
         }
       ],
-      [
+      errors: [
         {
           id: "B",
           error: {
@@ -312,8 +307,8 @@ describe("RecognizeLinkedEntitiesResultArray", () => {
           }
         }
       ],
-      ""
-    );
+      modelVersion: ""
+    });
     const inputOrder = input.map((item) => item.id);
     const outputOrder = result.map((item) => item.id);
     assert.deepEqual(inputOrder, outputOrder);

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/resultHelper.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/resultHelper.ts
@@ -3,14 +3,18 @@
 
 import { assert } from "chai";
 
-import { TextAnalyticsResult, TextAnalyticsSuccessResult } from "../../../src/";
+import { TextAnalyticsErrorResult, TextAnalyticsSuccessResult } from "../../../src/";
 
-export function assertAllSuccess(results: TextAnalyticsResult[]): void {
+export function assertAllSuccess<TSuccess extends TextAnalyticsSuccessResult>(
+  results: (TextAnalyticsErrorResult | TSuccess)[]
+): void {
   for (const result of results) {
     assert.ok(isSuccess(result));
   }
 }
 
-export function isSuccess(res: TextAnalyticsResult): res is TextAnalyticsSuccessResult {
+export function isSuccess<TSuccess extends TextAnalyticsSuccessResult>(
+  res: TextAnalyticsErrorResult | TSuccess
+): res is TSuccess {
   return res.error === undefined;
 }

--- a/sdk/textanalytics/ai-text-analytics/test/public/utils/stringIndexTypeHelpers.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/utils/stringIndexTypeHelpers.ts
@@ -14,7 +14,6 @@ import { Entity, StringIndexType, TextAnalyticsClient } from "../../../src";
  * @param offset - the expected offset of the first entity in the input document
  * @param length - the expected length of the first entity in the input document
  * @internal
- * @hidden
  */
 export async function checkOffsetAndLength(
   client: TextAnalyticsClient,
@@ -43,7 +42,6 @@ export async function checkOffsetAndLength(
  * @param offset - the expected offset of the first entity in the input document
  * @param length - the expected length of the first entity in the input document
  * @internal
- * @hidden
  */
 export function checkEntityTextOffset(
   doc: string,


### PR DESCRIPTION
Makes some refactorings that have been on my mind for some time to make processing of service responses more uniform using generic utilities. Furthermore, it removes the `TextAnalyticsResult` type that was not used anywhere other than in tests. It also fixes https://github.com/Azure/azure-sdk-for-js/issues/13438 by removeing all uses of `@hidden`.