### PR TITLE
[communication] disable extensible enums

### DIFF
--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -66,7 +66,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "1.0.0-beta.4",
+    "@azure/communication-common": "1.0.0-beta.6",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -66,7 +66,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "1.0.0-beta.6",
+    "@azure/communication-common": "1.0.0-beta.5",
     "@azure/core-auth": "^1.1.3",
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",

--- a/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
+++ b/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
@@ -41,48 +41,11 @@ export interface BeginSearchAvailablePhoneNumbersOptions extends PhoneNumberPoll
 export interface BeginUpdatePhoneNumberOptions extends PhoneNumberPollerOptionsBase, OperationOptions {
 }
 
-// @public
-export type BillingFrequency = string;
-
 // @public (undocumented)
 export type GetPhoneNumberOptions = OperationOptions;
 
 // @public (undocumented)
 export type GetPhoneNumberResponse = WithResponse<AcquiredPhoneNumber>;
-
-// @public
-export const enum KnownBillingFrequency {
-    // (undocumented)
-    Monthly = "monthly"
-}
-
-// @public
-export const enum KnownPhoneNumberAssignmentType {
-    // (undocumented)
-    Application = "application",
-    // (undocumented)
-    Person = "person"
-}
-
-// @public
-export const enum KnownPhoneNumberCapabilityValue {
-    // (undocumented)
-    Inbound = "inbound",
-    // (undocumented)
-    InboundOutbound = "inbound+outbound",
-    // (undocumented)
-    None = "none",
-    // (undocumented)
-    Outbound = "outbound"
-}
-
-// @public
-export const enum KnownPhoneNumberType {
-    // (undocumented)
-    Geographic = "geographic",
-    // (undocumented)
-    TollFree = "tollFree"
-}
 
 // @public
 export interface ListPhoneNumbersOptions extends OperationOptions {
@@ -91,7 +54,7 @@ export interface ListPhoneNumbersOptions extends OperationOptions {
 }
 
 // @public
-export type PhoneNumberAssignmentType = string;
+export type PhoneNumberAssignmentType = "person" | "application";
 
 // @public
 export interface PhoneNumberCapabilities {
@@ -106,12 +69,12 @@ export interface PhoneNumberCapabilitiesRequest {
 }
 
 // @public
-export type PhoneNumberCapabilityValue = string;
+export type PhoneNumberCapabilityValue = "none" | "inbound" | "outbound" | "inbound+outbound";
 
 // @public
 export interface PhoneNumberCost {
     amount: number;
-    billingFrequency: BillingFrequency;
+    billingFrequency: "monthly";
     currencyCode: string;
 }
 
@@ -161,7 +124,7 @@ export interface PhoneNumberSearchResult {
 }
 
 // @public
-export type PhoneNumberType = string;
+export type PhoneNumberType = "geographic" | "tollFree";
 
 // @public
 export type VoidResponse = WithResponse<{}>;

--- a/sdk/communication/communication-phone-numbers/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/models/index.ts
@@ -56,7 +56,7 @@ export interface PhoneNumberCost {
   /** The ISO 4217 currency code for the cost amount, e.g. USD. */
   currencyCode: string;
   /** The frequency with which the cost gets billed. */
-  billingFrequency: BillingFrequency;
+  billingFrequency: "monthly";
 }
 
 /** The Communication Services error. */
@@ -203,111 +203,20 @@ export interface PhoneNumbersUpdateCapabilitiesHeaders {
   capabilitiesId?: string;
 }
 
-/** Known values of {@link PhoneNumberType} that the service accepts. */
-export const enum KnownPhoneNumberType {
-  Geographic = "geographic",
-  TollFree = "tollFree"
-}
-
-/**
- * Defines values for PhoneNumberType. \
- * {@link KnownPhoneNumberType} can be used interchangeably with PhoneNumberType,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **geographic** \
- * **tollFree**
- */
-export type PhoneNumberType = string;
-
-/** Known values of {@link PhoneNumberAssignmentType} that the service accepts. */
-export const enum KnownPhoneNumberAssignmentType {
-  Person = "person",
-  Application = "application"
-}
-
-/**
- * Defines values for PhoneNumberAssignmentType. \
- * {@link KnownPhoneNumberAssignmentType} can be used interchangeably with PhoneNumberAssignmentType,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **person** \
- * **application**
- */
-export type PhoneNumberAssignmentType = string;
-
-/** Known values of {@link PhoneNumberCapabilityValue} that the service accepts. */
-export const enum KnownPhoneNumberCapabilityValue {
-  None = "none",
-  Inbound = "inbound",
-  Outbound = "outbound",
-  InboundOutbound = "inbound+outbound"
-}
-
-/**
- * Defines values for PhoneNumberCapabilityValue. \
- * {@link KnownPhoneNumberCapabilityValue} can be used interchangeably with PhoneNumberCapabilityValue,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **none** \
- * **inbound** \
- * **outbound** \
- * **inbound+outbound**
- */
-export type PhoneNumberCapabilityValue = string;
-
-/** Known values of {@link BillingFrequency} that the service accepts. */
-export const enum KnownBillingFrequency {
-  Monthly = "monthly"
-}
-
-/**
- * Defines values for BillingFrequency. \
- * {@link KnownBillingFrequency} can be used interchangeably with BillingFrequency,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **monthly**
- */
-export type BillingFrequency = string;
-
-/** Known values of {@link PhoneNumberOperationStatus} that the service accepts. */
-export const enum KnownPhoneNumberOperationStatus {
-  NotStarted = "notStarted",
-  Running = "running",
-  Succeeded = "succeeded",
-  Failed = "failed"
-}
-
-/**
- * Defines values for PhoneNumberOperationStatus. \
- * {@link KnownPhoneNumberOperationStatus} can be used interchangeably with PhoneNumberOperationStatus,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **notStarted** \
- * **running** \
- * **succeeded** \
- * **failed**
- */
-export type PhoneNumberOperationStatus = string;
-
-/** Known values of {@link PhoneNumberOperationType} that the service accepts. */
-export const enum KnownPhoneNumberOperationType {
-  Purchase = "purchase",
-  ReleasePhoneNumber = "releasePhoneNumber",
-  Search = "search",
-  UpdatePhoneNumberCapabilities = "updatePhoneNumberCapabilities"
-}
-
-/**
- * Defines values for PhoneNumberOperationType. \
- * {@link KnownPhoneNumberOperationType} can be used interchangeably with PhoneNumberOperationType,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **purchase** \
- * **releasePhoneNumber** \
- * **search** \
- * **updatePhoneNumberCapabilities**
- */
-export type PhoneNumberOperationType = string;
+/** Defines values for PhoneNumberType. */
+export type PhoneNumberType = "geographic" | "tollFree";
+/** Defines values for PhoneNumberAssignmentType. */
+export type PhoneNumberAssignmentType = "person" | "application";
+/** Defines values for PhoneNumberCapabilityValue. */
+export type PhoneNumberCapabilityValue = "none" | "inbound" | "outbound" | "inbound+outbound";
+/** Defines values for PhoneNumberOperationStatus. */
+export type PhoneNumberOperationStatus = "notStarted" | "running" | "succeeded" | "failed";
+/** Defines values for PhoneNumberOperationType. */
+export type PhoneNumberOperationType =
+  | "purchase"
+  | "releasePhoneNumber"
+  | "search"
+  | "updatePhoneNumberCapabilities";
 
 /** Optional parameters. */
 export interface PhoneNumbersSearchAvailablePhoneNumbersOptionalParams

--- a/sdk/communication/communication-phone-numbers/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/models/mappers.ts
@@ -17,16 +17,14 @@ export const PhoneNumberSearchRequest: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["geographic", "tollFree"]
+          name: "String"
         }
       },
       assignmentType: {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["person", "application"]
+          name: "String"
         }
       },
       capabilities: {
@@ -66,16 +64,14 @@ export const PhoneNumberCapabilities: coreHttp.CompositeMapper = {
         serializedName: "calling",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
+          name: "String"
         }
       },
       sms: {
         serializedName: "sms",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
+          name: "String"
         }
       }
     }
@@ -110,16 +106,14 @@ export const PhoneNumberSearchResult: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["geographic", "tollFree"]
+          name: "String"
         }
       },
       assignmentType: {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["person", "application"]
+          name: "String"
         }
       },
       capabilities: {
@@ -268,8 +262,7 @@ export const PhoneNumberOperation: coreHttp.CompositeMapper = {
         serializedName: "status",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["notStarted", "running", "succeeded", "failed"]
+          name: "String"
         }
       },
       resourceLocation: {
@@ -303,13 +296,7 @@ export const PhoneNumberOperation: coreHttp.CompositeMapper = {
         serializedName: "operationType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: [
-            "purchase",
-            "releasePhoneNumber",
-            "search",
-            "updatePhoneNumberCapabilities"
-          ]
+          name: "String"
         }
       },
       lastActionDateTime: {
@@ -353,8 +340,7 @@ export const AcquiredPhoneNumber: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["geographic", "tollFree"]
+          name: "String"
         }
       },
       capabilities: {
@@ -368,8 +354,7 @@ export const AcquiredPhoneNumber: coreHttp.CompositeMapper = {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "Enum",
-          allowedValues: ["person", "application"]
+          name: "String"
         }
       },
       purchaseDate: {
@@ -425,15 +410,13 @@ export const PhoneNumberCapabilitiesRequest: coreHttp.CompositeMapper = {
       calling: {
         serializedName: "calling",
         type: {
-          name: "Enum",
-          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
+          name: "String"
         }
       },
       sms: {
         serializedName: "sms",
         type: {
-          name: "Enum",
-          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
+          name: "String"
         }
       }
     }

--- a/sdk/communication/communication-phone-numbers/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/models/mappers.ts
@@ -17,14 +17,16 @@ export const PhoneNumberSearchRequest: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["geographic", "tollFree"]
         }
       },
       assignmentType: {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["person", "application"]
         }
       },
       capabilities: {
@@ -64,14 +66,16 @@ export const PhoneNumberCapabilities: coreHttp.CompositeMapper = {
         serializedName: "calling",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
         }
       },
       sms: {
         serializedName: "sms",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
         }
       }
     }
@@ -106,14 +110,16 @@ export const PhoneNumberSearchResult: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["geographic", "tollFree"]
         }
       },
       assignmentType: {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["person", "application"]
         }
       },
       capabilities: {
@@ -161,8 +167,9 @@ export const PhoneNumberCost: coreHttp.CompositeMapper = {
         }
       },
       billingFrequency: {
+        defaultValue: "monthly",
+        isConstant: true,
         serializedName: "billingFrequency",
-        required: true,
         type: {
           name: "String"
         }
@@ -261,7 +268,8 @@ export const PhoneNumberOperation: coreHttp.CompositeMapper = {
         serializedName: "status",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["notStarted", "running", "succeeded", "failed"]
         }
       },
       resourceLocation: {
@@ -295,7 +303,13 @@ export const PhoneNumberOperation: coreHttp.CompositeMapper = {
         serializedName: "operationType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: [
+            "purchase",
+            "releasePhoneNumber",
+            "search",
+            "updatePhoneNumberCapabilities"
+          ]
         }
       },
       lastActionDateTime: {
@@ -339,7 +353,8 @@ export const AcquiredPhoneNumber: coreHttp.CompositeMapper = {
         serializedName: "phoneNumberType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["geographic", "tollFree"]
         }
       },
       capabilities: {
@@ -353,7 +368,8 @@ export const AcquiredPhoneNumber: coreHttp.CompositeMapper = {
         serializedName: "assignmentType",
         required: true,
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["person", "application"]
         }
       },
       purchaseDate: {
@@ -409,13 +425,15 @@ export const PhoneNumberCapabilitiesRequest: coreHttp.CompositeMapper = {
       calling: {
         serializedName: "calling",
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
         }
       },
       sms: {
         serializedName: "sms",
         type: {
-          name: "String"
+          name: "Enum",
+          allowedValues: ["none", "inbound", "outbound", "inbound+outbound"]
         }
       }
     }

--- a/sdk/communication/communication-phone-numbers/src/models.ts
+++ b/sdk/communication/communication-phone-numbers/src/models.ts
@@ -38,11 +38,6 @@ export interface ListPhoneNumbersOptions extends OperationOptions {
 
 export {
   AcquiredPhoneNumber,
-  BillingFrequency,
-  KnownBillingFrequency,
-  KnownPhoneNumberAssignmentType,
-  KnownPhoneNumberCapabilityValue,
-  KnownPhoneNumberType,
   PhoneNumberAssignmentType,
   PhoneNumberCapabilities,
   PhoneNumberCapabilitiesRequest,

--- a/sdk/communication/communication-phone-numbers/swagger/README.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README.md
@@ -20,3 +20,17 @@ use-extension:
 add-credentials: false
 azure-arm: false
 ```
+
+## Customizations
+
+### Disable extensible enums
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions[*].properties[*]["x-ms-enum"]
+    transform: >
+      if ($.modelAsString) {
+        $.modelAsString = false
+      }
+```

--- a/sdk/communication/communication-phone-numbers/swagger/README.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README.md
@@ -16,9 +16,10 @@ model-date-time-as-string: false
 optional-response-headers: true
 payload-flattening-threshold: 10
 use-extension:
-  "@autorest/typescript": "6.0.0-dev.20210202.1"
+  "@autorest/typescript": "https://bit.ly/2Zncabl"
 add-credentials: false
 azure-arm: false
+skip-enum-validation: true
 ```
 
 ## Customizations

--- a/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
@@ -3,12 +3,7 @@
 
 import { isLiveMode, isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 import { assert } from "chai";
-import {
-  PhoneNumberSearchRequest,
-  KnownPhoneNumberType,
-  KnownPhoneNumberAssignmentType,
-  PhoneNumberSearchResult
-} from "../src";
+import { PhoneNumberSearchRequest, PhoneNumberSearchResult } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
 
@@ -43,8 +38,8 @@ describe("PhoneNumbersClient - lro - purchase", function() {
       }
 
       const searchRequest: PhoneNumberSearchRequest = {
-        phoneNumberType: KnownPhoneNumberType.TollFree,
-        assignmentType: KnownPhoneNumberAssignmentType.Application,
+        phoneNumberType: "tollFree",
+        assignmentType: "application",
         capabilities: {
           sms: "inbound+outbound",
           calling: "none"

--- a/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
@@ -3,11 +3,7 @@
 
 import { isLiveMode, isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 import { assert } from "chai";
-import {
-  KnownPhoneNumberAssignmentType,
-  KnownPhoneNumberType,
-  PhoneNumberSearchRequest
-} from "../src";
+import { PhoneNumberSearchRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
 
@@ -17,8 +13,8 @@ describe("PhoneNumbersClient - lro - search", function() {
   let includePhoneNumberLiveTests: boolean;
   const countryCode = "US";
   const searchRequest: PhoneNumberSearchRequest = {
-    phoneNumberType: KnownPhoneNumberType.TollFree,
-    assignmentType: KnownPhoneNumberAssignmentType.Application,
+    phoneNumberType: "tollFree",
+    assignmentType: "application",
     capabilities: {
       sms: "inbound+outbound",
       calling: "none"

--- a/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
@@ -22,7 +22,7 @@ export const getPhoneNumberHttpClient: HttpClient = createMockHttpClient<Acquire
   phoneNumber: "+18005550100",
   countryCode: "US",
   phoneNumberType: "geographic",
-  assignmentType: "user",
+  assignmentType: "person",
   purchaseDate: new Date(),
   capabilities: {
     sms: "inbound+outbound",


### PR DESCRIPTION
This PR sets `modelAsString` to false for all `x-ms-enum` properties so autorest does not treat them as extensible. This way we retain string unions for these types.