### PR TITLE
[Identity] DefaultAzureCredential clarification

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -73,7 +73,11 @@ See [Credential Classes](#credential-classes).
 
 ### DefaultAzureCredential
 
-The `DefaultAzureCredential` is appropriate for most scenarios where the application is intended to ultimately be run in the Azure Cloud. This is because the `DefaultAzureCredential` combines credentials commonly used to authenticate when deployed, with credentials used to authenticate in a development environment. If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate via the following mechanisms in order:
+The `DefaultAzureCredential` is appropriate for most scenarios where the application is intended to ultimately be run in the Azure Cloud. This is because the `DefaultAzureCredential` combines credentials commonly used to authenticate when deployed, with credentials used to authenticate in a development environment.
+
+Keep in mind that while `DefaultAzureCredential` is intended to simplify getting started with the SDK by handling common scenarios with reasonable default behavior, developers who want more control, or whose scenario isn't served by the defaults we chose, should use other credential types.
+
+If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate via the following mechanisms in order:
 
 ![DefaultAzureCredential authentication flow][defaultauthflow_image]
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -73,9 +73,9 @@ See [Credential Classes](#credential-classes).
 
 ### DefaultAzureCredential
 
-The `DefaultAzureCredential` is appropriate for most scenarios where the application is intended to ultimately be run in the Azure Cloud. This is because the `DefaultAzureCredential` combines credentials commonly used to authenticate when deployed, with credentials used to authenticate in a development environment.
+The `DefaultAzureCredential` is appropriate for most scenarios where the application is intended to ultimately be run in the Azure Cloud. This is because the `DefaultAzureCredential` combines credentials commonly used to authenticate when deployed with credentials used to authenticate in a development environment.
 
-Keep in mind that while `DefaultAzureCredential` is intended to simplify getting started with the SDK by handling common scenarios with reasonable default behavior, developers who want more control, or whose scenario isn't served by the defaults we chose, should use other credential types.
+> Note: `DefaultAzureCredential` is intended to simplify getting started with the SDK by handling common scenarios with reasonable default behaviors. Developers who want more control or whose scenario isn't served by the default settings should use other credential types.
 
 If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate via the following mechanisms in order:
 


### PR DESCRIPTION
This PR is intended to help portray a better message to our customers about the DefaultAzureCredential. This credential is intended to be used to get things started, and not as the universal way to go over time. I took this text from something Charles Lowell sent me on Teams 😁 I loved the phrasing!

Related to: #13799