### PR TITLE
[KeyVault] - Regenerate swagger and fill missing properties

### DIFF
--- a/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_authentication_should_work_for_parallel_requests.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_authentication_should_work_for_parallel_requests.json
@@ -2,33 +2,6 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": "",
-   "status": 401,
-   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"Request is missing a Bearer or PoP token.\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "87",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "401",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "9092b470-33e3-4d87-951b-8c9e279e36ac",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "POST",
    "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/create",
    "query": {
     "api-version": "7.2"
@@ -40,7 +13,7 @@
     "cache-control": "no-cache",
     "content-length": "87",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:48 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "401",
@@ -50,7 +23,34 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "2cb3ffe3-a087-4b44-ba4d-33baf5fa7bc6",
+    "x-ms-request-id": "cab4ea84-4922-4242-9720-32143bb63d4d",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "87",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:54:48 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "401",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "96e5fd6e-5b7d-45be-9369-8f5488c4abf0",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -65,15 +65,15 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:48 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.6 - WUS2 ProdSlices",
-    "x-ms-request-id": "6f8dc614-01c3-43e1-9974-f89c4f462200"
+    "x-ms-ests-server": "2.1.11496.5 - NCUS ProdSlices",
+    "x-ms-request-id": "8686affe-9d15-40a5-871b-a516c8745801"
    }
   },
   {
@@ -87,15 +87,15 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:48 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.5 - EUS ProdSlices",
-    "x-ms-request-id": "d9623829-3276-4b5c-bf9e-bffcc4ba2701"
+    "x-ms-ests-server": "2.1.11496.5 - NCUS ProdSlices",
+    "x-ms-request-id": "f8fb82b8-e52f-48e4-a4d3-7633cd76a000"
    }
   },
   {
@@ -106,12 +106,12 @@
    },
    "requestBody": "{\"kty\":\"RSA\"}",
    "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/e804ae96e33845438fa0c32fc5c18fc3\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"y0K_nwyWPi0p5HgA9CFjBc4kY4BGUm6kkjcaeyMK66Lzdi5KlJAkceP0hQlrvSd69LwMtz473Aq9a3I7f9KcWKAPgGxpFmHW4IUElRD9c-l7lgjQydSV6ACc394OQVs9qF3tMDcW6xyLfr7c65D365ttFdPGW1yrhbwkIIe983ZGP_Q1wHamse2SwiDRPX4IDEzOrBN3tRgnqNXr66Uch30Ii1VXqeFDfPbUvquthYKPo7NoIgEGvAZbs9dV4XZxJlwzJeJEley9RCgI3ShPnYY4TSRIbiBDb0M5N0-1Qlftvt8dUUFCh9qiOc_to0SZacCVWbLQNJDC9iMinmvRlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "758",
+    "content-length": "757",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:49 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -120,33 +120,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "26149bba-7aba-4f86-b5ab-46ccfcfca262",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": "{\"kty\":\"RSA\"}",
-   "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "758",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "c2720f5d-0ff7-45a2-a798-71e2063d57c4",
+    "x-ms-request-id": "21a71940-ac78-488a-beb2-5e2c20bd4c52",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -158,12 +132,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613611091,\"scheduledPurgeDate\":1614215891,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613613289,\"scheduledPurgeDate\":1614218089,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/e804ae96e33845438fa0c32fc5c18fc3\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"y0K_nwyWPi0p5HgA9CFjBc4kY4BGUm6kkjcaeyMK66Lzdi5KlJAkceP0hQlrvSd69LwMtz473Aq9a3I7f9KcWKAPgGxpFmHW4IUElRD9c-l7lgjQydSV6ACc394OQVs9qF3tMDcW6xyLfr7c65D365ttFdPGW1yrhbwkIIe983ZGP_Q1wHamse2SwiDRPX4IDEzOrBN3tRgnqNXr66Uch30Ii1VXqeFDfPbUvquthYKPo7NoIgEGvAZbs9dV4XZxJlwzJeJEley9RCgI3ShPnYY4TSRIbiBDb0M5N0-1Qlftvt8dUUFCh9qiOc_to0SZacCVWbLQNJDC9iMinmvRlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "961",
+    "content-length": "959",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:49 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -172,7 +146,33 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "ff8317aa-e989-461a-b4a2-5694114cd315",
+    "x-ms-request-id": "43b0ca17-045b-4caf-8192-f46beeaad910",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"RSA\"}",
+   "status": 200,
+   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/e7e15622b9cf4d6d90181711a407a2cc\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"1N9Q5yLm2EHxQQCA8t0gkL2kcvdzm0A5KFDQdKfzwH0mpdhyQSBtqK-UZuCZxAALaMGwQR-E2GwVzC2hKvTzqnWtcdosZ3Yv4pNsTwjbPLO4SvpiitMwml_fkfmBI9ECDMRfxPB5TJ5IspFfDvIOU1AetjZeEW8goIB0dAvYpftwZ0lSkT62qG68xAOhjKVE0NBCXUNwFs2ngNWWomeudIqRVEARoHEUB8FKaUXPno0MilFKbi_yxX1X9vzW_EmR2bJSgczfhU2ZNiIgtsdAw3tzpZfEKsiOxK-7nRjZQq-BuE8_kxwHCd_6iHRRdAnkZDfJLi6Ksb5T2r6qPx7QKQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "757",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:54:49 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "436e431c-c6db-4430-9612-7596ec97e1a6",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -187,9 +187,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:49 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -198,7 +198,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "ef15140c-001b-45ae-8ab1-0756133814b5",
+    "x-ms-request-id": "fe4f6097-d20f-4630-bbaa-5cfc38656608",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -213,9 +213,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:49 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -224,7 +224,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "9eecd670-78af-4c98-8c05-d49bd48a5375",
+    "x-ms-request-id": "6dbca985-3c88-4cdc-b5c9-f91b18825d94",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -239,9 +239,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:13 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:51 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -250,7 +250,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "d4359b16-aa91-4347-9d9b-2d9fa29f3145",
+    "x-ms-request-id": "fa67c3b5-b23e-4986-982e-f419abf0e62a",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -265,9 +265,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:15 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:53 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -276,7 +276,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "82817e8a-dbd7-4728-955d-9d049fc6b763",
+    "x-ms-request-id": "7c04da4d-fc88-4da6-9ade-f92c9802b2d7",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -291,9 +291,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:17 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:56 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -302,7 +302,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "d1ab19a4-54d8-49e1-927a-1f8fd7bbbc25",
+    "x-ms-request-id": "ad2fcd3c-0d55-4a38-9500-b95344e05792",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -317,9 +317,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:19 GMT",
+    "date": "Thu, 18 Feb 2021 01:54:58 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -328,7 +328,59 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "82dd7e83-e236-411c-b93e-7d951074e305",
+    "x-ms-request-id": "f89e1629-7404-4c83-b88d-2976be51ff11",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "151",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:55:00 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "1f9d9b64-ecd2-4653-9dfe-c12271f23845",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "151",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:55:01 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "1dd8422e-15f9-40bf-ae99-4bdb87f98c16",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -340,12 +392,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613611091,\"scheduledPurgeDate\":1614215891,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613613289,\"scheduledPurgeDate\":1614218089,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/e804ae96e33845438fa0c32fc5c18fc3\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"y0K_nwyWPi0p5HgA9CFjBc4kY4BGUm6kkjcaeyMK66Lzdi5KlJAkceP0hQlrvSd69LwMtz473Aq9a3I7f9KcWKAPgGxpFmHW4IUElRD9c-l7lgjQydSV6ACc394OQVs9qF3tMDcW6xyLfr7c65D365ttFdPGW1yrhbwkIIe983ZGP_Q1wHamse2SwiDRPX4IDEzOrBN3tRgnqNXr66Uch30Ii1VXqeFDfPbUvquthYKPo7NoIgEGvAZbs9dV4XZxJlwzJeJEley9RCgI3ShPnYY4TSRIbiBDb0M5N0-1Qlftvt8dUUFCh9qiOc_to0SZacCVWbLQNJDC9iMinmvRlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "961",
+    "content-length": "959",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:03 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -354,7 +406,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "60609a3b-5f9a-45c1-8444-4210b2a16398",
+    "x-ms-request-id": "018cdd00-2a85-41aa-95b4-3bf814ab8281",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -369,7 +421,7 @@
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:03 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "204",
@@ -378,7 +430,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "a670278b-80dd-4d5b-b40f-943271ecadec",
+    "x-ms-request-id": "950aeec0-40b7-4e42-982b-ae4c76af8a12",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -390,12 +442,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613611101,\"scheduledPurgeDate\":1614215901,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613613304,\"scheduledPurgeDate\":1614218104,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/e7e15622b9cf4d6d90181711a407a2cc\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"1N9Q5yLm2EHxQQCA8t0gkL2kcvdzm0A5KFDQdKfzwH0mpdhyQSBtqK-UZuCZxAALaMGwQR-E2GwVzC2hKvTzqnWtcdosZ3Yv4pNsTwjbPLO4SvpiitMwml_fkfmBI9ECDMRfxPB5TJ5IspFfDvIOU1AetjZeEW8goIB0dAvYpftwZ0lSkT62qG68xAOhjKVE0NBCXUNwFs2ngNWWomeudIqRVEARoHEUB8FKaUXPno0MilFKbi_yxX1X9vzW_EmR2bJSgczfhU2ZNiIgtsdAw3tzpZfEKsiOxK-7nRjZQq-BuE8_kxwHCd_6iHRRdAnkZDfJLi6Ksb5T2r6qPx7QKQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "961",
+    "content-length": "959",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:03 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -404,7 +456,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "30ac4c22-2e65-4ab2-ba6f-7ce0ca38a8f8",
+    "x-ms-request-id": "fcb211b4-f02a-48dc-832a-b432b179940c",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -419,9 +471,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:03 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -430,7 +482,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "22aecff5-7215-4a35-a840-1e3801a77fe0",
+    "x-ms-request-id": "a5a2c45f-592d-401f-84e2-26268c04f7fc",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -445,9 +497,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:03 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -456,7 +508,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "16196647-6449-444b-bb1b-5f3a3dec68d6",
+    "x-ms-request-id": "fe7dc1be-ec3a-4a3a-b0b7-5e4ed7a89943",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -471,9 +523,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:23 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:06 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -482,7 +534,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "0850e283-e02b-40f0-aa47-31fa8f81d16e",
+    "x-ms-request-id": "6da782ba-00fb-4b17-bdc3-0d9ed8daf778",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -497,9 +549,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:25 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:08 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -508,7 +560,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "8ea2291f-8274-42a8-8edb-3873f79fdb65",
+    "x-ms-request-id": "7112c6e2-b6fe-47bc-a8e5-7c0908113564",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -523,9 +575,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:27 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:10 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -534,7 +586,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "f5a80d10-1214-4a02-b151-66eaba09723e",
+    "x-ms-request-id": "00038a04-bf28-4513-b120-5b46fd0671c5",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -549,9 +601,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "152",
+    "content-length": "151",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:29 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:12 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -560,59 +612,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "0a8dafea-09c3-4eff-9680-51fbe2d41251",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "152",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:31 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "fe9484e3-b5df-4ca2-8782-0230e458546f",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "152",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:33 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "c731061a-e5cb-4f77-97f5-8f0dbcb8a4d9",
+    "x-ms-request-id": "8129c0d1-c294-4227-9bf5-8ad748ae303c",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -624,12 +624,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613611101,\"scheduledPurgeDate\":1614215901,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613613304,\"scheduledPurgeDate\":1614218104,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/e7e15622b9cf4d6d90181711a407a2cc\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"1N9Q5yLm2EHxQQCA8t0gkL2kcvdzm0A5KFDQdKfzwH0mpdhyQSBtqK-UZuCZxAALaMGwQR-E2GwVzC2hKvTzqnWtcdosZ3Yv4pNsTwjbPLO4SvpiitMwml_fkfmBI9ECDMRfxPB5TJ5IspFfDvIOU1AetjZeEW8goIB0dAvYpftwZ0lSkT62qG68xAOhjKVE0NBCXUNwFs2ngNWWomeudIqRVEARoHEUB8FKaUXPno0MilFKbi_yxX1X9vzW_EmR2bJSgczfhU2ZNiIgtsdAw3tzpZfEKsiOxK-7nRjZQq-BuE8_kxwHCd_6iHRRdAnkZDfJLi6Ksb5T2r6qPx7QKQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613613289,\"updated\":1613613289,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "961",
+    "content-length": "959",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 18 Feb 2021 01:18:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:14 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -638,7 +638,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "e5de7cc8-5360-4df9-93ff-c51dc63af149",
+    "x-ms-request-id": "6a47efe3-bb19-4479-bee7-95da8755b331",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -653,7 +653,7 @@
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "date": "Thu, 18 Feb 2021 01:18:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:55:14 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "204",
@@ -662,7 +662,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "75577984-4892-433f-92cd-9558b49b42a6",
+    "x-ms-request-id": "fa564e03-7324-4f91-9839-ee6be1e13f50",
     "x-powered-by": "ASP.NET"
    }
   }

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_authentication_should_work_for_parallel_requests.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_authentication_should_work_for_parallel_requests.json
@@ -13,7 +13,7 @@
     "cache-control": "no-cache",
     "content-length": "87",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:33 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "401",
@@ -23,7 +23,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "5d46bafe-57d9-48bf-8cbc-2c0cfe3f2516",
+    "x-ms-request-id": "9092b470-33e3-4d87-951b-8c9e279e36ac",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -40,7 +40,7 @@
     "cache-control": "no-cache",
     "content-length": "87",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:33 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "401",
@@ -50,7 +50,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "294efc63-afe5-4ccc-a9b6-4b42975f4236",
+    "x-ms-request-id": "2cb3ffe3-a087-4b44-ba4d-33baf5fa7bc6",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -65,15 +65,15 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:34 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.5 - NCUS ProdSlices",
-    "x-ms-request-id": "75b07480-e804-4c30-8e43-9b9ee695f700"
+    "x-ms-ests-server": "2.1.11496.6 - WUS2 ProdSlices",
+    "x-ms-request-id": "6f8dc614-01c3-43e1-9974-f89c4f462200"
    }
   },
   {
@@ -87,41 +87,15 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:34 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.5 - NCUS ProdSlices",
-    "x-ms-request-id": "410fff9d-3eb1-4bcf-982f-e9cb7458e600"
-   }
-  },
-  {
-   "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": "{\"kty\":\"RSA\"}",
-   "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/4db29d6e88ef43fc9d72ecb769a30bff\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rmygjGVrGwvH33Qn8kpprV1pc4Q8wZOo3gNiia6120ZGyBLicjsqVuHhNk_PaQqW__t703v1aw6l28mr0NFQtwdK3usVDo401PJUxsLF10DS9tPxfZ2z1rJLelRkBdW2l4Il6tjYzysq0xtuM5i1b2vf8UsARPBnA-_5v2tEHASNzx86p8bXWxTlnbgmZEJY56nPcl3BrFNZjVqs8sUnVacKU89LMwmqvG1ek-gUIa_pLK5hiybr-r3HGIzkLIBEPFYvvmsJ6XnbPQlzKF_62nryrd_L2YdnxhTrI4P3LvDsja_KoZabDxqvtRQWrLcQO_ss6X5K_WCOFr2o507DRQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "757",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:35 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "45024ec6-143d-42e6-b61d-5011a13f3f3b",
-    "x-powered-by": "ASP.NET"
+    "x-ms-ests-server": "2.1.11496.5 - EUS ProdSlices",
+    "x-ms-request-id": "d9623829-3276-4b5c-bf9e-bffcc4ba2701"
    }
   },
   {
@@ -132,12 +106,12 @@
    },
    "requestBody": "{\"kty\":\"RSA\"}",
    "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/bf9f001a380c4a61b4856f9fda7fa19b\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"vginIdKfJjnM8GBJeRPtc-SsqWDwPVxE0bsXAhBl3shMXyhLS0Co-73Z34L-qMlQnUT6lxP5lxX4McdxoXtg6bHYFz2jYdaZD4yt3swwToKr0TksnDG2EA_YFTee5TKlTWodwoG1Xk-BIt8g_K0GsqUzUM7ikZPBDp7EF9OtJXnfh4H21BDBWimcokJKxZV3eFtYQh9z7-6Wd2iUPs6cFEioKs2z6CErS6wXQCXV7vLyXE2wqWaaseFzUAq3SHwXdkKjqucNzpfYGOGw8dlaPaV9kgPpl5WXEAyw8QkVQX7T93ZcTqFvv_9zVeHWvuuUsqAT4piellS7N9GRm9pDFQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "757",
+    "content-length": "758",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -146,7 +120,33 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "51a38bc1-8a20-4dd1-bd06-37830c1d6b62",
+    "x-ms-request-id": "26149bba-7aba-4f86-b5ab-46ccfcfca262",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"RSA\"}",
+   "status": 200,
+   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "758",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:18:10 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "c2720f5d-0ff7-45a2-a798-71e2063d57c4",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -158,12 +158,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613499695,\"scheduledPurgeDate\":1614104495,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/bf9f001a380c4a61b4856f9fda7fa19b\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"vginIdKfJjnM8GBJeRPtc-SsqWDwPVxE0bsXAhBl3shMXyhLS0Co-73Z34L-qMlQnUT6lxP5lxX4McdxoXtg6bHYFz2jYdaZD4yt3swwToKr0TksnDG2EA_YFTee5TKlTWodwoG1Xk-BIt8g_K0GsqUzUM7ikZPBDp7EF9OtJXnfh4H21BDBWimcokJKxZV3eFtYQh9z7-6Wd2iUPs6cFEioKs2z6CErS6wXQCXV7vLyXE2wqWaaseFzUAq3SHwXdkKjqucNzpfYGOGw8dlaPaV9kgPpl5WXEAyw8QkVQX7T93ZcTqFvv_9zVeHWvuuUsqAT4piellS7N9GRm9pDFQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613611091,\"scheduledPurgeDate\":1614215891,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "959",
+    "content-length": "961",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -172,7 +172,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "574d34d8-5f5b-4dd9-ae70-7b50da06d789",
+    "x-ms-request-id": "ff8317aa-e989-461a-b4a2-5694114cd315",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -187,9 +187,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -198,7 +198,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "17528a4f-021d-4983-a1a9-26fc14234351",
+    "x-ms-request-id": "ef15140c-001b-45ae-8ab1-0756133814b5",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -213,9 +213,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:35 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:11 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -224,7 +224,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "23d2f59f-deba-4239-831e-96ce6c5fb3d0",
+    "x-ms-request-id": "9eecd670-78af-4c98-8c05-d49bd48a5375",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -239,9 +239,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:37 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:13 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -250,7 +250,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "78552cda-632f-4a08-ab6c-136f36ea3a26",
+    "x-ms-request-id": "d4359b16-aa91-4347-9d9b-2d9fa29f3145",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -265,9 +265,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:39 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -276,7 +276,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "9a711510-9e7d-468f-974f-0719e18919f3",
+    "x-ms-request-id": "82817e8a-dbd7-4728-955d-9d049fc6b763",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -291,9 +291,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:41 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:17 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -302,7 +302,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "766ad4f0-49ba-4f09-b196-9f9e3b7d1bb3",
+    "x-ms-request-id": "d1ab19a4-54d8-49e1-927a-1f8fd7bbbc25",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -317,9 +317,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:43 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:19 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -328,33 +328,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "7dff54a7-7c56-4fc7-92cc-3de173a4354e",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "151",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:44 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "972290c0-e982-4129-a839-773064692592",
+    "x-ms-request-id": "82dd7e83-e236-411c-b93e-7d951074e305",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -366,12 +340,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613499695,\"scheduledPurgeDate\":1614104495,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/bf9f001a380c4a61b4856f9fda7fa19b\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"vginIdKfJjnM8GBJeRPtc-SsqWDwPVxE0bsXAhBl3shMXyhLS0Co-73Z34L-qMlQnUT6lxP5lxX4McdxoXtg6bHYFz2jYdaZD4yt3swwToKr0TksnDG2EA_YFTee5TKlTWodwoG1Xk-BIt8g_K0GsqUzUM7ikZPBDp7EF9OtJXnfh4H21BDBWimcokJKxZV3eFtYQh9z7-6Wd2iUPs6cFEioKs2z6CErS6wXQCXV7vLyXE2wqWaaseFzUAq3SHwXdkKjqucNzpfYGOGw8dlaPaV9kgPpl5WXEAyw8QkVQX7T93ZcTqFvv_9zVeHWvuuUsqAT4piellS7N9GRm9pDFQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0\",\"deletedDate\":1613611091,\"scheduledPurgeDate\":1614215891,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--0/7a17e5e3fc284b099df0218ac42a348d\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"sLE08D_2ACU-SH0hUQelGlxGLLuwSnKRPRFkdLIx12LVWqvGa_SLw1y_dv2d-0NW-VJVt5BvmIIu4q4568ulQzJajfYoXVsvJM5Xnn7pHk6k_R0EcU4PtULiDk6wTbuhjlJndT7UAe-8Z4D-SQpxj2XfW9m8-lzbprVuoMgFFu9SLc6MdBgEJuaTR5C5zouZlA7DgElQP8zAiq01bLMxm21OQ9U8LCHXh6tPb5ADeJ1m-v_AZRQC9Kf-J-MDR8GE2QoKpzaxv18Gp5v6zqYHHpOU6-aS9yzZJ6e4s1taxbRhE9eNG25d15aEbVQSwUt4QfMuQUxJpRECHVsH830eVQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "959",
+    "content-length": "961",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:47 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -380,7 +354,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "4f84f8a1-332a-4f83-8beb-1d940d637b0a",
+    "x-ms-request-id": "60609a3b-5f9a-45c1-8444-4210b2a16398",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -395,7 +369,7 @@
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "date": "Tue, 16 Feb 2021 18:21:47 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "204",
@@ -404,7 +378,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "9af1f6fe-4e58-4418-a938-70245b2248a9",
+    "x-ms-request-id": "a670278b-80dd-4d5b-b40f-943271ecadec",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -416,12 +390,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613499708,\"scheduledPurgeDate\":1614104508,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/4db29d6e88ef43fc9d72ecb769a30bff\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rmygjGVrGwvH33Qn8kpprV1pc4Q8wZOo3gNiia6120ZGyBLicjsqVuHhNk_PaQqW__t703v1aw6l28mr0NFQtwdK3usVDo401PJUxsLF10DS9tPxfZ2z1rJLelRkBdW2l4Il6tjYzysq0xtuM5i1b2vf8UsARPBnA-_5v2tEHASNzx86p8bXWxTlnbgmZEJY56nPcl3BrFNZjVqs8sUnVacKU89LMwmqvG1ek-gUIa_pLK5hiybr-r3HGIzkLIBEPFYvvmsJ6XnbPQlzKF_62nryrd_L2YdnxhTrI4P3LvDsja_KoZabDxqvtRQWrLcQO_ss6X5K_WCOFr2o507DRQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613611101,\"scheduledPurgeDate\":1614215901,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "959",
+    "content-length": "961",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:47 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -430,7 +404,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "a9247072-7285-45d4-b470-802ee0903884",
+    "x-ms-request-id": "30ac4c22-2e65-4ab2-ba6f-7ce0ca38a8f8",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -445,9 +419,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:47 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -456,7 +430,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "14eb78e7-25f6-48cf-92b3-411350f9f411",
+    "x-ms-request-id": "22aecff5-7215-4a35-a840-1e3801a77fe0",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -471,9 +445,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:48 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:21 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -482,7 +456,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "68697b4b-4032-4d3a-99b8-f34b724b6ca8",
+    "x-ms-request-id": "16196647-6449-444b-bb1b-5f3a3dec68d6",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -497,9 +471,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:50 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:23 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -508,7 +482,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "69af6579-a172-4f5a-8ea4-897ac3c5da82",
+    "x-ms-request-id": "0850e283-e02b-40f0-aa47-31fa8f81d16e",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -523,9 +497,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:51 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:25 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -534,7 +508,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "ddef7bde-5550-4460-a4ba-861410605e3f",
+    "x-ms-request-id": "8ea2291f-8274-42a8-8edb-3873f79fdb65",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -549,9 +523,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:53 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:27 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -560,7 +534,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "234e38dc-31ca-4511-9381-477c8276c455",
+    "x-ms-request-id": "f5a80d10-1214-4a02-b151-66eaba09723e",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -575,9 +549,9 @@
    "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "151",
+    "content-length": "152",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:55 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:29 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "404",
@@ -586,7 +560,59 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "8e55059f-8007-41da-8fa9-36aa8c9cc4a6",
+    "x-ms-request-id": "0a8dafea-09c3-4eff-9680-51fbe2d41251",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "152",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:18:31 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "fe9484e3-b5df-4ca2-8782-0230e458546f",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "152",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 18 Feb 2021 01:18:33 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus2",
+    "x-ms-keyvault-service-version": "1.2.164.2",
+    "x-ms-request-id": "c731061a-e5cb-4f77-97f5-8f0dbcb8a4d9",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -598,12 +624,12 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613499708,\"scheduledPurgeDate\":1614104508,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/4db29d6e88ef43fc9d72ecb769a30bff\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rmygjGVrGwvH33Qn8kpprV1pc4Q8wZOo3gNiia6120ZGyBLicjsqVuHhNk_PaQqW__t703v1aw6l28mr0NFQtwdK3usVDo401PJUxsLF10DS9tPxfZ2z1rJLelRkBdW2l4Il6tjYzysq0xtuM5i1b2vf8UsARPBnA-_5v2tEHASNzx86p8bXWxTlnbgmZEJY56nPcl3BrFNZjVqs8sUnVacKU89LMwmqvG1ek-gUIa_pLK5hiybr-r3HGIzkLIBEPFYvvmsJ6XnbPQlzKF_62nryrd_L2YdnxhTrI4P3LvDsja_KoZabDxqvtRQWrLcQO_ss6X5K_WCOFr2o507DRQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499694,\"updated\":1613499694,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1\",\"deletedDate\":1613611101,\"scheduledPurgeDate\":1614215901,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Authenticationshouldworkforparallelrequests--1/410dfead9db846b3b7393a61915aa7b0\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"uZctbzYgoJHqlP3FWJubIVHk--rM-H-fmsHqMIRcoazzSTiYt3uW0A6tx7KoE6d6qM8XklWVdG47YPbfwRaKLJ6EXfpw-1pP2oyALMDswb7hwSYVtQE100382aRA8vfcLY5b4zf33J0d8BOlkeWhvOu5P3XgsLMHthCUK1m5IKaNsiVLaYKvUk48moBH3V95yiQtg5Jn5IX_oLqzum8rOCbg37dVOU1y4rH04LNJlQvEJHO1dHVXyE9yM9bp4jRSiNMj-pbMW2tuHTz7t4spdgrfZWb8VPS4f7kV87jQys3hxBrf7KI4SrvTmZo0bgHRZ-GUZWROtUFMqZrfe6kaJQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613611090,\"updated\":1613611090,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "959",
+    "content-length": "961",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:57 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:35 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
@@ -612,7 +638,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "090a1e50-2df5-4681-a438-d86bb68e1148",
+    "x-ms-request-id": "e5de7cc8-5360-4df9-93ff-c51dc63af149",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -627,7 +653,7 @@
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "date": "Tue, 16 Feb 2021 18:21:57 GMT",
+    "date": "Thu, 18 Feb 2021 01:18:35 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "204",
@@ -636,7 +662,7 @@
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
     "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "512b9d1e-a75d-4a2e-bb7e-d344f4845a3b",
+    "x-ms-request-id": "75577984-4892-433f-92cd-9558b49b42a6",
     "x-powered-by": "ASP.NET"
    }
   }

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_all_decrypts_happen_remotely/recording_encrypt_with_additional_parameters_returns_them.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_all_decrypts_happen_remotely/recording_encrypt_with_additional_parameters_returns_them.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "3b6f039cbf350c2338797f50460f5ade";
+module.exports.hash = "a2c4a9c3ba60805d4b212ecbd0305589";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-encryptdecryptRSA15-/create')
+  .post('/keys/cryptography-client-test/create')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3b3b1534-3d1e-47b0-b95e-bac4356a4308',
+  '105ed1c9-4773-4d78-b354-f8b0ab35632f',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
+  'Thu, 18 Feb 2021 01:32:11 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7716efac-1903-470b-b215-0f916e395d01',
+  '7e393d35-08a3-4aee-994b-2a688f219200',
   'x-ms-ests-server',
-  '2.1.11496.5 - NCUS ProdSlices',
+  '2.1.11496.6 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDAwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:28 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AomKd8loD1ZEtvuRqyiTEnMA4qsDAQAAAJu6v9cOAAAA; expires=Sat, 20-Mar-2021 01:32:12 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
+  'Thu, 18 Feb 2021 01:32:12 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-encryptdecryptRSA15-/create', {"kty":"RSA"})
+  .post('/keys/cryptography-client-test/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rgMJnhP6Qh8sv-54oGCbLopnR7hvsZ8o5kWxVmX-oco784-Lwmn2rbm6Uh0AKACU6JQWPU-_ZfTJSIVsiygfGwJL8WjxpqBKT3NSskIjvvCUMcl97QundiU6xF1aKMQPjswU-Wo6Pndq23oaoysGbLv1CG12WdA5cu96IdW6kLowfCRn77kd0HI7UkyBwFMPi8c5_wu4PAJLBV4m00wlDp07XozDbUx8vAQ8WKNyfXhHrnNu_3QOrnwBz2rjWIlHIfwGPxoWqJhxnjVlJvO8ULrK42n0nVYQbn2d4HAPFYYLDpIAuv3CsfbI2Rgtzq6Ifzql4EGLlOp6slP04eKTKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611528,"updated":1613611528,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sLgs-S-oXSCMuqNNWF-9wlONdxNwYtgt6Y_IMcNKLBOj7RcmAZ3rv6VNuWgZlxh5_VeWC1Y1XzEiiUmTIHYvOtQ7nthJ_UX5N8J0EX1U7Z7CVEDkcg2d9tSLHieBSH2IBK_-n7DeiUgiQnT1S-D-TAb1q3IqGxjNdGKx7Sq5LJO-EwDfZjio0z0Dl4sUwclHkdm-8rlp7-B2YvcbDBlGAYVdgReICWC_o1CmypYp9Uo53J7G1UNHS0OclqawSDTKblOz9ZTBhdp8BJ7QsyQ3H3_hBXTLgw6foMkVqTT0xH_IgDuidu8AFhIDoLomDiEsigUjQJ3WlZ2GQNU8Nl98SQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611932,"updated":1613611932,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '57a3e93d-e005-4e58-b2b0-35e1f40dd026',
+  '5e611e01-a331-40f6-9c88-c3f7350a8410',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT',
+  'Thu, 18 Feb 2021 01:32:12 GMT',
   'Content-Length',
-  '729'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149')
+  .get('/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '56f833b1-b4cf-40e6-bd91-69ed2f4a5972',
+  'e5ec5fc0-35a1-4207-a1d4-859cfa6629cc',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
+  'Thu, 18 Feb 2021 01:32:12 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -144,8 +144,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -157,23 +155,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '173e2c82-2164-4429-a884-f9ee18951600',
+  'ea6e5d9a-032b-4a20-9ba9-56e1d7211600',
   'x-ms-ests-server',
   '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBAAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:28 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AomKd8loD1ZEtvuRqyiTEnMA4qsDAgAAAJu6v9cOAAAA; expires=Sat, 20-Mar-2021 01:32:13 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
+  'Thu, 18 Feb 2021 01:32:13 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149')
+  .get('/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rgMJnhP6Qh8sv-54oGCbLopnR7hvsZ8o5kWxVmX-oco784-Lwmn2rbm6Uh0AKACU6JQWPU-_ZfTJSIVsiygfGwJL8WjxpqBKT3NSskIjvvCUMcl97QundiU6xF1aKMQPjswU-Wo6Pndq23oaoysGbLv1CG12WdA5cu96IdW6kLowfCRn77kd0HI7UkyBwFMPi8c5_wu4PAJLBV4m00wlDp07XozDbUx8vAQ8WKNyfXhHrnNu_3QOrnwBz2rjWIlHIfwGPxoWqJhxnjVlJvO8ULrK42n0nVYQbn2d4HAPFYYLDpIAuv3CsfbI2Rgtzq6Ifzql4EGLlOp6slP04eKTKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611528,"updated":1613611528,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sLgs-S-oXSCMuqNNWF-9wlONdxNwYtgt6Y_IMcNKLBOj7RcmAZ3rv6VNuWgZlxh5_VeWC1Y1XzEiiUmTIHYvOtQ7nthJ_UX5N8J0EX1U7Z7CVEDkcg2d9tSLHieBSH2IBK_-n7DeiUgiQnT1S-D-TAb1q3IqGxjNdGKx7Sq5LJO-EwDfZjio0z0Dl4sUwclHkdm-8rlp7-B2YvcbDBlGAYVdgReICWC_o1CmypYp9Uo53J7G1UNHS0OclqawSDTKblOz9ZTBhdp8BJ7QsyQ3H3_hBXTLgw6foMkVqTT0xH_IgDuidu8AFhIDoLomDiEsigUjQJ3WlZ2GQNU8Nl98SQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611932,"updated":1613611932,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '9096dcb6-f468-499b-a0db-a84e0b55eca0',
+  '2d6a29b9-bda0-42db-8ea1-4a6149dfd707',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT',
+  'Thu, 18 Feb 2021 01:32:12 GMT',
   'Content-Length',
-  '729'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149/decrypt', {"alg":"RSA1_5","value":"VUrte_KIA-kq25Yl9C-uGtfOaaGMKv9AEEnKo713K98XqIloQifujxV_t7BMgihcO77Y3FZvmwpGLfw-aH7ekiYFMqM2SV-ElbN9zY25WrVf2OxPu7JL-4hQmEj7Gkdlc8skMvihBREmqHGMmA9Q7OLTuOvxTLVBCBgN--egyWD4kP9uGhBWnv78d_mlq3vDx4VH3e2kX4Eeu1wjj99lnE4FBALemCtl8Em7Ub1XgswalWMsEW1ktlqLSf5lQG3uXda7u3mdCHzoxGhlfYaOqyp6NQaqrCClqvudcbfKYzc__-usDHvoUQdpeVAn3txPN24wjZ4mlKvgZgWX1hoMXg"})
+  .delete('/keys/cryptography-client-test')
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149","value":"ZW5jcnlwdCAmIGRlY3J5cHQgUlNBMV81"}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test","deletedDate":1613611933,"scheduledPurgeDate":1614216733,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sLgs-S-oXSCMuqNNWF-9wlONdxNwYtgt6Y_IMcNKLBOj7RcmAZ3rv6VNuWgZlxh5_VeWC1Y1XzEiiUmTIHYvOtQ7nthJ_UX5N8J0EX1U7Z7CVEDkcg2d9tSLHieBSH2IBK_-n7DeiUgiQnT1S-D-TAb1q3IqGxjNdGKx7Sq5LJO-EwDfZjio0z0Dl4sUwclHkdm-8rlp7-B2YvcbDBlGAYVdgReICWC_o1CmypYp9Uo53J7G1UNHS0OclqawSDTKblOz9ZTBhdp8BJ7QsyQ3H3_hBXTLgw6foMkVqTT0xH_IgDuidu8AFhIDoLomDiEsigUjQJ3WlZ2GQNU8Nl98SQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611932,"updated":1613611932,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0b66b352-3b3d-42f6-be68-962c44bbc0fd',
+  '3dfa9ae1-cdb4-47b3-ba1b-e4169464fe7d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,15 +229,175 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT',
+  'Thu, 18 Feb 2021 01:32:12 GMT',
   'Content-Length',
-  '180'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/keys/localCryptoKeyName-encryptdecryptRSA15-')
+  .get('/deletedkeys/cryptography-client-test')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-","deletedDate":1613611528,"scheduledPurgeDate":1614216328,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rgMJnhP6Qh8sv-54oGCbLopnR7hvsZ8o5kWxVmX-oco784-Lwmn2rbm6Uh0AKACU6JQWPU-_ZfTJSIVsiygfGwJL8WjxpqBKT3NSskIjvvCUMcl97QundiU6xF1aKMQPjswU-Wo6Pndq23oaoysGbLv1CG12WdA5cu96IdW6kLowfCRn77kd0HI7UkyBwFMPi8c5_wu4PAJLBV4m00wlDp07XozDbUx8vAQ8WKNyfXhHrnNu_3QOrnwBz2rjWIlHIfwGPxoWqJhxnjVlJvO8ULrK42n0nVYQbn2d4HAPFYYLDpIAuv3CsfbI2Rgtzq6Ifzql4EGLlOp6slP04eKTKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611528,"updated":1613611528,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: cryptography-client-test"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '771505f0-5056-40ec-a7cd-f5733ded34ad',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:32:12 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: cryptography-client-test"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '9fb2a790-c64c-47b2-948c-c9126a9e0ce8',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:32:12 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: cryptography-client-test"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'c40ac5f8-764b-4df6-a048-969a9fecaa47',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:32:14 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: cryptography-client-test"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'cd299a26-4114-4cc8-9dfc-eac4b5e0b9be',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:32:17 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: cryptography-client-test"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '89837936-32cf-47a3-9205-08f678e1fe11',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:32:19 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test","deletedDate":1613611933,"scheduledPurgeDate":1614216733,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a23951eb91684346a43d00a0838e29c4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sLgs-S-oXSCMuqNNWF-9wlONdxNwYtgt6Y_IMcNKLBOj7RcmAZ3rv6VNuWgZlxh5_VeWC1Y1XzEiiUmTIHYvOtQ7nthJ_UX5N8J0EX1U7Z7CVEDkcg2d9tSLHieBSH2IBK_-n7DeiUgiQnT1S-D-TAb1q3IqGxjNdGKx7Sq5LJO-EwDfZjio0z0Dl4sUwclHkdm-8rlp7-B2YvcbDBlGAYVdgReICWC_o1CmypYp9Uo53J7G1UNHS0OclqawSDTKblOz9ZTBhdp8BJ7QsyQ3H3_hBXTLgw6foMkVqTT0xH_IgDuidu8AFhIDoLomDiEsigUjQJ3WlZ2GQNU8Nl98SQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611932,"updated":1613611932,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +409,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2de64329-cc5f-4b5f-83a5-e8ee77ff91a1',
+  'cc6ad53b-786d-49bf-b817-d3b25bfa1ce3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,237 +421,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT',
+  'Thu, 18 Feb 2021 01:32:21 GMT',
   'Content-Length',
-  '903'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '25208968-84e7-4fdc-addd-d7fb373b8acd',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '99d51847-e459-4ffd-aa68-a69439cb72bc',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:27 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '65bf4094-1d53-4606-b29d-1199d88e07bc',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:30 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '071f9711-ed9e-4d0a-8f76-1723bf72ce1e',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:32 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'b58491fc-95ef-4a7c-82d6-7b22017a2d97',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:34 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA15-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '123',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '37e0eb77-aa14-4d2b-95f4-9ef6dc81ba26',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:36 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-","deletedDate":1613611528,"scheduledPurgeDate":1614216328,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA15-/3e5a989e18d1458ebcdbe8093bd4d149","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rgMJnhP6Qh8sv-54oGCbLopnR7hvsZ8o5kWxVmX-oco784-Lwmn2rbm6Uh0AKACU6JQWPU-_ZfTJSIVsiygfGwJL8WjxpqBKT3NSskIjvvCUMcl97QundiU6xF1aKMQPjswU-Wo6Pndq23oaoysGbLv1CG12WdA5cu96IdW6kLowfCRn77kd0HI7UkyBwFMPi8c5_wu4PAJLBV4m00wlDp07XozDbUx8vAQ8WKNyfXhHrnNu_3QOrnwBz2rjWIlHIfwGPxoWqJhxnjVlJvO8ULrK42n0nVYQbn2d4HAPFYYLDpIAuv3CsfbI2Rgtzq6Ifzql4EGLlOp6slP04eKTKQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611528,"updated":1613611528,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'e4749d03-8c72-4b9e-b8fe-9ef28aa2cfef',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Thu, 18 Feb 2021 01:25:38 GMT',
-  'Content-Length',
-  '903'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/deletedkeys/localCryptoKeyName-encryptdecryptRSA15-')
+  .delete('/deletedkeys/cryptography-client-test')
   .query(true)
   .reply(204, "", [
   'Cache-Control',
@@ -503,7 +439,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'e9ae2db6-91dc-49b0-97fa-cf627b23551e',
+  '58c8bbad-fcb6-4937-a9fa-cb1c4d933130',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -515,5 +451,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:38 GMT'
+  'Thu, 18 Feb 2021 01:32:21 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_encrypt__decrypt_rsaoaep.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_encrypt__decrypt_rsaoaep.js
@@ -1,5 +1,519 @@
 let nock = require('nock');
 
-module.exports.hash = "4411207d1a3cdbfce37d3d14cba1167d";
+module.exports.hash = "1fe7d8a69335a419803d2eeec88fcfd5";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '727e1365-063e-4daf-ba90-b640e8127957',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:38 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1315',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7d7eaf67-31be-4265-86c5-1cb72e915001',
+  'x-ms-ests-server',
+  '2.1.11496.5 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:39 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:39 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/create', {"kty":"RSA"})
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2FyKRPoPFae5ToKrsM3_BTnAznQalzIr2l1K-v2tglXN6Kk1NSbuS4xErSVKM-d20EKBxvCvsSkcWmQ8MYSaxn2pQ3aiOBcm32roOAJHSRh1GyLz-GqfQ5-tNzaFWDK5T_ZFSV-gnwqHII-S4vDkLLB1zjna-kzfzycwylZ6UxMu52gSO5m5nnBWCQp9aJE80p_ifT6KcX0JQK8UoMCBoOzE1XbGC_w5M5_sEMLcSviGfUJJTVIPhfK_7UGInuhOPiuWmRNZFlUeDDMTkoLS9GpRLvWsopsZBcGtkbkLHJ9QZqsk6vGBvbPSuz0yxnuVUu9lq_Yp6PHpVLxu65VpqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611539,"updated":1613611539,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '55ea484f-4fc9-44e9-916d-ca4d796b4052',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:38 GMT',
+  'Content-Length',
+  '732'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'a4fad492-804f-482d-ad6a-941b869f6556',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:38 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'd038511a-872d-4cef-8a15-8b165d3e5301',
+  'x-ms-ests-server',
+  '2.1.11496.5 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBgAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:39 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:39 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c')
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2FyKRPoPFae5ToKrsM3_BTnAznQalzIr2l1K-v2tglXN6Kk1NSbuS4xErSVKM-d20EKBxvCvsSkcWmQ8MYSaxn2pQ3aiOBcm32roOAJHSRh1GyLz-GqfQ5-tNzaFWDK5T_ZFSV-gnwqHII-S4vDkLLB1zjna-kzfzycwylZ6UxMu52gSO5m5nnBWCQp9aJE80p_ifT6KcX0JQK8UoMCBoOzE1XbGC_w5M5_sEMLcSviGfUJJTVIPhfK_7UGInuhOPiuWmRNZFlUeDDMTkoLS9GpRLvWsopsZBcGtkbkLHJ9QZqsk6vGBvbPSuz0yxnuVUu9lq_Yp6PHpVLxu65VpqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611539,"updated":1613611539,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '3e1317a3-9ab8-431e-9ef1-056f3fab04f7',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:38 GMT',
+  'Content-Length',
+  '732'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c/decrypt', {"alg":"RSA-OAEP","value":"PYqdQHDB4KPMsz5t2GQF-H7VYH3PGXLXrcq3pYknDEPCT2R_n7GQnTmCmZAEDXNgkc-CLzxRTzkKbSPcaBHs8JAY3hQWaSQsntqsoX1wge6LF4XqSiwLFDGG_CkAOaINtpbXVNj-BuNRk7XUJi95ZmEfcLSMePWnFCBrrncthK27X1rf4LTAL1ptroig-SWVDIRlm5WMU2pLV_Wq0jSAgyqXlK71IAtFPLFUQQJv3XPbDpu5JaF9VFjLwEbbFcLqUszK4BIGLyKAMUtsD_ZFaX35is41JwKXa5G370bzTgAlhB8zwUfRU7NnJ0N0RveCQr4uXH-OSgUV4nIdoktewA"})
+  .query(true)
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c","value":"ZW5jcnlwdCAmIGRlY3J5cHQgUlNBLU9BRVA"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'f1760bd0-c178-4393-bf39-d772b6aef4fa',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:38 GMT',
+  'Content-Length',
+  '186'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-","deletedDate":1613611539,"scheduledPurgeDate":1614216339,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2FyKRPoPFae5ToKrsM3_BTnAznQalzIr2l1K-v2tglXN6Kk1NSbuS4xErSVKM-d20EKBxvCvsSkcWmQ8MYSaxn2pQ3aiOBcm32roOAJHSRh1GyLz-GqfQ5-tNzaFWDK5T_ZFSV-gnwqHII-S4vDkLLB1zjna-kzfzycwylZ6UxMu52gSO5m5nnBWCQp9aJE80p_ifT6KcX0JQK8UoMCBoOzE1XbGC_w5M5_sEMLcSviGfUJJTVIPhfK_7UGInuhOPiuWmRNZFlUeDDMTkoLS9GpRLvWsopsZBcGtkbkLHJ9QZqsk6vGBvbPSuz0yxnuVUu9lq_Yp6PHpVLxu65VpqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611539,"updated":1613611539,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'ab99d5ff-be64-4c0e-b462-ed9fcb00426f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:39 GMT',
+  'Content-Length',
+  '909'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '3311b7bc-2ecd-4e36-8782-8bfeb8723dc5',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:39 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '5bcfe5fb-2839-43c2-86ff-ea7767ad894e',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:39 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '2e9acbf4-c5f7-4202-b554-a8572848359f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:40 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '87fead2b-b331-45ba-88b9-e7a63789009c',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:43 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'ee9a037d-6c70-4e3a-b663-5a2c44dd4892',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:45 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-encryptdecryptRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '727a09c4-c644-4df1-ade5-cfc08816002f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:47 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-","deletedDate":1613611539,"scheduledPurgeDate":1614216339,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-encryptdecryptRSA-OAEP-/babe70cf14154d818773eab4698e9e2c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2FyKRPoPFae5ToKrsM3_BTnAznQalzIr2l1K-v2tglXN6Kk1NSbuS4xErSVKM-d20EKBxvCvsSkcWmQ8MYSaxn2pQ3aiOBcm32roOAJHSRh1GyLz-GqfQ5-tNzaFWDK5T_ZFSV-gnwqHII-S4vDkLLB1zjna-kzfzycwylZ6UxMu52gSO5m5nnBWCQp9aJE80p_ifT6KcX0JQK8UoMCBoOzE1XbGC_w5M5_sEMLcSviGfUJJTVIPhfK_7UGInuhOPiuWmRNZFlUeDDMTkoLS9GpRLvWsopsZBcGtkbkLHJ9QZqsk6vGBvbPSuz0yxnuVUu9lq_Yp6PHpVLxu65VpqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611539,"updated":1613611539,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'd970a1b8-0f29-4f66-824a-fc3435793f2d',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:49 GMT',
+  'Content-Length',
+  '909'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/localCryptoKeyName-encryptdecryptRSA-OAEP-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '854fc02d-7abd-4584-8fca-48692dac3160',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:49 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_returns_additional_parameters_when_encrypting.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_returns_additional_parameters_when_encrypting.js
@@ -1,0 +1,388 @@
+let nock = require('nock');
+
+module.exports.hash = "2f673ca3465f5a66d1f9f068f3c383f2";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '1b47b157-be1f-4208-977b-2ee2a5a9fdb0',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:16 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1315',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7516a9dd-19be-4178-95d5-e40285ec4200',
+  'x-ms-ests-server',
+  '2.1.11496.6 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDAgAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:17 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:16 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-/create', {"kty":"RSA"})
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-/cd70e305512c4d9fbe393fe153ec8cdf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wQRGiFrbCdoaUGYeV5O7MmxU6vkOj-4pEr5TS5lGVh_9fteQF_3arEStP9gd-dqBDM3R4JnA2KvBAY146kSlU4aMAv8DGki8sRoswuVTvElRQ1Q6tXK1MoO4zdobMytEm_0TOv7D-0ZKGgk57qW4wkmS4vCAgByjaVc3ibNHP1k0j6z4JIZyCySUgctT8EosH3UuiGrKYHmx_3xhGJBbJOYMcm5BnLnbHxG1GD0r0CWntemZ3E2Qx4HcWlsKWkiMB9CoCacHcuLAvfyZQSAH0eNqaTBJKJEt-q_3z2DD5jKEMEio_fytkbydsB6eiPoRXLhBomWNqJenAUh4coNW8Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611517,"updated":1613611517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'c0318c11-f275-480b-9750-c0da220dcabc',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:17 GMT',
+  'Content-Length',
+  '752'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-","deletedDate":1613611517,"scheduledPurgeDate":1614216317,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-/cd70e305512c4d9fbe393fe153ec8cdf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wQRGiFrbCdoaUGYeV5O7MmxU6vkOj-4pEr5TS5lGVh_9fteQF_3arEStP9gd-dqBDM3R4JnA2KvBAY146kSlU4aMAv8DGki8sRoswuVTvElRQ1Q6tXK1MoO4zdobMytEm_0TOv7D-0ZKGgk57qW4wkmS4vCAgByjaVc3ibNHP1k0j6z4JIZyCySUgctT8EosH3UuiGrKYHmx_3xhGJBbJOYMcm5BnLnbHxG1GD0r0CWntemZ3E2Qx4HcWlsKWkiMB9CoCacHcuLAvfyZQSAH0eNqaTBJKJEt-q_3z2DD5jKEMEio_fytkbydsB6eiPoRXLhBomWNqJenAUh4coNW8Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611517,"updated":1613611517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'b1d0082b-dbc4-41f1-a94f-d6b2531b8903',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:17 GMT',
+  'Content-Length',
+  '949'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '6dba8613-945d-4f44-a6a2-780a918b47c6',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:17 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'c34ca421-d8a5-4ad7-bab3-b34e457ac1b8',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:17 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '085cbb87-c530-4ffb-90d2-32cf239602f6',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:19 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '28399b99-6582-4c05-b523-e4a2eeb50ffc',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:21 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'c111219d-6412-4985-8edc-767ea3ef220f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:23 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-returnsadditionalparameterswhenencrypting-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '1fce149d-e260-419a-bf09-9039afcb18d1',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:25 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-","deletedDate":1613611517,"scheduledPurgeDate":1614216317,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-/cd70e305512c4d9fbe393fe153ec8cdf","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wQRGiFrbCdoaUGYeV5O7MmxU6vkOj-4pEr5TS5lGVh_9fteQF_3arEStP9gd-dqBDM3R4JnA2KvBAY146kSlU4aMAv8DGki8sRoswuVTvElRQ1Q6tXK1MoO4zdobMytEm_0TOv7D-0ZKGgk57qW4wkmS4vCAgByjaVc3ibNHP1k0j6z4JIZyCySUgctT8EosH3UuiGrKYHmx_3xhGJBbJOYMcm5BnLnbHxG1GD0r0CWntemZ3E2Qx4HcWlsKWkiMB9CoCacHcuLAvfyZQSAH0eNqaTBJKJEt-q_3z2DD5jKEMEio_fytkbydsB6eiPoRXLhBomWNqJenAUh4coNW8Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611517,"updated":1613611517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '2062a954-939c-497e-b0db-f66592402c42',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:26 GMT',
+  'Content-Length',
+  '949'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/localCryptoKeyName-returnsadditionalparameterswhenencrypting-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '328b9863-966b-43fa-bc13-7972538a61db',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:27 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsa1_5.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsa1_5.js
@@ -1,5 +1,455 @@
 let nock = require('nock');
 
-module.exports.hash = "af0fdcf5479f74009b92bed535d99e6a";
+module.exports.hash = "28a850557cd5498b3106c1da299c70fa";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '9cc8926f-e391-4a22-b319-6af7d680a03c',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:49 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7750e8e4-ca6f-453c-9bc8-80f3f93c1800',
+  'x-ms-ests-server',
+  '2.1.11496.5 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:50 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/create', {"kty":"RSA"})
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rtDLphNQqgtqPg08WVwwaUIojmKAyEn4tTadJROaqajmPmcmLo-ESpt-KWeOpcuryBIakjJc-jIi2_2nyChSVaPHBO3Wc-FfoELvfwzApzorlMMpRus0Lxt90WvQLRU4EbAnZ4ggpXfxP-BUtZOCRWqdqc6w3uD5FY33WeU9iLSVbci7YUWHN8cYEw48xcmj7msq0WTwv39LGkLzD6uExvJMhTftNRYseYGWmsTXHrU_HOJOVCA9ziod-BNECzwUAPxkEX93xkiaUe7qNu-XHeusFCnApCrT0B3jy_nOc_ESkctYPq3RfbklRcF0IBOmtUpWjH6K_bABx3dNFVKYgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611550,"updated":1613611550,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'd572ba4d-04f6-4b6d-a1ec-ad7fdd17386f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '732'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '11dee167-f106-42ca-886b-7e8850059547',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7750e8e4-ca6f-453c-9bc8-80f3173d1800',
+  'x-ms-ests-server',
+  '2.1.11496.5 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:50 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9')
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rtDLphNQqgtqPg08WVwwaUIojmKAyEn4tTadJROaqajmPmcmLo-ESpt-KWeOpcuryBIakjJc-jIi2_2nyChSVaPHBO3Wc-FfoELvfwzApzorlMMpRus0Lxt90WvQLRU4EbAnZ4ggpXfxP-BUtZOCRWqdqc6w3uD5FY33WeU9iLSVbci7YUWHN8cYEw48xcmj7msq0WTwv39LGkLzD6uExvJMhTftNRYseYGWmsTXHrU_HOJOVCA9ziod-BNECzwUAPxkEX93xkiaUe7qNu-XHeusFCnApCrT0B3jy_nOc_ESkctYPq3RfbklRcF0IBOmtUpWjH6K_bABx3dNFVKYgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611550,"updated":1613611550,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'c2785433-d1fb-45f2-9f4f-d8ad59f4a84f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '732'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9/unwrapkey', {"alg":"RSA1_5","value":"MrDQD_rV5P-q3xgL9j2NZEUw6NcPJ9_Z0mPNif86cPazuRXamGNQsK8V0-pemgYWVwXixyguDrAsisIbQk_uU0_trmZo9A4tlLo81ufmM_uI1EINnzPPTb_JEMlWFvLbEpIATFbKcLeGuRHkyAH7V-CXCUxGG7yj0duZz-SdFW7n9R6x4hqxFiafa-KQUK5wSSx_mRhI0C0D47EDI9cOdLFRXLGzz_gIISBh3buvS-g3akqCJkFWt_v1a4qDw8u9kXXl8uu9Nl68GG-n1bwm6R6skbVhBY18GmWzFhHiMcMSUyxo-vg6wu_enEQgdouRoTIwE7zj-2GW3aLBzh0Ndw"})
+  .query(true)
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9","value":"YXJlcGE"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '15928b76-dfdf-4901-be74-6396f774feec',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '158'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-","deletedDate":1613611550,"scheduledPurgeDate":1614216350,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rtDLphNQqgtqPg08WVwwaUIojmKAyEn4tTadJROaqajmPmcmLo-ESpt-KWeOpcuryBIakjJc-jIi2_2nyChSVaPHBO3Wc-FfoELvfwzApzorlMMpRus0Lxt90WvQLRU4EbAnZ4ggpXfxP-BUtZOCRWqdqc6w3uD5FY33WeU9iLSVbci7YUWHN8cYEw48xcmj7msq0WTwv39LGkLzD6uExvJMhTftNRYseYGWmsTXHrU_HOJOVCA9ziod-BNECzwUAPxkEX93xkiaUe7qNu-XHeusFCnApCrT0B3jy_nOc_ESkctYPq3RfbklRcF0IBOmtUpWjH6K_bABx3dNFVKYgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611550,"updated":1613611550,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'e0bc53e8-e9aa-4a7b-bc25-de98d363df0e',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT',
+  'Content-Length',
+  '909'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA15-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'b388deeb-e139-4ff8-a908-26142b6c0eb3',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA15-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '5f704c72-7b0b-481d-abdf-dee98c380ec7',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:50 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA15-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '073e0261-2a9f-4a49-a5e5-5a14cffc2097',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:52 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA15-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '126',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '3703f35f-24be-4159-904f-a91a0c3e40d2',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:54 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-","deletedDate":1613611550,"scheduledPurgeDate":1614216350,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-/fb8bfa8846724a1aaa724047b7996cc9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"rtDLphNQqgtqPg08WVwwaUIojmKAyEn4tTadJROaqajmPmcmLo-ESpt-KWeOpcuryBIakjJc-jIi2_2nyChSVaPHBO3Wc-FfoELvfwzApzorlMMpRus0Lxt90WvQLRU4EbAnZ4ggpXfxP-BUtZOCRWqdqc6w3uD5FY33WeU9iLSVbci7YUWHN8cYEw48xcmj7msq0WTwv39LGkLzD6uExvJMhTftNRYseYGWmsTXHrU_HOJOVCA9ziod-BNECzwUAPxkEX93xkiaUe7qNu-XHeusFCnApCrT0B3jy_nOc_ESkctYPq3RfbklRcF0IBOmtUpWjH6K_bABx3dNFVKYgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611550,"updated":1613611550,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'e58de1b6-9e42-49af-a7d1-bf922b844328',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Content-Length',
+  '909'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA15-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'e6669dca-1a43-4bcf-8fb3-81cccd0413a0',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsaoaep.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsaoaep.js
@@ -1,5 +1,519 @@
 let nock = require('nock');
 
-module.exports.hash = "25b03cd30b2a3adf00e280bd5c5332d7";
+module.exports.hash = "f63210fea139547449beaf87731f72af";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '3dd8a06c-735f-4dcd-9bcf-11b9d1e9df04',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1315',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '7d7eaf67-31be-4265-86c5-1cb7fe935001',
+  'x-ms-ests-server',
+  '2.1.11496.5 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:57 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/create', {"kty":"RSA"})
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '6a51248c-434f-4f60-bead-8dcd0255efcd',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Content-Length',
+  '734'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '96f8bc02-838a-4042-bd72-63d886a7d16f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1315',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'd14948e5-3d75-42b6-b23a-ddf3c9079000',
+  'x-ms-ests-server',
+  '2.1.11496.6 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCAAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:57 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8')
+  .query(true)
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '475cba95-e346-4ebd-9a6a-19d1158b1e4b',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Content-Length',
+  '734'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8/unwrapkey', {"alg":"RSA-OAEP","value":"DqMK5s2xFy45CtAX2JYLVHSzY-VD7hSXWQxC3PWP1B5LAp2e2qKgIV4ACIQC9ac4wjKYJL6Bq51S0kWPkVA8gKilrFoB92IDrInjKcGWUVgZ8wtsIK6zBNXmk0JSm_XqbetePXEFlgsc7SWFZtJRSlH2j7GfDY7og_L1Z0AZnG89_oxGlsXa7t-wpbRfQ_Yc_mDhIBQ08FCVkziG95YDwGrPKLQAPJPWdOWcpv_Nq0-SSqvALN7WQ2GEbmXkf9BrW3cx49cG3eK_1edcxtdNnQZ5NJELHst5bsTgw2XAcW_AanyrqykM8bv8wJSoaIWNPJhiii0ynu9lpCstFjLrZg"})
+  .query(true)
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","value":"YXJlcGE"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '56f7d47b-75c9-4d3a-805e-9f75a6c8f48f',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Content-Length',
+  '160'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613611557,"scheduledPurgeDate":1614216357,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'f57fe97e-0ede-4c71-a7b0-5aa49f3693ae',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Content-Length',
+  '913'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '2f35bc79-cab4-43fa-88c4-5df9e178b56a',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:57 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '795c1755-c7c2-488d-af72-f4d0d10c4741',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:57 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'a0cf900a-9e19-4c4b-b6ce-f5ca9fb66c10',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:25:59 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'a41f8f7a-8fab-4ea2-9b11-fc3a71b8c6b0',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:02 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '5ba6f12e-3029-43f8-8737-e100fefd0374',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:03 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '128',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '596fea13-eb9a-495b-a033-6f769f6260e3',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:05 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613611557,"scheduledPurgeDate":1614216357,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '829be2b2-fa8a-4b98-a364-ed72904df7d5',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:07 GMT',
+  'Content-Length',
+  '913'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '33d08370-6623-4b64-8fed-5c84180f64ca',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:07 GMT'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsaoaep.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests/recording_wrapkey__unwrapkey_rsaoaep.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3dd8a06c-735f-4dcd-9bcf-11b9d1e9df04',
+  'a9448dd4-c9a8-4b31-b102-82853b8bdd17',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT'
+  'Thu, 18 Feb 2021 01:54:26 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '7d7eaf67-31be-4265-86c5-1cb7fe935001',
+  'f275c851-4f98-46c6-b31a-aa2e94eb5101',
   'x-ms-ests-server',
   '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDBwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=At3kzPnPC3BNjH06RVqDv2EA4qsDAQAAANK_v9cOAAAA; expires=Sat, 20-Mar-2021 01:54:27 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 18 Feb 2021 01:25:57 GMT'
+  'Thu, 18 Feb 2021 01:54:26 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"91pRxcODI_mBenCUX0RyDgoedr29V2rqYtAHrVXqBF9tztmlMpv7g6MZ8Wvyn-zElLNIg-4lWMLq5h9elPxTjqzwES3-tJJ56hhx8s1doS9ZNwxEcRxc2IfEbWsSgjcjkNk5pwQfnFpWfnIP59QuT2NlsxdQi9ZZFZ5v3hxU96abqudhJ0yC2TABp-mwGmDwCqh0eX0M8xRgUvRgh7_XfORH2-MLYzPqkM7nsF4MYGlmXZvoXudVFhoEVDLuJCXksnzYPL8lPhAC-d7PNKCXM-ohG_pUdSvTYO3kKg-6s31A8yWyl6ClTyHgnnNp8i0KKPT8lCBUSaId3yykeD1gPQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613613267,"updated":1613613267,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '6a51248c-434f-4f60-bead-8dcd0255efcd',
+  '49bc0d13-ceaf-461d-baf0-f440376528fd',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Thu, 18 Feb 2021 01:54:27 GMT',
   'Content-Length',
-  '734'
+  '735'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8')
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '96f8bc02-838a-4042-bd72-63d886a7d16f',
+  'dceafba2-0f0f-4f36-bccf-43565acbfc3c',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT'
+  'Thu, 18 Feb 2021 01:54:27 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -157,23 +157,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'd14948e5-3d75-42b6-b23a-ddf3c9079000',
+  'f275c851-4f98-46c6-b31a-aa2eb1eb5101',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCAAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:25:57 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=At3kzPnPC3BNjH06RVqDv2EA4qsDAQAAANK_v9cOAAAA; expires=Sat, 20-Mar-2021 01:54:27 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Thu, 18 Feb 2021 01:25:57 GMT'
+  'Thu, 18 Feb 2021 01:54:27 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8')
+  .get('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"91pRxcODI_mBenCUX0RyDgoedr29V2rqYtAHrVXqBF9tztmlMpv7g6MZ8Wvyn-zElLNIg-4lWMLq5h9elPxTjqzwES3-tJJ56hhx8s1doS9ZNwxEcRxc2IfEbWsSgjcjkNk5pwQfnFpWfnIP59QuT2NlsxdQi9ZZFZ5v3hxU96abqudhJ0yC2TABp-mwGmDwCqh0eX0M8xRgUvRgh7_XfORH2-MLYzPqkM7nsF4MYGlmXZvoXudVFhoEVDLuJCXksnzYPL8lPhAC-d7PNKCXM-ohG_pUdSvTYO3kKg-6s31A8yWyl6ClTyHgnnNp8i0KKPT8lCBUSaId3yykeD1gPQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613613267,"updated":1613613267,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '475cba95-e346-4ebd-9a6a-19d1158b1e4b',
+  '7ae6db0f-b6c5-45ab-84e7-6332e019437d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Thu, 18 Feb 2021 01:54:27 GMT',
   'Content-Length',
-  '734'
+  '735'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8/unwrapkey', {"alg":"RSA-OAEP","value":"DqMK5s2xFy45CtAX2JYLVHSzY-VD7hSXWQxC3PWP1B5LAp2e2qKgIV4ACIQC9ac4wjKYJL6Bq51S0kWPkVA8gKilrFoB92IDrInjKcGWUVgZ8wtsIK6zBNXmk0JSm_XqbetePXEFlgsc7SWFZtJRSlH2j7GfDY7og_L1Z0AZnG89_oxGlsXa7t-wpbRfQ_Yc_mDhIBQ08FCVkziG95YDwGrPKLQAPJPWdOWcpv_Nq0-SSqvALN7WQ2GEbmXkf9BrW3cx49cG3eK_1edcxtdNnQZ5NJELHst5bsTgw2XAcW_AanyrqykM8bv8wJSoaIWNPJhiii0ynu9lpCstFjLrZg"})
+  .post('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527/unwrapkey', {"alg":"RSA-OAEP","value":"DmajsEmDk7zczvSMebSqT0FKaTm4Cjrm1ZLVrKNk1VlcIn9qSc5rTUoNQCnOsKV0dSAw01GUOuKS3sauYgG_EtNwoVtwXORIXQWvMIQcoZMfYbfjKFS6UHbtUDpWFECf_q5OHZqLNzo2KeXOnsems1Huik9XhcaCmad-KkJN_iCFx6tngieA2RIvErSNVdXW8bTGibqe8px_txyMTpTP8TdsttxcZI033Y0780M71z071_LFMbKatofqYHYhRwP0S2U3Na2mvBeVdw35sLWtkfBayv7QPtHR3U2uzi1jXhNeUsvO6LnsEQySgGbzAXspZdTUe3qgWZ6cNqIHuMAGgA"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","value":"YXJlcGE"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527","value":"YXJlcGE"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '56f7d47b-75c9-4d3a-805e-9f75a6c8f48f',
+  '24fb1f7f-2a9d-48da-a936-6f9d2f6fd6b7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,15 +229,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Thu, 18 Feb 2021 01:54:27 GMT',
   'Content-Length',
-  '160'
+  '161'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613611557,"scheduledPurgeDate":1614216357,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613613267,"scheduledPurgeDate":1614218067,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"91pRxcODI_mBenCUX0RyDgoedr29V2rqYtAHrVXqBF9tztmlMpv7g6MZ8Wvyn-zElLNIg-4lWMLq5h9elPxTjqzwES3-tJJ56hhx8s1doS9ZNwxEcRxc2IfEbWsSgjcjkNk5pwQfnFpWfnIP59QuT2NlsxdQi9ZZFZ5v3hxU96abqudhJ0yC2TABp-mwGmDwCqh0eX0M8xRgUvRgh7_XfORH2-MLYzPqkM7nsF4MYGlmXZvoXudVFhoEVDLuJCXksnzYPL8lPhAC-d7PNKCXM-ohG_pUdSvTYO3kKg-6s31A8yWyl6ClTyHgnnNp8i0KKPT8lCBUSaId3yykeD1gPQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613613267,"updated":1613613267,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'f57fe97e-0ede-4c71-a7b0-5aa49f3693ae',
+  '36374c6e-e378-4b2f-b5c9-bb9c1255f1a7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,9 +261,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:56 GMT',
+  'Thu, 18 Feb 2021 01:54:27 GMT',
   'Content-Length',
-  '913'
+  '915'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -275,7 +275,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2f35bc79-cab4-43fa-88c4-5df9e178b56a',
+  '809e76cd-d398-43d6-8789-e28e3e8039d3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:57 GMT'
+  'Thu, 18 Feb 2021 01:54:27 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -307,7 +307,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '795c1755-c7c2-488d-af72-f4d0d10c4741',
+  'eb61dcad-2df5-4951-8b92-6febdb195bce',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:57 GMT'
+  'Thu, 18 Feb 2021 01:54:27 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -339,7 +339,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a0cf900a-9e19-4c4b-b6ce-f5ca9fb66c10',
+  'b4f28d12-a3f8-42ef-93cc-eddd8713069f',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:25:59 GMT'
+  'Thu, 18 Feb 2021 01:54:29 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -371,7 +371,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a41f8f7a-8fab-4ea2-9b11-fc3a71b8c6b0',
+  '5e56ccaa-39ac-47c8-ba2b-969ba1b438f9',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:26:02 GMT'
+  'Thu, 18 Feb 2021 01:54:31 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -403,7 +403,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '5ba6f12e-3029-43f8-8737-e100fefd0374',
+  '9e9be1de-1363-4c89-a941-3e3e97b6598c',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,7 +423,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:26:03 GMT'
+  'Thu, 18 Feb 2021 01:54:33 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -435,7 +435,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '128',
+  '129',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -443,7 +443,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '596fea13-eb9a-495b-a033-6f769f6260e3',
+  '502f154b-8774-4bcc-94f8-8f7632c1d33e',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -455,13 +455,77 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:26:05 GMT'
+  'Thu, 18 Feb 2021 01:54:35 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613611557,"scheduledPurgeDate":1614216357,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/c9214e4260c0442fbb374bb0ed421ae8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oTZsLi0oF_G5H2mpDLlj7qR660_ePVGy8xFFUjcgiqgKPMJYLDbSzpyL_IJe8I8BWyFNUmspDQlAHsCFELb7NLMYDVih8dZ66Ue0axjpeObvvmehbmyQsDjW9r1CpjX-YKz9e37ojxumVF__TcpJuSQifTnqpuhEGq7I2c34xCWO3w_FtWSVfaf7s-J2OfRtkuz58x2tTXVo0XMluk8SG6e0lW2yGWmNsu9Wm9xBLAl7rbrQ_MH3DznVhQgvE0QOi-makL4VvdJzfZMqsbOM5wlVSM_-PxQoLbuhloTpk3XnxgIMNyt15Og600m5OHb1TUxPXb6_vtimP9AKBnWKfQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611557,"updated":1613611557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '129',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '74512a1f-bdc1-4978-8df3-1c75d278839d',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:54:37 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '129',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  '0ffec151-76ae-44d1-bb06-623854ff4557',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:54:39 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-","deletedDate":1613613267,"scheduledPurgeDate":1614218067,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-wrapKeyunwrapKeyRSA-OAEP-/312923a86b3944c7bb45a318dc8aa527","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"91pRxcODI_mBenCUX0RyDgoedr29V2rqYtAHrVXqBF9tztmlMpv7g6MZ8Wvyn-zElLNIg-4lWMLq5h9elPxTjqzwES3-tJJ56hhx8s1doS9ZNwxEcRxc2IfEbWsSgjcjkNk5pwQfnFpWfnIP59QuT2NlsxdQi9ZZFZ5v3hxU96abqudhJ0yC2TABp-mwGmDwCqh0eX0M8xRgUvRgh7_XfORH2-MLYzPqkM7nsF4MYGlmXZvoXudVFhoEVDLuJCXksnzYPL8lPhAC-d7PNKCXM-ohG_pUdSvTYO3kKg-6s31A8yWyl6ClTyHgnnNp8i0KKPT8lCBUSaId3yykeD1gPQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613613267,"updated":1613613267,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -473,7 +537,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '829be2b2-fa8a-4b98-a364-ed72904df7d5',
+  '3071dded-ab9f-4803-a645-a0e7d032e873',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -485,9 +549,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:26:07 GMT',
+  'Thu, 18 Feb 2021 01:54:41 GMT',
   'Content-Length',
-  '913'
+  '915'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -503,7 +567,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '33d08370-6623-4b64-8fed-5c84180f64ca',
+  '482ef8fc-da4b-46d8-8a57-a17447940fa3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -515,5 +579,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Thu, 18 Feb 2021 01:26:07 GMT'
+  'Thu, 18 Feb 2021 01:54:41 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps256.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps256.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0465bace-47af-4e72-ae35-5c4a8a6cec17',
+  '0474c0c9-9d26-42fe-bace-5a0352826ba1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT'
+  'Thu, 18 Feb 2021 01:26:10 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -56,17 +56,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '10e905d8-91c2-4de8-91c9-d5ebb2354500',
+  '9e789a74-21c3-486e-a84c-ab5b1d2c4b01',
   'x-ms-ests-server',
-  '2.1.11496.5 - NCUS ProdSlices',
+  '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:49 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:11 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT',
+  'Thu, 18 Feb 2021 01:26:11 GMT',
   'Content-Length',
   '1315'
 ]);
@@ -74,7 +74,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-PS256-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xJ5eW-S2lXf7QSquHeFxVU-vnkKTqz63gtOVWzXn-K0VX30VwpwlfOkTudWsg1hX8Eji5ecKsVq7BA8kS4AbtVVFAoD0nHDDqG-_r-dhnAb3XQN4NuW_pxVzJaaQx3NozvG37QVY2OLJhorzu32WR3q0xNGX7nGj4gyYueNHwDhcKFbPx9kjXEgj4yOfZAxuZrrpe7PmpKkuZ4N8LAY1yn9w09I6pqICHhJm7-S58DFVwAwmzSlLZm-C-sVfto3RfM0yj8Xjis9BJfQ_X9qFpqb0ScjbYsQt_WK4nmSLp8lu-Pa7j01mJSsoIKaSF245DscFM9yRYzhf1p6EddbAJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499469,"updated":1613499469,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wGja_BWddNAU54hOuBRUTrAtXZXt-i8ftMjAN1XD19cB5aWpZhNtHV4UFLThFf9Cx7uPNPLMfjpJzoUAjGclyfgBaPCwQ3eQBVbyouymikHsn1r4-JheIToKnLzJcxMF0Tr6pdgX2Fg5UjdKYa3AQyn8OqzXMW7UrGPEDzxJ0Q8uAS7rZv_aFxpl7xs3F9ckAKRBJSFWHWGhRKwzgPjyB2njU_w_9w8y_sYJ85hHrp1yuKWVRWm6Zxwg7w-r9cSCi1KFF6tB1hTRMkn5lmKXa64sY68U2v0N-xO6xVHqrf7dcTpMO4KskXqh6_5NAqFv_im2CefPBzzlBSJNPy3XBQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611571,"updated":1613611571,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3b035a3f-5e57-487a-a09e-3abc94947ec7',
+  'e77ce0c4-97fe-4231-965d-aaa060a60f02',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT',
+  'Thu, 18 Feb 2021 01:26:11 GMT',
   'Content-Length',
   '716'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee')
+  .get('/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '48a64da4-928d-441c-a0bf-edc96a4b3b31',
+  '2040f913-de75-4620-b059-0a22f2ba6e4a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT'
+  'Thu, 18 Feb 2021 01:26:11 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -144,6 +144,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -155,25 +157,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '962de970-8496-499d-83b8-cd612be74200',
+  '9e789a74-21c3-486e-a84c-ab5b2e2c4b01',
   'x-ms-ests-server',
   '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:49 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:11 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT',
-  'Content-Length',
-  '1315'
+  'Thu, 18 Feb 2021 01:26:11 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee')
+  .get('/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xJ5eW-S2lXf7QSquHeFxVU-vnkKTqz63gtOVWzXn-K0VX30VwpwlfOkTudWsg1hX8Eji5ecKsVq7BA8kS4AbtVVFAoD0nHDDqG-_r-dhnAb3XQN4NuW_pxVzJaaQx3NozvG37QVY2OLJhorzu32WR3q0xNGX7nGj4gyYueNHwDhcKFbPx9kjXEgj4yOfZAxuZrrpe7PmpKkuZ4N8LAY1yn9w09I6pqICHhJm7-S58DFVwAwmzSlLZm-C-sVfto3RfM0yj8Xjis9BJfQ_X9qFpqb0ScjbYsQt_WK4nmSLp8lu-Pa7j01mJSsoIKaSF245DscFM9yRYzhf1p6EddbAJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499469,"updated":1613499469,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wGja_BWddNAU54hOuBRUTrAtXZXt-i8ftMjAN1XD19cB5aWpZhNtHV4UFLThFf9Cx7uPNPLMfjpJzoUAjGclyfgBaPCwQ3eQBVbyouymikHsn1r4-JheIToKnLzJcxMF0Tr6pdgX2Fg5UjdKYa3AQyn8OqzXMW7UrGPEDzxJ0Q8uAS7rZv_aFxpl7xs3F9ckAKRBJSFWHWGhRKwzgPjyB2njU_w_9w8y_sYJ85hHrp1yuKWVRWm6Zxwg7w-r9cSCi1KFF6tB1hTRMkn5lmKXa64sY68U2v0N-xO6xVHqrf7dcTpMO4KskXqh6_5NAqFv_im2CefPBzzlBSJNPy3XBQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611571,"updated":1613611571,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '55cc03c5-d95f-44ef-9451-b59186cead39',
+  'ced60191-419c-445f-89bd-9b8b71e62ab3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT',
+  'Thu, 18 Feb 2021 01:26:11 GMT',
   'Content-Length',
   '716'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee/sign', {"alg":"PS256","value":"Ddu8v3v5O1eeK7tVDrtEQAeJxk287_ILYDv98miPFSo"})
+  .post('/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e/sign', {"alg":"PS256","value":"Ddu8v3v5O1eeK7tVDrtEQAeJxk287_ILYDv98miPFSo"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee","value":"AC5fyPQkKTwHdYxg7W4AE0t5Zq0Wim29r_EosbuS47nwutE9JO0EdvROiHQFbgd_ecZniV8qK3e_qO8AAB2qjw1vwFQi02zUkV5O8q5jCL_EHjb1xpVMPOvfkEMAkdqazB8eVv3yTG48bdh1JOifs7AmD5qnSsg36jsDKwdCqJp-Ej1uqDcTPhHvDApFXIQ3rq53L44fzfPP7UxlgH2iuFJAdYqBphWDWlrsh1aFubz8h6YQ9pCb1QwoRIHtNHR3tWxm2Uonbgsm10fm-LittS97a0vovUkxszT3pCKJvnduQOGmDsddMsxPu9DvZo-lrWK9sU4ujIupiebA9k_TUg"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e","value":"D4K5gaKKjWfHQiJIq-uCgWTKN59vwYymGG9nJrx4gLq8wbdfo9esnmc-RvBZMTkGdVjmJN6oxiZrio0po5hkSNBq23uxuMd9vZWp9fQmrwG9pS4-g2c2KNie8An_fEf5Pn1qe7nDtBuo-7ktqOq-hQiEJLIj4ODHQk1fIg-xWug6PKS5arrpJ0dPPBIWP5TpTv-UKbk5v3Ldpcon7hj74B8IDYgSVB1eRREBPcGg0IWsePDVenDM9UrNg9FVPNukpL6Y8x8GPY_bKvBOVkYCTFec7gT-nTNT3NuSGDZ4iC08Yi15EuaXYZ6O7t4X6WmJxl965BNkHPRNv368FcGaHg"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '9ddfb1c8-6b0e-4648-ba3e-b31771ac5e9e',
+  'cc1441e6-2cd9-448f-b9f2-d0e6d3da8c39',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,7 +229,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT',
+  'Thu, 18 Feb 2021 01:26:11 GMT',
   'Content-Length',
   '477'
 ]);
@@ -237,7 +237,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-PS256-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS256-","deletedDate":1613499469,"scheduledPurgeDate":1614104269,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xJ5eW-S2lXf7QSquHeFxVU-vnkKTqz63gtOVWzXn-K0VX30VwpwlfOkTudWsg1hX8Eji5ecKsVq7BA8kS4AbtVVFAoD0nHDDqG-_r-dhnAb3XQN4NuW_pxVzJaaQx3NozvG37QVY2OLJhorzu32WR3q0xNGX7nGj4gyYueNHwDhcKFbPx9kjXEgj4yOfZAxuZrrpe7PmpKkuZ4N8LAY1yn9w09I6pqICHhJm7-S58DFVwAwmzSlLZm-C-sVfto3RfM0yj8Xjis9BJfQ_X9qFpqb0ScjbYsQt_WK4nmSLp8lu-Pa7j01mJSsoIKaSF245DscFM9yRYzhf1p6EddbAJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499469,"updated":1613499469,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS256-","deletedDate":1613611572,"scheduledPurgeDate":1614216372,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wGja_BWddNAU54hOuBRUTrAtXZXt-i8ftMjAN1XD19cB5aWpZhNtHV4UFLThFf9Cx7uPNPLMfjpJzoUAjGclyfgBaPCwQ3eQBVbyouymikHsn1r4-JheIToKnLzJcxMF0Tr6pdgX2Fg5UjdKYa3AQyn8OqzXMW7UrGPEDzxJ0Q8uAS7rZv_aFxpl7xs3F9ckAKRBJSFWHWGhRKwzgPjyB2njU_w_9w8y_sYJ85hHrp1yuKWVRWm6Zxwg7w-r9cSCi1KFF6tB1hTRMkn5lmKXa64sY68U2v0N-xO6xVHqrf7dcTpMO4KskXqh6_5NAqFv_im2CefPBzzlBSJNPy3XBQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611571,"updated":1613611571,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'abdd2d6c-61f4-4d98-8953-347760c2b717',
+  'cae325bf-06fa-40b4-9fb9-9d25724d82ee',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,7 +261,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT',
+  'Thu, 18 Feb 2021 01:26:11 GMT',
   'Content-Length',
   '877'
 ]);
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a716a488-a9a9-4297-a770-586e7b1cc01c',
+  '50744272-9af2-4c1a-b2f3-5075e98d74df',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT'
+  'Thu, 18 Feb 2021 01:26:11 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2398be0a-f582-4ae4-9018-f2dfb3ca0d85',
+  'c1ed07ae-615e-4c04-806d-78a8b6859cb7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:49 GMT'
+  'Thu, 18 Feb 2021 01:26:11 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0124c17e-09d3-4370-b1f7-ce513d036d1a',
+  '78955255-e7bd-4923-9d88-339d568abc6a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:51 GMT'
+  'Thu, 18 Feb 2021 01:26:13 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'b034aa1f-56a9-4ba4-a4fb-f8dd46d4736c',
+  '59f526ba-3a0f-40b5-9dcc-9e588df884b2',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:53 GMT'
+  'Thu, 18 Feb 2021 01:26:15 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '4ff4f9e5-b7a1-43e5-b222-2b6a588e998b',
+  '739631d6-f540-4ccf-9487-0db800cdf3cd',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,7 +423,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:55 GMT'
+  'Thu, 18 Feb 2021 01:26:18 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -443,7 +443,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '1edfd695-ed97-4067-b83f-380a88915df1',
+  'eec9910a-d35a-448a-86ae-49be2a9881f1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -455,7 +455,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:57 GMT'
+  'Thu, 18 Feb 2021 01:26:20 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -475,7 +475,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '9219ce84-3de9-4369-9fac-a6bb612fdf70',
+  'ff2a3603-083a-4bf7-8140-9ae5bf99dfa7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -487,7 +487,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:00 GMT'
+  'Thu, 18 Feb 2021 01:26:21 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -507,7 +507,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a39cb1db-a323-4f90-a60d-6c509a62ddad',
+  'b8525253-fa0f-4827-b737-385bc611a343',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -519,13 +519,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:01 GMT'
+  'Thu, 18 Feb 2021 01:26:23 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-PS256-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS256-","deletedDate":1613499469,"scheduledPurgeDate":1614104269,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/990616d6d86e4d689a5350323f0657ee","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xJ5eW-S2lXf7QSquHeFxVU-vnkKTqz63gtOVWzXn-K0VX30VwpwlfOkTudWsg1hX8Eji5ecKsVq7BA8kS4AbtVVFAoD0nHDDqG-_r-dhnAb3XQN4NuW_pxVzJaaQx3NozvG37QVY2OLJhorzu32WR3q0xNGX7nGj4gyYueNHwDhcKFbPx9kjXEgj4yOfZAxuZrrpe7PmpKkuZ4N8LAY1yn9w09I6pqICHhJm7-S58DFVwAwmzSlLZm-C-sVfto3RfM0yj8Xjis9BJfQ_X9qFpqb0ScjbYsQt_WK4nmSLp8lu-Pa7j01mJSsoIKaSF245DscFM9yRYzhf1p6EddbAJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499469,"updated":1613499469,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS256-","deletedDate":1613611572,"scheduledPurgeDate":1614216372,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS256-/7d443bc96f1e41cea9bac785d5dbc33e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wGja_BWddNAU54hOuBRUTrAtXZXt-i8ftMjAN1XD19cB5aWpZhNtHV4UFLThFf9Cx7uPNPLMfjpJzoUAjGclyfgBaPCwQ3eQBVbyouymikHsn1r4-JheIToKnLzJcxMF0Tr6pdgX2Fg5UjdKYa3AQyn8OqzXMW7UrGPEDzxJ0Q8uAS7rZv_aFxpl7xs3F9ckAKRBJSFWHWGhRKwzgPjyB2njU_w_9w8y_sYJ85hHrp1yuKWVRWm6Zxwg7w-r9cSCi1KFF6tB1hTRMkn5lmKXa64sY68U2v0N-xO6xVHqrf7dcTpMO4KskXqh6_5NAqFv_im2CefPBzzlBSJNPy3XBQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611571,"updated":1613611571,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -537,7 +537,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '29c83b58-7393-4d1f-b962-c452c7757de9',
+  'e3c328f3-c2a8-40db-b0b3-ca81480f93c3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -549,7 +549,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT',
+  'Thu, 18 Feb 2021 01:26:25 GMT',
   'Content-Length',
   '877'
 ]);
@@ -567,7 +567,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '81f03b8a-f279-4748-945e-e53a4c735f65',
+  'e47b59f0-9989-4a0d-ae3c-09f777f252da',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -579,5 +579,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:03 GMT'
+  'Thu, 18 Feb 2021 01:26:25 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps384.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps384.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '8af06ed2-3828-453c-ab3b-fe6f7fe1e754',
+  '9feef5d9-6294-4b2c-8d5a-d7298934bbc5',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -56,17 +56,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '4c138d46-450a-4b7b-93d6-89b8ac320401',
+  '7d7eaf67-31be-4265-86c5-1cb7e49b5001',
   'x-ms-ests-server',
-  '2.1.11496.5 - EUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:19 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:39 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:39 GMT',
   'Content-Length',
   '1315'
 ]);
@@ -74,7 +74,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-PS384-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0EKAW4uCgl1lxUCp4cqvktOFYPGmzsxWDbEcA9w1BuVGYi_lutIT0nnsd0kRP1FUvQC_24scJ4TuUWzC_7kGIVTE3oMp9QY-59DeaRQ8XCKVVNNh4HCtM1Uxryd_U7_EGOOc4O1UHfomV0tzMaAOwAqkQZQRg49LYsoyW47lEzak-U4B-vKGWWBeurgdvhR4ZaVWAOuOq664vjXL36npiUmlvT8OFD7VF5PbcJvMKSP3fjrtV-50I1jCGI9abWpPAou2NuDgATtUS0cexixgggRdxqwR0a6yyiKXRJqrIer7ni6VLLkCZVWsN_9VWuSOTxrfMe5nFnnAgr21yuUMGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499499,"updated":1613499499,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l6YlxDqhoCGDUFuYx1-rKePVJQpi95tqypCEL7kQDGA1-NMA4mzavtl7SieJqV4gG0MZtzomS6ayeI24oCu-IKNdy0GZtVTdw3Xxu-Aa3cktOcTcAa9rB078WNq-avqSz40eS_XrZeCiUvWG2S8_TjS9_4MfaMRc5hXR1AvgGkAu4SooC9zuy4R6Jifh6UP1_nMnJLZ0X4r9yhZDc0cve47E9eIVQM-vSUJbREeK4AtkuYqL2VzC-DHp4K5FSx9sYU4UN4W_6X8yZqlJ5qVBKUkEARjovdx9NRU7oLuKm_6hS73gdqcAQtvS3kWeICjJazqyYe17dB0T6-HInG53NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611599,"updated":1613611599,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '8a7b3ea2-20ca-4a38-867f-56eb5c11bf5e',
+  'd95dbd80-aa83-4d50-aded-18883fe4b023',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:39 GMT',
   'Content-Length',
-  '716'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2')
+  .get('/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'e833af55-15d6-4bc8-a2e2-db5fa699fc23',
+  '1dd19f9a-3b11-4607-984f-488091887872',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,18 +134,16 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":86398,"ext_expires_in":86398,"access_token":"access_token"}, [
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -157,23 +155,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '995515c4-8f09-43d7-bcd8-dfc4699e0101',
+  '9e789a74-21c3-486e-a84c-ab5b75314b01',
   'x-ms-ests-server',
-  '2.1.11496.5 - NCUS ProdSlices',
+  '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:20 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:40 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2')
+  .get('/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0EKAW4uCgl1lxUCp4cqvktOFYPGmzsxWDbEcA9w1BuVGYi_lutIT0nnsd0kRP1FUvQC_24scJ4TuUWzC_7kGIVTE3oMp9QY-59DeaRQ8XCKVVNNh4HCtM1Uxryd_U7_EGOOc4O1UHfomV0tzMaAOwAqkQZQRg49LYsoyW47lEzak-U4B-vKGWWBeurgdvhR4ZaVWAOuOq664vjXL36npiUmlvT8OFD7VF5PbcJvMKSP3fjrtV-50I1jCGI9abWpPAou2NuDgATtUS0cexixgggRdxqwR0a6yyiKXRJqrIer7ni6VLLkCZVWsN_9VWuSOTxrfMe5nFnnAgr21yuUMGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499499,"updated":1613499499,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l6YlxDqhoCGDUFuYx1-rKePVJQpi95tqypCEL7kQDGA1-NMA4mzavtl7SieJqV4gG0MZtzomS6ayeI24oCu-IKNdy0GZtVTdw3Xxu-Aa3cktOcTcAa9rB078WNq-avqSz40eS_XrZeCiUvWG2S8_TjS9_4MfaMRc5hXR1AvgGkAu4SooC9zuy4R6Jifh6UP1_nMnJLZ0X4r9yhZDc0cve47E9eIVQM-vSUJbREeK4AtkuYqL2VzC-DHp4K5FSx9sYU4UN4W_6X8yZqlJ5qVBKUkEARjovdx9NRU7oLuKm_6hS73gdqcAQtvS3kWeICjJazqyYe17dB0T6-HInG53NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611599,"updated":1613611599,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '40ef6156-0465-459a-8baa-23d1d2fe7a00',
+  'd888d99d-8294-4855-9969-8acc8d46eda7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:39 GMT',
   'Content-Length',
-  '716'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2/sign', {"alg":"PS384","value":"0l4LGQIGx3h4tKvtYkm0UpyuXVNh_uavUS2WlYfyU1tD4dronxAsDyxnAN80h55g"})
+  .post('/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445/sign', {"alg":"PS384","value":"0l4LGQIGx3h4tKvtYkm0UpyuXVNh_uavUS2WlYfyU1tD4dronxAsDyxnAN80h55g"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2","value":"c9vZXMjzXQPrJXcTGvbmsT0OGrDCQ8LC_gDKdD0RcWC9pbZmG9oBCDiGZGUbHWFqvHtzOlzGUYZFlS5ziKP3oWsKJNBJ4lYS9-C9-trTCgfn41kGm_IfBQ6L4mTyeklPuvm1avMXkm_qPn6FlzmRVdVlhukiO5KiBjuwTh_fHjxD6HYDapH935U8padpQ06ykgyPKbJfMsqcgbOrwZJgkCge0qpEE9rpIAYk3I7klwO4sZEwCyg7VaIDgx0jqmw-BnjD4AmjkGf-BhBUO5y8QZGKmqn5gERktXKMCGHFKu7gUGVpwO5_Ouod3zld-vwOk6LqZ5PtPCCnsuvvqicBAA"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445","value":"Nxyli7TbylfXSWVGx0_vDd5UM1y4wS93RZKRKofcZTUGaCTcf_YkhvzZ5GvYiI7Q8OeQ9oqFoRgpNEDhwDWTZrmDqoqHW9eCZSYKSiOM_3IC7pg-7taOPvGge31zGJTPhJvniK7-BHlN5XpZc4I7prsprybnuocPvkG1cubeShGQTokVwW_pOPsTQbZdDQrmeaWlEc2SvXfq6zU4CSfaScq_atmXZ8MBgkIWGmQA-RJjHT_IpRQb8RjYsHFLndJ4uHhSvw_xXR2m_1BBsFQfGSYyfdc_mRngCIhUE8d1j1rbo_m7xghbw18BdfOHadrIqel_arw1MrJgDyTmY7VrWg"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '77459c07-6503-431b-a007-55487c16478f',
+  '4d0a7658-d19e-4383-91b3-bdf067a230fb',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,15 +229,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:39 GMT',
   'Content-Length',
-  '477'
+  '476'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-PS384-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS384-","deletedDate":1613499500,"scheduledPurgeDate":1614104300,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0EKAW4uCgl1lxUCp4cqvktOFYPGmzsxWDbEcA9w1BuVGYi_lutIT0nnsd0kRP1FUvQC_24scJ4TuUWzC_7kGIVTE3oMp9QY-59DeaRQ8XCKVVNNh4HCtM1Uxryd_U7_EGOOc4O1UHfomV0tzMaAOwAqkQZQRg49LYsoyW47lEzak-U4B-vKGWWBeurgdvhR4ZaVWAOuOq664vjXL36npiUmlvT8OFD7VF5PbcJvMKSP3fjrtV-50I1jCGI9abWpPAou2NuDgATtUS0cexixgggRdxqwR0a6yyiKXRJqrIer7ni6VLLkCZVWsN_9VWuSOTxrfMe5nFnnAgr21yuUMGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499499,"updated":1613499499,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS384-","deletedDate":1613611600,"scheduledPurgeDate":1614216400,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l6YlxDqhoCGDUFuYx1-rKePVJQpi95tqypCEL7kQDGA1-NMA4mzavtl7SieJqV4gG0MZtzomS6ayeI24oCu-IKNdy0GZtVTdw3Xxu-Aa3cktOcTcAa9rB078WNq-avqSz40eS_XrZeCiUvWG2S8_TjS9_4MfaMRc5hXR1AvgGkAu4SooC9zuy4R6Jifh6UP1_nMnJLZ0X4r9yhZDc0cve47E9eIVQM-vSUJbREeK4AtkuYqL2VzC-DHp4K5FSx9sYU4UN4W_6X8yZqlJ5qVBKUkEARjovdx9NRU7oLuKm_6hS73gdqcAQtvS3kWeICjJazqyYe17dB0T6-HInG53NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611599,"updated":1613611599,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a8974aa4-ed23-48ed-a4b0-45db9d2a6754',
+  '5e931235-3682-45da-84e9-73791523c3d1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,9 +261,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:39 GMT',
   'Content-Length',
-  '877'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -275,7 +275,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a85b68a8-da73-41a1-af87-71b3dc27c960',
+  'a795addc-5ebe-4ecd-82fa-16231df0fce1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -307,7 +307,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'd02d3a0e-b67b-47dc-9d61-8c4a76f469dc',
+  'cf0b0d7e-a89f-41fc-acdd-e99810f53c38',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -339,7 +339,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'dca08712-67b7-4818-8786-83b04897d532',
+  'dd4b6b29-30f3-4e58-a9f1-46ff0260885e',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:22 GMT'
+  'Thu, 18 Feb 2021 01:26:41 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -371,7 +371,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '7f36aba8-d1a1-40a9-9f75-f2a35637f450',
+  '017b318d-c182-45b3-8b6f-45c900c68602',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:23 GMT'
+  'Thu, 18 Feb 2021 01:26:44 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -403,7 +403,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '6c40610a-099a-456d-b968-12378442820a',
+  '82125239-76d5-4a66-ba4d-385792adb0fc',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,13 +423,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:25 GMT'
+  'Thu, 18 Feb 2021 01:26:46 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-PS384-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS384-","deletedDate":1613499500,"scheduledPurgeDate":1614104300,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/9ee85d8627fd495484db2bdd5fcb91c2","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0EKAW4uCgl1lxUCp4cqvktOFYPGmzsxWDbEcA9w1BuVGYi_lutIT0nnsd0kRP1FUvQC_24scJ4TuUWzC_7kGIVTE3oMp9QY-59DeaRQ8XCKVVNNh4HCtM1Uxryd_U7_EGOOc4O1UHfomV0tzMaAOwAqkQZQRg49LYsoyW47lEzak-U4B-vKGWWBeurgdvhR4ZaVWAOuOq664vjXL36npiUmlvT8OFD7VF5PbcJvMKSP3fjrtV-50I1jCGI9abWpPAou2NuDgATtUS0cexixgggRdxqwR0a6yyiKXRJqrIer7ni6VLLkCZVWsN_9VWuSOTxrfMe5nFnnAgr21yuUMGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499499,"updated":1613499499,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS384-","deletedDate":1613611600,"scheduledPurgeDate":1614216400,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS384-/fe4ca6e4659c480089a2e0ea93324445","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l6YlxDqhoCGDUFuYx1-rKePVJQpi95tqypCEL7kQDGA1-NMA4mzavtl7SieJqV4gG0MZtzomS6ayeI24oCu-IKNdy0GZtVTdw3Xxu-Aa3cktOcTcAa9rB078WNq-avqSz40eS_XrZeCiUvWG2S8_TjS9_4MfaMRc5hXR1AvgGkAu4SooC9zuy4R6Jifh6UP1_nMnJLZ0X4r9yhZDc0cve47E9eIVQM-vSUJbREeK4AtkuYqL2VzC-DHp4K5FSx9sYU4UN4W_6X8yZqlJ5qVBKUkEARjovdx9NRU7oLuKm_6hS73gdqcAQtvS3kWeICjJazqyYe17dB0T6-HInG53NQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611599,"updated":1613611599,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -441,7 +441,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '14da843e-9d57-4f34-a0ea-1a57a71ae8d3',
+  '66990bbc-d476-4e12-a967-fa42e6528426',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -453,9 +453,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT',
+  'Thu, 18 Feb 2021 01:26:48 GMT',
   'Content-Length',
-  '877'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -471,7 +471,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '663371e5-f1b3-41bc-bbab-a626b7134587',
+  'a0ba8b0c-7d2d-465b-a61e-4f21a222fb64',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -483,5 +483,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps512.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_ps512.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '99194038-852a-49e8-bc83-facf3a52f041',
+  'b11b1fe5-06b6-4507-9e6b-c1011388e15b',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:36 GMT'
+  'Thu, 18 Feb 2021 01:26:58 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -56,17 +56,17 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'b4b49a55-ce7e-4f5d-90e2-26f5b1e4fd00',
+  '173e2c82-2164-4429-a884-f9ee6da11600',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:37 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:59 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT',
+  'Thu, 18 Feb 2021 01:26:59 GMT',
   'Content-Length',
   '1315'
 ]);
@@ -74,7 +74,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-PS512-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"px--K7gjp7Oiwp69wuKzAnDs8xi74lGF471H9YYL5XedDM_-_NNrn67w5nUpAEC_7Aa_24sYerVNBqnmpVrNqb_VS9zYrpYN4G8lWkCaq1isx_eJgKkP5wZmh1KcR_RPGY4ER-2kl_7fQrujteQaew_DNtFDTxspJTZ3AHE-HyecnHTS65Vh4EwwsxzW8PibDOPmnlSr-pDELzV0CDiSffLYfn3H0z6iw48kBuFZIIpZGNzxdium1ZH3hsyuIaowOFCErp-_gxBB-w4ZqLlqHhdKdSQWC3OyW5O0pjmZbPP8oos3RecafPEgg6NW9oKXN2uQxfuLjqh8R3EHZREkJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499517,"updated":1613499517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"m40sk3k_fCWdZNNcHo_Ed2jBzAIlUeZldfbAZZEsxUK_IUuRpRgQOSMydB6l2YhFSwbBjysXrQrpTnhRv5enegAwNN1oox_-jU5TFSbMid-BYTdKBrKPSOnE80rVTHtXevRb3QBX9nnxYOKfOJBcTc8RLRCS8XGqD0oJSd-2iLPzoY8KusS1TLmJmH4lIKccYUN9dp07qfFjGFr-aoYAPJ6tpdckP5DqGgAt2R-6Bn6kp3O4Yl7Ezd1qZQG-iswNRZl5gBl1Z3zj47R4gbd4q_NKtipyJ690BKgPSUk2F-A58Zh5Z8rnM4umGNEHlrkUcfedGomoHUMW-9o_nlB83Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611619,"updated":1613611619,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '092807e0-f32d-4321-92bb-1cfb6d2f45f6',
+  'd22bd231-f1c5-4a7e-a577-7b0cdd1adcc8',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT',
+  'Thu, 18 Feb 2021 01:26:58 GMT',
   'Content-Length',
   '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005')
+  .get('/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '611b31f5-59c5-455a-a68f-32ae32f52340',
+  '01fa9d50-6d48-4113-b85a-5980e3639318',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT'
+  'Thu, 18 Feb 2021 01:26:58 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -144,8 +144,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -157,23 +155,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '0e690c11-1753-4330-bc02-db0e2f4bdf00',
+  '7716efac-1903-470b-b215-0f91e7475d01',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:37 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:59 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT'
+  'Thu, 18 Feb 2021 01:26:59 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005')
+  .get('/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"px--K7gjp7Oiwp69wuKzAnDs8xi74lGF471H9YYL5XedDM_-_NNrn67w5nUpAEC_7Aa_24sYerVNBqnmpVrNqb_VS9zYrpYN4G8lWkCaq1isx_eJgKkP5wZmh1KcR_RPGY4ER-2kl_7fQrujteQaew_DNtFDTxspJTZ3AHE-HyecnHTS65Vh4EwwsxzW8PibDOPmnlSr-pDELzV0CDiSffLYfn3H0z6iw48kBuFZIIpZGNzxdium1ZH3hsyuIaowOFCErp-_gxBB-w4ZqLlqHhdKdSQWC3OyW5O0pjmZbPP8oos3RecafPEgg6NW9oKXN2uQxfuLjqh8R3EHZREkJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499517,"updated":1613499517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"m40sk3k_fCWdZNNcHo_Ed2jBzAIlUeZldfbAZZEsxUK_IUuRpRgQOSMydB6l2YhFSwbBjysXrQrpTnhRv5enegAwNN1oox_-jU5TFSbMid-BYTdKBrKPSOnE80rVTHtXevRb3QBX9nnxYOKfOJBcTc8RLRCS8XGqD0oJSd-2iLPzoY8KusS1TLmJmH4lIKccYUN9dp07qfFjGFr-aoYAPJ6tpdckP5DqGgAt2R-6Bn6kp3O4Yl7Ezd1qZQG-iswNRZl5gBl1Z3zj47R4gbd4q_NKtipyJ690BKgPSUk2F-A58Zh5Z8rnM4umGNEHlrkUcfedGomoHUMW-9o_nlB83Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611619,"updated":1613611619,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'bb44a547-efe2-4cd7-9cbc-6ca698514b83',
+  '2192ac0c-818f-4eb5-9890-d551866b7bf5',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT',
+  'Thu, 18 Feb 2021 01:26:59 GMT',
   'Content-Length',
   '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005/sign', {"alg":"PS512","value":"N-pezlZMah39l8dyRzaKq0HwVUk7PQGpMkG1N-ogZB33pcAt09-5bL3a_NzW7QKNqZzNikQfEVgclTpgJafSAw"})
+  .post('/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687/sign', {"alg":"PS512","value":"N-pezlZMah39l8dyRzaKq0HwVUk7PQGpMkG1N-ogZB33pcAt09-5bL3a_NzW7QKNqZzNikQfEVgclTpgJafSAw"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005","value":"loPT7N6a8S7eyugsk1784ofB8ApgTStLbEyN9CE2rhCkZfmz6rvNBScI08afI_BESoocZLS4K8VOLQBw0qq-l94U5Cbuh6QGG_ruLeID9eFHt5gYuP0Jv-Ay_wQdY7W_j7dQy0iqgJvfEH2xI0ZqbKrzFLSYlCO_TxGzOs_NwhU5q7xVfJSIVncTj0Vp6ZPtfg9I_Zeop5MSkH8ms35Kk5TC4ScWmrXHGDlVAQGtDmUeDoPJ4aoPE6YSg2IDEMrnK0EdVYisoN4ZyA209ELKcQIcVp04L1X6mfhLNHjF0HVnKvjkqfBuc17tVtR_GaOI0HUkrfO9W1M7qrUyXeM3pA"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687","value":"DLF_EJdrhlfH1F3NxvaTXGhgdPq5jZEyimp22jHBVpNqMvoW_gdron6F3K_CbeeMnAyo7xQ1EYhIBd0VcYjo06dcBfDJsMKvdOPgq-PlsZNtPc9rGB8NjIiqyV9QfM5hdchUjyqsLXU1rmK2g9f7wC0e4BA8gkFcrh1wK7-s7mzDiv5vmfmr0Vr7OPFxw9a0GKdr7c53eFw32FeEbvJ9fucJHUPgiOita5nL0rVVqeaq51roacVd7a5q7qkXBnl7c7PLsgcb3lVCBXnKv2WxHtZT_YpS-ERWQIGN6HOcVclBg31xt5BFScY1Cy8hzcBM4-ptgYVyREH1mP9aGwCDYQ"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '6a714783-9320-409e-90ee-9cb3c7a2f61c',
+  '6aa9703e-10da-4939-99ef-cb0abc403ebb',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,7 +229,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT',
+  'Thu, 18 Feb 2021 01:26:59 GMT',
   'Content-Length',
   '476'
 ]);
@@ -237,7 +237,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-PS512-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS512-","deletedDate":1613499518,"scheduledPurgeDate":1614104318,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"px--K7gjp7Oiwp69wuKzAnDs8xi74lGF471H9YYL5XedDM_-_NNrn67w5nUpAEC_7Aa_24sYerVNBqnmpVrNqb_VS9zYrpYN4G8lWkCaq1isx_eJgKkP5wZmh1KcR_RPGY4ER-2kl_7fQrujteQaew_DNtFDTxspJTZ3AHE-HyecnHTS65Vh4EwwsxzW8PibDOPmnlSr-pDELzV0CDiSffLYfn3H0z6iw48kBuFZIIpZGNzxdium1ZH3hsyuIaowOFCErp-_gxBB-w4ZqLlqHhdKdSQWC3OyW5O0pjmZbPP8oos3RecafPEgg6NW9oKXN2uQxfuLjqh8R3EHZREkJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499517,"updated":1613499517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS512-","deletedDate":1613611619,"scheduledPurgeDate":1614216419,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"m40sk3k_fCWdZNNcHo_Ed2jBzAIlUeZldfbAZZEsxUK_IUuRpRgQOSMydB6l2YhFSwbBjysXrQrpTnhRv5enegAwNN1oox_-jU5TFSbMid-BYTdKBrKPSOnE80rVTHtXevRb3QBX9nnxYOKfOJBcTc8RLRCS8XGqD0oJSd-2iLPzoY8KusS1TLmJmH4lIKccYUN9dp07qfFjGFr-aoYAPJ6tpdckP5DqGgAt2R-6Bn6kp3O4Yl7Ezd1qZQG-iswNRZl5gBl1Z3zj47R4gbd4q_NKtipyJ690BKgPSUk2F-A58Zh5Z8rnM4umGNEHlrkUcfedGomoHUMW-9o_nlB83Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611619,"updated":1613611619,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '4d1cfb2a-2d10-423b-bbd9-b6443f7b605e',
+  'aa54eed2-9ac5-4495-8180-062ea0200ebd',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,7 +261,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT',
+  'Thu, 18 Feb 2021 01:26:59 GMT',
   'Content-Length',
   '875'
 ]);
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '4df0bcdf-e877-4beb-8d63-a598059f8260',
+  '81c58a8e-e167-415b-970c-825f6024dd7d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT'
+  'Thu, 18 Feb 2021 01:26:59 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '03139146-4bac-4e9e-9fb0-88428910c7e5',
+  '05855a80-6743-4e97-8bbe-cc6668f323c8',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT'
+  'Thu, 18 Feb 2021 01:26:59 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '97ad8694-1ed9-4ae1-b35a-f0b681d0e98d',
+  '121e3084-d096-4af7-be42-037a8a4247b1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:39 GMT'
+  'Thu, 18 Feb 2021 01:27:01 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3a415430-542f-4dd2-870c-8e9d9f2dee4d',
+  '787e9be2-31a6-43f1-b347-a80a511f44b3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:41 GMT'
+  'Thu, 18 Feb 2021 01:27:03 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '7fc76327-1379-476d-8b05-dbdada096ec2',
+  '7ad596c8-74fe-4932-9d61-80af5219b2fa',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,13 +423,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:44 GMT'
+  'Thu, 18 Feb 2021 01:27:05 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-PS512-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS512-","deletedDate":1613499518,"scheduledPurgeDate":1614104318,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/71f5ed1289284311808b87ede8c01005","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"px--K7gjp7Oiwp69wuKzAnDs8xi74lGF471H9YYL5XedDM_-_NNrn67w5nUpAEC_7Aa_24sYerVNBqnmpVrNqb_VS9zYrpYN4G8lWkCaq1isx_eJgKkP5wZmh1KcR_RPGY4ER-2kl_7fQrujteQaew_DNtFDTxspJTZ3AHE-HyecnHTS65Vh4EwwsxzW8PibDOPmnlSr-pDELzV0CDiSffLYfn3H0z6iw48kBuFZIIpZGNzxdium1ZH3hsyuIaowOFCErp-_gxBB-w4ZqLlqHhdKdSQWC3OyW5O0pjmZbPP8oos3RecafPEgg6NW9oKXN2uQxfuLjqh8R3EHZREkJQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499517,"updated":1613499517,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-PS512-","deletedDate":1613611619,"scheduledPurgeDate":1614216419,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-PS512-/29834cabeebd47958ad4ef8c5fdd0687","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"m40sk3k_fCWdZNNcHo_Ed2jBzAIlUeZldfbAZZEsxUK_IUuRpRgQOSMydB6l2YhFSwbBjysXrQrpTnhRv5enegAwNN1oox_-jU5TFSbMid-BYTdKBrKPSOnE80rVTHtXevRb3QBX9nnxYOKfOJBcTc8RLRCS8XGqD0oJSd-2iLPzoY8KusS1TLmJmH4lIKccYUN9dp07qfFjGFr-aoYAPJ6tpdckP5DqGgAt2R-6Bn6kp3O4Yl7Ezd1qZQG-iswNRZl5gBl1Z3zj47R4gbd4q_NKtipyJ690BKgPSUk2F-A58Zh5Z8rnM4umGNEHlrkUcfedGomoHUMW-9o_nlB83Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611619,"updated":1613611619,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -441,7 +441,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '54d0e59c-8c31-417c-afa0-ac42aef3b5b1',
+  '96c84ef2-3470-4c87-96d6-c73681af6763',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -453,7 +453,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT',
+  'Thu, 18 Feb 2021 01:27:07 GMT',
   'Content-Length',
   '875'
 ]);
@@ -471,7 +471,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '67f00979-9d1a-4bcd-9fda-c0fcc29a02e2',
+  '601d706d-a43e-4804-b08b-91e0cd05272c',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -483,5 +483,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:07 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs256.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs256.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '14f677ba-32d0-4400-9bea-ae92c00f957c',
+  '500e709a-cc52-49ec-98d4-6c29b8930ddf',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT'
+  'Thu, 18 Feb 2021 01:26:25 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '6f2d9718-5489-4e05-8dc0-50faf829f900',
+  'ebb9ca1a-06d6-4223-a578-b7a141ff4e01',
   'x-ms-ests-server',
   '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:04 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:26 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:03 GMT'
+  'Thu, 18 Feb 2021 01:26:26 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-RS256-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sQiYp8JleBi9cbJzgtWtx4YZMEG6ae2XRW0yrG6T8Tr0qUKdTcshT8FSAAHxhAz4TAB8nFeZMVwqKvVsKsd486zhAynwZYzc9EpFLrItTHKSZaGVdKJEyQT_7DNxGzruxhfx_d4zv_1ua6pKrdj3b7SUD7yEJQ4CYJvynE0axV-U1JCs17nte6Ye4TTSmFoDzDYsE9_esxmyzHzQK9vhhfr09kHa92W4uxW6Es1KGlLSjS40x4AUAQMC5ZPxBIXJjxITb3ywYBX5XCP21bVt12BE-HEVRRZxY1xvDmjJ11aQ6xPmVGoVc5I6GElYoqcEvzRj6QFzlyS2yk7RzenotQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499484,"updated":1613499484,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1qYVHUeb7SvHR9_uvdPdgFkCoHe_7mA3Wj1PH3825ZowOA5LTfjvY2GcNzClLRmCIFu40Wl-w_IXzRjN3IazhOHzwVqVY5Hja1DxgnSre3TfibN3PRrvXwrFtYA_hLU7dCSFzQm8snHd9rjwIl5XtOcb5e-D6N_i63H_4_nIMSXqJWV0XkEQMWIc5NpKmbo23huXMRu00Oqvex11S8hkfCS95NpSW4SUZtX6ksMtYERup-FoIMa-OjfgqIh0nmbuj03--0bsgKwaais-XYrShgh_u7v7ye1LG0Q9m8sIMNe-M9LoXNcNcRIVHGmwT0891nuMxmGYWxel9E8y1bERiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611586,"updated":1613611586,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '1396a735-a52b-43e0-83ea-e0cf4d1f854f',
+  'b2ea6988-2b0f-4ab6-9556-a356fb7e9265',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT',
+  'Thu, 18 Feb 2021 01:26:26 GMT',
   'Content-Length',
-  '715'
+  '714'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e')
+  .get('/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3215d391-2eb5-4cd3-9fd7-96ac836c3bfc',
+  'b312e058-7aea-4118-bdb7-b0d642118d1d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT'
+  'Thu, 18 Feb 2021 01:26:26 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -144,8 +144,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -157,23 +155,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '6f2d9718-5489-4e05-8dc0-50fa142af900',
+  '7716efac-1903-470b-b215-0f918f425d01',
   'x-ms-ests-server',
-  '2.1.11496.5 - EUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:04 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:27 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:03 GMT'
+  'Thu, 18 Feb 2021 01:26:26 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e')
+  .get('/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sQiYp8JleBi9cbJzgtWtx4YZMEG6ae2XRW0yrG6T8Tr0qUKdTcshT8FSAAHxhAz4TAB8nFeZMVwqKvVsKsd486zhAynwZYzc9EpFLrItTHKSZaGVdKJEyQT_7DNxGzruxhfx_d4zv_1ua6pKrdj3b7SUD7yEJQ4CYJvynE0axV-U1JCs17nte6Ye4TTSmFoDzDYsE9_esxmyzHzQK9vhhfr09kHa92W4uxW6Es1KGlLSjS40x4AUAQMC5ZPxBIXJjxITb3ywYBX5XCP21bVt12BE-HEVRRZxY1xvDmjJ11aQ6xPmVGoVc5I6GElYoqcEvzRj6QFzlyS2yk7RzenotQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499484,"updated":1613499484,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1qYVHUeb7SvHR9_uvdPdgFkCoHe_7mA3Wj1PH3825ZowOA5LTfjvY2GcNzClLRmCIFu40Wl-w_IXzRjN3IazhOHzwVqVY5Hja1DxgnSre3TfibN3PRrvXwrFtYA_hLU7dCSFzQm8snHd9rjwIl5XtOcb5e-D6N_i63H_4_nIMSXqJWV0XkEQMWIc5NpKmbo23huXMRu00Oqvex11S8hkfCS95NpSW4SUZtX6ksMtYERup-FoIMa-OjfgqIh0nmbuj03--0bsgKwaais-XYrShgh_u7v7ye1LG0Q9m8sIMNe-M9LoXNcNcRIVHGmwT0891nuMxmGYWxel9E8y1bERiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611586,"updated":1613611586,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'faf5198c-3318-4683-8d75-10c8f0573afd',
+  '5435c3ad-9c0f-4347-a563-f621e621aa53',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT',
+  'Thu, 18 Feb 2021 01:26:26 GMT',
   'Content-Length',
-  '715'
+  '714'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e/sign', {"alg":"RS256","value":"criF2FM29rTvc7HfcSXvj0FuY6ANYWeustyqw-LOFEY"})
+  .post('/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8/sign', {"alg":"RS256","value":"criF2FM29rTvc7HfcSXvj0FuY6ANYWeustyqw-LOFEY"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e","value":"FotZ6WtV8dGyMcOBSh-2qx3T6LLeTfArI5zaGN4XRYIvUdOYvoOJ7xV2STp8A_V6U-e3lL8AATw7RBq_0MmMUCSsBNpF-GOAwF5NhxMfob9EZmC9QI3eZ1Fn-4qsVcB90FYV_Q_V1NJg502eoLGMS4RJ5M_lGclvwM5XIV1lbv4eAQIEZQ6RvF70dHoLCcjcZRoOLfPoCjgZXZJ3GbbTNle-6ZUOQsraVSY9L2aIFlJSquu4etuFEm95aQhXQan-S8ah-CJ34mG0a6KaY48nzr08y5-2of4utuCC9SIAXFzjt_tS94hHyj_rY9Qd2UGCPp81dU2ogCHN8ajCiGU1uQ"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8","value":"rpz1seAFtGLIhUqEOzvwt2s5WVKA5zQnE_GyhBsvJsOMkZogSDLBD3yZhBCdRHQmZ8Vn8wZFTAF8DzThr0M-9dJxqAX0hE6yzfj1CXVKxgHU2Qm-P-MCXxoROvMoIC_0RSzFXLvXqwadqzaZ2Y0W1tjpZ11yNfhzOhzqLl7cpDAUrfsH7Tx8mKEL5nqKI4VBTiGeD-GF19hR7S7pOXlW1RiDzK6hMT8M3Q-fCiAhVgQH-q460xusauZ5zsz23iht39YG3lW3zVhNxkwZI0cPq4YxpiG91sn3ZXv7bEiF8C8nxyKLpvP03NvT79A_xOlAl2k12kShwA_1_jQdGcLrag"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '5133d7f1-1060-403d-9ce2-b188842b9afd',
+  'df9a4415-0ff9-4887-9340-ddca22e96c12',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,15 +229,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT',
+  'Thu, 18 Feb 2021 01:26:26 GMT',
   'Content-Length',
-  '476'
+  '475'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-RS256-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS256-","deletedDate":1613499484,"scheduledPurgeDate":1614104284,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sQiYp8JleBi9cbJzgtWtx4YZMEG6ae2XRW0yrG6T8Tr0qUKdTcshT8FSAAHxhAz4TAB8nFeZMVwqKvVsKsd486zhAynwZYzc9EpFLrItTHKSZaGVdKJEyQT_7DNxGzruxhfx_d4zv_1ua6pKrdj3b7SUD7yEJQ4CYJvynE0axV-U1JCs17nte6Ye4TTSmFoDzDYsE9_esxmyzHzQK9vhhfr09kHa92W4uxW6Es1KGlLSjS40x4AUAQMC5ZPxBIXJjxITb3ywYBX5XCP21bVt12BE-HEVRRZxY1xvDmjJ11aQ6xPmVGoVc5I6GElYoqcEvzRj6QFzlyS2yk7RzenotQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499484,"updated":1613499484,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS256-","deletedDate":1613611587,"scheduledPurgeDate":1614216387,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1qYVHUeb7SvHR9_uvdPdgFkCoHe_7mA3Wj1PH3825ZowOA5LTfjvY2GcNzClLRmCIFu40Wl-w_IXzRjN3IazhOHzwVqVY5Hja1DxgnSre3TfibN3PRrvXwrFtYA_hLU7dCSFzQm8snHd9rjwIl5XtOcb5e-D6N_i63H_4_nIMSXqJWV0XkEQMWIc5NpKmbo23huXMRu00Oqvex11S8hkfCS95NpSW4SUZtX6ksMtYERup-FoIMa-OjfgqIh0nmbuj03--0bsgKwaais-XYrShgh_u7v7ye1LG0Q9m8sIMNe-M9LoXNcNcRIVHGmwT0891nuMxmGYWxel9E8y1bERiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611586,"updated":1613611586,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '62ea07f5-50f1-4b60-b635-fe4d4e165815',
+  'c96eca97-ac3e-4322-b651-986323362d1e',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,9 +261,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT',
+  'Thu, 18 Feb 2021 01:26:26 GMT',
   'Content-Length',
-  '875'
+  '873'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -275,7 +275,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '1ef95817-ce3d-447a-91d7-4d4db6f9fcd7',
+  '15790cbb-2398-417b-9a00-fc88874a2e77',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT'
+  'Thu, 18 Feb 2021 01:26:26 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -307,7 +307,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '02f569d7-be9b-46cb-beb4-2a33977e5433',
+  'f4509ab8-6b6b-40cb-9a00-11fd85569621',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:04 GMT'
+  'Thu, 18 Feb 2021 01:26:26 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -339,7 +339,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'f746ae1c-66d4-4a4b-b3f1-004321ea7fb2',
+  'abd10725-08a4-488a-907d-86c11e0256c2',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:06 GMT'
+  'Thu, 18 Feb 2021 01:26:29 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -371,7 +371,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '95e8bf48-89b5-4972-b417-d5a689b0795e',
+  '7d6f1610-251a-4429-a68d-66b039cc0594',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:08 GMT'
+  'Thu, 18 Feb 2021 01:26:31 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -403,7 +403,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '5e0f71c4-ed90-4004-8e2f-be9f47447acc',
+  '223afdb5-6f16-41f2-ac56-817639d69f7a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,7 +423,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:10 GMT'
+  'Thu, 18 Feb 2021 01:26:33 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -435,7 +435,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -443,7 +443,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0d9b5795-0e34-4bc5-9606-5c69e11f2602',
+  'a9143794-016f-499f-8993-aa15b703971e',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -455,7 +455,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:12 GMT'
+  'Thu, 18 Feb 2021 01:26:35 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -467,7 +467,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '109',
+  '108',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -475,7 +475,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'dc82958c-0ae4-4337-a1b5-5bff83f06aed',
+  '3ad4557b-7dfc-4b0b-82d5-63181e6f2f3b',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -487,45 +487,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:14 GMT'
+  'Thu, 18 Feb 2021 01:26:37 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-RS256-')
   .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-RS256-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '109',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '71fb3eef-dc5b-4b2c-a1a2-564de582ca86',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:18:16 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-RS256-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS256-","deletedDate":1613499484,"scheduledPurgeDate":1614104284,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/728c6328f6324126a12d99bf08a8360e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sQiYp8JleBi9cbJzgtWtx4YZMEG6ae2XRW0yrG6T8Tr0qUKdTcshT8FSAAHxhAz4TAB8nFeZMVwqKvVsKsd486zhAynwZYzc9EpFLrItTHKSZaGVdKJEyQT_7DNxGzruxhfx_d4zv_1ua6pKrdj3b7SUD7yEJQ4CYJvynE0axV-U1JCs17nte6Ye4TTSmFoDzDYsE9_esxmyzHzQK9vhhfr09kHa92W4uxW6Es1KGlLSjS40x4AUAQMC5ZPxBIXJjxITb3ywYBX5XCP21bVt12BE-HEVRRZxY1xvDmjJ11aQ6xPmVGoVc5I6GElYoqcEvzRj6QFzlyS2yk7RzenotQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499484,"updated":1613499484,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS256-","deletedDate":1613611587,"scheduledPurgeDate":1614216387,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS256-/6561e3bf5ea74cf9861ac802f98a12d8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1qYVHUeb7SvHR9_uvdPdgFkCoHe_7mA3Wj1PH3825ZowOA5LTfjvY2GcNzClLRmCIFu40Wl-w_IXzRjN3IazhOHzwVqVY5Hja1DxgnSre3TfibN3PRrvXwrFtYA_hLU7dCSFzQm8snHd9rjwIl5XtOcb5e-D6N_i63H_4_nIMSXqJWV0XkEQMWIc5NpKmbo23huXMRu00Oqvex11S8hkfCS95NpSW4SUZtX6ksMtYERup-FoIMa-OjfgqIh0nmbuj03--0bsgKwaais-XYrShgh_u7v7ye1LG0Q9m8sIMNe-M9LoXNcNcRIVHGmwT0891nuMxmGYWxel9E8y1bERiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611586,"updated":1613611586,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -537,7 +505,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'd651ab0f-2bf1-4f10-9e3e-615ec1b369ac',
+  'c49edb7a-5674-43f2-b9c2-f976181edb75',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -549,9 +517,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:19 GMT',
+  'Thu, 18 Feb 2021 01:26:38 GMT',
   'Content-Length',
-  '875'
+  '873'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -567,7 +535,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'facbdc91-eaf1-4034-b848-0342e29f6bd7',
+  '460fcb0d-7b51-4b2f-aa1a-071c0fd63cab',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -579,5 +547,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:18 GMT'
+  'Thu, 18 Feb 2021 01:26:39 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs384.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs384.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '460394ff-4f67-44cf-b463-7a2f768f9bd9',
+  '19d094e4-fe6a-4660-a452-9a1df9d694f1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,8 +45,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -58,23 +56,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '1990b1a5-2ff7-4a65-a815-252dd9512b00',
+  '7716efac-1903-470b-b215-0f9112465d01',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:28 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:48 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-RS384-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"v_0wLplZXSAWFZiOfYZESziNSH3As6ge9-PGqjy90vs5cj8gWvPrPqzbpptYbUiExsRW-P2pYZrJDbKnaT8svPq4KM7VbSsJYpHcAzfkIU0tdNWc44ueZkye5BCM7_IEGyv5w3E9b5tN0AnzYkttnhhmfGzi3XeycW5wiUVEXgBLKqTZ_OySY2rY4zAF0V9Wzf7Sw1n4XdJi_dl2zf2UKcW5V_kQx0Va5Qt51QFfn5_XGtC7B6lpot5ER6OPIeO7z2tv8CDLJi_8cHtw2A7bLfMkkfsWtiMraRtB3omudLN9vT5vr5tS2iPn0cAskj1GCKT21fxO44PzJyjRjTuJQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499508,"updated":1613499508,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wIbZq7KF60WxLWUxlA0VcvC5N9Oe1oTzntAkuccCgBbfx3Y2L5dQ3G7p0hXC9rthB5JhXmLkOnKa6MRB8fJFcVGO_DcZFmCRKdLEAy6A0UOytnmA_OAuUjR-WtJIILE2rN19FMo1XvjGlqyT3TJJWfY9J3yO1lcwCGsugJfwdXlVmdikODnbs8UjzbX0SD9tZFRHqwDe_520zz466Y3PVou27OWnofjdxyPQ649VNXcTGjzdb_sKzHXwkdDPYz4CXhCijHrixCPKxk6I3H5DHvab8jECyHqqKdYEhTCU2gKTPnG1vSkQwfue7Iec2kcVZJCVdsDRiGXqKq0RyQdsGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611608,"updated":1613611608,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2b5a5380-e427-4e87-a2c3-7e01a8136e89',
+  '64e891b3-01b8-4586-9274-86f4e23bacdf',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT',
+  'Thu, 18 Feb 2021 01:26:48 GMT',
   'Content-Length',
   '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440')
+  .get('/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2570ce39-8b6e-43d2-b0fe-2e34dab481dc',
+  '401705d7-cc1b-48b1-9dfb-a0f98b7f4028',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -157,23 +157,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '0e690c11-1753-4330-bc02-db0e4c49df00',
+  '7716efac-1903-470b-b215-0f9125465d01',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:28 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:48 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440')
+  .get('/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"v_0wLplZXSAWFZiOfYZESziNSH3As6ge9-PGqjy90vs5cj8gWvPrPqzbpptYbUiExsRW-P2pYZrJDbKnaT8svPq4KM7VbSsJYpHcAzfkIU0tdNWc44ueZkye5BCM7_IEGyv5w3E9b5tN0AnzYkttnhhmfGzi3XeycW5wiUVEXgBLKqTZ_OySY2rY4zAF0V9Wzf7Sw1n4XdJi_dl2zf2UKcW5V_kQx0Va5Qt51QFfn5_XGtC7B6lpot5ER6OPIeO7z2tv8CDLJi_8cHtw2A7bLfMkkfsWtiMraRtB3omudLN9vT5vr5tS2iPn0cAskj1GCKT21fxO44PzJyjRjTuJQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499508,"updated":1613499508,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wIbZq7KF60WxLWUxlA0VcvC5N9Oe1oTzntAkuccCgBbfx3Y2L5dQ3G7p0hXC9rthB5JhXmLkOnKa6MRB8fJFcVGO_DcZFmCRKdLEAy6A0UOytnmA_OAuUjR-WtJIILE2rN19FMo1XvjGlqyT3TJJWfY9J3yO1lcwCGsugJfwdXlVmdikODnbs8UjzbX0SD9tZFRHqwDe_520zz466Y3PVou27OWnofjdxyPQ649VNXcTGjzdb_sKzHXwkdDPYz4CXhCijHrixCPKxk6I3H5DHvab8jECyHqqKdYEhTCU2gKTPnG1vSkQwfue7Iec2kcVZJCVdsDRiGXqKq0RyQdsGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611608,"updated":1613611608,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '9f782427-4f0e-4118-b9ae-9fce8f239b32',
+  '75c37a1a-1284-4876-8301-59058ea216f5',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT',
+  'Thu, 18 Feb 2021 01:26:48 GMT',
   'Content-Length',
   '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440/sign', {"alg":"RS384","value":"TIhkXuj1N6MQEvoRynn6PS-r6457Euk0K7ijtEDHgJoifny15et3CoFPYdEWQLXb"})
+  .post('/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617/sign', {"alg":"RS384","value":"TIhkXuj1N6MQEvoRynn6PS-r6457Euk0K7ijtEDHgJoifny15et3CoFPYdEWQLXb"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440","value":"IMeN0NW-V26MyXNUUii-5_SCOUq8x9t-k9CT5Ieh7YoWF0hwnQjKKlVi7D5mPJdGClFXd98glzEwJ8G5_0uSItd7Tp_raYG-pU8nVbBUFoUGba4iZtyRgiEr2FpSoJiQJmCsEy-iFZmSJGXxhorQiXcWaoSMCN6cioL6e6ExxBPN3aghP4xbWAMDI98mHMpI_efz_4o69SdSezzUH2eiRuo0oJl_3ojWjf-d-YR-Nx5u-EODhotuJ8iJY2JsHaZIIhG2rU8SnCGMdO8_W5-gTEL7ichVIE-FLaZBNtYH_EymqRhx9F7KJNEqtW3TyzfOJ36Eq4O9XOtAk96kMcYKPw"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617","value":"Fyfz4EBleSXsdLDbRKGRgc0ooPgleyXvAhtlJYskEuEGOjic1BeLPY6tOC2kzq3g61l3NqpmivdcvQvuOYjGGEzm09SHB4tmP7L55ZmyJEVyTiUTASYG5Du3dnYJfHqBBNbiFU0dkt2aSrgFHw2Eu0x21ljGpmM20rGBXdBV32xA7Haf23kwqK7w1NhgHK_gIJ6Umst6yipWcYYDX8Szt3gNtBsBmUylCvEjAJUK4hJbMyhuWfSTmo2V7CG0MORfhSwqPPZ1ema93J868XZ0N9LLICctbKTWZlCCJ2Jz7AR1FJA8lzL-7wKLckoZyzI5AHOlhClOy7R9iHv8Cw0cTA"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '8872c078-497e-4c39-a5a3-879858705f23',
+  '2275a6dc-f668-453a-96fd-a2eed8be3f2b',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,7 +229,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT',
+  'Thu, 18 Feb 2021 01:26:48 GMT',
   'Content-Length',
   '476'
 ]);
@@ -237,7 +237,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-RS384-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS384-","deletedDate":1613499509,"scheduledPurgeDate":1614104309,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"v_0wLplZXSAWFZiOfYZESziNSH3As6ge9-PGqjy90vs5cj8gWvPrPqzbpptYbUiExsRW-P2pYZrJDbKnaT8svPq4KM7VbSsJYpHcAzfkIU0tdNWc44ueZkye5BCM7_IEGyv5w3E9b5tN0AnzYkttnhhmfGzi3XeycW5wiUVEXgBLKqTZ_OySY2rY4zAF0V9Wzf7Sw1n4XdJi_dl2zf2UKcW5V_kQx0Va5Qt51QFfn5_XGtC7B6lpot5ER6OPIeO7z2tv8CDLJi_8cHtw2A7bLfMkkfsWtiMraRtB3omudLN9vT5vr5tS2iPn0cAskj1GCKT21fxO44PzJyjRjTuJQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499508,"updated":1613499508,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS384-","deletedDate":1613611609,"scheduledPurgeDate":1614216409,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wIbZq7KF60WxLWUxlA0VcvC5N9Oe1oTzntAkuccCgBbfx3Y2L5dQ3G7p0hXC9rthB5JhXmLkOnKa6MRB8fJFcVGO_DcZFmCRKdLEAy6A0UOytnmA_OAuUjR-WtJIILE2rN19FMo1XvjGlqyT3TJJWfY9J3yO1lcwCGsugJfwdXlVmdikODnbs8UjzbX0SD9tZFRHqwDe_520zz466Y3PVou27OWnofjdxyPQ649VNXcTGjzdb_sKzHXwkdDPYz4CXhCijHrixCPKxk6I3H5DHvab8jECyHqqKdYEhTCU2gKTPnG1vSkQwfue7Iec2kcVZJCVdsDRiGXqKq0RyQdsGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611608,"updated":1613611608,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '1da4f788-80c4-4f12-ac89-ddabcede241e',
+  '1d61dfe8-ce3d-48fd-8b50-bf57a3fef321',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,7 +261,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT',
+  'Thu, 18 Feb 2021 01:26:48 GMT',
   'Content-Length',
   '875'
 ]);
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a6ab95c9-6441-46e7-a2af-e7cc9ee4c538',
+  '89abcb5c-f5d4-42c3-b30d-ee233690d84e',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:28 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0e6497ce-4c32-41d5-b51f-3823eaa7e408',
+  '298111e9-284f-45ec-bd0f-531386ec698a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:29 GMT'
+  'Thu, 18 Feb 2021 01:26:48 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '8bd5e9c7-0ad4-4c00-88a2-0f062e663655',
+  '7d6085a1-9a50-44a6-8a9b-6b8effdfd264',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:30 GMT'
+  'Thu, 18 Feb 2021 01:26:50 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'b9693fbb-7726-4545-88ef-466cbc2f197d',
+  '127bcc78-3383-413c-a5d9-e2a0a49e115d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:32 GMT'
+  'Thu, 18 Feb 2021 01:26:52 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '88c3141e-58fa-4a51-b504-b6d62f63b86a',
+  'e10c94d5-8dd3-464f-9262-984c7608af1f',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,13 +423,45 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:35 GMT'
+  'Thu, 18 Feb 2021 01:26:54 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-RS384-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS384-","deletedDate":1613499509,"scheduledPurgeDate":1614104309,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/8a995164e1c24c05b6178c232fc4f440","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"v_0wLplZXSAWFZiOfYZESziNSH3As6ge9-PGqjy90vs5cj8gWvPrPqzbpptYbUiExsRW-P2pYZrJDbKnaT8svPq4KM7VbSsJYpHcAzfkIU0tdNWc44ueZkye5BCM7_IEGyv5w3E9b5tN0AnzYkttnhhmfGzi3XeycW5wiUVEXgBLKqTZ_OySY2rY4zAF0V9Wzf7Sw1n4XdJi_dl2zf2UKcW5V_kQx0Va5Qt51QFfn5_XGtC7B6lpot5ER6OPIeO7z2tv8CDLJi_8cHtw2A7bLfMkkfsWtiMraRtB3omudLN9vT5vr5tS2iPn0cAskj1GCKT21fxO44PzJyjRjTuJQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499508,"updated":1613499508,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-RS384-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '109',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus2',
+  'x-ms-request-id',
+  'e8deffb2-30b2-477e-b3cb-835d26b9f26c',
+  'x-ms-keyvault-service-version',
+  '1.2.164.2',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Thu, 18 Feb 2021 01:26:56 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/localCryptoKeyName-RS384-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS384-","deletedDate":1613611609,"scheduledPurgeDate":1614216409,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS384-/3d42d5781eb5490a81cc7a83d7f98617","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wIbZq7KF60WxLWUxlA0VcvC5N9Oe1oTzntAkuccCgBbfx3Y2L5dQ3G7p0hXC9rthB5JhXmLkOnKa6MRB8fJFcVGO_DcZFmCRKdLEAy6A0UOytnmA_OAuUjR-WtJIILE2rN19FMo1XvjGlqyT3TJJWfY9J3yO1lcwCGsugJfwdXlVmdikODnbs8UjzbX0SD9tZFRHqwDe_520zz466Y3PVou27OWnofjdxyPQ649VNXcTGjzdb_sKzHXwkdDPYz4CXhCijHrixCPKxk6I3H5DHvab8jECyHqqKdYEhTCU2gKTPnG1vSkQwfue7Iec2kcVZJCVdsDRiGXqKq0RyQdsGQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611608,"updated":1613611608,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -441,7 +473,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'ef6a6617-e0d4-4c23-8ba0-76ca45e8fc72',
+  '110449e9-5219-4dad-842e-8ac6ffd1495b',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -453,7 +485,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:36 GMT',
+  'Thu, 18 Feb 2021 01:26:58 GMT',
   'Content-Length',
   '875'
 ]);
@@ -471,7 +503,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'fdeb2ec1-26d3-4a61-a2e6-a3c9d74203b2',
+  'd5b65cbe-c3cc-422c-afcb-1aa8e9b6dc39',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -483,5 +515,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:37 GMT'
+  'Thu, 18 Feb 2021 01:26:58 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs512.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_verify/recording_rs512.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0a3c7418-f3e9-4204-8f9f-743fb54b1fd9',
+  'ba20d28b-1ef6-43cd-a76b-15f39b45b1ec',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:07 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '962de970-8496-499d-83b8-cd61bef24200',
+  '7750e8e4-ca6f-453c-9bc8-80f31e4b1800',
   'x-ms-ests-server',
-  '2.1.11496.5 - EUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:27:08 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:07 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-RS512-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"r6l-fpg6Tncyk9vt_RyscBorDlbkNMiwVoZL7Lx4n5T9ZCRtnCGXyhwFP-iY6ovR8XOOswtZEGcs-xsPTbv16Cphcciq5ur5RThJ6OHnD8PUdZMquL0cF95dODooNYhG-I9Hxxb83W-kvt7bvqGVnGEhN7_vGMbsLnfrJlkgwS_t8lAlOq5xkVTfrm5AAO9I2XkKNblBX75t8htkxetrsS0mj6tctns3ivOaZKI2O7aOu7GE_mTyqX2KKIqDGDtG9NbGfHfPH4xiwQWRF-s-ARu9urQsyU7EJqNf-hDuoth0QHm_K61sFxwGWq3A8SnQtUt3aDskL7-Ykonhbt4-oQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499526,"updated":1613499526,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2zHlwpi6I_Bund8PQEoAikxrdpSEWEzVTNZ9LRorw-SJfx3UPbiXyVm6plzko_3JMw2rBCSIUKuzYPCTPAmQxLa6bxUUE1Dh0unYhPl5vQiVXM79-KsnNbm4AJdgMdwEttM5PfhHb1PDx_Q1fF6ldpr2Vl0vqAVJbuK4pnf359DhYdI5p6ktx93FD2DM06JEX1z8A2w82kR2O04tXsAaSXwwjcqxH8xjpXPHAOMJ02o3xR93-Kpn-vA8-1-9zOJcU83mEyD1vRsb9wbqP4AzqSpIJgt5rRS5zlTgBdZouu3ONrIkgx0tMSsTDpDG0tCQnIPRxuNC9KK5kvCwIvemmQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611628,"updated":1613611628,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'c647a0cb-a3a8-4c67-ad35-0defc68bfb03',
+  '78d49de2-95a3-48c8-8c80-5a5ea2cc8c83',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,13 +98,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT',
+  'Thu, 18 Feb 2021 01:27:07 GMT',
   'Content-Length',
-  '716'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b')
+  .get('/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -122,7 +122,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'be222697-806d-4c23-94a9-1acc0b0c1d4e',
+  'ec115b74-ff77-4f8c-a364-9cddd924db57',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -134,7 +134,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:07 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -144,8 +144,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -157,23 +155,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '1990b1a5-2ff7-4a65-a815-252d6b552b00',
+  '6f8dc614-01c3-43e1-9974-f89ce6b92200',
   'x-ms-ests-server',
   '2.1.11496.6 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:18:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCwAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:27:08 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:08 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b')
+  .get('/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"r6l-fpg6Tncyk9vt_RyscBorDlbkNMiwVoZL7Lx4n5T9ZCRtnCGXyhwFP-iY6ovR8XOOswtZEGcs-xsPTbv16Cphcciq5ur5RThJ6OHnD8PUdZMquL0cF95dODooNYhG-I9Hxxb83W-kvt7bvqGVnGEhN7_vGMbsLnfrJlkgwS_t8lAlOq5xkVTfrm5AAO9I2XkKNblBX75t8htkxetrsS0mj6tctns3ivOaZKI2O7aOu7GE_mTyqX2KKIqDGDtG9NbGfHfPH4xiwQWRF-s-ARu9urQsyU7EJqNf-hDuoth0QHm_K61sFxwGWq3A8SnQtUt3aDskL7-Ykonhbt4-oQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499526,"updated":1613499526,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2zHlwpi6I_Bund8PQEoAikxrdpSEWEzVTNZ9LRorw-SJfx3UPbiXyVm6plzko_3JMw2rBCSIUKuzYPCTPAmQxLa6bxUUE1Dh0unYhPl5vQiVXM79-KsnNbm4AJdgMdwEttM5PfhHb1PDx_Q1fF6ldpr2Vl0vqAVJbuK4pnf359DhYdI5p6ktx93FD2DM06JEX1z8A2w82kR2O04tXsAaSXwwjcqxH8xjpXPHAOMJ02o3xR93-Kpn-vA8-1-9zOJcU83mEyD1vRsb9wbqP4AzqSpIJgt5rRS5zlTgBdZouu3ONrIkgx0tMSsTDpDG0tCQnIPRxuNC9KK5kvCwIvemmQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611628,"updated":1613611628,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -185,7 +185,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '113d1912-d6c0-44e0-b1d0-bdf94e9c1c12',
+  '741fccdd-0c2b-41d2-bf5b-d2689a3276ab',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -197,15 +197,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT',
+  'Thu, 18 Feb 2021 01:27:07 GMT',
   'Content-Length',
-  '716'
+  '715'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b/sign', {"alg":"RS512","value":"QaLHow25_feqs3pxKJmCGrAMc8htSHcJZviGWeoVGheXIeIBgTa7IeQF-Ti_oEfg5Uo3phll52kljUTpML3v1g"})
+  .post('/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a/sign', {"alg":"RS512","value":"QaLHow25_feqs3pxKJmCGrAMc8htSHcJZviGWeoVGheXIeIBgTa7IeQF-Ti_oEfg5Uo3phll52kljUTpML3v1g"})
   .query(true)
-  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b","value":"bMg4qfPYO89WX0CwoWWOyubEeHFlSO4Ltl27qEgLLvUiXPLVP6DZw2J8xgkTBUM_EnYXg9-ylnHVyVX-hKZtSWNOTzEP6q5eTs5LY9rQ3pZtSZ9BcV_-NfgnK2H4i77rMaJRF0UIHEyADHMWEtcOHWSkCPMS7GtfqCEbgrDFiDQ9aIRBCZgiD5j9t7Tx9vsbhtWK_EjwLjIFDxRCiS4-2JeZq1Iez-rRfoyIBrlz9O47kat2Xl3kxo7XMxSEYv5TEuZ2DtrzeAExPdE3Efk4JvrAvYHVouMproSKu4KHtAfo_uUW3w6jGOSARizk83BjP8-mEtdV4TKd67L2kbfynQ"}, [
+  .reply(200, {"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a","value":"ys3XINQ3jlAWe5jJLx9tTq5TCewuJUSb8HtizCzW92mYnt27oHZoCv_3p5YTEjPfZxDEH806iu8hQJYdMammUMbl1x3odvfzSxPnF_RjlIOMxmM0s9Tm48nUE9o8ZQXqGBJ6gkGD88UKilgmzLGBRrQHRQlQ5PzjnmOdBaqgtRxOaAQb3oUp9JbajazS7Q9VwAMj8M_WU-En7BY_KgUjZ0BEer3Oy2XzDK7fPOVRhhfk2FB-QoqDS9sGzDn7RWiSeyRjEXyi8NMnnqjFla0ncPmANpHeuV3aBWCnkt18nCUilhtWjxHSivVozmpRB-JBXFKWEFim1u9yliSJsnVqGA"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -217,7 +217,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '890a8c54-cba0-45c8-9022-d55ea6f7b3b9',
+  '2f525d18-2eb9-4960-8be1-e4ee65ff25dd',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -229,15 +229,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT',
+  'Thu, 18 Feb 2021 01:27:07 GMT',
   'Content-Length',
-  '477'
+  '476'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/localCryptoKeyName-RS512-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS512-","deletedDate":1613499526,"scheduledPurgeDate":1614104326,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"r6l-fpg6Tncyk9vt_RyscBorDlbkNMiwVoZL7Lx4n5T9ZCRtnCGXyhwFP-iY6ovR8XOOswtZEGcs-xsPTbv16Cphcciq5ur5RThJ6OHnD8PUdZMquL0cF95dODooNYhG-I9Hxxb83W-kvt7bvqGVnGEhN7_vGMbsLnfrJlkgwS_t8lAlOq5xkVTfrm5AAO9I2XkKNblBX75t8htkxetrsS0mj6tctns3ivOaZKI2O7aOu7GE_mTyqX2KKIqDGDtG9NbGfHfPH4xiwQWRF-s-ARu9urQsyU7EJqNf-hDuoth0QHm_K61sFxwGWq3A8SnQtUt3aDskL7-Ykonhbt4-oQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499526,"updated":1613499526,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS512-","deletedDate":1613611628,"scheduledPurgeDate":1614216428,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2zHlwpi6I_Bund8PQEoAikxrdpSEWEzVTNZ9LRorw-SJfx3UPbiXyVm6plzko_3JMw2rBCSIUKuzYPCTPAmQxLa6bxUUE1Dh0unYhPl5vQiVXM79-KsnNbm4AJdgMdwEttM5PfhHb1PDx_Q1fF6ldpr2Vl0vqAVJbuK4pnf359DhYdI5p6ktx93FD2DM06JEX1z8A2w82kR2O04tXsAaSXwwjcqxH8xjpXPHAOMJ02o3xR93-Kpn-vA8-1-9zOJcU83mEyD1vRsb9wbqP4AzqSpIJgt5rRS5zlTgBdZouu3ONrIkgx0tMSsTDpDG0tCQnIPRxuNC9KK5kvCwIvemmQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611628,"updated":1613611628,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -249,7 +249,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '2f7a44ae-dfce-473f-babf-13d2b5294c7d',
+  '45ceb5af-5b56-44fc-949c-294e7202c985',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -261,9 +261,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT',
+  'Thu, 18 Feb 2021 01:27:07 GMT',
   'Content-Length',
-  '877'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -275,7 +275,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -283,7 +283,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'ffcaf06c-1b4e-40ed-9853-03254114572e',
+  '9265e23c-de45-4f6c-a4a5-98d43fdd7507',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -295,7 +295,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:08 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -307,7 +307,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -315,7 +315,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'af1f3530-410d-4788-9e22-96c80556b540',
+  '776e6865-c0df-4dd7-991d-ddb5549e2feb',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -327,7 +327,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:46 GMT'
+  'Thu, 18 Feb 2021 01:27:08 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -339,7 +339,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -347,7 +347,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '71c5a9a8-207e-4bfc-91cb-74b82ea5f833',
+  'd4ecfa68-6019-4516-bdf2-3261fa89673d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -359,7 +359,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:48 GMT'
+  'Thu, 18 Feb 2021 01:27:10 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -371,7 +371,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -379,7 +379,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '27fcc8b0-9290-4dbf-a770-5e52ffbcb68d',
+  '87b3cc68-d7c7-43db-b9d4-15d528ee6263',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -391,7 +391,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:50 GMT'
+  'Thu, 18 Feb 2021 01:27:12 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -403,7 +403,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '110',
+  '109',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -411,7 +411,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'c48479b7-de45-4931-b5c9-5173b244410a',
+  'aafb946d-4c43-483e-8cf3-f9f06385839a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -423,45 +423,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:53 GMT'
+  'Thu, 18 Feb 2021 01:27:14 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/localCryptoKeyName-RS512-')
   .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: localCryptoKeyName-RS512-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '110',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '85aca324-182e-4058-9929-d3d02a3c618e',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:18:54 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/localCryptoKeyName-RS512-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS512-","deletedDate":1613499526,"scheduledPurgeDate":1614104326,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/324228804787436ba55641cad3d2c03b","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"r6l-fpg6Tncyk9vt_RyscBorDlbkNMiwVoZL7Lx4n5T9ZCRtnCGXyhwFP-iY6ovR8XOOswtZEGcs-xsPTbv16Cphcciq5ur5RThJ6OHnD8PUdZMquL0cF95dODooNYhG-I9Hxxb83W-kvt7bvqGVnGEhN7_vGMbsLnfrJlkgwS_t8lAlOq5xkVTfrm5AAO9I2XkKNblBX75t8htkxetrsS0mj6tctns3ivOaZKI2O7aOu7GE_mTyqX2KKIqDGDtG9NbGfHfPH4xiwQWRF-s-ARu9urQsyU7EJqNf-hDuoth0QHm_K61sFxwGWq3A8SnQtUt3aDskL7-Ykonhbt4-oQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499526,"updated":1613499526,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/localCryptoKeyName-RS512-","deletedDate":1613611628,"scheduledPurgeDate":1614216428,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-RS512-/866ee5b3d2504e779d24e548e07cc09a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2zHlwpi6I_Bund8PQEoAikxrdpSEWEzVTNZ9LRorw-SJfx3UPbiXyVm6plzko_3JMw2rBCSIUKuzYPCTPAmQxLa6bxUUE1Dh0unYhPl5vQiVXM79-KsnNbm4AJdgMdwEttM5PfhHb1PDx_Q1fF6ldpr2Vl0vqAVJbuK4pnf359DhYdI5p6ktx93FD2DM06JEX1z8A2w82kR2O04tXsAaSXwwjcqxH8xjpXPHAOMJ02o3xR93-Kpn-vA8-1-9zOJcU83mEyD1vRsb9wbqP4AzqSpIJgt5rRS5zlTgBdZouu3ONrIkgx0tMSsTDpDG0tCQnIPRxuNC9KK5kvCwIvemmQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611628,"updated":1613611628,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -473,7 +441,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'e9710232-cd5d-49b2-8ecd-410d77230eef',
+  '6cedebf7-ba1d-41b4-b888-b0b1430a2537',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -485,9 +453,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:57 GMT',
+  'Thu, 18 Feb 2021 01:27:16 GMT',
   'Content-Length',
-  '877'
+  '875'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -503,7 +471,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '21db8100-05b5-4a0f-ab26-9a4ced7ea491',
+  '796ba046-e733-4da4-8f4c-3edef4e208e8',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -515,5 +483,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:18:56 GMT'
+  'Thu, 18 Feb 2021 01:27:16 GMT'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken/recording_the_cryptographyclient_can_be_created_from_a_local_jsonwebkey_object.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken/recording_the_cryptographyclient_can_be_created_from_a_local_jsonwebkey_object.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '7c5dd8f5-f565-4129-97a7-ebda0f76a9a8',
+  'ba6d0058-b6ea-4192-81e7-e7d058227821',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:07 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '0e690c11-1753-4330-bc02-db0ebf41df00',
+  '35d65785-dae1-4b37-a681-da4b04351d00',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.6 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDEwAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:08 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/aaee0208ac124deda4b060fd43b69ebe","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"l8QCdietuUrFTfM3ZxQS8F-G2_UhmWpaRyM5d_fZowziVJOlapqb4Z-Ip0VLMtPkTU08JmBYE0p5JwtOhtokgqcdvoWNluI9XgbbLGpQzSoyEDPLQHgoiMu2QPo9rzuyCRPmsLWAyGT3vw6TbgAfufR9Wn9CUzv09YB0qdimBDoxBgi8HxSsl5Xvgi09JpFvYhH-dYgsUOxe8vLLWO25Tv23yVg-dYZizDkUmZRcNIEY8vBx9MHfSyEQ8GR65m0APjgJ2wF2oB-tmfJHeEEsCCtoU_wye1R1VClAsDabmHFjoSH5ndrZPprfjy3ETjZ5_fxQJ5b7t9qImgX6Vc768Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613499466,"updated":1613499466,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/a29c2ef29a0b409b8f3280fc674df4e6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6xO4bfM0v5xluFuRCfGjXWRNq7sqUWe1JfkdXBiAmC_QNNXi9E8xPNvb5Na-m9_rxG5zj53N1-xRQZ5V9GtkAMxLrg1tXJJ9-xUidtHBBk8OnCC1YpxwpMHqLKskj3oNQRwoa8JlTCB-NrQRIqi2A1bmCBY4fjCv6Rmy1p4MRyZvDFCjEyEsW2MxcT6KJbd2H0QPWL6SlNnZjXH1jBZqQVZZshXnjkVk-a3QkNmCvXj2RQUXL14iyGJHdPjdnYuzAfMe1McA_KpCeqoJBuSUDHFNVN4vjsbTceFMAiry9aKny23epKtW6MiQCNbp9fiEUUK2uhE8o315NaXEibqFiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611568,"updated":1613611568,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '1e6eee45-6c14-4e7d-aac0-c008ea1f109b',
+  '9d4fe4aa-2518-4f5a-9ccb-916f67f8fe40',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:46 GMT',
+  'Thu, 18 Feb 2021 01:26:08 GMT',
   'Content-Length',
-  '725'
+  '724'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_encrypt.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_encrypt.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '9cc3a38c-51ec-4740-a8a4-efcef6171cd0',
+  '30022afc-e223-4cec-8411-cbaebe69c678',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -46,7 +46,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '1310',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '71f5a6b0-6825-4695-b144-7f472a1efb00',
+  '7d7eaf67-31be-4265-86c5-1cb759965001',
   'x-ms-ests-server',
   '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDEwAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:08 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/52915c23aafc4ed3b2b3370d2669d6f1","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"uEONbk1cqnNGD3Z_R5Xz_5nZDQDZVx8uU3ZB8sXtFS4lngzXb1GWWCkUUYdXVK906jtRg4-0RbsNcp4Xl8vZMQbndGOxkSQJ5BnWmWK9KRcHDknyeJ4pxmzjkOf9lXmYBqG8r9Q7PzXcpgE2vsvCyHJB0t1ZKerQkzRnaSRNeYB8FDRUop_t2RGK_zRnltHTLRAfSCpFG3vCQHrX6CiEfNk6x_S2wrnNBed8MKNd69RBeUusQMYoEhu_IFOeE0bvGgy5pF7f_L54hnbgbTT7iQCbVY-gSEQz2OatQNCqPD2Q8zEeLPLHzk2QAppdHD6eXg6kH3INNV0owuOcflo0MQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499466,"updated":1613499466,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/77c12f44528b426497d99c52125ca081","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"9C5nkzx-NDGz-5SR05vlNyIAfKaqkNz7O4JqcF8ORrkMQXa4b7AFnWjYRKqAEJ1X-TePi49HIy2LTdhErT1IY3YMWqDAelPdt0JcPeg6tEPrOj_KEoP5CHVmFCtpQ_SEe8Jz6PkyiVlq_f73KZqKMPba6uj4M4wMZcs-pn2KWpjSdNPUhW84ROAvcqQ8JNzxlnPbA-HXUiJTNnIuLw6QzxpHzMPA9g8TzqqfIuFRwELhZOqa4Js1GFnpCYr2kGA0lHZ2XzbxsnzxJ06tJpK_h7pos6SaX_kFuniLjk3FYjKt86fzdR_j5XM46ynkyl1tau9VFAhtaKyAV_53QGlJ1Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613611568,"updated":1613611568,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'a552bcae-6783-4f80-a2cf-15ee59566422',
+  '9c1b32b3-abe2-4cc5-afa3-4b0268211975',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:46 GMT',
+  'Thu, 18 Feb 2021 01:26:08 GMT',
   'Content-Length',
-  '724'
+  '723'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_verifydata.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_verifydata.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'e49c836d-b864-4313-a797-509f7f4d3afb',
+  'f25f2853-54a4-45e3-8e51-a2cdd3349043',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,6 +45,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -56,25 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '6ffac599-7487-4784-ac52-4fedec4e2c00',
+  'd038511a-872d-4cef-8a15-8b162e445301',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:47 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:09 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:46 GMT',
-  'Content-Length',
-  '1315'
+  'Thu, 18 Feb 2021 01:26:09 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/95ddcca63e2a4b1189c19be984883e34","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"07hwIWJse28-Z0SGM2aI_cuPsNxPKVbgfWOZeyK7Hu8PeJ-dOYSZDcgpZ5qxkMJEiLHltB9o1y8XUFu1R-KbvawE__ScnHi1wlWqfEuhYUSrckNXEPj_g7VvncfBovFoKl5N5oj74HilBuzV7TeCmSqF8RbLFd2hSPbJKTdm24emjjEDRISh6x_n893dtv6RoXOG8LiuhlVjaKjvVL4XCdtCAxTpjElKQiKIlYJtf5JNUAByloF096lf5B5qLcaGT1O84uWGC7Tdni5L4L_ChpCktAgHtDRN04iVyQZM-ZFxBI5uQZbcGe5Y00ylKVsm7bnh-0BRxB-dQZx0LNwrPQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499467,"updated":1613499467,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/527bed8e17654cc887c9b9f6738a57ac","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sfw7TFkyF7lQZt_2EWqW3zfVomy5iH2Sans5HwpBu91-Bi6gwbY6TQ4Pomb8iAX8vGZk4FBKgQ-lpViAwcctjz_1x1Ky4pHh5eZrN47yxlrhc3_EH41th46cIa72uqq1W4JwZlugws_-QYe9-2ZkWW0EJT1b5hb3hjtbEWyOIV1VyTgIoKFItS92G8HXUE0nTW85Eaukw0DnvsJ_miXhoPnDYLewKNBRETRTvOCqpuPYM-nS6VETHOZe8u7Xm9muuJty1t9YMdo8jnzvZDBs664jPy0ZonBdC_NVClSMWDuXIXphU12G9DUaRSfpFOazaIdcgWg7q-NBOqrBrM4dyQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611569,"updated":1613611569,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '8842e961-9e8f-4878-8aec-94b574cdf0a0',
+  'b0739c9c-e974-4252-9ce6-8a6470fae4d3',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
+  'Thu, 18 Feb 2021 01:26:09 GMT',
   'Content-Length',
-  '724'
+  '726'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_wrapkey.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_algorithm/recording_throws_on_wrapkey.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'c93e0fda-5dff-46ed-ac95-a785c4fdb5d2',
+  '48209215-4ee5-41c6-b1fa-a3da9e89a042',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'ed4267ee-097d-4bf2-a931-a05076e12900',
+  '35d65785-dae1-4b37-a681-da4b38351d00',
   'x-ms-ests-server',
   '2.1.11496.6 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:46 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:09 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:45 GMT'
+  'Thu, 18 Feb 2021 01:26:08 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/b79b51469d8347dfb6aa8abd86a75411","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"pfvnfD2dZ-D5Vw5EuWOEg0Dk_Yj40qAyps2D8CAEUJ6WkmS0FVZlj5O18Zlha10oRNWoK_ANVVe1dNyWbFPidrvVWZHggfYMrLEmVvyKUMD4IGMuNEGRx5Oo61r5j-ewvXD627D8GzIHgVd0mWPxyaaDF9M1PfNYaQ4GLCUa8uoTwjztCDZWHHVnxcElxAyE6WHwp_M_SvSSHvRmFnN7_p9jjXOk-X2HpUY2k8L6gUGItvHPEJYXXWWyPZBhvT220zkPGYVF5muFYuDU0gpP_acY5_46RHEKs7ZR8IK52vNC0Aea6yRbt54mB70No9wOBJP9KPnNQMYlz0no2Wc5BQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499466,"updated":1613499466,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/bcd9e1affd9d4a0b8c7e91c150b3a578","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"2f7i8rm5TV38RSxxiZ4z3Fj1Tr9-rxgUzyrAL3iDHASBZ1-rw_J0a3J4swiSdtIxjlRHs3ZcAGjO9I_zds167sGHCL5-Wy4UDHOzWQF4bXCxupc_AZNbyV0_H_8SiDyjYlm9zNrwoDf80qDvHGVp76r4EkWofsJBoJ9UqGdpk1H8uoGvqBcacDAibbjMnIZqNM5bSvHvGadC9Lp6MnKRI7vYBb6EDQk17XKKv0pO9XW-auST3_GNtkYz0wcjTNLw8rMp1ZjrPceNpIEpugz9brjyM96797NzYBEakNJr_-2eF20h4yIpRuGvzDnMSxQ6h-iShMDRxiFA-xgXKhJ9IQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611569,"updated":1613611569,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'f196427a-b24c-461d-b839-d5f3bcce8563',
+  '38e18cee-9abf-4f04-9a1a-1298fb9843ed',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
+  'Thu, 18 Feb 2021 01:26:08 GMT',
   'Content-Length',
   '724'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_decrypt.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_decrypt.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3cf3058f-6f91-4f01-9731-89c03251055f',
+  '18a63c0e-321e-4493-a8d8-a98a4b84ceb5',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT'
+  'Thu, 18 Feb 2021 01:26:09 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,8 +45,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -58,23 +56,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '6ffac599-7487-4784-ac52-4fedfd4e2c00',
+  '173e2c82-2164-4429-a884-f9eeb09b1600',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11496.5 - EUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:47 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:09 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:46 GMT'
+  'Thu, 18 Feb 2021 01:26:09 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/707fea961bcc45c78c59f061abccc098","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wUnoaau6xC2upzfPyyss45HwyKpq3KnZ-kUetB_BOHQZj27U4cWuW9oGBW9sx_K2Y3XZO47e8-AjlvzsKOAyCcpkwnqBGEKca5KXEAfzNvE_nSxwCtdP0ftrU9BhwGW4RkmW27HsV8HO56OBnXBOn5GNYY784Alb4hITNYJnUzksm-SZoqr2pVfQYkbA3Q_7xL8VeH1DaJC_03z_HxK_fQEacfOxpVpfGurmaPhVoL27HZG_tuSzSOTSYBtZ7R3Cz3RyKAt38CjiR01wKX7h0F_H15k3qkLYEQmgaFdD_xntfsjLJcGhf7TCdH4bSmzOK_P1PFi3w4cCH11RARsjeQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499467,"updated":1613499467,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/e71b7b5cadea4e66b136f9c8f20b4b91","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vnT1noR4D1hAtSsZBeOkagKNrs6gwfs9epLwjPOiTtz7LZPPbxMZoH0NP2UJ2lvQEqi0p1pXmo8sHu7qy30-g_N6MXT0-Mh3e-1cnTgz4s9snwPYNUdT2gKN2sGJIgcJuCNNx-SfIvY-QQw0wipr9FfttZ6VHiJfsliNpCFMdoKJKJ9uPRNAFVE5cNrWqQcPCcjU3UQkMxUHjq8LydAEhFfY_Q44jTnYfp96OPkMoTZYI6bCEh6VusAdzvSirlc6yudSBMcB63a9vbWJ9SZNJ7Sl3bEEpiQs-IfHKzrGh2t8HNoQNkYrwKcFepYdkYXlclaJseLsRltlAibiqJ0HQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611569,"updated":1613611569,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '86ae8273-3ca5-4efa-9ae1-d99e48623aef',
+  '13aea837-ded0-4705-a2ec-47cb4bfaef54',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
+  'Thu, 18 Feb 2021 01:26:09 GMT',
   'Content-Length',
   '724'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_sign.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_sign.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '15a0c35b-127b-4cf1-a72a-771ea5206557',
+  '34b199c0-4182-4dff-a71b-590e60a42ed7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT'
+  'Thu, 18 Feb 2021 01:26:09 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,6 +45,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -56,25 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '10e905d8-91c2-4de8-91c9-d5eb8b354500',
+  '8487e8da-cfc4-4eed-9ba9-6bf190d04f01',
   'x-ms-ests-server',
   '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCgAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:10 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
-  'Content-Length',
-  '1315'
+  'Thu, 18 Feb 2021 01:26:10 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/1900f1f0d7084a3ab0344ec26d12384d","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"sky_Ia6YrmHm0OVqR8O1rq-vt5_HS6CGtcOL4BgZNsfFjZWUHIl2ZZrPXZeYQUDtV73QknF1cD8Bz_ajhvR6WKxrKDBJIm51YHsYAkjjEPidpA6OOTlBdrrHaKEisJZXus2I9QhQmve9sjyMwmOxTUxIBuzTiy8xxc6tkFTqWIBky3evVnC1Tj8F8ggdy_y4SG2XOCRlAVnYOk3V-ATm2Ecrr8zcJDhdk6hFy9fzHL11iy1YmY6KlfcXwJr18cg9tPIJVVjxttP8g_ETiZ9T8vGFv28sPJ4jKy0NCv7j-Bq_w5F3OOSqGvWJitSMOmboMQz4pKm92kOwSN2__OUrbQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499468,"updated":1613499468,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/f833f8d22ac34b7ba372d6458565aa0f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tl7JWy_PB-YOylok5eeiFSCu1RN2SH05HX16agTv_mz3kNLkm9oy5hDjGvaHUcVUK9_2676WAiqtJNT3Ov2ZxJ3O2unUZRAWkvZ3pgV7kkqBpDzjvGuTukXkvkb35BqZyDqnIBI4Z5GDfJRJu3kM_nV892KGDi2FmN8Bth02wBQMCis2TeGpdG6Y6-k3oiji764eO3nMbEJIZibd5PdXnukihfY_gUmGuWRLpF8nqWwbrSqqMtfSbG1BiC1dx-8r0ECev7idHPJhwFHY9-MEg-jWZ-cNOFkzqGaLPG2fcFffQnERmFH_kwrTw8znKp73lmtWoQfAtz6-H-D60EH9zQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611570,"updated":1613611570,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '7e777e41-ba5e-487d-993a-c934793e0187',
+  'a5f39469-9b31-4a68-9f69-68dfdde07a6d',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT',
+  'Thu, 18 Feb 2021 01:26:10 GMT',
   'Content-Length',
-  '725'
+  '724'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_signdata.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_signdata.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'c99226bf-1de5-490a-8c0e-0ea3d7f8ce42',
+  'a72719ea-13f3-4efa-ad9e-cc5e99fabfbc',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT'
+  'Thu, 18 Feb 2021 01:26:10 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,8 +45,6 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
-  'Content-Length',
-  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -58,23 +56,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'b4b49a55-ce7e-4f5d-90e2-26f593d9fd00',
+  '35d65785-dae1-4b37-a681-da4bb3351d00',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.6 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCgAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:11 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT'
+  'Thu, 18 Feb 2021 01:26:10 GMT',
+  'Content-Length',
+  '1315'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/fd1bf31328994f528722d4d2c514fcc4","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vLQCxRA3aRRbGODtv4U-LL08IaYtlkNV9I9jB9FkI1qCRZ-3uQqMGDH69PmfaQJoDFXy6pPiYTHh3-KQH4ng_VrfsxBUCP1Ig1yY3K1NLyJRvaCdyrhCe-UriWXHz5x-ZVGPaBmDlfgUl82AawIdz_Fx6yOhgi5HWpiZAa_CWprL1ibhZ5fqKWf_wCoN5xX7UPSbsphR9W4Chohvf01hMFWogTbwFDEY7wUgrNF_8aKzB1xE-HDczVEhkZgwPCg1LF1UMwGnK5hrwFgmyuXEKfefStQ3Wv2U5ttGY20PI88D7BecJwrt5hqwIAXXpWBMlmsnV5vnnJbBMg3RrYmR_Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613499468,"updated":1613499468,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/e82fa7456e524d4ca13e22bbe00fca62","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"6sbGO2JPgP4l-p5OIDcRcRRgfzGH_rk_RqiKCG1UuWLdQ9a8CzMr2b_qHFRrYQdak5-siMdrmDqA9L34YuHmaF-7X81-pCU8Nc1L-nFaYwH9ULbsp5WSUdEtB7rixZuHYhNjKjiPRu0ukw-v3Uf-0BWuZ-_8qRN4Wp5X3MQHjEZOz4AARTkANkVeVDhQM27xYxOpfaYZoWE9uXkm-E0pWN055_Zn3-R38xKSsv-p2w6VtKiOi_-CuJhjDkqvyqk7VYDcS7FjSXmFP4802AjD2T7xeXLFIHwegRiL0lAY5xbcRRscxzN7l3D1uaVtsyUl0AUy-pzGmvUFMtFrKF_gUQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611571,"updated":1613611571,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '7651702f-e61e-4059-9b60-ed53a7d70f15',
+  'c0ab364a-04d9-48e9-9238-6423c7490fd5',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT',
+  'Thu, 18 Feb 2021 01:26:10 GMT',
   'Content-Length',
   '725'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_unwrapkey.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_unwrapkey.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '0a64ab8b-81e4-466b-a25d-b9f7c401c367',
+  'dbe8776e-8e54-4466-8da4-02351aaa7f3a',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT'
+  'Thu, 18 Feb 2021 01:26:09 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,23 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '6ffac599-7487-4784-ac52-4fed194f2c00',
+  '7d7eaf67-31be-4265-86c5-1cb79a965001',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:47 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCQAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:10 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:46 GMT'
+  'Thu, 18 Feb 2021 01:26:09 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/112c977c382c4c6d9021462a2dfe8964","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"4yjEXSmRtII5u1ZEVtzauh8jA117Xq0lkxiASYwIM6Z21VX0Vs_DbyTZ40wUvoAnt6_xXBvyWpFtlck5puEGpc1blcyzNsxOSu3FRtn6ZCiKCOxfgJTBFb6Ii5Z4QxNcD24uHxzwOjs-VHezR4hp790MoG_bvEwL-sxEjmMZBbgNSTxD-2ry3bwn-9-lNwI1h-iPCX9EdHX7B4ad2Qsm4c5NdgvKxkAGRizL8hv3L26_CTGvPD8HihwrCc_urX60yOToAocFX1gwOwxEtbBIN_PSbdfNqEvP2MPwwEeZwReFrKHdMN6U50okNHv6Q1yvncROnAoi7DkBYSqflG58iQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499467,"updated":1613499467,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/9a443f6cbc2f4dd98c08a4861a3d0aab","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xOOwIgSerxe81tQOEml86T3bxOH7s5MirmoQ-TCLAfl8coP6708deqxfvVIhPs9gp6q1xLXhdhfrjkoQQ0be9eTxdiexdkgqENbrpM2AlzrUcGnvo730d7XSpcDYiojkPi5R55nRZBZwWfrbvRvYu59lu7uqwp0XKWjwUiVhKCgXN7K8IkOVy6LBG9g17PnAwEeZ4oqLwxVSdyCm4Gano-i9Yuvd5hC8VBsGDaSPydUJkeBRyLg44omPwKgmQoz8gk_kjWWXJyJ-9fTZL7nAX3Eq8PTfHKsycUDgBF6rniqlXyaiZrSniCc6Zt2N3HKPm9xWmkrZlxoOngKfsKuwjQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611570,"updated":1613611570,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '66eb31dd-f0aa-484c-8005-ce92c2212e45',
+  'b9e300ed-5955-43fe-a1b0-cdaf0829d0d1',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
+  'Thu, 18 Feb 2021 01:26:09 GMT',
   'Content-Length',
   '724'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_verify.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/local_cryptography_public_tests_when_using_a_local_jsonwebtoken_when_using_an_unsupported_operation/recording_throws_on_verify.js
@@ -23,7 +23,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  '3a7afded-17d2-4002-bcee-c7c17c28aae8',
+  '5c08f287-ccb1-4426-b3d9-869ad6d103b7',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -35,7 +35,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT'
+  'Thu, 18 Feb 2021 01:26:10 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,6 +45,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -56,25 +58,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'ae3f7834-b414-4cdd-9f0f-84dc5fddfd00',
+  '8487e8da-cfc4-4eed-9ba9-6bf199d04f01',
   'x-ms-ests-server',
-  '2.1.11496.5 - SCUS ProdSlices',
+  '2.1.11496.5 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDFAAAAIACvtcOAAAA; expires=Thu, 18-Mar-2021 18:17:48 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ag8YnLS1fBhKslvpke6qkmYA4qsDCgAAAPO4v9cOAAAA; expires=Sat, 20-Mar-2021 01:26:10 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:17:47 GMT',
-  'Content-Length',
-  '1315'
+  'Thu, 18 Feb 2021 01:26:10 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/localCryptoKeyName-beforeeachhook-/create', {"kty":"RSA"})
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/dc60e7ae31e4433ea1de9e7a616a16d8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"pHPDtxBmNjjebxoTakANWA1jWci4Qur9V91NmMyv0zAjMfoQw3Fe9XmcniqUfAIHl7fjPfRbCRiwYgILgHSZxd1A0UbZmqve6goix_RRbYIlUQT-wvC-NOlYshpx7lLb-qgAffEXMia6_UN-hrtDGdNzhfvAVsttvH7tgtJjy0LNbcRHAV7uIEheBVn5Du_7nzJyuOPZ7y1DNqElPBYRrQx5fFjNKKhyBYSjJPeOJ3e2Z4FU1lK6rmo4NsQw4vIG6o0WLUm1Aw9EKzKfN6qQ6b54sbdlM61t7GYR-nfsspcC_4B4r2F548OVkY1i2WQMSO8hn_3ze3uC31DdyQNJvQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613499468,"updated":1613499468,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/localCryptoKeyName-beforeeachhook-/49ce90eea0f44443a2463641bcb6e550","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"8UUfykdvCn3Jljg8aolUVdKSKCQzFDyyoPsZToZ7rrEeDWg3xbV2KRlsRkZDgYe3IR7q2sdGX1jfaMj0i7CXUfkEZxVc2YvRtvKHaMkAedin4yHjL1-ZXXWwM-uIaloDz0zY-S5daAFo-HyYJ6uxizy0Z-OuLMYPqCeMfzx2Cg9Vk-vIglP1f57sVg_kNcDfrJY3SVPC7jPwHF6fFUUj1_r97TJPU59krqoG4KIUCC8zXGIG3ptpkWZJHyfAtV9SCqm7z9jZga59N2jLZwstIUqMMKORH0GjIR3oYz2GJ7fzFen1xDfLTkPnccNLig3oGNcfeTTZcb5fGHfoD-ebQQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613611570,"updated":1613611570,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -86,7 +86,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'x-ms-keyvault-region',
   'westus2',
   'x-ms-request-id',
-  'c1898f38-5a16-4048-917b-9b1a8b97c933',
+  'df0dfd95-9f6d-48a0-8e52-9f9308a23e51',
   'x-ms-keyvault-service-version',
   '1.2.164.2',
   'x-ms-keyvault-network-info',
@@ -98,7 +98,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:17:48 GMT',
+  'Thu, 18 Feb 2021 01:26:10 GMT',
   'Content-Length',
-  '724'
+  '725'
 ]);

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -114,9 +114,12 @@ export interface EncryptOptions extends KeyOperationsOptions {
 
 // @public
 export interface EncryptResult {
+    readonly additionalAuthenticatedData?: Uint8Array;
     algorithm: EncryptionAlgorithm;
+    iv?: Uint8Array;
     keyID?: string;
     result: Uint8Array;
+    tag?: Uint8Array;
 }
 
 // @public
@@ -261,35 +264,20 @@ export const enum KnownDeletionRecoveryLevel {
 
 // @public
 export const enum KnownEncryptionAlgorithms {
-    // (undocumented)
     A128CBC = "A128CBC",
-    // (undocumented)
     A128Cbcpad = "A128CBCPAD",
-    // (undocumented)
     A128GCM = "A128GCM",
-    // (undocumented)
     A128KW = "A128KW",
-    // (undocumented)
     A192CBC = "A192CBC",
-    // (undocumented)
     A192Cbcpad = "A192CBCPAD",
-    // (undocumented)
     A192GCM = "A192GCM",
-    // (undocumented)
     A192KW = "A192KW",
-    // (undocumented)
     A256CBC = "A256CBC",
-    // (undocumented)
     A256Cbcpad = "A256CBCPAD",
-    // (undocumented)
     A256GCM = "A256GCM",
-    // (undocumented)
     A256KW = "A256KW",
-    // (undocumented)
     RSA15 = "RSA1_5",
-    // (undocumented)
     RSAOaep = "RSA-OAEP",
-    // (undocumented)
     RSAOaep256 = "RSA-OAEP-256"
 }
 
@@ -303,19 +291,12 @@ export const enum KnownKeyCurveNames {
 
 // @public
 export const enum KnownKeyOperations {
-    // (undocumented)
     Decrypt = "decrypt",
-    // (undocumented)
     Encrypt = "encrypt",
-    // (undocumented)
     Import = "import",
-    // (undocumented)
     Sign = "sign",
-    // (undocumented)
     UnwrapKey = "unwrapKey",
-    // (undocumented)
     Verify = "verify",
-    // (undocumented)
     WrapKey = "wrapKey"
 }
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -261,20 +261,35 @@ export const enum KnownDeletionRecoveryLevel {
 
 // @public
 export const enum KnownEncryptionAlgorithms {
+    // (undocumented)
     A128CBC = "A128CBC",
+    // (undocumented)
     A128Cbcpad = "A128CBCPAD",
+    // (undocumented)
     A128GCM = "A128GCM",
+    // (undocumented)
     A128KW = "A128KW",
+    // (undocumented)
     A192CBC = "A192CBC",
+    // (undocumented)
     A192Cbcpad = "A192CBCPAD",
+    // (undocumented)
     A192GCM = "A192GCM",
+    // (undocumented)
     A192KW = "A192KW",
+    // (undocumented)
     A256CBC = "A256CBC",
+    // (undocumented)
     A256Cbcpad = "A256CBCPAD",
+    // (undocumented)
     A256GCM = "A256GCM",
+    // (undocumented)
     A256KW = "A256KW",
+    // (undocumented)
     RSA15 = "RSA1_5",
+    // (undocumented)
     RSAOaep = "RSA-OAEP",
+    // (undocumented)
     RSAOaep256 = "RSA-OAEP-256"
 }
 
@@ -288,13 +303,19 @@ export const enum KnownKeyCurveNames {
 
 // @public
 export const enum KnownKeyOperations {
+    // (undocumented)
     Decrypt = "decrypt",
+    // (undocumented)
     Encrypt = "encrypt",
-    Export = "export",
+    // (undocumented)
     Import = "import",
+    // (undocumented)
     Sign = "sign",
+    // (undocumented)
     UnwrapKey = "unwrapKey",
+    // (undocumented)
     Verify = "verify",
+    // (undocumented)
     WrapKey = "wrapKey"
 }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -135,7 +135,8 @@ export class CryptographyClient {
       }
       return this.concreteClient.client.encrypt(
         algorithm as LocalSupportedAlgorithmName,
-        plaintext
+        plaintext,
+        options
       );
     }
   }

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -48,6 +48,19 @@ export interface EncryptResult {
    * The ID of the Key Vault Key used to encrypt the data.
    */
   keyID?: string;
+  /**
+   * Initialization vector for symmetric algorithms.
+   */
+  iv?: Uint8Array;
+  /**
+   * Additional data to authenticate but not encrypt/decrypt when using authenticated crypto
+   * algorithms.
+   */
+  readonly additionalAuthenticatedData?: Uint8Array;
+  /**
+   * The tag to authenticate when performing decryption with an authenticated algorithm.
+   */
+  tag?: Uint8Array;
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -41,7 +41,6 @@ import {
   KeyVaultClientWrapKeyResponse,
   KeyVaultClientUnwrapKeyOptionalParams,
   KeyVaultClientUnwrapKeyResponse,
-  KeyVaultClientExportKeyResponse,
   KeyVaultClientGetDeletedKeysOptionalParams,
   KeyVaultClientGetDeletedKeysResponse,
   KeyVaultClientGetDeletedKeyResponse,
@@ -524,35 +523,6 @@ export class KeyVaultClient extends KeyVaultClientContext {
   }
 
   /**
-   * The export key operation is applicable to all key types. The target key must be marked exportable.
-   * This operation requires the keys/export permission.
-   * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
-   * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
-   * @param environment The target environment assertion.
-   * @param options The options parameters.
-   */
-  exportKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    environment: string,
-    options?: coreHttp.OperationOptions
-  ): Promise<KeyVaultClientExportKeyResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      vaultBaseUrl,
-      keyName,
-      keyVersion,
-      environment,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      exportKeyOperationSpec
-    ) as Promise<KeyVaultClientExportKeyResponse>;
-  }
-
-  /**
    * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public
    * part of a deleted key. This operation includes deletion-specific information. The Get Deleted Keys
    * operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on
@@ -739,8 +709,7 @@ const createKeyOperationSpec: coreHttp.OperationSpec = {
       keyOps: ["options", "keyOps"],
       keyAttributes: ["options", "keyAttributes"],
       tags: ["options", "tags"],
-      curve: ["options", "curve"],
-      releasePolicy: ["options", "releasePolicy"]
+      curve: ["options", "curve"]
     },
     mapper: Mappers.KeyCreateParameters
   },
@@ -766,8 +735,7 @@ const importKeyOperationSpec: coreHttp.OperationSpec = {
       hsm: ["options", "hsm"],
       key: ["key"],
       keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"],
-      releasePolicy: ["options", "releasePolicy"]
+      tags: ["options", "tags"]
     },
     mapper: Mappers.KeyImportParameters
   },
@@ -808,8 +776,7 @@ const updateKeyOperationSpec: coreHttp.OperationSpec = {
     parameterPath: {
       keyOps: ["options", "keyOps"],
       keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"],
-      releasePolicy: ["options", "releasePolicy"]
+      tags: ["options", "tags"]
     },
     mapper: Mappers.KeyUpdateParameters
   },
@@ -1079,31 +1046,6 @@ const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
       tag: ["options", "tag"]
     },
     mapper: Mappers.KeyOperationsParameters
-  },
-  queryParameters: [Parameters.apiVersion],
-  urlParameters: [
-    Parameters.vaultBaseUrl,
-    Parameters.keyName1,
-    Parameters.keyVersion
-  ],
-  headerParameters: [Parameters.contentType, Parameters.accept],
-  mediaType: "json",
-  serializer
-};
-const exportKeyOperationSpec: coreHttp.OperationSpec = {
-  path: "/keys/{key-name}/{key-version}/export",
-  httpMethod: "POST",
-  responses: {
-    200: {
-      bodyMapper: Mappers.KeyBundle
-    },
-    default: {
-      bodyMapper: Mappers.KeyVaultError
-    }
-  },
-  requestBody: {
-    parameterPath: { environment: ["environment"] },
-    mapper: Mappers.KeyExportParameters
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -23,8 +23,6 @@ export interface KeyCreateParameters {
   tags?: { [propertyName: string]: string };
   /** Elliptic curve name. For valid values, see JsonWebKeyCurveName. */
   curve?: JsonWebKeyCurveName;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The object attributes managed by the KeyVault service. */
@@ -47,26 +45,6 @@ export interface Attributes {
   readonly updated?: Date;
 }
 
-export interface KeyReleasePolicy {
-  /** key release policy version */
-  version?: KeyReleasePolicyVersion;
-  anyOf?: KeyReleaseAuthority[];
-}
-
-export interface KeyReleaseAuthority {
-  /** Base URL of the attestation service. */
-  authorityURL?: string;
-  allOf?: KeyReleaseCondition[];
-}
-
-export interface KeyReleaseCondition {
-  /** claim type name */
-  claimType?: string;
-  /** condition to test */
-  claimCondition?: KeyReleaseConditionCondition;
-  value?: string;
-}
-
 /** A KeyBundle consisting of a WebKey plus its attributes. */
 export interface KeyBundle {
   /** The Json web key. */
@@ -80,8 +58,6 @@ export interface KeyBundle {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly managed?: boolean;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18 */
@@ -125,7 +101,7 @@ export interface KeyVaultError {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly error?: ErrorModel;
+  readonly error?: ErrorModel | null;
 }
 
 /** The key vault server error. */
@@ -144,7 +120,7 @@ export interface ErrorModel {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly innerError?: ErrorModel;
+  readonly innerError?: ErrorModel | null;
 }
 
 /** The key import parameters. */
@@ -157,8 +133,6 @@ export interface KeyImportParameters {
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The key update parameters. */
@@ -169,8 +143,6 @@ export interface KeyUpdateParameters {
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The key list result. */
@@ -239,6 +211,12 @@ export interface KeyOperationResult {
   readonly kid?: string;
   /** NOTE: This property will not be serialized. It can only be populated by the server. */
   readonly result?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly iv?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly authenticationTag?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly additionalAuthenticatedData?: Uint8Array;
 }
 
 /** The key operations parameters. */
@@ -267,12 +245,6 @@ export interface KeyVerifyResult {
   readonly value?: boolean;
 }
 
-/** The export key parameters. */
-export interface KeyExportParameters {
-  /** The target environment assertion. */
-  environment: string;
-}
-
 /** A list of keys that have been deleted in this vault. */
 export interface DeletedKeyListResult {
   /**
@@ -289,8 +261,6 @@ export interface DeletedKeyListResult {
 
 /** Properties of the key pair backing a certificate. */
 export interface KeyProperties {
-  /** Indicates if the private key can be exported. */
-  exportable?: boolean;
   /** The type of key pair to be used for the certificate. */
   keyType?: JsonWebKeyType;
   /** The key size in bits. For example: 2048, 3072, or 4096 for RSA. */
@@ -313,8 +283,6 @@ export type KeyAttributes = Attributes & {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly recoveryLevel?: DeletionRecoveryLevel;
-  /** Indicates if the private key can be exported. */
-  exportable?: boolean;
 };
 
 /** A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info */
@@ -396,22 +364,13 @@ export type JsonWebKeyType = string;
 
 /** Known values of {@link JsonWebKeyOperation} that the service accepts. */
 export const enum KnownJsonWebKeyOperation {
-  /** Key operation - encrypt */
   Encrypt = "encrypt",
-  /** Key operation - decrypt */
   Decrypt = "decrypt",
-  /** Key operation - sign */
   Sign = "sign",
-  /** Key operation - verify */
   Verify = "verify",
-  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
-  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
-  /** Key operation - import */
-  Import = "import",
-  /** Key operation - export */
-  Export = "export"
+  Import = "import"
 }
 
 /**
@@ -425,8 +384,7 @@ export const enum KnownJsonWebKeyOperation {
  * **verify** \
  * **wrapKey** \
  * **unwrapKey** \
- * **import** \
- * **export**
+ * **import**
  */
 export type JsonWebKeyOperation = string;
 
@@ -487,67 +445,22 @@ export const enum KnownJsonWebKeyCurveName {
  */
 export type JsonWebKeyCurveName = string;
 
-/** Known values of {@link KeyReleasePolicyVersion} that the service accepts. */
-export const enum KnownKeyReleasePolicyVersion {
-  /** Schema version 0.2 */
-  Zero2 = "0.2"
-}
-
-/**
- * Defines values for KeyReleasePolicyVersion. \
- * {@link KnownKeyReleasePolicyVersion} can be used interchangeably with KeyReleasePolicyVersion,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **0.2**: Schema version 0.2
- */
-export type KeyReleasePolicyVersion = string;
-
-/** Known values of {@link KeyReleaseConditionCondition} that the service accepts. */
-export const enum KnownKeyReleaseConditionCondition {
-  /** equals comparison. */
-  Equals = "equals"
-}
-
-/**
- * Defines values for KeyReleaseConditionCondition. \
- * {@link KnownKeyReleaseConditionCondition} can be used interchangeably with KeyReleaseConditionCondition,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **equals**: equals comparison.
- */
-export type KeyReleaseConditionCondition = string;
-
 /** Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts. */
 export const enum KnownJsonWebKeyEncryptionAlgorithm {
-  /** Encryption Algorithm - RSA-OAEP */
   RSAOaep = "RSA-OAEP",
-  /** Encryption Algorithm - RSA-OAEP-256 */
   RSAOaep256 = "RSA-OAEP-256",
-  /** Encryption Algorithm - RSA1_5 */
   RSA15 = "RSA1_5",
-  /** Encryption Algorithm - A128GCM */
   A128GCM = "A128GCM",
-  /** Encryption Algorithm - A192GCM */
   A192GCM = "A192GCM",
-  /** Encryption Algorithm - A256GCM */
   A256GCM = "A256GCM",
-  /** Encryption Algorithm - A128KW */
   A128KW = "A128KW",
-  /** Encryption Algorithm - A192KW */
   A192KW = "A192KW",
-  /** Encryption Algorithm - A256KW */
   A256KW = "A256KW",
-  /** Encryption Algorithm - A128CBC */
   A128CBC = "A128CBC",
-  /** Encryption Algorithm - A192CBC */
   A192CBC = "A192CBC",
-  /** Encryption Algorithm - A256CBC */
   A256CBC = "A256CBC",
-  /** Encryption Algorithm - A128CBCPAD */
   A128Cbcpad = "A128CBCPAD",
-  /** Encryption Algorithm - A192CBCPAD */
   A192Cbcpad = "A192CBCPAD",
-  /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD"
 }
 
@@ -634,8 +547,6 @@ export interface KeyVaultClientCreateKeyOptionalParams
   tags?: { [propertyName: string]: string };
   /** Elliptic curve name. For valid values, see JsonWebKeyCurveName. */
   curve?: JsonWebKeyCurveName;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the createKey operation. */
@@ -659,8 +570,6 @@ export interface KeyVaultClientImportKeyOptionalParams
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the importKey operation. */
@@ -696,8 +605,6 @@ export interface KeyVaultClientUpdateKeyOptionalParams
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the updateKey operation. */
@@ -899,18 +806,6 @@ export type KeyVaultClientUnwrapKeyResponse = KeyOperationResult & {
 
     /** The response body as parsed JSON or XML */
     parsedBody: KeyOperationResult;
-  };
-};
-
-/** Contains response data for the exportKey operation. */
-export type KeyVaultClientExportKeyResponse = KeyBundle & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The response body as text (string format) */
-    bodyAsText: string;
-
-    /** The response body as parsed JSON or XML */
-    parsedBody: KeyBundle;
   };
 };
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -364,12 +364,19 @@ export type JsonWebKeyType = string;
 
 /** Known values of {@link JsonWebKeyOperation} that the service accepts. */
 export const enum KnownJsonWebKeyOperation {
+  /** Key operation - encrypt */
   Encrypt = "encrypt",
+  /** Key operation - decrypt */
   Decrypt = "decrypt",
+  /** Key operation - sign */
   Sign = "sign",
+  /** Key operation - verify */
   Verify = "verify",
+  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
+  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
+  /** Key operation - import */
   Import = "import"
 }
 
@@ -447,20 +454,35 @@ export type JsonWebKeyCurveName = string;
 
 /** Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts. */
 export const enum KnownJsonWebKeyEncryptionAlgorithm {
+  /** Encryption Algorithm - RSA-OAEP */
   RSAOaep = "RSA-OAEP",
+  /** Encryption Algorithm - RSA-OAEP-256 */
   RSAOaep256 = "RSA-OAEP-256",
+  /** Encryption Algorithm - RSA1_5 */
   RSA15 = "RSA1_5",
+  /** Encryption Algorithm - A128GCM */
   A128GCM = "A128GCM",
+  /** Encryption Algorithm - A192GCM */
   A192GCM = "A192GCM",
+  /** Encryption Algorithm - A256GCM */
   A256GCM = "A256GCM",
+  /** Encryption Algorithm - A128KW */
   A128KW = "A128KW",
+  /** Encryption Algorithm - A192KW */
   A192KW = "A192KW",
+  /** Encryption Algorithm - A256KW */
   A256KW = "A256KW",
+  /** Encryption Algorithm - A128CBC */
   A128CBC = "A128CBC",
+  /** Encryption Algorithm - A192CBC */
   A192CBC = "A192CBC",
+  /** Encryption Algorithm - A256CBC */
   A256CBC = "A256CBC",
+  /** Encryption Algorithm - A128CBCPAD */
   A128Cbcpad = "A128CBCPAD",
+  /** Encryption Algorithm - A192CBCPAD */
   A192Cbcpad = "A192CBCPAD",
+  /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD"
 }
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
@@ -62,13 +62,6 @@ export const KeyCreateParameters: coreHttp.CompositeMapper = {
         type: {
           name: "String"
         }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
-        }
       }
     }
   }
@@ -115,93 +108,6 @@ export const Attributes: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyReleasePolicy: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleasePolicy",
-    modelProperties: {
-      version: {
-        serializedName: "version",
-        type: {
-          name: "String"
-        }
-      },
-      anyOf: {
-        serializedName: "anyOf",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "KeyReleaseAuthority"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const KeyReleaseAuthority: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleaseAuthority",
-    modelProperties: {
-      authorityURL: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "authority",
-        type: {
-          name: "String"
-        }
-      },
-      allOf: {
-        serializedName: "allOf",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "KeyReleaseCondition"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const KeyReleaseCondition: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleaseCondition",
-    modelProperties: {
-      claimType: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "claim",
-        type: {
-          name: "String"
-        }
-      },
-      claimCondition: {
-        serializedName: "condition",
-        type: {
-          name: "String"
-        }
-      },
-      value: {
-        serializedName: "value",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const KeyBundle: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
@@ -233,13 +139,6 @@ export const KeyBundle: coreHttp.CompositeMapper = {
         readOnly: true,
         type: {
           name: "Boolean"
-        }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
         }
       }
     }
@@ -433,13 +332,6 @@ export const KeyImportParameters: coreHttp.CompositeMapper = {
           name: "Dictionary",
           value: { type: { name: "String" } }
         }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
-        }
       }
     }
   }
@@ -473,13 +365,6 @@ export const KeyUpdateParameters: coreHttp.CompositeMapper = {
         type: {
           name: "Dictionary",
           value: { type: { name: "String" } }
-        }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
         }
       }
     }
@@ -642,6 +527,27 @@ export const KeyOperationResult: coreHttp.CompositeMapper = {
         type: {
           name: "Base64Url"
         }
+      },
+      iv: {
+        serializedName: "iv",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
+      },
+      authenticationTag: {
+        serializedName: "tag",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
+      },
+      additionalAuthenticatedData: {
+        serializedName: "aad",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
       }
     }
   }
@@ -716,25 +622,6 @@ export const KeyVerifyResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyExportParameters: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyExportParameters",
-    modelProperties: {
-      environment: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "env",
-        required: true,
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const DeletedKeyListResult: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
@@ -769,12 +656,6 @@ export const KeyProperties: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "KeyProperties",
     modelProperties: {
-      exportable: {
-        serializedName: "exportable",
-        type: {
-          name: "Boolean"
-        }
-      },
       keyType: {
         serializedName: "kty",
         type: {
@@ -821,12 +702,6 @@ export const KeyAttributes: coreHttp.CompositeMapper = {
         readOnly: true,
         type: {
           name: "String"
-        }
-      },
-      exportable: {
-        serializedName: "exportable",
-        type: {
-          name: "Boolean"
         }
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
@@ -18,8 +18,7 @@ import {
   KeyRestoreParameters as KeyRestoreParametersMapper,
   KeyOperationsParameters as KeyOperationsParametersMapper,
   KeySignParameters as KeySignParametersMapper,
-  KeyVerifyParameters as KeyVerifyParametersMapper,
-  KeyExportParameters as KeyExportParametersMapper
+  KeyVerifyParameters as KeyVerifyParametersMapper
 } from "../models/mappers";
 
 export const contentType: OperationParameter = {
@@ -81,11 +80,6 @@ export const curve: OperationParameter = {
   mapper: KeyCreateParametersMapper
 };
 
-export const releasePolicy: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
-  mapper: KeyCreateParametersMapper
-};
-
 export const vaultBaseUrl: OperationURLParameter = {
   parameterPath: "vaultBaseUrl",
   mapper: {
@@ -143,11 +137,6 @@ export const tags1: OperationParameter = {
   mapper: KeyImportParametersMapper
 };
 
-export const releasePolicy1: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
-  mapper: KeyImportParametersMapper
-};
-
 export const keyName1: OperationURLParameter = {
   parameterPath: "keyName",
   mapper: {
@@ -171,11 +160,6 @@ export const keyAttributes2: OperationParameter = {
 
 export const tags2: OperationParameter = {
   parameterPath: ["options", "tags"],
-  mapper: KeyUpdateParametersMapper
-};
-
-export const releasePolicy2: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
   mapper: KeyUpdateParametersMapper
 };
 
@@ -257,11 +241,6 @@ export const digest: OperationParameter = {
 export const signature: OperationParameter = {
   parameterPath: "signature",
   mapper: KeyVerifyParametersMapper
-};
-
-export const environment: OperationParameter = {
-  parameterPath: "environment",
-  mapper: KeyExportParametersMapper
 };
 
 export const nextLink: OperationURLParameter = {

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -16,7 +16,7 @@ import {
   EncryptResult
 } from "./cryptographyClientModels";
 import { runOperation } from "./localCryptography/runOperation";
-import { EncryptionAlgorithm } from ".";
+import { EncryptionAlgorithm, EncryptOptions } from ".";
 
 /**
  * A client used to perform local cryptographic operations with JSON Web Keys.
@@ -40,7 +40,8 @@ export class LocalCryptographyClient {
    */
   public async encrypt(
     algorithm: LocalSupportedAlgorithmName,
-    plaintext: Uint8Array
+    plaintext: Uint8Array,
+    options: EncryptOptions
   ): Promise<EncryptResult> {
     if (!isNode) {
       throw new LocalCryptographyUnsupportedError("Encryption is only available in NodeJS");
@@ -52,7 +53,14 @@ export class LocalCryptographyClient {
       Buffer.from(plaintext)
     )) as Buffer;
     const keyID = this.key.kid;
-    return { result, algorithm: algorithm as EncryptionAlgorithm, keyID };
+    return {
+      result,
+      algorithm: algorithm as EncryptionAlgorithm,
+      keyID,
+      additionalAuthenticatedData: options.additionalAuthenticatedData,
+      iv: options.iv,
+      tag: options.tag
+    };
   }
 
   /**

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -11,7 +11,7 @@ azure-arm: false
 generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f9caf92527ccff06c5b66380e6f2b4f50f5e82b3/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/612f78afd05911d0e1e82ba72b41781f655dbffb/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -14,7 +14,7 @@ import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 
-describe.only("CryptographyClient (all decrypts happen remotely)", () => {
+describe("CryptographyClient (all decrypts happen remotely)", () => {
   const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;
   let client: KeyClient;
   let testClient: TestClient;
@@ -60,7 +60,7 @@ describe.only("CryptographyClient (all decrypts happen remotely)", () => {
       assert.equal(text, decryptedText);
     });
 
-    it.only("encrypt with additional parameters returns them", async function() {
+    it("encrypt with additional parameters returns them", async function() {
       const text = this.test!.title;
       const encryptResult = await cryptoClient.encrypt("RSA1_5", stringToUint8Array(text), {
         iv: stringToUint8Array("iv"),

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -14,7 +14,7 @@ import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 
-describe("CryptographyClient (all decrypts happen remotely)", () => {
+describe.only("CryptographyClient (all decrypts happen remotely)", () => {
   const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;
   let client: KeyClient;
   let testClient: TestClient;
@@ -58,6 +58,19 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const decryptResult = await cryptoClient.decrypt("RSA1_5", encryptResult.result);
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
+    });
+
+    it.only("encrypt with additional parameters returns them", async function() {
+      const text = this.test!.title;
+      const encryptResult = await cryptoClient.encrypt("RSA1_5", stringToUint8Array(text), {
+        iv: stringToUint8Array("iv"),
+        tag: stringToUint8Array("tag"),
+        additionalAuthenticatedData: stringToUint8Array("aad")
+      });
+      console.log("encryptResult", encryptResult);
+      assert.equal(uint8ArrayToString(encryptResult.iv!), "iv");
+      assert.equal(uint8ArrayToString(encryptResult.tag!), "tag");
+      assert.equal(uint8ArrayToString(encryptResult.additionalAuthenticatedData!), "aad");
     });
 
     it("manually encrypt locally and decrypt remotely, both with RSA1_5", async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -144,6 +144,7 @@ describe("Local cryptography public tests", () => {
   });
 
   it("encrypt & decrypt RSA1_5", async function() {
+    recorder.skip(undefined, "Local encryption can't be tested on playback");
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const keyVaultKey = await client.createKey(keyName, "RSA");
     const cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
@@ -157,6 +158,7 @@ describe("Local cryptography public tests", () => {
   });
 
   it("encrypt & decrypt RSA-OAEP", async function() {
+    recorder.skip(undefined, "Local encryption can't be tested on playback");
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const keyVaultKey = await client.createKey(keyName, "RSA");
     const cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
@@ -170,6 +172,7 @@ describe("Local cryptography public tests", () => {
   });
 
   it("wrapKey & unwrapKey RSA1_5", async function() {
+    recorder.skip(undefined, "Local encryption can't be tested on playback");
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const keyVaultKey = await client.createKey(keyName, "RSA");
     const cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
@@ -186,6 +189,7 @@ describe("Local cryptography public tests", () => {
   });
 
   it("wrapKey & unwrapKey RSA-OAEP", async function() {
+    recorder.skip(undefined, "Local encryption can't be tested on playback");
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const keyVaultKey = await client.createKey(keyName, "RSA");
     const cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);


### PR DESCRIPTION
## What

- Regenerate from latest swagger file for KV Keys
- Ensure that additionalAuthenticatedData, iv, and tag are properly populated in EncryptResult

## Why

- For AES decryption the user must pass these parameters back from the encryption result
- These all come from the service (with the user supplying defaults) so we must return them as part of the result
- These are new in the swagger as well, so were not available when this was last code-gen'd

## Todo

- [ ] changelog

Fixes #13843