### PR TITLE
OpenTelemetry test versions to use specific folder

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
@@ -26,7 +26,7 @@ async function exec(cmd) {
       // Note: this moves devDeps to dependencies, but it does not matter for these tests
       const packagesToInstall = packages.map((package) => `${package}@${version}`).join(" ");
       console.log(`Installing ${packagesToInstall}`);
-      await exec(`npm install --no-save ${packagesToInstall}`);
+      await exec(`npm install --no-save --prefix ./test-opentelemetry-versions ${packagesToInstall}`);
 
       console.log(`Compiling on version: ${version}`);
       await exec(`npm run build`);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test-opentelemetry-versions.js
@@ -26,7 +26,9 @@ async function exec(cmd) {
       // Note: this moves devDeps to dependencies, but it does not matter for these tests
       const packagesToInstall = packages.map((package) => `${package}@${version}`).join(" ");
       console.log(`Installing ${packagesToInstall}`);
-      await exec(`npm install --no-save --prefix ./test-opentelemetry-versions ${packagesToInstall}`);
+      await exec(
+        `npm install --no-save --prefix ./test-opentelemetry-versions ${packagesToInstall}`
+      );
 
       console.log(`Compiling on version: ${version}`);
       await exec(`npm run build`);


### PR DESCRIPTION
Daily build keeps failing and the error is related to npm install executed in the tests that is conflicting with rush update install in the build machine

Related to #13758 