### PR TITLE
Modify Changelog of Search Documents SDK

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## 11.1.0 (2021-02-11)
 
-### Changes since 11.0.3
+- The list the changes in 11.1.0 since 11.0.3 & 11.1.0-beta.2 are provided below:
+
+**Changes since 11.0.3**
 
 - Added Batching ability to the search SDK. The `SearchIndexingBufferedSender` class enables the user to perform indexing documents in batch mode. There are several user configurable properties such as `autoFlush`, `flushWindowInMs`, `throttlingDelayInMs`, etc.
 - The types `BlobIndexerDataToExtract`, `BlobIndexerImageAction`, `BlobIndexerParsingMode`, `BlobIndexerPDFTextRotationAlgorithm` have changed from union of string literals to string. This is to support the service definition for these types to be extensible enums. The documentation on methods that use these have been updated with known values that can be used for these types.
 
-### Changes since 11.1.0-beta.2
+**Changes since 11.1.0-beta.2**
 
 - The types `BlobIndexerDataToExtract`, `BlobIndexerImageAction`, `BlobIndexerParsingMode`, `BlobIndexerPDFTextRotationAlgorithm` have changed from union of string literals to string. This is to allow the service to support additional values after the release of this SDK. The documentation on methods that use these types have been updated with currently known values. Please refer [#12829](https://github.com/Azure/azure-sdk-for-js/pull/12829) for further details.
 - [Breaking] The `SearchIndexingBufferedSender` interface has been removed. Please refer [#13405](https://github.com/Azure/azure-sdk-for-js/pull/13405) for further details.


### PR DESCRIPTION
I released the search-documents SDK on Feb 11, 2021. The package was published successfully. But, there is one error:

```
Entry has no content. Please ensure to provide some content of what changed in this version.
```

You can see the error here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=732026&view=results

This PR is to fix the issue.