### PR TITLE
[core-amqp] Update async methods to support cancellation

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
 
-## 2.1.1 (Unreleased)
+## 2.2.0 (Unreleased)
 
+- Addresses issue [9988](https://github.com/Azure/azure-sdk-for-js/issues/9988)
+  by updating the following operations to accept an `abortSignal` to allow cancellation:
+  - CbsClient.init()
+  - CbsClient.negotiateClaim()
+  - RequestResponseLink.create()
 
 ## 2.1.0 (2021-02-08)
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -90,7 +90,9 @@ export class CbsClient {
     connection: Connection;
     readonly connectionLock: string;
     readonly endpoint: string;
-    init(): Promise<void>;
+    init(options?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<void>;
     negotiateClaim(audience: string, token: string, tokenType: TokenType, options?: {
         abortSignal?: AbortSignalLike;
     }): Promise<CbsResponse>;
@@ -448,7 +450,9 @@ export class RequestResponseLink implements ReqResLink {
     constructor(session: Session, sender: Sender, receiver: Receiver);
     close(): Promise<void>;
     get connection(): Connection;
-    static create(connection: Connection, senderOptions: SenderOptions, receiverOptions: ReceiverOptions): Promise<RequestResponseLink>;
+    static create(connection: Connection, senderOptions: SenderOptions, receiverOptions: ReceiverOptions, options?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<RequestResponseLink>;
     isOpen(): boolean;
     // (undocumented)
     receiver: Receiver;

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -91,7 +91,9 @@ export class CbsClient {
     readonly connectionLock: string;
     readonly endpoint: string;
     init(): Promise<void>;
-    negotiateClaim(audience: string, token: string, tokenType: TokenType): Promise<CbsResponse>;
+    negotiateClaim(audience: string, token: string, tokenType: TokenType, options?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<CbsResponse>;
     remove(): void;
     readonly replyTo: string;
 }

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -450,7 +450,7 @@ export class RequestResponseLink implements ReqResLink {
     constructor(session: Session, sender: Sender, receiver: Receiver);
     close(): Promise<void>;
     get connection(): Connection;
-    static create(connection: Connection, senderOptions: SenderOptions, receiverOptions: ReceiverOptions, options?: {
+    static create(connection: Connection, senderOptions: SenderOptions, receiverOptions: ReceiverOptions, createOptions?: {
         abortSignal?: AbortSignalLike;
     }): Promise<RequestResponseLink>;
     isOpen(): boolean;

--- a/sdk/core/core-amqp/src/cbs.ts
+++ b/sdk/core/core-amqp/src/cbs.ts
@@ -89,10 +89,7 @@ export class CbsClient {
       if (!this.connection.isOpen()) {
         logger.verbose("The CBS client is trying to establish an AMQP connection.");
         await defaultLock.acquire(this.connectionLock, () => {
-          if (abortSignal?.aborted) {
-            return Promise.reject(new AbortError(initAbortMessage));
-          }
-          return this.connection.open();
+          return this.connection.open({ abortSignal });
         });
       }
 

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -215,16 +215,20 @@ export class RequestResponseLink implements ReqResLink {
    * @param connection - The amqp connection.
    * @param senderOptions - Options that must be provided to create the sender link.
    * @param receiverOptions - Options that must be provided to create the receiver link.
+   * @param options - Optional parameters that can be used to affect this method's behavior.
+   *    For example, `abortSignal` can be passed to allow cancelling an in-progress `create` invocation.
    * @returns Promise<RequestResponseLink>
    */
   static async create(
     connection: Connection,
     senderOptions: SenderOptions,
-    receiverOptions: ReceiverOptions
+    receiverOptions: ReceiverOptions,
+    options: { abortSignal?: AbortSignalLike } = {}
   ): Promise<RequestResponseLink> {
-    const session = await connection.createSession();
-    const sender = await session.createSender(senderOptions);
-    const receiver = await session.createReceiver(receiverOptions);
+    const { abortSignal } = options;
+    const session = await connection.createSession({ abortSignal });
+    const sender = await session.createSender({ ...senderOptions, abortSignal });
+    const receiver = await session.createReceiver({ ...receiverOptions, abortSignal });
     logger.verbose(
       "[%s] Successfully created the sender and receiver links on the same session.",
       connection.id

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -215,7 +215,7 @@ export class RequestResponseLink implements ReqResLink {
    * @param connection - The amqp connection.
    * @param senderOptions - Options that must be provided to create the sender link.
    * @param receiverOptions - Options that must be provided to create the receiver link.
-   * @param options - Optional parameters that can be used to affect this method's behavior.
+   * @param createOptions - Optional parameters that can be used to affect this method's behavior.
    *    For example, `abortSignal` can be passed to allow cancelling an in-progress `create` invocation.
    * @returns Promise<RequestResponseLink>
    */
@@ -223,9 +223,9 @@ export class RequestResponseLink implements ReqResLink {
     connection: Connection,
     senderOptions: SenderOptions,
     receiverOptions: ReceiverOptions,
-    options: { abortSignal?: AbortSignalLike } = {}
+    createOptions: { abortSignal?: AbortSignalLike } = {}
   ): Promise<RequestResponseLink> {
-    const { abortSignal } = options;
+    const { abortSignal } = createOptions;
     const session = await connection.createSession({ abortSignal });
     const sender = await session.createSender({ ...senderOptions, abortSignal });
     const receiver = await session.createReceiver({ ...receiverOptions, abortSignal });

--- a/sdk/core/core-amqp/test/cbs.spec.ts
+++ b/sdk/core/core-amqp/test/cbs.spec.ts
@@ -3,11 +3,76 @@
 
 import { assert } from "chai";
 import { AbortController } from "@azure/abort-controller";
-import { CbsClient, TokenType } from "../src";
+import { CbsClient, defaultLock, TokenType } from "../src";
 import { createConnectionStub } from "./utils/createConnectionStub";
+import { Connection } from "rhea-promise";
+import { stub } from "sinon";
 
 describe("CbsClient", function() {
   const TEST_FAILURE = "Test failure";
+
+  describe("init", function() {
+    it("honors already aborted abortSignal", async function() {
+      const cbsClient = new CbsClient(new Connection(), "lock");
+
+      // Create an abort signal that is already aborted.
+      const controller = new AbortController();
+      controller.abort();
+      const signal = controller.signal;
+
+      try {
+        await cbsClient.init({ abortSignal: signal });
+        throw new Error(TEST_FAILURE);
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+      }
+    });
+
+    it("honors abortSignal inside locking code", async function() {
+      const lock = "lock";
+      const cbsClient = new CbsClient(new Connection(), "lock");
+
+      // Create an abort signal that will be aborted on a future tick of the event loop.
+      const controller = new AbortController();
+      const signal = controller.signal;
+
+      // Make the existing `init` invocation wait until the abortSignal
+      // is aborted before acquiring it's lock.
+      await defaultLock.acquire(lock, (done) => {
+        setTimeout(() => {
+          controller.abort();
+          done();
+        }, 0);
+      });
+
+      try {
+        await cbsClient.init({ abortSignal: signal });
+        throw new Error(TEST_FAILURE);
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+      }
+    });
+
+    it("honors abortSignal", async function() {
+      const connectionStub = new Connection();
+      // Stub 'open' because creating a real connection will fail.
+      stub(connectionStub, "open").resolves({} as any);
+
+      const cbsClient = new CbsClient(connectionStub, "lock");
+
+      // Create an abort signal that will be aborted on a future tick of the event loop.
+      const controller = new AbortController();
+      const signal = controller.signal;
+      setTimeout(() => controller.abort(), 0);
+
+      try {
+        await cbsClient.init({ abortSignal: signal });
+        throw new Error(TEST_FAILURE);
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+      }
+    });
+  });
 
   describe("negotiateClaim", function() {
     it("throws an error if the cbs link doesn't exist.", async function() {

--- a/sdk/core/core-amqp/test/cbs.spec.ts
+++ b/sdk/core/core-amqp/test/cbs.spec.ts
@@ -2,17 +2,18 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { Connection } from "rhea-promise";
-import { stub } from "sinon";
+import { AbortController } from "@azure/abort-controller";
 import { CbsClient, TokenType } from "../src";
+import { createConnectionStub } from "./utils/createConnectionStub";
 
 describe("CbsClient", function() {
   const TEST_FAILURE = "Test failure";
+
   describe("negotiateClaim", function() {
     it("throws an error if the cbs link doesn't exist.", async function() {
-      const connectionStub = stub(new Connection()) as any;
-
+      const connectionStub = createConnectionStub();
       const cbsClient = new CbsClient(connectionStub, "lock");
+
       try {
         await cbsClient.negotiateClaim("audience", "token", TokenType.CbsTokenTypeSas);
         throw new Error(TEST_FAILURE);
@@ -22,6 +23,50 @@ describe("CbsClient", function() {
           "Attempted to negotiate a claim but the CBS link does not exist."
         );
       }
+    });
+
+    describe("cancellation", function() {
+      it("honors already aborted abortSignal", async function() {
+        const connectionStub = createConnectionStub();
+        const cbsClient = new CbsClient(connectionStub, "lock");
+
+        // Create an abort signal that is already aborted.
+        const controller = new AbortController();
+        controller.abort();
+        const signal = controller.signal;
+
+        try {
+          // Pass the already aborted abortSignal to make sure negotiateClaim will exit quickly.
+          await cbsClient.negotiateClaim("audience", "token", TokenType.CbsTokenTypeSas, {
+            abortSignal: signal
+          });
+          throw new Error(TEST_FAILURE);
+        } catch (err) {
+          assert.equal(err.name, "AbortError");
+        }
+      });
+
+      it("honors abortSignal", async function() {
+        const connectionStub = createConnectionStub();
+        const cbsClient = new CbsClient(connectionStub, "lock");
+
+        // Call `init()` to ensure the CbsClient has a RequestResponseLink.
+        await cbsClient.init();
+
+        // Create an abort signal that will be aborted on a future tick of the event loop.
+        const controller = new AbortController();
+        const signal = controller.signal;
+        setTimeout(() => controller.abort(), 0);
+
+        try {
+          await cbsClient.negotiateClaim("audience", "token", TokenType.CbsTokenTypeSas, {
+            abortSignal: signal
+          });
+          throw new Error(TEST_FAILURE);
+        } catch (err) {
+          assert.equal(err.name, "AbortError");
+        }
+      });
     });
   });
 });

--- a/sdk/core/core-amqp/test/utils/createConnectionStub.ts
+++ b/sdk/core/core-amqp/test/utils/createConnectionStub.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import EventEmitter from "events";
+import { Connection } from "rhea-promise";
+import { stub } from "sinon";
+
+/**
+ * Creates a stubbed rhea-promise Connection object.
+ */
+export function createConnectionStub(): Connection {
+  const connectionStub = new Connection();
+  stub(connectionStub, "open").resolves({} as any);
+  stub(connectionStub, "createSession").resolves({
+    connection: {
+      id: "connection-1"
+    },
+    createSender: () => {
+      const sender = new EventEmitter() as any;
+      sender.send = () => {};
+      return Promise.resolve(sender);
+    },
+    createReceiver: () => {
+      return Promise.resolve(new EventEmitter());
+    }
+  } as any);
+  stub(connectionStub, "id").get(() => "connection-1");
+  return connectionStub;
+}

--- a/sdk/core/core-amqp/test/utils/createConnectionStub.ts
+++ b/sdk/core/core-amqp/test/utils/createConnectionStub.ts
@@ -17,7 +17,9 @@ export function createConnectionStub(): Connection {
     },
     createSender: () => {
       const sender = new EventEmitter() as any;
-      sender.send = () => {};
+      sender.send = () => {
+        /* no-op */
+      };
       return Promise.resolve(sender);
     },
     createReceiver: () => {


### PR DESCRIPTION
Fixes #9988 and part of #4422.

This PR updates 3 async methods to support cancellation:
- CbsClient.negotiateClaim()
- CbsClient.init()
- RequestResponseLink.create()

Note that I needed to update `RequestResponseLink.create()` to accept an `abortSignal` so that `CbsClient.init()` could be properly cancelled.

Updates to event hubs and service bus will come in a separate PR.

[API View link](https://apiview.dev/Assemblies/Review/ec633b2b71c14c81ba99a896f8af2400)
