### PR TITLE
[core-https] Hide client constructors

### DIFF
--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.2.0",
-    "@azure/core-https": "1.0.0-beta.1",
+    "@azure/core-https": "1.0.0-beta.2",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"

--- a/sdk/core/core-client/src/httpClientCache.ts
+++ b/sdk/core/core-client/src/httpClientCache.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { HttpsClient, DefaultHttpsClient } from "@azure/core-https";
+import { HttpsClient, createDefaultHttpsClient } from "@azure/core-https";
 
 let cachedHttpsClient: HttpsClient | undefined;
 
 export function getCachedDefaultHttpsClient(): HttpsClient {
   if (!cachedHttpsClient) {
-    cachedHttpsClient = new DefaultHttpsClient();
+    cachedHttpsClient = createDefaultHttpsClient();
   }
 
   return cachedHttpsClient;

--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-beta.2 (Unreleased)
 
+- Changed from exposing `DefaultHttpsClient` as a class directly, to providing `createDefaultHttpsClient()` to instantiate the appropriate runtime class.
+
 ## 1.0.0-beta.1 (2021-02-04)
 
 - Changes from `core-http`:

--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -30,6 +30,9 @@ export interface BearerTokenAuthenticationPolicyOptions {
 }
 
 // @public
+export function createDefaultHttpsClient(): HttpsClient;
+
+// @public
 export function createEmptyPipeline(): Pipeline;
 
 // @public
@@ -46,11 +49,6 @@ export function decompressResponsePolicy(): PipelinePolicy;
 
 // @public
 export const decompressResponsePolicyName = "decompressResponsePolicy";
-
-// @public
-export class DefaultHttpsClient implements HttpsClient {
-    sendRequest(request: PipelineRequest): Promise<PipelineResponse>;
-}
 
 // @public
 export function exponentialRetryPolicy(options?: ExponentialRetryPolicyOptions): PipelinePolicy;

--- a/sdk/core/core-https/src/accessTokenCache.ts
+++ b/sdk/core/core-https/src/accessTokenCache.ts
@@ -31,6 +31,7 @@ export interface AccessTokenCache {
  * Provides an AccessTokenCache implementation which clears
  * the cached AccessToken's after the expiresOnTimestamp has
  * passed.
+ * @internal
  */
 export class ExpiringAccessTokenCache implements AccessTokenCache {
   private tokenRefreshBufferMs: number;

--- a/sdk/core/core-https/src/defaultHttpsClient.browser.ts
+++ b/sdk/core/core-https/src/defaultHttpsClient.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { XhrHttpsClient as DefaultHttpsClient } from "./xhrHttpsClient";
+export { createXhrHttpsClient as createDefaultHttpsClient } from "./xhrHttpsClient";

--- a/sdk/core/core-https/src/defaultHttpsClient.ts
+++ b/sdk/core/core-https/src/defaultHttpsClient.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { NodeHttpsClient as DefaultHttpsClient } from "./nodeHttpsClient";
+export { createNodeHttpsClient as createDefaultHttpsClient } from "./nodeHttpsClient";

--- a/sdk/core/core-https/src/index.ts
+++ b/sdk/core/core-https/src/index.ts
@@ -25,7 +25,7 @@ export {
   PipelineOptions,
   createPipelineFromOptions
 } from "./pipeline";
-export { DefaultHttpsClient } from "./defaultHttpsClient";
+export { createDefaultHttpsClient } from "./defaultHttpsClient";
 export { createHttpHeaders } from "./httpHeaders";
 export { createPipelineRequest, PipelineRequestOptions } from "./pipelineRequest";
 export { RestError, RestErrorOptions } from "./restError";

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -60,8 +60,9 @@ class ReportTransform extends Transform {
 
 /**
  * A HttpsClient implementation that uses Node's "https" module to send HTTPS requests.
+ * @internal
  */
-export class NodeHttpsClient implements HttpsClient {
+class NodeHttpsClient implements HttpsClient {
   private keepAliveAgent?: https.Agent;
   private proxyAgent?: https.Agent;
 
@@ -305,4 +306,11 @@ function getBodyLength(body: RequestBodyType): number | null {
   } else {
     return null;
   }
+}
+
+/**
+ * Create a new HttpsClient instance for the NodeJS environment.
+ */
+export function createNodeHttpsClient(): HttpsClient {
+  return new NodeHttpsClient();
 }

--- a/sdk/core/core-https/src/xhrHttpsClient.ts
+++ b/sdk/core/core-https/src/xhrHttpsClient.ts
@@ -20,8 +20,9 @@ function isReadableStream(body: any): body is NodeJS.ReadableStream {
 
 /**
  * A HttpsClient implementation that uses XMLHttpRequest to send HTTPS requests.
+ * @internal
  */
-export class XhrHttpsClient implements HttpsClient {
+class XhrHttpsClient implements HttpsClient {
   /**
    * Makes a request over an underlying transport layer and returns the response.
    * @param request - The request to be made.
@@ -187,4 +188,11 @@ function rejectOnTerminalEvent(
   const abortError = new AbortError("The operation was aborted.");
   xhr.addEventListener("abort", () => reject(abortError));
   xhr.addEventListener("timeout", () => reject(abortError));
+}
+
+/**
+ * Create a new HttpsClient instance for the browser environment.
+ */
+export function createXhrHttpsClient(): HttpsClient {
+  return new XhrHttpsClient();
 }

--- a/sdk/core/core-https/test/browser/xhrHttpsClient.spec.ts
+++ b/sdk/core/core-https/test/browser/xhrHttpsClient.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import * as sinon from "sinon";
 import { AbortController } from "@azure/abort-controller";
-import { DefaultHttpsClient, createPipelineRequest } from "../../src";
+import { createDefaultHttpsClient, createPipelineRequest } from "../../src";
 
 describe("XhrHttpsClient", function() {
   let xhrMock: sinon.SinonFakeXMLHttpRequestStatic;
@@ -27,7 +27,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("shouldn't throw on 404", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const request = createPipelineRequest({ url: "https://example.com" });
     const promise = client.sendRequest(request);
     assert.equal(requests.length, 1);
@@ -37,7 +37,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should allow canceling of requests", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const controller = new AbortController();
     const request = createPipelineRequest({
       url: "https://example.com",
@@ -54,7 +54,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should allow canceling of requests before the request is made", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const controller = new AbortController();
     controller.abort();
     const request = createPipelineRequest({
@@ -71,7 +71,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should report upload and download progress", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     let downloadCalled = false;
     let uploadCalled = false;
     const request = createPipelineRequest({
@@ -97,7 +97,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should honor timeout", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
 
     const timeoutLength = 2000;
     const request = createPipelineRequest({
@@ -115,7 +115,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("parses headers", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const request = createPipelineRequest({ url: "https://example.com" });
     const promise = client.sendRequest(request);
     assert.equal(requests.length, 1);
@@ -127,7 +127,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("parses empty string headers", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const request = createPipelineRequest({ url: "https://example.com" });
     const promise = client.sendRequest(request);
     assert.equal(requests.length, 1);
@@ -139,7 +139,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should stream response body on matching status code", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const request = createPipelineRequest({
       url: "https://example.com",
       streamResponseStatusCodes: new Set([200])
@@ -154,7 +154,7 @@ describe("XhrHttpsClient", function() {
   });
 
   it("should not stream response body on non-matching status code", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const request = createPipelineRequest({
       url: "https://example.com",
       streamResponseStatusCodes: new Set([200])

--- a/sdk/core/core-https/test/node/nodeHttpsClient.spec.ts
+++ b/sdk/core/core-https/test/node/nodeHttpsClient.spec.ts
@@ -7,7 +7,7 @@ import { PassThrough } from "stream";
 import { IncomingMessage, ClientRequest, IncomingHttpHeaders } from "http";
 import * as https from "https";
 import { AbortController } from "@azure/abort-controller";
-import { DefaultHttpsClient, createPipelineRequest } from "../../src";
+import { createDefaultHttpsClient, createPipelineRequest } from "../../src";
 
 class FakeResponse extends PassThrough {
   public statusCode?: number;
@@ -51,7 +51,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("shouldn't throw on 404", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     stubbedRequest.returns(createRequest());
     const request = createPipelineRequest({ url: "https://example.com" });
     const promise = client.sendRequest(request);
@@ -61,7 +61,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should allow canceling of requests", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const controller = new AbortController();
     stubbedRequest.returns(createRequest());
     const request = createPipelineRequest({
@@ -79,7 +79,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should allow canceling of requests before the request is made", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     const controller = new AbortController();
     controller.abort();
     stubbedRequest.returns(createRequest());
@@ -97,7 +97,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should report upload and download progress", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     stubbedRequest.returns(createRequest());
     let downloadCalled = false;
     let uploadCalled = false;
@@ -123,7 +123,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should fail if progress callbacks throw", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     stubbedRequest.returns(createRequest());
     const errorMessage = "it failed horribly!";
     const request = createPipelineRequest({
@@ -143,7 +143,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should honor timeout", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
 
     const timeoutLength = 2000;
     stubbedRequest.returns(createRequest());
@@ -162,7 +162,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should stream response body on matching status code", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     stubbedRequest.returns(createRequest());
     const request = createPipelineRequest({
       url: "https://example.com",
@@ -176,7 +176,7 @@ describe("NodeHttpsClient", function() {
   });
 
   it("should not stream response body on non-matching status code", async function() {
-    const client = new DefaultHttpsClient();
+    const client = createDefaultHttpsClient();
     stubbedRequest.returns(createRequest());
     const request = createPipelineRequest({
       url: "https://example.com",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -80,8 +80,8 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.2.0",
-    "@azure/core-client": "1.0.0-beta.1",
-    "@azure/core-https": "1.0.0-beta.1",
+    "@azure/core-client": "1.0.0-beta.2",
+    "@azure/core-https": "1.0.0-beta.2",
     "@azure/core-tracing": "1.0.0-preview.9",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -129,7 +129,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@azure/core-https": "1.0.0-beta.1",
+    "@azure/core-https": "1.0.0-beta.2",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",

--- a/sdk/storage/storage-blob/test/perfstress/track-2/core-https.spec.ts
+++ b/sdk/storage/storage-blob/test/perfstress/track-2/core-https.spec.ts
@@ -2,15 +2,20 @@
 // Licensed under the MIT license.
 
 import { StorageBlobDownloadWithSASTest } from "./dowloadWithSAS.spec";
-import { DefaultHttpsClient, createPipelineRequest, PipelineRequest } from "@azure/core-https";
+import {
+  createDefaultHttpsClient,
+  HttpsClient,
+  createPipelineRequest,
+  PipelineRequest
+} from "@azure/core-https";
 import { drainStream } from "@azure/test-utils-perfstress";
 
 export class CoreHTTPSDownloadWithSASTest extends StorageBlobDownloadWithSASTest {
-  client: DefaultHttpsClient;
+  client: HttpsClient;
   request: PipelineRequest;
   constructor() {
     super();
-    this.client = new DefaultHttpsClient();
+    this.client = createDefaultHttpsClient();
     this.request = createPipelineRequest({
       url: this.sasUrl,
       streamResponseStatusCodes: new Set([200, 206]),

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -66,8 +66,8 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-client": "1.0.0-beta.1",
-    "@azure/core-https": "1.0.0-beta.1",
+    "@azure/core-client": "1.0.0-beta.2",
+    "@azure/core-https": "1.0.0-beta.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-xml": "1.0.0-beta.1",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
Our ACS friends pointed out that we were leaking some implementation details of `HttpsClient`, so this PR cleans up the mess and updates consuming code in master.