### PR TITLE
Fix the links of API Reference Documentation

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector/README.md
+++ b/sdk/anomalydetector/ai-anomaly-detector/README.md
@@ -4,7 +4,7 @@
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/anomalydetector/ai-anomaly-detector/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-anomaly-detector) |
-[API reference documentation](https://aka.ms/azsdk/net/docs/ref/anomalydetector) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-anomaly-detector) |
 [Product documentation](https://docs.microsoft.com/azure/cognitive-services/anomaly-detector/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/anomalydetector/ai-anomaly-detector/samples)
 

--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -10,7 +10,7 @@ Use the client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventgrid/eventgrid/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/eventgrid/v/next) |
-[API reference documentation](https://aka.ms/azsdk-js-eventgrid-ref-docs) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/eventgrid) |
 [Product documentation](https://docs.microsoft.com/azure/event-grid/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventgrid/eventgrid/samples)
 

--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -10,7 +10,7 @@ Use the client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventgrid/eventgrid/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/eventgrid/v/next) |
-[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/eventgrid) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/eventgrid/?view=azure-node-preview) |
 [Product documentation](https://docs.microsoft.com/azure/event-grid/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventgrid/eventgrid/samples)
 

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -10,7 +10,7 @@ Azure Cognitive Services [Form Recognizer](https://azure.microsoft.com/services/
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/formrecognizer/ai-form-recognizer/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-form-recognizer) |
-[API reference documentation](https://aka.ms/azsdk/js/formrecognizer/docs) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-form-recognizer) |
 [Product documentation](https://docs.microsoft.com/azure/cognitive-services/form-recognizer/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/formrecognizer/ai-form-recognizer/samples)
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -9,7 +9,7 @@ Metrics Advisor is a part of Azure Cognitive Services that uses AI perform data 
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/metricsadvisor/ai-metrics-advisor/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-metrics-advisor) |
-[API reference documentation](https://aka.ms/azsdk/js/metricsadvisor/docs) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-metrics-advisor) |
 [Product documentation](https://docs.microsoft.com/azure/cognitive-services/metrics-advisor/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/metricsadvisor/ai-metrics-advisor/samples)
 
@@ -77,6 +77,7 @@ const credential = new MetricsAdvisorKeyCredential("<subscription Key>", "<API k
 const client = new MetricsAdvisorClient("<endpoint>", credential);
 const adminClient = new MetricsAdvisorAdministrationClient("<endpoint>", credential);
 ```
+
 #### Using Azure Service Directory
 
 API key authorization is used in most of the examples, but you can also authenticate the client with Azure Active Directory using the Azure Identity library. To use the DefaultAzureCredential provider shown below or other credential providers provided with the Azure SDK, please install the @azure/identity package:

--- a/sdk/mixedreality/mixedreality-authentication/README.md
+++ b/sdk/mixedreality/mixedreality-authentication/README.md
@@ -6,7 +6,7 @@ token from the STS that can be used to access Mixed Reality services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/mixedreality/mixedreality-authentication/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/mixedreality-authentication) |
-[API reference documentation](https://aka.ms/azsdk/js/textanalytics/docs) |
+[API reference documentation](https://aka.ms/azsdk/js/mixedreality-authentication/docs) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/mixedreality/mixedreality-authentication/samples)
 
 ![Mixed Reality service authentication diagram](https://docs.microsoft.com/azure/spatial-anchors/concepts/media/spatial-anchors-authentication-overview.png)

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -21,7 +21,7 @@ Use the @azure/search-documents client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/search/search-documents/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/search-documents) |
-[API reference documentation](https://aka.ms/azsdk/js/search/docs) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/search-documents) |
 [REST API documentation](https://docs.microsoft.com/rest/api/searchservice/) |
 [Product documentation](https://docs.microsoft.com/azure/search/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/search/search-documents/samples)

--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -16,7 +16,7 @@ Azure Cosmos DB provides a Table API for applications that are written for Azure
 - Automatic secondary indexing.
 - The Azure Tables client library can seamlessly target either Azure table storage or Azure Cosmos DB table service endpoints with no code changes.
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/tables/data-tables/) | [Package (NPM)](https://www.npmjs.com/package/@azure/data-tables) | [API reference documentation](https://aka.ms/js-docs) | [Product documentation](https://docs.microsoft.com/azure/storage/tables/table-storage-overview/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/tables/data-tables/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/tables/data-tables/) | [Package (NPM)](https://www.npmjs.com/package/@azure/data-tables) | [API reference documentation](https://docs.microsoft.com/javascript/api/@azure/data-tables) | [Product documentation](https://docs.microsoft.com/azure/storage/tables/table-storage-overview/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/tables/data-tables/samples)
 
 ## Getting started
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -23,7 +23,7 @@ Use the client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/textanalytics/ai-text-analytics/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-text-analytics) |
-[API reference documentation](https://aka.ms/azsdk/js/textanalytics/docs) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-text-analytics) |
 [Product documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples)
 


### PR DESCRIPTION
The README.md files in our repository has a link for ```API Reference Documentation```. In some of the SDKs, they are pointing to the docs in github io. This is ok for initial release. But, after the initial release, the link must be updated to the location in msdocs. 

I have updated the links in this PR.

@ramya-rao-a Please review and approve. 