### PR TITLE
[Event Hub] Ignore test/perf/track-1 when linting

### DIFF
--- a/sdk/.eslintrc.json
+++ b/sdk/.eslintrc.json
@@ -1,4 +1,5 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "ignorePatterns": ["**/test/perf/track-1"]
 }

--- a/sdk/eventhub/event-hubs/.eslintrc.json
+++ b/sdk/eventhub/event-hubs/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "ignorePatterns": ["test/perf/track-1"]
-}

--- a/sdk/eventhub/event-hubs/.eslintrc.json
+++ b/sdk/eventhub/event-hubs/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "ignorePatterns": ["test/perf/track-1"]
+}


### PR DESCRIPTION
Otherwise, we will get these errors because linted files must be included in the `tsconfig.json` file:
```
/home/dealmaha/repo/sdk/eventhub/event-hubs/test/perf/track-1/index.spec.ts
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: test/perf/track-1/index.spec.ts.
The file must be included in at least one of the projects provided

/home/dealmaha/repo/sdk/eventhub/event-hubs/test/perf/track-1/receive.spec.ts
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: test/perf/track-1/receive.spec.ts.
The file must be included in at least one of the projects provided

/home/dealmaha/repo/sdk/eventhub/event-hubs/test/perf/track-1/send.spec.ts
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: test/perf/track-1/send.spec.ts.
The file must be included in at least one of the projects provided
```