### PR TITLE
[core-https] Token refresher

### DIFF
--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -52,7 +52,7 @@
     "test:node": "npm run build:test:node && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && npm run build:ts && npm run bundle:test:node && npm run unit-test:node && npm run bundle:test:browser && npm run unit-test:browser && npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "mocha --require source-map-support/register --timeout 20000 --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
+    "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -52,7 +52,7 @@
     "test:node": "npm run build:test:node && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && npm run build:ts && npm run bundle:test:node && npm run unit-test:node && npm run bundle:test:browser && npm run unit-test:browser && npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "mocha --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
+    "unit-test:node": "mocha --require source-map-support/register --timeout 20000 --reporter ../../../common/tools/mocha-multi-reporter.js dist-test/index.node.js",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },

--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -25,10 +25,10 @@ export const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPol
 
 // @public
 export interface BearerTokenAuthenticationPolicyOptions {
+    beforeTokenExpiresInMs?: number;
     credential: TokenCredential;
-    refreshAttemptsBufferMs?: number;
     scopes: string | string[];
-    tokenRefreshBufferMs?: number;
+    tokenRefreshIntervalInMs?: number;
 }
 
 // @public

--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -26,7 +26,9 @@ export const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPol
 // @public
 export interface BearerTokenAuthenticationPolicyOptions {
     credential: TokenCredential;
+    refreshAttemptsBufferMs?: number;
     scopes: string | string[];
+    tokenRefreshBufferMs?: number;
 }
 
 // @public

--- a/sdk/core/core-https/src/accessTokenCache.ts
+++ b/sdk/core/core-https/src/accessTokenCache.ts
@@ -49,18 +49,18 @@ export class ExpiringAccessTokenCache implements AccessTokenCache {
   }
 
   readyToRefresh(): boolean {
-    return (
-      !this.cachedToken ||
-      Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
+    return Boolean(
+      this.cachedToken &&
+        Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
     );
   }
 
-  isExpired(): boolean {
-    return Boolean(this.cachedToken && Date.now() >= this.cachedToken?.expiresOnTimestamp);
+  isTokenValid(): boolean {
+    return Boolean(this.cachedToken && Date.now() < this.cachedToken.expiresOnTimestamp);
   }
 
   getCachedToken(): AccessToken | undefined {
-    if (this.isExpired()) {
+    if (!this.isTokenValid()) {
       this.cachedToken = undefined;
     }
 

--- a/sdk/core/core-https/src/accessTokenCache.ts
+++ b/sdk/core/core-https/src/accessTokenCache.ts
@@ -48,11 +48,19 @@ export class ExpiringAccessTokenCache implements AccessTokenCache {
     this.cachedToken = accessToken;
   }
 
-  getCachedToken(): AccessToken | undefined {
-    if (
-      this.cachedToken &&
+  readyToRefresh(): boolean {
+    return (
+      !this.cachedToken ||
       Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
-    ) {
+    );
+  }
+
+  isExpired(): boolean {
+    return Boolean(this.cachedToken && Date.now() >= this.cachedToken?.expiresOnTimestamp);
+  }
+
+  getCachedToken(): AccessToken | undefined {
+    if (this.isExpired()) {
       this.cachedToken = undefined;
     }
 

--- a/sdk/core/core-https/src/accessTokenCache.ts
+++ b/sdk/core/core-https/src/accessTokenCache.ts
@@ -48,10 +48,10 @@ export class ExpiringAccessTokenCache implements AccessTokenCache {
     this.cachedToken = accessToken;
   }
 
-  readyToRefresh(): boolean {
+  isReadyToRefresh(): boolean {
     return Boolean(
       this.cachedToken &&
-        Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
+      Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
     );
   }
 

--- a/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -53,7 +53,7 @@ export function bearerTokenAuthenticationPolicy(
 
   let refreshPromise: Promise<AccessToken | undefined> | undefined;
 
-  let refreshAttemptsBufferMs = options.tokenRefreshIntervalInMs ?? DefaultTokenRefreshIntervalInMs;
+  const refreshAttemptsBufferMs = options.tokenRefreshIntervalInMs ?? DefaultTokenRefreshIntervalInMs;
 
   // When the refresh buffer is hit, we trigger this refresher
   // which tries to update the token every so often.

--- a/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -48,7 +48,7 @@ export function bearerTokenAuthenticationPolicy(
 
   let refreshPromise: Promise<AccessToken | null> | undefined;
 
-  let refreshAttemptsBufferMs = options.refreshAttemptsBufferMs || 30000;
+  let refreshAttemptsBufferMs = options.refreshAttemptsBufferMs ?? 30000;
 
   // When the refresh buffer is hit, we trigger this refresher
   // which tries to update the token every so often.

--- a/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-https/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -73,7 +73,7 @@ export function bearerTokenAuthenticationPolicy(
   }
 
   async function getToken(tokenOptions: GetTokenOptions): Promise<string | undefined> {
-    if (!refreshPromise && tokenCache.readyToRefresh()) {
+    if (!refreshPromise && tokenCache.isReadyToRefresh()) {
       refreshPromise = refresher(tokenOptions);
     }
 

--- a/sdk/core/core-https/test/bearerTokenAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-https/test/bearerTokenAuthenticationPolicy.spec.ts
@@ -99,14 +99,14 @@ describe("BearerTokenAuthenticationPolicy", function () {
     // The token is cached and remains cached for a bit.
     await policy.sendRequest(request, next);
     await policy.sendRequest(request, next);
-    assert.strictEqual(credential.authCount, 1);
+    assert.strictEqual(credential.authCount, 1, "The first authentication should have happened");
 
     // The token will remain cached until tokenExpiration - testTokenRefreshBufferMs, so in (5000 - 1000) milliseconds.
 
     // For safe measure, we test the token is still cached a second earlier than the refresh expectation.
     clock.tick(expireDelayMs - beforeTokenExpiresInMs - 1000);
     await policy.sendRequest(request, next);
-    assert.strictEqual(credential.authCount, 1);
+    assert.strictEqual(credential.authCount, 1, "before the refresh period, only one authentication should have happened");
 
     // The new token will last 5 seconds again.
     tokenExpiration = Date.now() + expireDelayMs;
@@ -115,7 +115,7 @@ describe("BearerTokenAuthenticationPolicy", function () {
     // Now we wait until it starts refreshing:
     clock.tick(1000);
     await policy.sendRequest(request, next);
-    assert.strictEqual(credential.authCount, 2);
+    assert.strictEqual(credential.authCount, 2, "after the refresh, a second authentication should have happened");
   });
 
   it("access token refresher should prevent refreshers to happen too fast", async () => {
@@ -137,7 +137,7 @@ describe("BearerTokenAuthenticationPolicy", function () {
     const policy = createBearerTokenPolicy("test-scope", credential);
 
     await policy.sendRequest(request, next);
-    assert.strictEqual(credential.authCount, 1, "Expected authCount to be initially called");
+    assert.strictEqual(credential.authCount, 1, "The first authentication should have happened");
 
     clock.tick(expireDelayMs - beforeTokenExpiresInMs); // Until we start refreshing the token
 


### PR DESCRIPTION
This PR replicates what the old core-http did with the token refreshes, but in the new core. The idea comes from: https://github.com/Azure/azure-sdk-for-js/pull/13736

This is just a draft PR! It's intended to showcase the target. I don't like the parameter names, for example.

With this PR, here's what we will be doing:
1. If a token is not there or has expired, we ask for a new one (of course).
2. Before a token expires, in a time window, we try to retrieve the token through a refresh promise.
3. As we get new requests to retrieve that token, we re-use the same refresh promise.
4. [Important difference] The refresh promise will try to refresh the token once every 30 milliseconds (configurable) until the token expires, then it will do one final attempt to refresh the token, then it will stop.

About the important difference: The old core-http doesn't have this same behavior, it treats the token as if it expired and tries to refresh it only once each 30 milliseconds. This means that any request in that timeframe will fail. In this version, these requests won't fail, since they will always receive the token that hasn't expired yet.

Please let me know how this looks! Feedback appreciated.

Related to #13369 