### PR TITLE
[monitor] Fix some of the more obvious breakages (CI is still broken afterwards, however)

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test/common/scenario/basic.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/common/scenario/basic.ts
@@ -91,7 +91,7 @@ export class BasicScenario implements Scenario {
           version: 1,
           name: "BasicScenario.Root",
           duration: msToTimeSpan(600),
-          responseCode: StatusCode.OK.toString(),
+          responseCode: SpanStatusCode.OK.toString(),
           success: true,
           properties: {
             foo: "bar"
@@ -108,7 +108,7 @@ export class BasicScenario implements Scenario {
               name: "BasicScenario.Child.1",
               duration: msToTimeSpan(100),
               success: true,
-              resultCode: StatusCode.OK.toString(),
+              resultCode: SpanStatusCode.OK.toString(),
               properties: {
                 numbers: "123"
               }
@@ -125,7 +125,7 @@ export class BasicScenario implements Scenario {
               name: "BasicScenario.Child.2",
               duration: msToTimeSpan(100),
               success: true,
-              resultCode: StatusCode.OK.toString(),
+              resultCode: SpanStatusCode.OK.toString(),
               properties: {
                 numbers: "1234"
               }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/common/scenario/basic.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/common/scenario/basic.ts
@@ -91,7 +91,7 @@ export class BasicScenario implements Scenario {
           version: 1,
           name: "BasicScenario.Root",
           duration: msToTimeSpan(600),
-          responseCode: "0",
+          responseCode: StatusCode.OK.toString(),
           success: true,
           properties: {
             foo: "bar"
@@ -108,7 +108,7 @@ export class BasicScenario implements Scenario {
               name: "BasicScenario.Child.1",
               duration: msToTimeSpan(100),
               success: true,
-              resultCode: "0",
+              resultCode: StatusCode.OK.toString(),
               properties: {
                 numbers: "123"
               }
@@ -125,7 +125,7 @@ export class BasicScenario implements Scenario {
               name: "BasicScenario.Child.2",
               duration: msToTimeSpan(100),
               success: true,
-              resultCode: "0",
+              resultCode: StatusCode.OK.toString(),
               properties: {
                 numbers: "1234"
               }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/functional/trace.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/functional/trace.test.ts
@@ -46,7 +46,7 @@ describe("Trace Exporter Scenarios", () => {
           });
         })
         .catch((e) => {
-          throw e;
+          done(e);
         });
     });
   });


### PR DESCRIPTION
Fixes some low hanging fruit in the test that's breaking the "js - opentelemetry-exporter-azure-monitor - tests" in the 'functional-tests' stage.

There is still a break where it appears the output structure changed, but I haven't gotten a chance to look into it.
