### PR TITLE
[Cosmos] Be TSDoc compliant

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -723,7 +723,6 @@ export class GlobalEndpointManager {
     constructor(options: CosmosClientOptions, readDatabaseAccount: (opts: RequestOptions) => Promise<ResourceResponse<DatabaseAccount>>);
     // (undocumented)
     canUseMultipleWriteLocations(resourceType?: ResourceType, operationType?: OperationType): boolean;
-    // (undocumented)
     enableEndpointDiscovery: boolean;
     getReadEndpoint(): Promise<string>;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
@@ -23,13 +23,6 @@ export class ChangeFeedIterator<T> {
 
   /**
    * @internal
-   * @hidden
-   *
-   * @param clientContext
-   * @param resourceId
-   * @param resourceLink
-   * @param isPartitionedContainer
-   * @param changeFeedOptions
    */
   constructor(
     private clientContext: ClientContext,

--- a/sdk/cosmosdb/cosmos/src/ChangeFeedResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedResponse.ts
@@ -9,12 +9,6 @@ import { CosmosHeaders } from "./queryExecutionContext";
 export class ChangeFeedResponse<T> {
   /**
    * @internal
-   * @hidden
-   *
-   * @param result
-   * @param count
-   * @param statusCode
-   * @param headers
    */
   constructor(
     /**

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -505,7 +505,7 @@ export class ClientContext {
 
   /**
    * Gets the Database account information.
-   * @param {string} [options.urlConnection]   - The endpoint url whose database account needs to be retrieved. \
+   * @param options - `urlConnection` in the options is the endpoint url whose database account needs to be retrieved.
    * If not present, current client's url will be used.
    */
   public async getDatabaseAccount(

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -56,7 +56,7 @@ export class CosmosClient {
   constructor(connectionString: string);
   /**
    * Creates a new {@link CosmosClient} object. See {@link CosmosClientOptions} for more details on what options you can use.
-   * @param options bag of options - require at least endpoint and auth to be configured
+   * @param options - bag of options; require at least endpoint and auth to be configured
    */
   constructor(options: CosmosClientOptions); // tslint:disable-line:unified-signatures
   constructor(optionsOrConnectionString: string | CosmosClientOptions) {
@@ -131,7 +131,7 @@ export class CosmosClient {
    *
    * This does not make a network call. Use `.read` to get info about the database after getting the {@link Database} object.
    *
-   * @param id The id of the database.
+   * @param id - The id of the database.
    * @example Create a new container off of an existing database
    * ```typescript
    * const container = client.database("<database id>").containers.create("<container id>");
@@ -148,7 +148,7 @@ export class CosmosClient {
 
   /**
    * Used for reading, or updating a existing offer by id.
-   * @param id The id of the offer.
+   * @param id - The id of the offer.
    */
   public offer(id: string) {
     return new Offer(this, id, this.clientContext);

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -29,8 +29,8 @@ export interface CosmosClientOptions {
    * Allows users to generating their own auth tokens, potentially using a separate service
    */
   tokenProvider?: TokenProvider;
-  /** AAD token from @azure/identity
-   * Obtain a credential object by creating an @azure/identity credential object
+  /** AAD token from `@azure/identity`
+   * Obtain a credential object by creating an `@azure/identity` credential object
    * We will then use your credential object and a scope URL (your cosmos db endpoint)
    * to authenticate requests to Cosmos
    * This feature is in private preview and not yet available for every Cosmos account

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -24,12 +24,6 @@ export type TokenProvider = (requestInfo: RequestInfo) => Promise<string>;
 
 /**
  * @hidden
- * @param clientOptions
- * @param verb
- * @param path
- * @param resourceId
- * @param resourceType
- * @param headers
  */
 export async function setAuthorizationHeader(
   clientOptions: CosmosClientOptions,
@@ -102,9 +96,6 @@ export async function setAuthorizationTokenHeaderUsingMasterKey(
 
 /**
  * @hidden
- * @param resourceTokens
- * @param path
- * @param resourceId
  */
 // TODO: Resource tokens
 export function getAuthorizationTokenUsingResourceTokens(

--- a/sdk/cosmosdb/cosmos/src/client/Conflict/Conflict.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Conflict/Conflict.ts
@@ -21,8 +21,8 @@ export class Conflict {
   }
   /**
    * @hidden
-   * @param container The parent {@link Container}.
-   * @param id The id of the given {@link Conflict}.
+   * @param container - The parent {@link Container}.
+   * @param id - The id of the given {@link Conflict}.
    */
   constructor(
     public readonly container: Container,
@@ -32,7 +32,6 @@ export class Conflict {
 
   /**
    * Read the {@link ConflictDefinition} for the given {@link Conflict}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<ConflictResponse> {
     const path = getPathFromLink(this.url, ResourceType.conflicts);
@@ -49,7 +48,6 @@ export class Conflict {
 
   /**
    * Delete the given {@link ConflictDefinition}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<ConflictResponse> {
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Conflict/Conflicts.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Conflict/Conflicts.ts
@@ -22,15 +22,15 @@ export class Conflicts {
 
   /**
    * Queries all conflicts.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return results in an array or iterate over them one at a time.
    */
   public query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Queries all conflicts.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return results in an array or iterate over them one at a time.
    */
   public query<T>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
@@ -52,7 +52,7 @@ export class Conflicts {
 
   /**
    * Reads all conflicts
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    */
   public readAll(options?: FeedOptions): QueryIterator<ConflictDefinition & Resource> {
     return this.query<ConflictDefinition & Resource>(undefined, options);

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -86,8 +86,8 @@ export class Container {
 
   /**
    * Returns a container instance. Note: You should get this from `database.container(id)`, rather than creating your own object.
-   * @param database The parent {@link Database}.
-   * @param id The id of the given container.
+   * @param database - The parent {@link Database}.
+   * @param id - The id of the given container.
    * @hidden
    */
   constructor(
@@ -101,10 +101,10 @@ export class Container {
    *
    * Use `.items` for creating new items, or querying/reading all items.
    *
-   * @param id The id of the {@link Item}.
-   * @param partitionKeyValue The value of the {@link Item} partition key
+   * @param id - The id of the {@link Item}.
+   * @param partitionKeyValue - The value of the {@link Item} partition key
    * @example Replace an item
-   * const {body: replacedItem} = await container.item("<item id>", "<partition key value>").replace({id: "<item id>", title: "Updated post", authorID: 5});
+   * `const {body: replacedItem} = await container.item("<item id>", "<partition key value>").replace({id: "<item id>", title: "Updated post", authorID: 5});`
    */
   public item(id: string, partitionKeyValue?: any): Item {
     return new Item(this, id, partitionKeyValue, this.clientContext);
@@ -114,7 +114,7 @@ export class Container {
    * Used to read, replace, or delete a specific, existing {@link Conflict} by id.
    *
    * Use `.conflicts` for creating new conflicts, or querying/reading all conflicts.
-   * @param id The id of the {@link Conflict}.
+   * @param id - The id of the {@link Conflict}.
    */
   public conflict(id: string): Conflict {
     return new Conflict(this, id, this.clientContext);
@@ -175,9 +175,6 @@ export class Container {
   /**
    * Gets the partition key definition first by looking into the cache otherwise by reading the collection.
    * @deprecated This method has been renamed to readPartitionKeyDefinition.
-   * @param {string} collectionLink   - Link to the collection whose partition key needs to be extracted.
-   * @param {function} callback       - \
-   * The arguments to the callback are(in order): error, partitionKeyDefinition, response object and response headers
    */
   public async getPartitionKeyDefinition(): Promise<ResourceResponse<PartitionKeyDefinition>> {
     return this.readPartitionKeyDefinition();
@@ -186,9 +183,6 @@ export class Container {
   /**
    * Gets the partition key definition first by looking into the cache otherwise by reading the collection.
    * @hidden
-   * @param {string} collectionLink   - Link to the collection whose partition key needs to be extracted.
-   * @param {function} callback       - \
-   * The arguments to the callback are(in order): error, partitionKeyDefinition, response object and response headers
    */
   public async readPartitionKeyDefinition(): Promise<ResourceResponse<PartitionKeyDefinition>> {
     // $ISSUE-felixfan-2016-03-17: Make name based path and link based path use the same key
@@ -211,7 +205,6 @@ export class Container {
 
   /**
    * Gets offer on container. If none exists, returns an OfferResponse with undefined.
-   * @param options
    */
   public async readOffer(options: RequestOptions = {}): Promise<OfferResponse> {
     const { resource: container } = await this.read();

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -36,8 +36,8 @@ export class Containers {
 
   /**
    * Queries all containers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return specific containers in an array or iterate over them one at a time.
    * @example Read all containers to array.
    * ```typescript
@@ -53,8 +53,8 @@ export class Containers {
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Queries all containers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return specific containers in an array or iterate over them one at a time.
    * @example Read all containers to array.
    * ```typescript
@@ -98,8 +98,8 @@ export class Containers {
    * Since containers are application resources, they can be authorized using either the
    * master key or resource keys.
    *
-   * @param body Represents the body of the container.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param body - Represents the body of the container.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    */
   public async create(
     body: ContainerRequest,
@@ -182,8 +182,8 @@ export class Containers {
    * Since containers are application resources, they can be authorized using either the
    * master key or resource keys.
    *
-   * @param body Represents the body of the container.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param body - Represents the body of the container.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    */
   public async createIfNotExists(
     body: ContainerRequest,
@@ -213,7 +213,7 @@ export class Containers {
 
   /**
    * Read all containers.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return all containers in an array or iterate over them one at a time.
    * @example Read all containers to array.
    * ```typescript

--- a/sdk/cosmosdb/cosmos/src/client/Database/Database.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Database.ts
@@ -111,7 +111,6 @@ export class Database {
 
   /**
    * Gets offer on database. If none exists, returns an OfferResponse with undefined.
-   * @param options
    */
   public async readOffer(options: RequestOptions = {}): Promise<OfferResponse> {
     const { resource: record } = await this.read();

--- a/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Database/Databases.ts
@@ -26,7 +26,7 @@ import { validateOffer } from "../../utils/offers";
 export class Databases {
   /**
    * @hidden
-   * @param client The parent {@link CosmosClient} for the Database.
+   * @param client - The parent {@link CosmosClient} for the Database.
    */
   constructor(
     public readonly client: CosmosClient,
@@ -35,8 +35,8 @@ export class Databases {
 
   /**
    * Queries all databases.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return all databases in an array or iterate over them one at a time.
    * @example Read all databases to array.
    * ```typescript
@@ -52,8 +52,8 @@ export class Databases {
   public query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Queries all databases.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return all databases in an array or iterate over them one at a time.
    * @example Read all databases to array.
    * ```typescript
@@ -92,8 +92,8 @@ export class Databases {
    * documents. Since databases are an administrative resource, the Service Master Key will be
    * required in order to access and successfully complete any action using the User APIs.
    *
-   * @param body The {@link DatabaseDefinition} that represents the {@link Database} to be created.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param body - The {@link DatabaseDefinition} that represents the {@link Database} to be created.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    */
   public async create(
     body: DatabaseRequest,
@@ -155,8 +155,8 @@ export class Databases {
    * documents. Since databases are an an administrative resource, the Service Master Key will be
    * required in order to access and successfully complete any action using the User APIs.
    *
-   * @param body The {@link DatabaseDefinition} that represents the {@link Database} to be created.
-   * @param options
+   * @param body - The {@link DatabaseDefinition} that represents the {@link Database} to be created.
+   * @param options - Additional options for the request
    */
   public async createIfNotExists(
     body: DatabaseRequest,
@@ -187,7 +187,7 @@ export class Databases {
   // TODO: DatabaseResponse for QueryIterator?
   /**
    * Reads all databases.
-   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @param options - Use to set options like response page size, continuation tokens, etc.
    * @returns {@link QueryIterator} Allows you to return all databases in an array or iterate over them one at a time.
    * @example Read all databases to array.
    * ```typescript

--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -33,9 +33,9 @@ export class Item {
 
   /**
    * @hidden
-   * @param container The parent {@link Container}.
-   * @param id The id of the given {@link Item}.
-   * @param partitionKey The primary key of the given {@link Item} (only for partitioned containers).
+   * @param container - The parent {@link Container}.
+   * @param id - The id of the given {@link Item}.
+   * @param partitionKey - The primary key of the given {@link Item} (only for partitioned containers).
    */
   constructor(
     public readonly container: Container,
@@ -56,7 +56,7 @@ export class Item {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param options Additional options for the request
+   * @param options - Additional options for the request
    *
    * @example Using custom type for response
    * ```typescript
@@ -111,8 +111,8 @@ export class Item {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param body The definition to replace the existing {@link Item}'s definition with.
-   * @param options Additional options for the request
+   * @param body - The definition to replace the existing {@link Item}'s definition with.
+   * @param options - Additional options for the request
    */
   public replace(
     body: ItemDefinition,
@@ -126,8 +126,8 @@ export class Item {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param body The definition to replace the existing {@link Item}'s definition with.
-   * @param options Additional options for the request
+   * @param body - The definition to replace the existing {@link Item}'s definition with.
+   * @param options - Additional options for the request
    */
   public replace<T extends ItemDefinition>(
     body: T,
@@ -175,7 +175,7 @@ export class Item {
    * Any provided type, T, is not necessarily enforced by the SDK.
    * You may get more or less properties and it's up to your logic to enforce it.
    *
-   * @param options Additional options for the request
+   * @param options - Additional options for the request
    */
   public async delete<T extends ItemDefinition = any>(
     options: RequestOptions = {}

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -373,7 +373,7 @@ export class Items {
    * The choices are: Create, Upsert, Read, Replace, and Delete
    *
    * Usage example:
-   *```typescript
+   * ```typescript
    * // partitionKey is optional at the top level if present in the resourceBody
    * const operations: OperationInput[] = [
    *    {

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -27,7 +27,6 @@ import { hashV2PartitionKey } from "../../utils/hashing/v2";
 
 /**
  * @hidden
- * @param options
  */
 function isChangeFeedOptions(options: unknown): options is ChangeFeedOptions {
   const optionsType = typeof options;
@@ -44,7 +43,7 @@ function isChangeFeedOptions(options: unknown): options is ChangeFeedOptions {
 export class Items {
   /**
    * Create an instance of {@link Items} linked to the parent {@link Container}.
-   * @param container The parent container.
+   * @param container - The parent container.
    * @hidden
    */
   constructor(
@@ -54,8 +53,8 @@ export class Items {
 
   /**
    * Queries all items.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    * @example Read all items to array.
    * ```typescript
    * const querySpec: SqlQuerySpec = {
@@ -70,8 +69,8 @@ export class Items {
   public query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Queries all items.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    * @example Read all items to array.
    * ```typescript
    * const querySpec: SqlQuerySpec = {
@@ -113,8 +112,6 @@ export class Items {
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
    *
-   * @param partitionKey
-   * @param changeFeedOptions
    * @deprecated Use `changeFeed` instead.
    *
    * @example Read from the beginning of the change feed.
@@ -133,15 +130,11 @@ export class Items {
    * Create a `ChangeFeedIterator` to iterate over pages of changes
    * @deprecated Use `changeFeed` instead.
    *
-   * @param changeFeedOptions
    */
   public readChangeFeed(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
    * @deprecated Use `changeFeed` instead.
-   *
-   * @param partitionKey
-   * @param changeFeedOptions
    */
   public readChangeFeed<T>(
     partitionKey: string | number | boolean,
@@ -150,8 +143,6 @@ export class Items {
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
    * @deprecated Use `changeFeed` instead.
-   *
-   * @param changeFeedOptions
    */
   public readChangeFeed<T>(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<T>;
   public readChangeFeed<T>(
@@ -168,9 +159,6 @@ export class Items {
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
    *
-   * @param partitionKey
-   * @param changeFeedOptions
-   *
    * @example Read from the beginning of the change feed.
    * ```javascript
    * const iterator = items.readChangeFeed({ startFromBeginning: true });
@@ -185,15 +173,10 @@ export class Items {
   ): ChangeFeedIterator<any>;
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
-   *
-   * @param changeFeedOptions
    */
   public changeFeed(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
-   *
-   * @param partitionKey
-   * @param changeFeedOptions
    */
   public changeFeed<T>(
     partitionKey: string | number | boolean,
@@ -201,8 +184,6 @@ export class Items {
   ): ChangeFeedIterator<T>;
   /**
    * Create a `ChangeFeedIterator` to iterate over pages of changes
-   *
-   * @param changeFeedOptions
    */
   public changeFeed<T>(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<T>;
   public changeFeed<T>(
@@ -234,7 +215,7 @@ export class Items {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    * @example Read all items to array.
    * ```typescript
    * const {body: containerList} = await items.readAll().fetchAll();
@@ -249,7 +230,7 @@ export class Items {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    * @example Read all items to array.
    * ```typescript
    * const {body: containerList} = await items.readAll().fetchAll();
@@ -268,8 +249,8 @@ export class Items {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param body Represents the body of the item. Can contain any number of user defined properties.
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param body - Represents the body of the item. Can contain any number of user defined properties.
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    */
   public async create<T extends ItemDefinition = any>(
     body: T,
@@ -321,8 +302,8 @@ export class Items {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param body Represents the body of the item. Can contain any number of user defined properties.
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param body - Represents the body of the item. Can contain any number of user defined properties.
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    */
   public async upsert(body: any, options?: RequestOptions): Promise<ItemResponse<ItemDefinition>>;
   /**
@@ -333,8 +314,8 @@ export class Items {
    *
    * There is no set schema for JSON items. They may contain any number of custom properties.
    *
-   * @param body Represents the body of the item. Can contain any number of user defined properties.
-   * @param options Used for modifying the request (for instance, specifying the partition key).
+   * @param body - Represents the body of the item. Can contain any number of user defined properties.
+   * @param options - Used for modifying the request (for instance, specifying the partition key).
    */
   public async upsert<T extends ItemDefinition>(
     body: T,
@@ -392,7 +373,7 @@ export class Items {
    * The choices are: Create, Upsert, Read, Replace, and Delete
    *
    * Usage example:
-   *
+   *```typescript
    * // partitionKey is optional at the top level if present in the resourceBody
    * const operations: OperationInput[] = [
    *    {
@@ -407,9 +388,10 @@ export class Items {
    * ]
    *
    * await database.container.items.bulk(operation)
+   * ```
    *
-   * @param operations. List of operations. Limit 100
-   * @param options Used for modifying the request.
+   * @param operations - List of operations. Limit 100
+   * @param options - Used for modifying the request.
    */
   public async bulk(
     operations: OperationInput[],

--- a/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/Offer.ts
@@ -21,8 +21,8 @@ export class Offer {
   }
   /**
    * @hidden
-   * @param client The parent {@link CosmosClient} for the Database Account.
-   * @param id The id of the given {@link Offer}.
+   * @param client - The parent {@link CosmosClient} for the Database Account.
+   * @param id - The id of the given {@link Offer}.
    */
   constructor(
     public readonly client: CosmosClient,
@@ -32,7 +32,6 @@ export class Offer {
 
   /**
    * Read the {@link OfferDefinition} for the given {@link Offer}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<OfferResponse> {
     const response = await this.clientContext.read<OfferDefinition>({
@@ -46,8 +45,7 @@ export class Offer {
 
   /**
    * Replace the given {@link Offer} with the specified {@link OfferDefinition}.
-   * @param body The specified {@link OfferDefinition}
-   * @param options
+   * @param body - The specified {@link OfferDefinition}
    */
   public async replace(body: OfferDefinition, options?: RequestOptions): Promise<OfferResponse> {
     const err = {};

--- a/sdk/cosmosdb/cosmos/src/client/Offer/Offers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Offer/Offers.ts
@@ -17,7 +17,7 @@ import { OfferDefinition } from "./OfferDefinition";
 export class Offers {
   /**
    * @hidden
-   * @param client The parent {@link CosmosClient} for the offers.
+   * @param client - The parent {@link CosmosClient} for the offers.
    */
   constructor(
     public readonly client: CosmosClient,
@@ -26,14 +26,12 @@ export class Offers {
 
   /**
    * Query all offers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all offers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
@@ -51,7 +49,6 @@ export class Offers {
 
   /**
    * Read all offers.
-   * @param options
    * @example Read all offers to array.
    * ```typescript
    * const {body: offerList} = await client.offers.readAll().fetchAll();

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permission.ts
@@ -28,8 +28,8 @@ export class Permission {
   }
   /**
    * @hidden
-   * @param user The parent {@link User}.
-   * @param id The id of the given {@link Permission}.
+   * @param user - The parent {@link User}.
+   * @param id - The id of the given {@link Permission}.
    */
   constructor(
     public readonly user: User,
@@ -39,7 +39,6 @@ export class Permission {
 
   /**
    * Read the {@link PermissionDefinition} of the given {@link Permission}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<PermissionResponse> {
     const path = getPathFromLink(this.url);
@@ -56,8 +55,7 @@ export class Permission {
 
   /**
    * Replace the given {@link Permission} with the specified {@link PermissionDefinition}.
-   * @param body The specified {@link PermissionDefinition}.
-   * @param options
+   * @param body - The specified {@link PermissionDefinition}.
    */
   public async replace(
     body: PermissionDefinition,
@@ -83,7 +81,6 @@ export class Permission {
 
   /**
    * Delete the given {@link Permission}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<PermissionResponse> {
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Permission/Permissions.ts
@@ -20,20 +20,18 @@ import { PermissionResponse } from "./PermissionResponse";
 export class Permissions {
   /**
    * @hidden
-   * @param user The parent {@link User}.
+   * @param user - The parent {@link User}.
    */
   constructor(public readonly user: User, private readonly clientContext: ClientContext) {}
 
   /**
    * Query all permissions.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all permissions.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
@@ -54,7 +52,6 @@ export class Permissions {
 
   /**
    * Read all permissions.
-   * @param options
    * @example Read all permissions to array.
    * ```typescript
    * const {body: permissionList} = await user.permissions.readAll().fetchAll();
@@ -69,7 +66,7 @@ export class Permissions {
    *
    * A permission represents a per-User Permission to access a specific resource
    * e.g. Item or Container.
-   * @param body Represents the body of the permission.
+   * @param body - Represents the body of the permission.
    */
   public async create(
     body: PermissionDefinition,

--- a/sdk/cosmosdb/cosmos/src/client/Script/Scripts.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Script/Scripts.ts
@@ -8,7 +8,7 @@ import { Container } from "../Container/Container";
 
 export class Scripts {
   /**
-   * @param container The parent {@link Container}.
+   * @param container - The parent {@link Container}.
    * @hidden
    */
   constructor(
@@ -20,7 +20,7 @@ export class Scripts {
    * Used to read, replace, or delete a specific, existing {@link StoredProcedure} by id.
    *
    * Use `.storedProcedures` for creating new stored procedures, or querying/reading all stored procedures.
-   * @param id The id of the {@link StoredProcedure}.
+   * @param id - The id of the {@link StoredProcedure}.
    */
   public storedProcedure(id: string): StoredProcedure {
     return new StoredProcedure(this.container, id, this.clientContext);
@@ -30,7 +30,7 @@ export class Scripts {
    * Used to read, replace, or delete a specific, existing {@link Trigger} by id.
    *
    * Use `.triggers` for creating new triggers, or querying/reading all triggers.
-   * @param id The id of the {@link Trigger}.
+   * @param id - The id of the {@link Trigger}.
    */
   public trigger(id: string): Trigger {
     return new Trigger(this.container, id, this.clientContext);
@@ -40,7 +40,7 @@ export class Scripts {
    * Used to read, replace, or delete a specific, existing {@link UserDefinedFunction} by id.
    *
    * Use `.userDefinedFunctions` for creating new user defined functions, or querying/reading all user defined functions.
-   * @param id The id of the {@link UserDefinedFunction}.
+   * @param id - The id of the {@link UserDefinedFunction}.
    */
   public userDefinedFunction(id: string): UserDefinedFunction {
     return new UserDefinedFunction(this.container, id, this.clientContext);

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedure.ts
@@ -28,8 +28,8 @@ export class StoredProcedure {
   }
   /**
    * Creates a new instance of {@link StoredProcedure} linked to the parent {@link Container}.
-   * @param container The parent {@link Container}.
-   * @param id The id of the given {@link StoredProcedure}.
+   * @param container - The parent {@link Container}.
+   * @param id - The id of the given {@link StoredProcedure}.
    * @hidden
    */
   constructor(
@@ -40,7 +40,6 @@ export class StoredProcedure {
 
   /**
    * Read the {@link StoredProcedureDefinition} for the given {@link StoredProcedure}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<StoredProcedureResponse> {
     const path = getPathFromLink(this.url);
@@ -56,8 +55,7 @@ export class StoredProcedure {
 
   /**
    * Replace the given {@link StoredProcedure} with the specified {@link StoredProcedureDefinition}.
-   * @param body The specified {@link StoredProcedureDefinition} to replace the existing definition.
-   * @param options
+   * @param body - The specified {@link StoredProcedureDefinition} to replace the existing definition.
    */
   public async replace(
     body: StoredProcedureDefinition,
@@ -87,7 +85,6 @@ export class StoredProcedure {
 
   /**
    * Delete the given {@link StoredProcedure}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<StoredProcedureResponse> {
     const path = getPathFromLink(this.url);
@@ -108,9 +105,9 @@ export class StoredProcedure {
    * The specified type, T, is not enforced by the client.
    * Be sure to validate the response from the stored procedure matches the type, T, you provide.
    *
-   * @param partitionKey The partition key to use when executing the stored procedure
-   * @param params Array of parameters to pass as arguments to the given {@link StoredProcedure}.
-   * @param options Additional options, such as the partition key to invoke the {@link StoredProcedure} on.
+   * @param partitionKey - The partition key to use when executing the stored procedure
+   * @param params - Array of parameters to pass as arguments to the given {@link StoredProcedure}.
+   * @param options - Additional options, such as the partition key to invoke the {@link StoredProcedure} on.
    */
   public async execute<T = any>(
     partitionKey: any,

--- a/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
+++ b/sdk/cosmosdb/cosmos/src/client/StoredProcedure/StoredProcedures.ts
@@ -18,7 +18,7 @@ import { StoredProcedureResponse } from "./StoredProcedureResponse";
  */
 export class StoredProcedures {
   /**
-   * @param container The parent {@link Container}.
+   * @param container - The parent {@link Container}.
    * @hidden
    */
   constructor(
@@ -28,8 +28,7 @@ export class StoredProcedures {
 
   /**
    * Query all Stored Procedures.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @example Read all stored procedures to array.
    * ```typescript
    * const querySpec: SqlQuerySpec = {
@@ -44,8 +43,7 @@ export class StoredProcedures {
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all Stored Procedures.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @example Read all stored procedures to array.
    * ```typescript
    * const querySpec: SqlQuerySpec = {
@@ -76,7 +74,6 @@ export class StoredProcedures {
 
   /**
    * Read all stored procedures.
-   * @param options
    * @example Read all stored procedures to array.
    * ```typescript
    * const {body: sprocList} = await containers.storedProcedures.readAll().fetchAll();

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Trigger.ts
@@ -28,8 +28,8 @@ export class Trigger {
 
   /**
    * @hidden
-   * @param container The parent {@link Container}.
-   * @param id The id of the given {@link Trigger}.
+   * @param container - The parent {@link Container}.
+   * @param id - The id of the given {@link Trigger}.
    */
   constructor(
     public readonly container: Container,
@@ -39,7 +39,6 @@ export class Trigger {
 
   /**
    * Read the {@link TriggerDefinition} for the given {@link Trigger}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<TriggerResponse> {
     const path = getPathFromLink(this.url);
@@ -56,8 +55,7 @@ export class Trigger {
 
   /**
    * Replace the given {@link Trigger} with the specified {@link TriggerDefinition}.
-   * @param body The specified {@link TriggerDefinition} to replace the existing definition with.
-   * @param options
+   * @param body - The specified {@link TriggerDefinition} to replace the existing definition with.
    */
   public async replace(
     body: TriggerDefinition,
@@ -87,7 +85,6 @@ export class Trigger {
 
   /**
    * Delete the given {@link Trigger}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<TriggerResponse> {
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Trigger/Triggers.ts
@@ -19,7 +19,7 @@ import { TriggerResponse } from "./TriggerResponse";
 export class Triggers {
   /**
    * @hidden
-   * @param container The parent {@link Container}.
+   * @param container - The parent {@link Container}.
    */
   constructor(
     public readonly container: Container,
@@ -28,14 +28,12 @@ export class Triggers {
 
   /**
    * Query all Triggers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all Triggers.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
@@ -56,7 +54,6 @@ export class Triggers {
 
   /**
    * Read all Triggers.
-   * @param options
    * @example Read all trigger to array.
    * ```typescript
    * const {body: triggerList} = await container.triggers.readAll().fetchAll();
@@ -72,8 +69,6 @@ export class Triggers {
    * on creates, updates and deletes.
    *
    * For additional details, refer to the server-side JavaScript API documentation.
-   * @param body
-   * @param options
    */
   public async create(body: TriggerDefinition, options?: RequestOptions): Promise<TriggerResponse> {
     if (body.body) {

--- a/sdk/cosmosdb/cosmos/src/client/User/User.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/User.ts
@@ -36,8 +36,7 @@ export class User {
   }
   /**
    * @hidden
-   * @param database The parent {@link Database}.
-   * @param id
+   * @param database - The parent {@link Database}.
    */
   constructor(
     public readonly database: Database,
@@ -51,7 +50,6 @@ export class User {
    * Operations to read, replace, or delete a specific Permission by id.
    *
    * See `client.permissions` for creating, upserting, querying, or reading all operations.
-   * @param id
    */
   public permission(id: string): Permission {
     return new Permission(this, id, this.clientContext);
@@ -59,7 +57,6 @@ export class User {
 
   /**
    * Read the {@link UserDefinition} for the given {@link User}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<UserResponse> {
     const path = getPathFromLink(this.url);
@@ -75,8 +72,7 @@ export class User {
 
   /**
    * Replace the given {@link User}'s definition with the specified {@link UserDefinition}.
-   * @param body The specified {@link UserDefinition} to replace the definition.
-   * @param options
+   * @param body - The specified {@link UserDefinition} to replace the definition.
    */
   public async replace(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};
@@ -99,7 +95,6 @@ export class User {
 
   /**
    * Delete the given {@link User}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<UserResponse> {
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/User/Users.ts
+++ b/sdk/cosmosdb/cosmos/src/client/User/Users.ts
@@ -19,20 +19,18 @@ import { UserResponse } from "./UserResponse";
 export class Users {
   /**
    * @hidden
-   * @param database The parent {@link Database}.
+   * @param database - The parent {@link Database}.
    */
   constructor(public readonly database: Database, private readonly clientContext: ClientContext) {}
 
   /**
    * Query all users.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all users.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
@@ -52,8 +50,7 @@ export class Users {
   }
 
   /**
-   * Read all users.
-   * @param options
+   * Read all users.-
    * @example Read all users to array.
    * ```typescript
    * const {body: usersList} = await database.users.readAll().fetchAll();
@@ -65,8 +62,7 @@ export class Users {
 
   /**
    * Create a database user with the specified {@link UserDefinition}.
-   * @param body The specified {@link UserDefinition}.
-   * @param options
+   * @param body - The specified {@link UserDefinition}.
    */
   public async create(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};
@@ -89,8 +85,7 @@ export class Users {
 
   /**
    * Upsert a database user with a specified {@link UserDefinition}.
-   * @param body The specified {@link UserDefinition}.
-   * @param options
+   * @param body - The specified {@link UserDefinition}.
    */
   public async upsert(body: UserDefinition, options?: RequestOptions): Promise<UserResponse> {
     const err = {};

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunction.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunction.ts
@@ -27,8 +27,8 @@ export class UserDefinedFunction {
   }
   /**
    * @hidden
-   * @param container The parent {@link Container}.
-   * @param id The id of the given {@link UserDefinedFunction}.
+   * @param container - The parent {@link Container}.
+   * @param id - The id of the given {@link UserDefinedFunction}.
    */
   constructor(
     public readonly container: Container,
@@ -38,7 +38,6 @@ export class UserDefinedFunction {
 
   /**
    * Read the {@link UserDefinedFunctionDefinition} for the given {@link UserDefinedFunction}.
-   * @param options
    */
   public async read(options?: RequestOptions): Promise<UserDefinedFunctionResponse> {
     const path = getPathFromLink(this.url);
@@ -55,8 +54,7 @@ export class UserDefinedFunction {
 
   /**
    * Replace the given {@link UserDefinedFunction} with the specified {@link UserDefinedFunctionDefinition}.
-   * @param body The specified {@link UserDefinedFunctionDefinition}.
-   * @param options
+   * @param options -
    */
   public async replace(
     body: UserDefinedFunctionDefinition,
@@ -86,7 +84,6 @@ export class UserDefinedFunction {
 
   /**
    * Delete the given {@link UserDefined}.
-   * @param options
    */
   public async delete(options?: RequestOptions): Promise<UserDefinedFunctionResponse> {
     const path = getPathFromLink(this.url);

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
@@ -21,7 +21,7 @@ export class UserDefinedFunctionResponse extends ResourceResponse<
   /** A reference to the {@link UserDefinedFunction} corresponding to the returned {@link UserDefinedFunctionDefinition}. */
   public readonly userDefinedFunction: UserDefinedFunction;
   /**
-   * Alias for `userDefinedFunction(id).
+   * Alias for `userDefinedFunction(id)`.
    *
    * A reference to the {@link UserDefinedFunction} corresponding to the returned {@link UserDefinedFunctionDefinition}.
    */

--- a/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
+++ b/sdk/cosmosdb/cosmos/src/client/UserDefinedFunction/UserDefinedFunctions.ts
@@ -19,7 +19,7 @@ import { UserDefinedFunctionResponse } from "./UserDefinedFunctionResponse";
 export class UserDefinedFunctions {
   /**
    * @hidden
-   * @param container The parent {@link Container}.
+   * @param container - The parent {@link Container}.
    */
   constructor(
     public readonly container: Container,
@@ -28,14 +28,12 @@ export class UserDefinedFunctions {
 
   /**
    * Query all User Defined Functions.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Query all User Defined Functions.
-   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
-   * @param options
+   * @param query - Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    */
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
   public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
@@ -56,7 +54,6 @@ export class UserDefinedFunctions {
 
   /**
    * Read all User Defined Functions.
-   * @param options
    * @example Read all User Defined Functions to array.
    * ```typescript
    * const {body: udfList} = await container.userDefinedFunctions.readAll().fetchAll();

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -267,7 +267,6 @@ export function validateResourceId(resourceId: string) {
 
 /**
  * @hidden
- * @param resourcePath
  */
 export function getResourceIdFromPath(resourcePath: string) {
   if (!resourcePath || typeof resourcePath !== "string") {

--- a/sdk/cosmosdb/cosmos/src/common/uriFactory.ts
+++ b/sdk/cosmosdb/cosmos/src/common/uriFactory.ts
@@ -4,13 +4,13 @@ import { Constants } from "./constants";
 import { trimSlashFromLeftAndRight, validateResourceId } from "./helper";
 
 /**
+ * Would be used when creating or deleting a DocumentCollection
+ * or a User in Azure Cosmos DB database service
  * @hidden
  * Given a database id, this creates a database link.
- * @param {string} databaseId -The database id
- * @returns {string}          -A database link in the format of dbs/{0} \
- * with {0} being a Uri escaped version of the databaseId
- * @description Would be used when creating or deleting a DocumentCollection \
- * or a User in Azure Cosmos DB database service
+ * @param databaseId - The database id
+ * @returns A database link in the format of `dbs/{0}`
+ * with `{0}` being a Uri escaped version of the databaseId
  */
 export function createDatabaseUri(databaseId: string) {
   databaseId = trimSlashFromLeftAndRight(databaseId);
@@ -21,13 +21,13 @@ export function createDatabaseUri(databaseId: string) {
 
 /**
  * Given a database and collection id, this creates a collection link.
- * @param {string} databaseId        -The database id
- * @param {string} collectionId      -The collection id
- * @returns {string}                 A collection link in the format of dbs/{0}/colls/{1} \
- * with {0} being a Uri escaped version of the databaseId and {1} being collectionId
- * @description Would be used when updating or deleting a DocumentCollection, creating a \
- * Document, a StoredProcedure, a Trigger, a UserDefinedFunction, or when executing a query \
+ * Would be used when updating or deleting a DocumentCollection, creating a
+ * Document, a StoredProcedure, a Trigger, a UserDefinedFunction, or when executing a query
  * with CreateDocumentQuery in Azure Cosmos DB database service.
+ * @param databaseId - The database id
+ * @param collectionId - The collection id
+ * @returns A collection link in the format of `dbs/{0}/colls/{1}`
+ * with `{0}` being a Uri escaped version of the databaseId and `{1}` being collectionId
  * @hidden
  */
 export function createDocumentCollectionUri(databaseId: string, collectionId: string) {
@@ -41,12 +41,12 @@ export function createDocumentCollectionUri(databaseId: string, collectionId: st
 
 /**
  * Given a database and user id, this creates a user link.
- * @param {string} databaseId        -The database id
- * @param {string} userId            -The user id
- * @returns {string}                 A user link in the format of dbs/{0}/users/{1} \
- * with {0} being a Uri escaped version of the databaseId and {1} being userId
- * @description Would be used when creating a Permission, or when replacing or deleting \
+ * Would be used when creating a Permission, or when replacing or deleting
  * a User in Azure Cosmos DB database service
+ * @param databaseId - The database id
+ * @param userId - The user id
+ * @returns A user link in the format of `dbs/{0}/users/{1}`
+ * with `{0}` being a Uri escaped version of the databaseId and `{1}` being userId
  * @hidden
  */
 export function createUserUri(databaseId: string, userId: string) {
@@ -58,14 +58,14 @@ export function createUserUri(databaseId: string, userId: string) {
 
 /**
  * Given a database and collection id, this creates a collection link.
- * @param {string} databaseId        -The database id
- * @param {string} collectionId      -The collection id
- * @param {string} documentId        -The document id
- * @returns {string}                 -A document link in the format of \
- * dbs/{0}/colls/{1}/docs/{2} with {0} being a Uri escaped version of \
- * the databaseId, {1} being collectionId and {2} being the documentId
- * @description Would be used when creating an Attachment, or when replacing \
+ * Would be used when creating an Attachment, or when replacing
  * or deleting a Document in Azure Cosmos DB database service
+ * @param databaseId - The database id
+ * @param collectionId - The collection id
+ * @param documentId - The document id
+ * @returns A document link in the format of
+ * `dbs/{0}/colls/{1}/docs/{2}` with `{0}` being a Uri escaped version of
+ * the databaseId, `{1}` being collectionId and `{2}` being the documentId
  * @hidden
  */
 export function createDocumentUri(databaseId: string, collectionId: string, documentId: string) {
@@ -83,12 +83,12 @@ export function createDocumentUri(databaseId: string, collectionId: string, docu
 
 /**
  * Given a database, collection and document id, this creates a document link.
- * @param {string} databaseId    -The database Id
- * @param {string} userId        -The user Id
- * @param {string} permissionId  - The permissionId
- * @returns {string} A permission link in the format of dbs/{0}/users/{1}/permissions/{2} \
- * with {0} being a Uri escaped version of the databaseId, {1} being userId and {2} being permissionId
- * @description Would be used when replacing or deleting a Permission in Azure Cosmos DB database service.
+ * Would be used when replacing or deleting a Permission in Azure Cosmos DB database service.
+ * @param databaseId    -The database Id
+ * @param userId        -The user Id
+ * @param permissionId  - The permissionId
+ * @returns A permission link in the format of `dbs/{0}/users/{1}/permissions/{2}`
+ * with `{0}` being a Uri escaped version of the databaseId, `{1}` being userId and `{2}` being permissionId
  * @hidden
  */
 export function createPermissionUri(databaseId: string, userId: string, permissionId: string) {
@@ -106,14 +106,14 @@ export function createPermissionUri(databaseId: string, userId: string, permissi
 
 /**
  * Given a database, collection and stored proc id, this creates a stored proc link.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @param {string} storedProcedureId -The stored procedure Id
- * @returns {string}                 -A stored procedure link in the format of \
- * dbs/{0}/colls/{1}/sprocs/{2} with {0} being a Uri escaped version of the databaseId, \
- * {1} being collectionId and {2} being the storedProcedureId
- * @description Would be used when replacing, executing, or deleting a StoredProcedure in \
+ * Would be used when replacing, executing, or deleting a StoredProcedure in
  * Azure Cosmos DB database service.
+ * @param databaseId        -The database Id
+ * @param collectionId      -The collection Id
+ * @param storedProcedureId -The stored procedure Id
+ * @returns A stored procedure link in the format of
+ * `dbs/{0}/colls/{1}/sprocs/{2}` with `{0}` being a Uri escaped version of the databaseId,
+ * `{1}` being collectionId and `{2}` being the storedProcedureId
  * @hidden
  */
 export function createStoredProcedureUri(
@@ -134,14 +134,14 @@ export function createStoredProcedureUri(
 }
 
 /**
- * @summary Given a database, collection and trigger id, this creates a trigger link.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @param {string} triggerId         -The trigger Id
- * @returns {string}                 -A trigger link in the format of \
- * dbs/{0}/colls/{1}/triggers/{2} with {0} being a Uri escaped version of the databaseId, \
- * {1} being collectionId and {2} being the triggerId
- * @description Would be used when replacing, executing, or deleting a Trigger in Azure Cosmos DB database service
+ * Given a database, collection and trigger id, this creates a trigger link.
+ * Would be used when replacing, executing, or deleting a Trigger in Azure Cosmos DB database service
+ * @param databaseId        -The database Id
+ * @param collectionId      -The collection Id
+ * @param triggerId         -The trigger Id
+ * @returns A trigger link in the format of
+ * `dbs/{0}/colls/{1}/triggers/{2}` with `{0}` being a Uri escaped version of the databaseId,
+ * `{1}` being collectionId and `{2}` being the triggerId
  * @hidden
  */
 export function createTriggerUri(databaseId: string, collectionId: string, triggerId: string) {
@@ -158,14 +158,14 @@ export function createTriggerUri(databaseId: string, collectionId: string, trigg
 }
 
 /**
- * @summary Given a database, collection and udf id, this creates a udf link.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @param {string} udfId             -The User Defined Function Id
- * @returns {string}                 -A udf link in the format of dbs/{0}/colls/{1}/udfs/{2} \
- * with {0} being a Uri escaped version of the databaseId, {1} being collectionId and {2} being the udfId
- * @description Would be used when replacing, executing, or deleting a UserDefinedFunction in \
+ * Given a database, collection and udf id, this creates a udf link.
+ * Would be used when replacing, executing, or deleting a UserDefinedFunction in
  * Azure Cosmos DB database service
+ * @param databaseId        -The database Id
+ * @param collectionId      -The collection Id
+ * @param udfId             -The User Defined Function Id
+ * @returns A udf link in the format of `dbs/{0}/colls/{1}/udfs/{2}`
+ * with `{0}` being a Uri escaped version of the databaseId, `{1}` being collectionId and `{2}` being the udfId
  * @hidden
  */
 export function createUserDefinedFunctionUri(
@@ -186,13 +186,13 @@ export function createUserDefinedFunctionUri(
 }
 
 /**
- * @summary Given a database, collection and conflict id, this creates a conflict link.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @param {string} conflictId        -The conflict Id
- * @returns {string}                 -A conflict link in the format of dbs/{0}/colls/{1}/conflicts/{2} \
- * with {0} being a Uri escaped version of the databaseId, {1} being collectionId and {2} being the conflictId
- * @description Would be used when creating a Conflict in Azure Cosmos DB database service.
+ * Given a database, collection and conflict id, this creates a conflict link.
+ * Would be used when creating a Conflict in Azure Cosmos DB database service.
+ * @param databaseId        -The database Id
+ * @param collectionId      -The collection Id
+ * @param conflictId        -The conflict Id
+ * @returns A conflict link in the format of `dbs/{0}/colls/{1}/conflicts/{2}`
+ * with `{0}` being a Uri escaped version of the databaseId, `{1}` being collectionId and `{2}` being the conflictId
  * @hidden
  */
 export function createConflictUri(databaseId: string, collectionId: string, conflictId: string) {
@@ -209,14 +209,14 @@ export function createConflictUri(databaseId: string, collectionId: string, conf
 }
 
 /**
- * @summary Given a database, collection and conflict id, this creates a conflict link.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @param {string} documentId        -The document Id\
- * @param {string} attachmentId      -The attachment Id
- * @returns {string}                 -A conflict link in the format of dbs/{0}/colls/{1}/conflicts/{2} \
- * with {0} being a Uri escaped version of the databaseId, {1} being collectionId and {2} being the conflictId
- * @description Would be used when creating a Conflict in Azure Cosmos DB database service.
+ * Given a database, collection and conflict id, this creates a conflict link.
+ * Would be used when creating a Conflict in Azure Cosmos DB database service.
+ * @param databaseId        -The database Id
+ * @param collectionId      -The collection Id
+ * @param documentId        -The document Id
+ * @param attachmentId      -The attachment Id
+ * @returns A conflict link in the format of `dbs/{0}/colls/{1}/conflicts/{2}`
+ * with `{0}` being a Uri escaped version of the databaseId, `{1}` being collectionId and `{2}` being the conflictId
  * @hidden
  */
 export function createAttachmentUri(
@@ -238,12 +238,12 @@ export function createAttachmentUri(
 }
 
 /**
- * @summary Given a database and collection, this creates a partition key ranges link in\
+ * Given a database and collection, this creates a partition key ranges link in
  *  the Azure Cosmos DB database service.
- * @param {string} databaseId        -The database Id
- * @param {string} collectionId      -The collection Id
- * @returns {string}                 -A partition key ranges link in the format of \
- * dbs/{0}/colls/{1}/pkranges with {0} being a Uri escaped version of the databaseId and {1} being collectionId
+ * @param databaseId - The database Id
+ * @param collectionId - The collection Id
+ * @returns A partition key ranges link in the format of
+ * `dbs/{0}/colls/{1}/pkranges` with `{0}` being a Uri escaped version of the databaseId and `{1}` being collectionId
  * @hidden
  */
 export function createPartitionKeyRangesUri(databaseId: string, collectionId: string) {

--- a/sdk/cosmosdb/cosmos/src/documents/ConsistencyLevel.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConsistencyLevel.ts
@@ -32,7 +32,7 @@ export enum ConsistencyLevel {
   Eventual = "Eventual",
   /**
    * ConsistentPrefix Consistency guarantees that reads will return some prefix of all writes with no gaps.
-   * All writes will be eventually be available for reads.`
+   * All writes will be eventually be available for reads.
    */
   ConsistentPrefix = "ConsistentPrefix"
 }

--- a/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
@@ -32,7 +32,7 @@ export class DatabaseAccount {
   public readonly mediaLink: string;
   /**
    * Attachment content (media) storage quota in MBs ( Retrieved from gateway ).
-   * @deprecated use `maxMediaStorageUsageInMB
+   * @deprecated use `maxMediaStorageUsageInMB`
    */
   public get MaxMediaStorageUsageInMB() {
     return this.maxMediaStorageUsageInMB;

--- a/sdk/cosmosdb/cosmos/src/documents/IndexingMode.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/IndexingMode.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 /**
  * Specifies the supported indexing modes.
- * @property Consistent
- * @property Lazy
  */
 export enum IndexingMode {
   /**

--- a/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
@@ -5,8 +5,6 @@ import { PartitionKey, PartitionKeyDefinition } from "./documents";
 
 /**
  * @hidden
- * @param document
- * @param partitionKeyDefinition
  */
 export function extractPartitionKey(
   document: any,
@@ -38,7 +36,6 @@ export function extractPartitionKey(
 }
 /**
  * @hidden
- * @param partitionKeyDefinition
  */
 export function undefinedPartitionKey(partitionKeyDefinition: PartitionKeyDefinition) {
   if (partitionKeyDefinition.systemKey === true) {

--- a/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
+++ b/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
@@ -9,26 +9,27 @@ import { ResourceResponse } from "./request";
 /**
  * @hidden
  * This internal class implements the logic for endpoint management for geo-replicated database accounts.
- * @property {object} client                       - The document client instance.
- * @property {string} defaultEndpoint              - The endpoint used to create the client instance.
- * @property {bool} enableEndpointDiscovery        - Flag to enable/disable automatic redirecting of requests
- *                                                   based on read/write operations.
- * @property {Array} preferredLocations            - List of azure regions to be used as preferred locations
- *                                                   for read requests.
- * @property {bool} isEndpointCacheInitialized     - Flag to determine whether the endpoint cache is initialized or not.
  */
 export class GlobalEndpointManager {
+  /**
+   * The endpoint used to create the client instance.
+   */
   private defaultEndpoint: string;
+  /**
+   * Flag to enable/disable automatic redirecting of requests based on read/write operations.
+   */
   public enableEndpointDiscovery: boolean;
   private isRefreshing: boolean;
   private options: CosmosClientOptions;
+  /**
+   * List of azure regions to be used as preferred locations for read requests.
+   */
   private preferredLocations: string[];
   private writeableLocations: Location[];
   private readableLocations: Location[];
 
   /**
-   * @constructor GlobalEndpointManager
-   * @param {object} options                          - The document client instance.
+   * @param options - The document client instance.
    */
   constructor(
     options: CosmosClientOptions,
@@ -183,9 +184,6 @@ export class GlobalEndpointManager {
    * Gets the database account first by using the default endpoint, and if that doesn't returns
    * use the endpoints for the preferred locations in the order they are specified to get
    * the database account.
-   * @memberof GlobalEndpointManager
-   * @instance
-   * @param {function} callback        - The callback function which takes databaseAccount(object) as an argument.
    */
   private async getDatabaseAccountFromAnyEndpoint(): Promise<DatabaseAccount> {
     try {
@@ -223,10 +221,9 @@ export class GlobalEndpointManager {
 
   /**
    * Gets the locational endpoint using the location name passed to it using the default endpoint.
-   * @memberof GlobalEndpointManager
-   * @instance
-   * @param {string} defaultEndpoint - The default endpoint to use for the endpoint.
-   * @param {string} locationName    - The location name for the azure region like "East US".
+   *
+   * @param defaultEndpoint - The default endpoint to use for the endpoint.
+   * @param locationName    - The location name for the azure region like "East US".
    */
   private static getLocationalEndpoint(defaultEndpoint: string, locationName: string) {
     // For defaultEndpoint like 'https://contoso.documents.azure.com:443/' parse it to generate URL format

--- a/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
+++ b/sdk/cosmosdb/cosmos/src/plugins/Plugin.ts
@@ -38,7 +38,7 @@ export interface PluginConfig {
 /**
  * Plugins allow you to customize the behavior of the SDk with additional logging, retry, or additional functionality.
  *
- * A plugin is a function which returns a Promise<Response<T>>, and is passed a RequestContext and Next object.
+ * A plugin is a function which returns a `Promise<Response<T>>`, and is passed a RequestContext and Next object.
  *
  * Next is a function which takes in requestContext returns a promise. You must await/then that promise which will contain the response from further plugins,
  * allowing you to log those results or handle errors.
@@ -59,9 +59,6 @@ export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
 
 /**
  * @internal
- * @param requestContext
- * @param next
- * @param on
  */
 export async function executePlugins(
   requestContext: RequestContext,

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/AverageAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/AverageAggregator.ts
@@ -14,9 +14,6 @@ export class AverageAggregator implements Aggregator {
   public count: number;
   /**
    * Add the provided item to aggregation result.
-   * @memberof AverageAggregator
-   * @instance
-   * @param other
    */
   public aggregate(other: AverageAggregateResult) {
     if (other == null || other.sum == null) {
@@ -32,8 +29,6 @@ export class AverageAggregator implements Aggregator {
 
   /**
    * Get the aggregation result.
-   * @memberof AverageAggregator
-   * @instance
    */
   public getResult() {
     if (this.sum == null || this.count <= 0) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/CountAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/CountAggregator.ts
@@ -7,7 +7,6 @@ export class CountAggregator implements Aggregator {
   public value: number;
   /**
    * Represents an aggregator for COUNT operator.
-   * @constructor CountAggregator
    * @hidden
    */
   constructor() {
@@ -15,9 +14,6 @@ export class CountAggregator implements Aggregator {
   }
   /**
    * Add the provided item to aggregation result.
-   * @memberof CountAggregator
-   * @instance
-   * @param other
    */
   public aggregate(other: number) {
     this.value += other;
@@ -25,8 +21,6 @@ export class CountAggregator implements Aggregator {
 
   /**
    * Get the aggregation result.
-   * @memberof CountAggregator
-   * @instance
    */
   public getResult() {
     return this.value;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MaxAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MaxAggregator.ts
@@ -14,7 +14,6 @@ export class MaxAggregator implements Aggregator {
   private comparer: OrderByDocumentProducerComparator;
   /**
    * Represents an aggregator for MAX operator.
-   * @constructor MaxAggregator
    * @hidden
    */
   constructor() {
@@ -23,9 +22,6 @@ export class MaxAggregator implements Aggregator {
   }
   /**
    * Add the provided item to aggregation result.
-   * @memberof MaxAggregator
-   * @instance
-   * @param other
    */
   public aggregate(other: MaxAggregateResult) {
     if (this.value === undefined) {
@@ -39,8 +35,6 @@ export class MaxAggregator implements Aggregator {
 
   /**
    * Get the aggregation result.
-   * @memberof MaxAggregator
-   * @instance
    */
   public getResult() {
     return this.value;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MinAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/MinAggregator.ts
@@ -14,7 +14,6 @@ export class MinAggregator implements Aggregator {
   private comparer: OrderByDocumentProducerComparator;
   /**
    * Represents an aggregator for MIN operator.
-   * @constructor MinAggregator
    * @hidden
    */
   constructor() {
@@ -23,9 +22,6 @@ export class MinAggregator implements Aggregator {
   }
   /**
    * Add the provided item to aggregation result.
-   * @memberof MinAggregator
-   * @instance
-   * @param other
    */
   public aggregate(other: MinAggregateResult) {
     if (this.value === undefined) {
@@ -42,8 +38,6 @@ export class MinAggregator implements Aggregator {
 
   /**
    * Get the aggregation result.
-   * @memberof MinAggregator
-   * @instance
    */
   public getResult() {
     return this.value;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/SumAggregator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/Aggregators/SumAggregator.ts
@@ -7,9 +7,6 @@ export class SumAggregator implements Aggregator {
   public sum: number;
   /**
    * Add the provided item to aggregation result.
-   * @memberof SumAggregator
-   * @instance
-   * @param other
    */
   public aggregate(other: number) {
     if (other === undefined) {
@@ -24,8 +21,6 @@ export class SumAggregator implements Aggregator {
 
   /**
    * Get the aggregation result.
-   * @memberof SumAggregator
-   * @instance
    */
   public getResult() {
     return this.sum;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderByEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderByEndpointComponent.ts
@@ -6,17 +6,15 @@ import { ExecutionContext } from "../ExecutionContext";
 /** @hidden */
 export class OrderByEndpointComponent implements ExecutionContext {
   /**
-   * Represents an endpoint in handling an order by query. For each processed orderby \
+   * Represents an endpoint in handling an order by query. For each processed orderby
    * result it returns 'payload' item of the result
-   * @constructor OrderByEndpointComponent
-   * @param {object} executionContext              - Underlying Execution Context
+   *
+   * @param executionContext - Underlying Execution Context
    * @hidden
    */
   constructor(private executionContext: ExecutionContext) {}
   /**
    * Execute a provided function on the next element in the OrderByEndpointComponent.
-   * @memberof OrderByEndpointComponent
-   * @instance
    */
   public async nextItem(): Promise<Response<any>> {
     const { result: item, headers } = await this.executionContext.nextItem();
@@ -28,9 +26,7 @@ export class OrderByEndpointComponent implements ExecutionContext {
 
   /**
    * Determine if there are still remaining resources to processs.
-   * @memberof OrderByEndpointComponent
-   * @instance
-   * @returns {Boolean} true if there is other elements to process in the OrderByEndpointComponent.
+   * @returns true if there is other elements to process in the OrderByEndpointComponent.
    */
   public hasMoreResults() {
     return this.executionContext.hasMoreResults();

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
@@ -15,9 +15,9 @@ export class FetchResult {
   /**
    * Wraps fetch results for the document producer.
    * This allows the document producer to buffer exceptions so that actual results don't get flushed during splits.
-   * @constructor DocumentProducer
-   * @param {object} feedReponse                  - The response the document producer got back on a successful fetch
-   * @param {object} error                        - The exception meant to be buffered on an unsuccessful fetch
+   *
+   * @param feedReponse - The response the document producer got back on a successful fetch
+   * @param error - The exception meant to be buffered on an unsuccessful fetch
    * @hidden
    */
   constructor(feedResponse: any, error: any) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
@@ -26,7 +26,7 @@ export interface SqlQuerySpec {
  * Represents a parameter in a Parameterized SQL query, specified in {@link SqlQuerySpec}
  */
 export interface SqlParameter {
-  /** Name of the parameter. (i.e. "@lastName") */
+  /** Name of the parameter. (i.e. `@lastName`) */
   name: string;
   /** Value of the parameter (this is safe to come from users, assuming they are authorized) */
   value: JSONValue;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -37,11 +37,11 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
   /**
    * Provides the basic Query Execution Context.
    * This wraps the internal logic query execution using provided fetch functions
-   * @constructor DefaultQueryExecutionContext
-   * @param {ClientContext} clientContext          - Is used to read the partitionKeyRanges for split proofing
-   * @param {SqlQuerySpec | string} query          - A SQL query.
-   * @param {FeedOptions} [options]                - Represents the feed options.
-   * @param {callback | callback[]} fetchFunctions - A function to retrieve each page of data.
+   *
+   * @param clientContext  - Is used to read the partitionKeyRanges for split proofing
+   * @param query          - A SQL query.
+   * @param options        - Represents the feed options.
+   * @param fetchFunctions - A function to retrieve each page of data.
    *                          An array of functions may be used to query more than one partition.
    * @hidden
    */
@@ -58,8 +58,6 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
 
   /**
    * Execute a provided callback on the next element in the execution context.
-   * @memberof DefaultQueryExecutionContext
-   * @instance
    */
   public async nextItem(): Promise<Response<any>> {
     ++this.currentIndex;
@@ -69,8 +67,6 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
 
   /**
    * Retrieve the current element on the execution context.
-   * @memberof DefaultQueryExecutionContext
-   * @instance
    */
   public async current(): Promise<Response<any>> {
     if (this.currentIndex < this.resources.length) {
@@ -101,9 +97,8 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
   /**
    * Determine if there are still remaining resources to processs based on
    * the value of the continuation token or the elements remaining on the current batch in the execution context.
-   * @memberof DefaultQueryExecutionContext
-   * @instance
-   * @returns {Boolean} true if there is other elements to process in the DefaultQueryExecutionContext.
+   *
+   * @returns true if there is other elements to process in the DefaultQueryExecutionContext.
    */
   public hasMoreResults() {
     return (
@@ -116,13 +111,6 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
 
   /**
    * Fetches the next batch of the feed and pass them as an array to a callback
-   * @memberof DefaultQueryExecutionContext
-   * @instance
-   */
-  /**
-   * Fetches the next batch of the feed and pass them as an array to a callback
-   * @memberof DefaultQueryExecutionContext
-   * @instance
    */
   public async fetchMore(): Promise<Response<any>> {
     if (this.currentPartitionIndex >= this.fetchFunctions.length) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -32,11 +32,10 @@ export class DocumentProducer {
 
   /**
    * Provides the Target Partition Range Query Execution Context.
-   * @constructor DocumentProducer
-   * @param {ClientContext} clientContext        - The service endpoint to use to create the client.
-   * @param {String} collectionLink                - Represents collection link
-   * @param {SqlQuerySpec | string} query          - A SQL query.
-   * @param {object} targetPartitionKeyRange       - Query Target Partition key Range
+   * @param clientContext  - The service endpoint to use to create the client.
+   * @param collectionLink - Represents collection link
+   * @param query          - A SQL query.
+   * @param targetPartitionKeyRange - Query Target Partition key Range
    * @hidden
    */
   constructor(
@@ -64,7 +63,7 @@ export class DocumentProducer {
   }
   /**
    * Synchronously gives the contiguous buffered results (stops at the first non result) if any
-   * @returns {Object}       - buffered current items if any
+   * @returns buffered current items if any
    * @hidden
    */
   public peekBufferedItems() {
@@ -150,8 +149,6 @@ export class DocumentProducer {
 
   /**
    * Fetches and bufferes the next page of results and executes the given callback
-   * @memberof DocumentProducer
-   * @instance
    */
   public async bufferMore(): Promise<Response<any>> {
     if (this.err) {
@@ -204,7 +201,7 @@ export class DocumentProducer {
 
   /**
    * Synchronously gives the bufferend current item if any
-   * @returns {Object}       - buffered current item if any
+   * @returns buffered current item if any
    * @hidden
    */
   public getTargetParitionKeyRange() {
@@ -212,11 +209,7 @@ export class DocumentProducer {
   }
 
   /**
-   * Execute a provided function on the next element in the DocumentProducer.
-   * @memberof DocumentProducer
-   * @instance
-   * @param {callback} callback - Function to execute for each element. the function \
-   * takes two parameters error, element.
+   * Fetches the next element in the DocumentProducer.
    */
   public async nextItem(): Promise<Response<any>> {
     if (this.err) {
@@ -249,10 +242,6 @@ export class DocumentProducer {
 
   /**
    * Retrieve the current element on the DocumentProducer.
-   * @memberof DocumentProducer
-   * @instance
-   * @param {callback} callback - Function to execute for the current element. \
-   * the function takes two parameters error, element.
    */
   public async current(): Promise<Response<any>> {
     // If something is buffered just give that

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
@@ -40,8 +40,6 @@ export function getInitialHeader(): CosmosHeaders {
 
 /**
  * @hidden
- * @param headers
- * @param toBeMergedHeaders
  */
 // TODO: The name of this method isn't very accurate to what it does
 export function mergeHeaders(headers: CosmosHeaders, toBeMergedHeaders: CosmosHeaders) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByQueryExecutionContext.ts
@@ -18,11 +18,10 @@ export class OrderByQueryExecutionContext extends ParallelQueryExecutionContextB
    * When handling a parallelized query, it instantiates one instance of
    * DocumentProcuder per target partition key range and aggregates the result of each.
    *
-   * @constructor ParallelQueryExecutionContext
-   * @param {ClientContext} clientContext        - The service endpoint to use to create the client.
-   * @param {string} collectionLink                - The Collection Link
-   * @param {FeedOptions} [options]                - Represents the feed options.
-   * @param {object} partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
+   * @param clientContext - The service endpoint to use to create the client.
+   * @param collectionLink - The Collection Link
+   * @param options - Represents the feed options.
+   * @param partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
    * @hidden
    */
   constructor(
@@ -41,7 +40,7 @@ export class OrderByQueryExecutionContext extends ParallelQueryExecutionContextB
   // Overriding documentProducerComparator for OrderByQueryExecutionContexts
   /**
    * Provides a Comparator for document producers which respects orderby sort order.
-   * @returns {object}        - Comparator Function
+   * @returns Comparator Function
    * @hidden
    */
   public documentProducerComparator(docProd1: DocumentProducer, docProd2: DocumentProducer) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContext.ts
@@ -13,11 +13,10 @@ export class ParallelQueryExecutionContext extends ParallelQueryExecutionContext
    * Provides the ParallelQueryExecutionContext.
    * This class is capable of handling parallelized queries and dervives from ParallelQueryExecutionContextBase.
    *
-   * @constructor ParallelQueryExecutionContext
-   * @param {ClientContext} clientContext        - The service endpoint to use to create the client.
-   * @param {string} collectionLink                - The Collection Link
-   * @param {FeedOptions} [options]                - Represents the feed options.
-   * @param {object} partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
+   * @param clientContext - The service endpoint to use to create the client.
+   * @param collectionLink - The Collection Link
+   * @param options - Represents the feed options.
+   * @param partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
    * @hidden
    */
   constructor(
@@ -35,7 +34,7 @@ export class ParallelQueryExecutionContext extends ParallelQueryExecutionContext
   // Overriding documentProducerComparator for ParallelQueryExecutionContexts
   /**
    * Provides a Comparator for document producers using the min value of the corresponding target partition.
-   * @returns {object}        - Comparator Function
+   * @returns Comparator Function
    * @hidden
    */
   public documentProducerComparator(docProd1: DocumentProducer, docProd2: DocumentProducer) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -43,11 +43,10 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
    * When handling a parallelized query, it instantiates one instance of
    * DocumentProcuder per target partition key range and aggregates the result of each.
    *
-   * @constructor ParallelQueryExecutionContext
-   * @param {ClientContext} clientContext        - The service endpoint to use to create the client.
-   * @param {string} collectionLink                - The Collection Link
-   * @param {FeedOptions} [options]                - Represents the feed options.
-   * @param {object} partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
+   * @param clientContext - The service endpoint to use to create the client.
+   * @param collectionLink - The Collection Link
+   * @param options - Represents the feed options.
+   * @param partitionedQueryExecutionInfo - PartitionedQueryExecutionInfo
    * @hidden
    */
   constructor(
@@ -192,8 +191,6 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
 
   /**
    * Gets the replacement ranges for a partitionkeyrange that has been split
-   * @memberof ParallelQueryExecutionContextBase
-   * @instance
    */
   private async _getReplacementPartitionKeyRanges(documentProducer: DocumentProducer) {
     const partitionKeyRange = documentProducer.targetPartitionKeyRange;
@@ -209,8 +206,6 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
    * Removes the current document producer from the priqueue,
    * replaces that document producer with child document producers,
    * then reexecutes the originFunction with the corrrected executionContext
-   * @memberof ParallelQueryExecutionContextBase
-   * @instance
    */
   private async _repairExecutionContext(originFunction: any) {
     // TODO: any
@@ -284,8 +279,6 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
    * Checks to see if the executionContext needs to be repaired.
    * if so it repairs the execution context and executes the ifCallback,
    * else it continues with the current execution context and executes the elseCallback
-   * @memberof ParallelQueryExecutionContextBase
-   * @instance
    */
   private async _repairExecutionContextIfNeeded(ifCallback: any, elseCallback: any) {
     const documentProducer = this.orderByPQ.peek();
@@ -306,11 +299,7 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   }
 
   /**
-   * Execute a provided function on the next element in the ParallelQueryExecutionContextBase.
-   * @memberof ParallelQueryExecutionContextBase
-   * @instance
-   * @param {callback} callback - Function to execute for each element. the function takes two \
-   * parameters error, element.
+   * Fetches the next element in the ParallelQueryExecutionContextBase.
    */
   public async nextItem(): Promise<Response<any>> {
     if (this.err) {
@@ -443,11 +432,9 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   }
 
   /**
-   * Determine if there are still remaining resources to processs based on the value of the continuation \
+   * Determine if there are still remaining resources to processs based on the value of the continuation
    * token or the elements remaining on the current batch in the QueryIterator.
-   * @memberof ParallelQueryExecutionContextBase
-   * @instance
-   * @returns {Boolean} true if there is other elements to process in the ParallelQueryExecutionContextBase.
+   * @returns true if there is other elements to process in the ParallelQueryExecutionContextBase.
    */
   public hasMoreResults() {
     return !(

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -104,9 +104,9 @@ export class QueryIterator<T> {
   }
 
   /**
-   * Determine if there are still remaining resources to processs based on the value of the continuation token or the\
+   * Determine if there are still remaining resources to processs based on the value of the continuation token or the
    * elements remaining on the current batch in the QueryIterator.
-   * @returns {Boolean} true if there is other elements to process in the QueryIterator.
+   * @returns true if there is other elements to process in the QueryIterator.
    */
   public hasMoreResults(): boolean {
     return this.queryExecutionContext.hasMoreResults();

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetrics.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetrics.ts
@@ -26,8 +26,6 @@ export class QueryMetrics {
 
   /**
    * Gets the IndexHitRatio
-   * @memberof QueryMetrics
-   * @instance
    * @hidden
    */
   public get indexHitRatio() {
@@ -93,8 +91,6 @@ export class QueryMetrics {
 
   /**
    * Output the QueryMetrics as a delimited string.
-   * @memberof QueryMetrics
-   * @instance
    * @hidden
    */
   public toDelimitedString() {
@@ -163,8 +159,6 @@ export class QueryMetrics {
 
   /**
    * Returns a new instance of the QueryMetrics class that is the aggregation of an array of query metrics.
-   * @memberof QueryMetrics
-   * @instance
    */
   public static createFromArray(queryMetricsArray: QueryMetrics[]) {
     if (!queryMetricsArray) {
@@ -176,8 +170,6 @@ export class QueryMetrics {
 
   /**
    * Returns a new instance of the QueryMetrics class this is deserialized from a delimited string.
-   * @memberof QueryMetrics
-   * @instance
    */
   public static createFromDelimitedString(
     delimitedString: string,

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetricsUtils.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/queryMetricsUtils.ts
@@ -4,7 +4,6 @@ import { TimeSpan } from "./timeSpan";
 
 /**
  * @hidden
- * @param delimitedString
  */
 export function parseDelimitedString(delimitedString: string) {
   if (delimitedString == null) {
@@ -32,8 +31,6 @@ export function parseDelimitedString(delimitedString: string) {
 
 /**
  * @hidden
- * @param metrics
- * @param key
  */
 export function timeSpanFromMetrics(metrics: { [key: string]: any } /* TODO: any */, key: string) {
   if (key in metrics) {
@@ -45,7 +42,6 @@ export function timeSpanFromMetrics(metrics: { [key: string]: any } /* TODO: any
 
 /**
  * @hidden
- * @param input
  */
 export function isNumeric(input: any) {
   return !isNaN(parseFloat(input)) && isFinite(input);

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/queryPreparationTime.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/queryPreparationTime.ts
@@ -74,8 +74,6 @@ export class QueryPreparationTimes {
   /**
    * Returns a new instance of the QueryPreparationTimes class that is the
    * aggregation of an array of QueryPreparationTimes.
-   * @memberof QueryMetrics
-   * @instance
    */
   public static createFromArray(queryPreparationTimesArray: QueryPreparationTimes[]) {
     if (queryPreparationTimesArray == null) {
@@ -87,8 +85,6 @@ export class QueryPreparationTimes {
 
   /**
    * Returns a new instance of the QueryPreparationTimes class this is deserialized from a delimited string.
-   * @memberof QueryMetrics
-   * @instance
    */
   public static createFromDelimitedString(delimitedString: string) {
     const metrics = parseDelimitedString(delimitedString);

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/timeSpan.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/timeSpan.ts
@@ -47,12 +47,11 @@ const minMilliSeconds = Number.MIN_SAFE_INTEGER / ticksPerMillisecond;
 /**
  * Represents a time interval.
  *
- * @constructor TimeSpan
- * @param {number} days                 - Number of days.
- * @param {number} hours                - Number of hours.
- * @param {number} minutes              - Number of minutes.
- * @param {number} seconds              - Number of seconds.
- * @param {number} milliseconds         - Number of milliseconds.
+ * @param days                 - Number of days.
+ * @param hours                - Number of hours.
+ * @param minutes              - Number of minutes.
+ * @param seconds              - Number of seconds.
+ * @param milliseconds         - Number of milliseconds.
  * @hidden
  */
 export class TimeSpan {
@@ -91,9 +90,7 @@ export class TimeSpan {
 
   /**
    * Returns a new TimeSpan object whose value is the sum of the specified TimeSpan object and this instance.
-   * @param {TimeSpan} ts              - The time interval to add.
-   * @memberof TimeSpan
-   * @instance
+   * @param ts - The time interval to add.
    */
   public add(ts: TimeSpan) {
     if (TimeSpan.additionDoesOverflow(this._ticks, ts._ticks)) {
@@ -106,9 +103,7 @@ export class TimeSpan {
 
   /**
    * Returns a new TimeSpan object whose value is the difference of the specified TimeSpan object and this instance.
-   * @param {TimeSpan} ts              - The time interval to subtract.
-   * @memberof TimeSpan
-   * @instance
+   * @param ts - The time interval to subtract.
    */
   public subtract(ts: TimeSpan) {
     if (TimeSpan.subtractionDoesUnderflow(this._ticks, ts._ticks)) {
@@ -122,9 +117,7 @@ export class TimeSpan {
   /**
    * Compares this instance to a specified object and returns an integer that indicates whether this
    * instance is shorter than, equal to, or longer than the specified object.
-   * @param {TimeSpan} value              - The time interval to add.
-   * @memberof TimeSpan
-   * @instance
+   * @param value - The time interval to add.
    */
   public compareTo(value: TimeSpan) {
     if (value == null) {
@@ -140,8 +133,6 @@ export class TimeSpan {
 
   /**
    * Returns a new TimeSpan object whose value is the absolute value of the current TimeSpan object.
-   * @memberof TimeSpan
-   * @instance
    */
   public duration() {
     return TimeSpan.fromTicks(this._ticks >= 0 ? this._ticks : -this._ticks);
@@ -149,9 +140,7 @@ export class TimeSpan {
 
   /**
    * Returns a value indicating whether this instance is equal to a specified object.
-   * @memberof TimeSpan
-   * @param {TimeSpan} value              - The time interval to check for equality.
-   * @instance
+   * @param value - The time interval to check for equality.
    */
   public equals(value: TimeSpan) {
     if (TimeSpan.isTimeSpan(value)) {
@@ -163,9 +152,7 @@ export class TimeSpan {
 
   /**
    * Returns a new TimeSpan object whose value is the negated value of this instance.
-   * @memberof TimeSpan
-   * @param {TimeSpan} value              - The time interval to check for equality.
-   * @instance
+   * @param value - The time interval to check for equality.
    */
   public negate() {
     return TimeSpan.fromTicks(-this._ticks);

--- a/sdk/cosmosdb/cosmos/src/request/FeedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedOptions.ts
@@ -89,8 +89,8 @@ export interface FeedOptions extends SharedOptions {
    *
    *  Scoping a query to a single partition can be accomplished two ways:
    *
-   * container.items.query('SELECT * from c', { partitionKey: "foo" }).toArray()
-   * container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').toArray()
+   * `container.items.query('SELECT * from c', { partitionKey: "foo" }).toArray()`
+   * `container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').toArray()`
    *
    * The former is useful when the query body is out of your control
    * but you still want to restrict it to a single partition. Example: an end user specified query.

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -23,7 +23,6 @@ async function executeRequest(requestContext: RequestContext) {
 
 /**
  * @hidden
- * @param requestContext
  */
 async function httpRequest(requestContext: RequestContext) {
   const controller = new AbortController();
@@ -135,7 +134,6 @@ async function httpRequest(requestContext: RequestContext) {
 
 /**
  * @hidden
- * @param requestContext
  */
 export async function request<T>(requestContext: RequestContext): Promise<CosmosResponse<T>> {
   if (requestContext.body) {

--- a/sdk/cosmosdb/cosmos/src/request/request.ts
+++ b/sdk/cosmosdb/cosmos/src/request/request.ts
@@ -48,7 +48,6 @@ const JsonContentType = "application/json";
 
 /**
  * @hidden
- * @param param0
  */
 export async function getHeaders({
   clientOptions,

--- a/sdk/cosmosdb/cosmos/src/retry/defaultRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/defaultRetryPolicy.ts
@@ -122,8 +122,6 @@ function needsRetry(operationType: OperationType, code: number | string) {
 
 /**
  * This class implements the default connection retry policy for requests.
- * @property {int} currentRetryAttemptCount           - Current retry attempt count.
- * @hidden
  * @hidden
  */
 export class DefaultRetryPolicy implements RetryPolicy {
@@ -134,7 +132,7 @@ export class DefaultRetryPolicy implements RetryPolicy {
   constructor(private operationType: OperationType) {}
   /**
    * Determines whether the request should be retried or not.
-   * @param {object} err - Error returned by the request.
+   * @param err - Error returned by the request.
    */
   public async shouldRetry(err: ErrorResponse): Promise<boolean> {
     if (err) {

--- a/sdk/cosmosdb/cosmos/src/retry/endpointDiscoveryRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/endpointDiscoveryRetryPolicy.ts
@@ -23,8 +23,7 @@ export class EndpointDiscoveryRetryPolicy implements RetryPolicy {
   private static readonly retryAfterInMs = 1000;
 
   /**
-   * @constructor EndpointDiscoveryRetryPolicy
-   * @param {object} globalEndpointManager The GlobalEndpointManager instance.
+   * @param globalEndpointManager - The GlobalEndpointManager instance.
    */
   constructor(
     private globalEndpointManager: GlobalEndpointManager,
@@ -37,7 +36,7 @@ export class EndpointDiscoveryRetryPolicy implements RetryPolicy {
 
   /**
    * Determines whether the request should be retried or not.
-   * @param {object} err - Error returned by the request.
+   * @param err - Error returned by the request.
    */
   public async shouldRetry(
     err: ErrorResponse,

--- a/sdk/cosmosdb/cosmos/src/retry/resourceThrottleRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/resourceThrottleRetryPolicy.ts
@@ -17,11 +17,10 @@ export class ResourceThrottleRetryPolicy {
   /** Max wait time in milliseconds to wait for a request while the retries are happening. */
   private timeoutInMs: number;
   /**
-   * @constructor ResourceThrottleRetryPolicy
-   * @param {int} maxTries - Max number of retries to be performed for a request.
-   * @param {int} fixedRetryIntervalInMs - Fixed retry interval in milliseconds to wait between each \
+   * @param maxTries - Max number of retries to be performed for a request.
+   * @param fixedRetryIntervalInMs - Fixed retry interval in milliseconds to wait between each
    * retry ignoring the retryAfter returned as part of the response.
-   * @param {int} timeoutInSeconds - Max wait time in seconds to wait for a request while the \
+   * @param timeoutInSeconds - Max wait time in seconds to wait for a request while the
    * retries are happening.
    */
   constructor(
@@ -35,7 +34,7 @@ export class ResourceThrottleRetryPolicy {
   }
   /**
    * Determines whether the request should be retried or not.
-   * @param {object} err - Error returned by the request.
+   * @param err - Error returned by the request.
    */
   public async shouldRetry(err: ErrorResponse): Promise<boolean> {
     // TODO: any custom error object

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -33,8 +33,6 @@ interface RetryPolicies {
 }
 
 /**
- *
- * @param param0
  * @hidden
  */
 export async function execute({

--- a/sdk/cosmosdb/cosmos/src/retry/sessionRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/sessionRetryPolicy.ts
@@ -18,9 +18,7 @@ export class SessionRetryPolicy implements RetryPolicy {
   public retryAfterInMs = 0;
 
   /**
-   * @constructor SessionReadRetryPolicy
-   * @param {object} globalEndpointManager                           - The GlobalEndpointManager instance.
-   * @property {object} request                                      - The Http request information
+   * @param globalEndpointManager - The GlobalEndpointManager instance.
    */
   constructor(
     private globalEndpointManager: GlobalEndpointManager,
@@ -31,8 +29,8 @@ export class SessionRetryPolicy implements RetryPolicy {
 
   /**
    * Determines whether the request should be retried or not.
-   * @param {object} err - Error returned by the request.
-   * @param {function} callback - The callback function which takes bool argument which specifies whether the request\
+   * @param err - Error returned by the request.
+   * @param callback - The callback function which takes bool argument which specifies whether the request
    * will be retried or not.
    */
   public async shouldRetry(err: ErrorResponse, retryContext?: RetryContext): Promise<boolean> {

--- a/sdk/cosmosdb/cosmos/src/routing/QueryRange.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/QueryRange.ts
@@ -11,11 +11,11 @@ export class QueryRange {
 
   /**
    * Represents a QueryRange.
-   * @constructor QueryRange
-   * @param {string} rangeMin                - min
-   * @param {string} rangeMin                - max
-   * @param {boolean} isMinInclusive         - isMinInclusive
-   * @param {boolean} isMaxInclusive         - isMaxInclusive
+   *
+   * @param rangeMin                - min
+   * @param rangeMin                - max
+   * @param isMinInclusive         - isMinInclusive
+   * @param isMaxInclusive         - isMaxInclusive
    * @hidden
    */
   constructor(

--- a/sdk/cosmosdb/cosmos/src/routing/partitionKeyRangeCache.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/partitionKeyRangeCache.ts
@@ -17,7 +17,7 @@ export class PartitionKeyRangeCache {
   }
   /**
    * Finds or Instantiates the requested Collection Routing Map
-   * @param {string} collectionLink            - Requested collectionLink
+   * @param collectionLink - Requested collectionLink
    * @hidden
    */
   public async onCollectionRoutingMap(
@@ -34,8 +34,6 @@ export class PartitionKeyRangeCache {
 
   /**
    * Given the query ranges and a collection, invokes the callback on the list of overlapping partition key ranges
-   * @param collectionLink
-   * @param queryRange
    * @hidden
    */
   public async getOverlappingRanges(collectionLink: string, queryRange: QueryRange) {

--- a/sdk/cosmosdb/cosmos/src/routing/smartRoutingMapProvider.ts
+++ b/sdk/cosmosdb/cosmos/src/routing/smartRoutingMapProvider.ts
@@ -64,10 +64,8 @@ export class SmartRoutingMapProvider {
 
   /**
    * Given the sorted ranges and a collection, invokes the callback on the list of overlapping partition key ranges
-   * @param {callback} callback - Function execute on the overlapping partition key ranges result,
-   *                              takes two parameters error, partition key ranges
-   * @param collectionLink
-   * @param sortedRanges
+   * @param callback - Function execute on the overlapping partition key ranges result,
+   *                   takes two parameters error, partition key ranges
    * @hidden
    */
   public async getOverlappingRanges(

--- a/sdk/cosmosdb/cosmos/src/session/VectorSessionToken.ts
+++ b/sdk/cosmosdb/cosmos/src/session/VectorSessionToken.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 /**
  * Models vector clock bases session token. Session token has the following format:
- * {Version}#{GlobalLSN}#{RegionId1}={LocalLsn1}#{RegionId2}={LocalLsn2}....#{RegionIdN}={LocalLsnN}
+ * `{Version}#{GlobalLSN}#{RegionId1}={LocalLsn1}#{RegionId2}={LocalLsn2}....#{RegionIdN}={LocalLsnN}`
  * 'Version' captures the configuration number of the partition which returned this session token.
  * 'Version' is incremented everytime topology of the partition is updated (say due to Add/Remove/Failover).
  *
  * The choice of separators '#' and '=' is important. Separators ';' and ',' are used to delimit
  * per-partitionKeyRange session token
  * @hidden
- * @private
  *
  */
 export class VectorSessionToken {
@@ -147,8 +146,6 @@ export class VectorSessionToken {
 
 /**
  * @hidden
- * @param int1
- * @param int2
  */
 function max(int1: string, int2: string) {
   // NOTE: This only works for positive numbers


### PR DESCRIPTION
This PR updates the cosmosdb package to be TSDoc compliant. See #12912 for why we are making the move from JSDoc to TSDoc. Resolves #12951

Majority of the changes in this PR fall under the below categories:
- Remove type info from `@param` and `@returns` tags. TS tooling can infer this without us adding to these tags
- Remove the `@param` tag if only the parameter name is present without parameter description. Such instances add no value to TS tooling. This can also serve as a reminder to add relevant description. Feel free to provide suggested edits in this PR for such cases.
- Use the hypen as a delimitor between parameter name and description when using the `@param` tag
- Remove `@hidden` tag if  `@internal` is already applied
- Remove JSDoc tags that make sense in JS files, but not are not required in TS files and so are invalid in TSDoc.
    - `@class`
    - `@constructor`
    - `@interface`
    - `@instance`
    - `@memberof`
    - `@summary`
    - `@description`
- In some cases, I found stale docs detailing parameters that are no longer used in the methods. I have deleted such entries   
- Use backticks where applicable to avoid the linter from thinking that presence of `{`, `}` is some kind of TSDoc entity
- Remove trailing backslash in the end of a line. I believe this was added to denote that the text continues in the next line. This is invalid in TSDoc, and I am not aware of any tooling that relies on this. Please do share if any such tooling exists