### PR TITLE
[KeyVault] - Provide Encrypt/Decrypt parameter overloads and add managed HSM tests

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Updated the Latest service version to 7.2.
 - Added `curve` to `createKeyOptions` to be used when creating an `EC` key.
+- Deprecated the current `encrypt` and `decrypt` methods in favor of the more flexible overloads that take an `{Encrypt|Decrypt}Parameters` and allow passing in algorithm specific parameters. This enables support for the various AES algorithms used in Managed HSM. The deprecated methods continue to function and there's no timeline for their removal.
+- Added `additionalAuthenticatedData`, `iv`, and `authenticationTag` to `EncryptResult` in order to support AES encryption and decryption.
 
 ## 4.2.0-beta.3 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-keys/karma.conf.js
+++ b/sdk/keyvault/keyvault-keys/karma.conf.js
@@ -50,6 +50,7 @@ module.exports = function(config) {
       "AZURE_TENANT_ID",
       "KEYVAULT_NAME",
       "KEYVAULT_URI",
+      "AZURE_MANAGEDHSM_URI",
       "TEST_MODE"
     ],
 

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
@@ -1,0 +1,261 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "cc6f53b2-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 22:42:51 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - SCUS ProdSlices",
+    "x-ms-request-id": "3e55bf0b-fca2-46f5-87aa-16495b980b00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774571,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774571},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "360",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cc9b7848-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "157"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "OK",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-request-id": "cccceb26-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 22:42:51 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - EUS ProdSlices",
+    "x-ms-request-id": "d46e2f68-9c1e-4073-a035-d2829def3400"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774571,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774571},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "360",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "ccfa5034-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "76"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f/encrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"value\":\"GLS9TkdfML6aKB5w2bkTVXuvCjp8Bs6kYSyhvW_61FJnr55wtpHotVEtd1pAg2Td\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "224",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cd1e67b2-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f/decrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"GLS9TkdfML6aKB5w2bkTVXuvCjp8Bs6kYSyhvW_61FJnr55wtpHotVEtd1pAg2Td\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "207",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cd36e7e2-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774571,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774571},\"deletedDate\":1613774573,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621550573}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "527",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cd4fc79e-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "84"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774571,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774571},\"deletedDate\":1613774573,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/2b1f70f4eb004f442c093e6b41a94b7f\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621550573}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "527",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cd752638-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "34"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cd92c26a-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "110"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "96eafd8e16ef41103b66d5111d0bbd12"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
@@ -1,0 +1,261 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "caff5a36-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 22:42:48 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - EUS ProdSlices",
+    "x-ms-request-id": "f1670df7-71af-41ca-a384-c31e20283900"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "361",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cb31d948-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "226"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "OK",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-request-id": "cb6e88fc-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 22:42:49 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - NCUS ProdSlices",
+    "x-ms-request-id": "f2d33824-78ad-48c5-942d-f137847f3600"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "361",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cb9af072-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "119"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe/encrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256GCM\",\"iv\":\"Gy0ySkENZluDUPphAAAAAA\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"tag\":\"SKyfIORegG8jgvpn76YCbw\",\"value\":\"P6HErWTUgBUJRuzwVH67I7AdKqTVsyF-CLslW5SmTPidRDw\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "266",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cbc5bc4e-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe/decrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"P6HErWTUgBUJRuzwVH67I7AdKqTVsyF-CLslW5SmTPidRDw\",\"iv\":\"Gy0ySkENZluDUPphAAAAAA\",\"tag\":\"SKyfIORegG8jgvpn76YCbw\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256GCM\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "205",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cbdf5ad2-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774569},\"deletedDate\":1613774570,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621550570}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "529",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cbf85c30-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "87"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613774569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613774569},\"deletedDate\":1613774570,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/faaa5008ebed08c11afabdf0b6bebabe\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621550570}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "529",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cc1f5b3c-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "54"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "cc41208c-7303-11eb-9799-0242ac120009",
+    "x-ms-server-latency": "117"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "cd354e57cc232aa1217b1b2b448d3409"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_rsa_crypto_algorithms/recording_encrypts_and_decrypts_using_rsa.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_rsa_crypto_algorithms/recording_encrypts_and_decrypts_using_rsa.json
@@ -1,0 +1,261 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "4e15c578-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 21:27:44 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - NCUS ProdSlices",
+    "x-ms-request-id": "038b9084-2bb2-4064-973f-0d5f1b6a2f00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"RSA\"}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613770065,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613770065},\"key\":{\"e\":\"AQAB\",\"key_ops\":[\"wrapKey\",\"decrypt\",\"encrypt\",\"unwrapKey\",\"sign\",\"verify\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"kty\":\"RSA-HSM\",\"n\":\"hyhL19uGn93LzcTE9Xj9Qme6TXLfUz2Q1mtBukYWSnaG8PD-__pMShcVmsr1xO4JnEx7y25LB4AnDfPd_CJ76siy5CF0TZ6bMZvQ0lbat5Qh2sCii0JfCrS4E2diojvrdJNMFdKVP4YpqRrFFQxSs2IsdxcVLprWm4HZDTkzjoBpAAlmXNXkFPJJyS7GZhC7w5WbC6IajK3aJWYyRI1icpFLg1HoeMO4hbZGdIV6y4UWKDagGD7rGJ4OjEeY1NlJxZg-bolqVEcFIoHTVc16YuMXmcl-EghyXJ-mTEFj-b2a52w3XTKgItMWex4NleEBe3aLL7OE-OhqaFWIjIBiCw\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "736",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4e47931e-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "218"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "OK",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-request-id": "4e813b82-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 19 Feb 2021 21:27:44 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - EUS ProdSlices",
+    "x-ms-request-id": "2e501adc-3360-4d7e-8fcd-9ee68d292d00"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613770065,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613770065},\"key\":{\"e\":\"AQAB\",\"key_ops\":[\"wrapKey\",\"verify\",\"sign\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"kty\":\"RSA-HSM\",\"n\":\"hyhL19uGn93LzcTE9Xj9Qme6TXLfUz2Q1mtBukYWSnaG8PD-__pMShcVmsr1xO4JnEx7y25LB4AnDfPd_CJ76siy5CF0TZ6bMZvQ0lbat5Qh2sCii0JfCrS4E2diojvrdJNMFdKVP4YpqRrFFQxSs2IsdxcVLprWm4HZDTkzjoBpAAlmXNXkFPJJyS7GZhC7w5WbC6IajK3aJWYyRI1icpFLg1HoeMO4hbZGdIV6y4UWKDagGD7rGJ4OjEeY1NlJxZg-bolqVEcFIoHTVc16YuMXmcl-EghyXJ-mTEFj-b2a52w3XTKgItMWex4NleEBe3aLL7OE-OhqaFWIjIBiCw\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "736",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4eb31c9c-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "128"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12/encrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"RSA1_5\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIFJTQQ\"}",
+   "status": 200,
+   "response": "{\"alg\":\"RSA1_5\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"value\":\"LstgSlbHU5hAf4QU4k4ICzqRFuMI-H0c-p4oVzxrB3rwEurUN1OTEQAjzeg3C7uF68QGNBodn27Ibe4sfd_68lidOhUH7pOBa8ztt3XPOefbzc2T5im4a_gosHlB9GF-nhgQ0ayfXYtzaq8M3OS-FitoYVZ1aYKCV7qBJF20_u7s4_PBXqiUSO3C7VC416m6fLjA7q5_ftDQt_o7wFmNZwCEadzcFRFeq4XKVWxuYWClvcYFRQVO_eAAr30UqBDgph88G2Kqw_z33ZMhzQLuKFRJjo8I3ZnxhA5Rm95JNeJR-ZLwc7Fec6RpmpDL9ora59IOSh50VWCoNsLKfh9vYA\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "498",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4edf20f8-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12/decrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"RSA1_5\",\"value\":\"LstgSlbHU5hAf4QU4k4ICzqRFuMI-H0c-p4oVzxrB3rwEurUN1OTEQAjzeg3C7uF68QGNBodn27Ibe4sfd_68lidOhUH7pOBa8ztt3XPOefbzc2T5im4a_gosHlB9GF-nhgQ0ayfXYtzaq8M3OS-FitoYVZ1aYKCV7qBJF20_u7s4_PBXqiUSO3C7VC416m6fLjA7q5_ftDQt_o7wFmNZwCEadzcFRFeq4XKVWxuYWClvcYFRQVO_eAAr30UqBDgph88G2Kqw_z33ZMhzQLuKFRJjo8I3ZnxhA5Rm95JNeJR-ZLwc7Fec6RpmpDL9ora59IOSh50VWCoNsLKfh9vYA\"}",
+   "status": 200,
+   "response": "{\"alg\":\"RSA1_5\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIFJTQQ\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "198",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4ef8795e-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "2"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613770065,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613770065},\"deletedDate\":1613770066,\"key\":{\"e\":\"AQAB\",\"key_ops\":[\"wrapKey\",\"encrypt\",\"decrypt\",\"unwrapKey\",\"sign\",\"verify\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"kty\":\"RSA-HSM\",\"n\":\"hyhL19uGn93LzcTE9Xj9Qme6TXLfUz2Q1mtBukYWSnaG8PD-__pMShcVmsr1xO4JnEx7y25LB4AnDfPd_CJ76siy5CF0TZ6bMZvQ0lbat5Qh2sCii0JfCrS4E2diojvrdJNMFdKVP4YpqRrFFQxSs2IsdxcVLprWm4HZDTkzjoBpAAlmXNXkFPJJyS7GZhC7w5WbC6IajK3aJWYyRI1icpFLg1HoeMO4hbZGdIV6y4UWKDagGD7rGJ4OjEeY1NlJxZg-bolqVEcFIoHTVc16YuMXmcl-EghyXJ-mTEFj-b2a52w3XTKgItMWex4NleEBe3aLL7OE-OhqaFWIjIBiCw\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621546066}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "903",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4f11e0ba-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "83"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613770065,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613770065},\"deletedDate\":1613770066,\"key\":{\"e\":\"AQAB\",\"key_ops\":[\"verify\",\"sign\",\"unwrapKey\",\"encrypt\",\"decrypt\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/43396df1ad1f02b9286d96c8055c1c12\",\"kty\":\"RSA-HSM\",\"n\":\"hyhL19uGn93LzcTE9Xj9Qme6TXLfUz2Q1mtBukYWSnaG8PD-__pMShcVmsr1xO4JnEx7y25LB4AnDfPd_CJ76siy5CF0TZ6bMZvQ0lbat5Qh2sCii0JfCrS4E2diojvrdJNMFdKVP4YpqRrFFQxSs2IsdxcVLprWm4HZDTkzjoBpAAlmXNXkFPJJyS7GZhC7w5WbC6IajK3aJWYyRI1icpFLg1HoeMO4hbZGdIV6y4UWKDagGD7rGJ4OjEeY1NlJxZg-bolqVEcFIoHTVc16YuMXmcl-EghyXJ-mTEFj-b2a52w3XTKgItMWex4NleEBe3aLL7OE-OhqaFWIjIBiCw\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621546066}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "903",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4f379490-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "34"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "4f552bd6-72f9-11eb-b0c0-0242ac12000a",
+    "x-ms-server-latency": "120"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "13d4b1fe0ed49a3a02e481ea780abdc6"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
@@ -1,0 +1,261 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "17149da4-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 20 Feb 2021 00:39:28 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - SCUS ProdSlices",
+    "x-ms-request-id": "107458da-d83a-485c-b7a6-d39642c01000"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "361",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "173f699e-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "175"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "OK",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-request-id": "177396b0-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 20 Feb 2021 00:39:29 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11513.13 - WUS2 ProdSlices",
+    "x-ms-request-id": "6b1260e4-4839-4b05-8fc6-3ff760210900"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "361",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1796c4aa-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "113"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2/encrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"value\":\"77mhtBNfzpSkpdDyF-ubxDWQBLg3-afmZtVwamFq0Re7ueGnX0ftqcpAPhXRvejJ\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "225",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "17c01c7e-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2/decrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"77mhtBNfzpSkpdDyF-ubxDWQBLg3-afmZtVwamFq0Re7ueGnX0ftqcpAPhXRvejJ\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "208",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "17d87e40-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"deletedDate\":1613781570,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557570}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "529",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "17f1ced6-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "76"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"deletedDate\":1613781570,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557570}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "529",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1815fb6c-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "31"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "18341714-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "112"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "96eafd8e16ef41103b66d5111d0bbd12"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
@@ -1,0 +1,261 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "15c17634-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 20 Feb 2021 00:39:26 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - NCUS ProdSlices",
+    "x-ms-request-id": "048c32e5-2f7f-44ca-b0dd-c9d700af3900"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "360",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "15f1f390-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "163"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "OK",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-request-id": "1623bf92-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 20 Feb 2021 00:39:26 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11513.13 - WUS2 ProdSlices",
+    "x-ms-request-id": "9db08715-d946-4df2-b2b7-130ac27c0900"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "360",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1645b908-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "113"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220/encrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256GCM\",\"iv\":\"1iin7lGfm3rPJ6qkAAAAAA\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"tag\":\"AMDEeHbdAX8JqfrSGISGWw\",\"value\":\"tINXpDH2Z9yu_7AoOXr5TQBJsQYTAnlumGP5kX2mB2ciQFM\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "265",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1670d44e-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220/decrypt",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"tINXpDH2Z9yu_7AoOXr5TQBJsQYTAnlumGP5kX2mB2ciQFM\",\"iv\":\"1iin7lGfm3rPJ6qkAAAAAA\",\"tag\":\"AMDEeHbdAX8JqfrSGISGWw\"}",
+   "status": 200,
+   "response": "{\"alg\":\"A256GCM\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "204",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "16897e54-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "0"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"deletedDate\":1613781568,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557568}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "527",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "16a32714-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "79"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"deletedDate\":1613781568,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557568}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "527",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "16c87726-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "38"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "16e7403e-7314-11eb-89bd-0242ac120006",
+    "x-ms-server-latency": "112"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "cd354e57cc232aa1217b1b2b448d3409"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.json
@@ -1,0 +1,146 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-request-id": "1dfe6b3c-731d-11eb-a34d-0242ac120009",
+    "x-ms-server-latency": "1"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1322",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 20 Feb 2021 01:44:05 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11496.7 - EUS ProdSlices",
+    "x-ms-request-id": "dfe35c80-8b71-4758-96c9-7d29db4a3500"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": "{\"kty\":\"oct-HSM\",\"attributes\":{}}",
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "377",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1e46dbd8-731d-11eb-a34d-0242ac120009",
+    "x-ms-server-latency": "182"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"deletedDate\":1613785446,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1621561446}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "561",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1e7b4f30-731d-11eb-a34d-0242ac120009",
+    "x-ms-server-latency": "168"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"deletedDate\":1613785446,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1621561446}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "561",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1ead6420-731d-11eb-a34d-0242ac120009",
+    "x-ms-server-latency": "37"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "query": {
+    "api-version": "7.2"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "0",
+    "content-security-policy": "default-src 'self'",
+    "content-type": "application/json; charset=utf-8",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ms-keyvault-network-info": "addr=50.35.231.105",
+    "x-ms-keyvault-region": "westeurope",
+    "x-ms-request-id": "1ecb8658-731d-11eb-a34d-0242ac120009",
+    "x-ms-server-latency": "132"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "96a57ba357ac2a222e1d4dc23843e857"
+}

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
@@ -1,0 +1,325 @@
+let nock = require('nock');
+
+module.exports.hash = "7f019cb2f2bc3d2aab41a5758a39bea7";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  'c6476448-7303-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'b50ba1b1-c0fd-4aef-8eda-2029875c3000',
+  'x-ms-ests-server',
+  '2.1.11496.7 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoCBmAFNJcxCmRJtqAiMqNf8QxJoAwAAAN41wtcOAAAA; expires=Sun, 21-Mar-2021 22:42:41 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 22:42:41 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774561,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774561},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '360',
+  'x-ms-request-id',
+  'c673b8c2-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '160',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208')
+  .query(true)
+  .reply(401, "OK", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '2',
+  'x-ms-request-id',
+  'c6a47fac-7303-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'cache-control',
+  'no-cache',
+  'x-ms-server-latency',
+  '0'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '33d201aa-b4a4-4450-a96f-43e0de2a0c00',
+  'x-ms-ests-server',
+  '2.1.11496.7 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoCBmAFNJcxCmRJtqAiMqNf8QxJoBAAAAN41wtcOAAAA; expires=Sun, 21-Mar-2021 22:42:42 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 22:42:41 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774561,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774561},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","kty":"oct-HSM"}}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  'c6cf0ec0-7303-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '360',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '110'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208/encrypt', {"alg":"A256CBCPAD","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM","iv":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"})
+  .query(true)
+  .reply(200, {"alg":"A256CBCPAD","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","value":"WhELIQfFmoobat8Km-tp5JJrgtuchLsmi_--3UeC7eN3YpxDxMi93Hj7ZvN5Qy4f"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '224',
+  'x-ms-request-id',
+  'c6f83f34-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '1',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208/decrypt', {"alg":"A256CBCPAD","value":"WhELIQfFmoobat8Km-tp5JJrgtuchLsmi_--3UeC7eN3YpxDxMi93Hj7ZvN5Qy4f","iv":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"})
+  .query(true)
+  .reply(200, {"alg":"A256CBCPAD","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '207',
+  'x-ms-request-id',
+  'c710a592-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774561,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774561},"deletedDate":1613774562,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621550562}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '527',
+  'x-ms-request-id',
+  'c7291500-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '97',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774561,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774561},"deletedDate":1613774562,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c05a26c782154eba987f521797b1b208","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621550562}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  'c7500a02-7303-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '527',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '28'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  'c76c9726-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '106',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
@@ -1,0 +1,325 @@
+let nock = require('nock');
+
+module.exports.hash = "4b644a3a4de1b95ee31429b07ed2eaf1";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  'c4f32c3a-7303-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '63ca4872-c129-4d73-865a-2f12483a3700',
+  'x-ms-ests-server',
+  '2.1.11496.7 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoCBmAFNJcxCmRJtqAiMqNf8QxJoAQAAAN41wtcOAAAA; expires=Sun, 21-Mar-2021 22:42:39 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 22:42:39 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774559,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774559},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '360',
+  'x-ms-request-id',
+  'c52305f4-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '183',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258')
+  .query(true)
+  .reply(401, "OK", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '2',
+  'x-ms-request-id',
+  'c557f7b4-7303-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'cache-control',
+  'no-cache',
+  'x-ms-server-latency',
+  '0'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'e8a99aa4-34b3-4a27-9aca-48e899b93500',
+  'x-ms-ests-server',
+  '2.1.11496.7 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoCBmAFNJcxCmRJtqAiMqNf8QxJoAgAAAN41wtcOAAAA; expires=Sun, 21-Mar-2021 22:42:39 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 22:42:39 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774559,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774559},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","kty":"oct-HSM"}}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  'c582db6e-7303-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '360',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '98'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258/encrypt', {"alg":"A256GCM","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"})
+  .query(true)
+  .reply(200, {"alg":"A256GCM","iv":"HOI5mYwDclJrTsgRAAAAAA","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","tag":"WWiBimsoY-fvV60dl0m2ZQ","value":"uanyK_j7Fs9YGCslN9g-iqJruA2SC8vgrvTQ_6gwjCl4AQA"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '265',
+  'x-ms-request-id',
+  'c5aa2372-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258/decrypt', {"alg":"A256GCM","value":"uanyK_j7Fs9YGCslN9g-iqJruA2SC8vgrvTQ_6gwjCl4AQA","iv":"HOI5mYwDclJrTsgRAAAAAA","tag":"WWiBimsoY-fvV60dl0m2ZQ"})
+  .query(true)
+  .reply(200, {"alg":"A256GCM","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '204',
+  'x-ms-request-id',
+  'c5c47466-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774559,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774559},"deletedDate":1613774560,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621550560}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '527',
+  'x-ms-request-id',
+  'c5dcf1b2-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '75',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613774559,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613774559},"deletedDate":1613774560,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/a418bd0c833740c7978a9b6416149258","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621550560}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  'c6009acc-7303-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '527',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '34'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  'c61e7a06-7303-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '105',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_rsa_crypto_algorithms/recording_encrypts_and_decrypts_using_rsa.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_all_decrypts_happen_remotely_with_rsa_crypto_algorithms/recording_encrypts_and_decrypts_using_rsa.js
@@ -1,0 +1,297 @@
+let nock = require('nock');
+
+module.exports.hash = "87113d81ecbf973bef1da935110db6f9";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '46638d10-72f9-11eb-9617-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '5e6d3b55-0a7c-4d69-8888-dcd7978a0100',
+  'x-ms-ests-server',
+  '2.1.11513.13 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=AmZKm4Y4MO9NuVLbCyqKd3f8QxJoAwAAAD4kwtcOAAAA; expires=Sun, 21-Mar-2021 21:27:32 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 21:27:31 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create', {"kty":"RSA"})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613770052,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613770052},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe","kty":"RSA-HSM","n":"qUWERKm5LqLVY355ZHrjgsl9HYVS8atcIPtXy18-j_CItxHlcwaEXsGX-FBDbQiQPmy0ORGM9vFOY9AELmVBHhls00LsytobzNCzmv20zb86QYqMvTMaM5py9BeNiLhIq3Q3OWmQ41igY9HC7Teq5D-719D075C6JIuKeHTljXyQt5VTJV0hWJH2oo5e1sOAdNepD-80uBbjlFXzpbf4MvD3r4mqNuNqyJMGeKV-OepYxxqwWVR3LRAOtdLz3JkN2B__KJChIC9VrF0Hk2WUaCE5CjU06tmgYoMvb0yLS5K9kV6Bj7ZhDnEcn1gN4A5vlupGcRhmI3VY2B2qT6DLiw"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '737',
+  'x-ms-request-id',
+  '46948ab4-72f9-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '263',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe')
+  .query(true)
+  .reply(401, "OK", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '2',
+  'x-ms-request-id',
+  '46d537d0-72f9-11eb-9617-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'cache-control',
+  'no-cache',
+  'x-ms-server-latency',
+  '0'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '5e6d3b55-0a7c-4d69-8888-dcd7bc8a0100',
+  'x-ms-ests-server',
+  '2.1.11513.13 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=AmZKm4Y4MO9NuVLbCyqKd3f8QxJoAwAAAD4kwtcOAAAA; expires=Sun, 21-Mar-2021 21:27:32 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 19 Feb 2021 21:27:32 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613770052,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613770052},"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe","kty":"RSA-HSM","n":"qUWERKm5LqLVY355ZHrjgsl9HYVS8atcIPtXy18-j_CItxHlcwaEXsGX-FBDbQiQPmy0ORGM9vFOY9AELmVBHhls00LsytobzNCzmv20zb86QYqMvTMaM5py9BeNiLhIq3Q3OWmQ41igY9HC7Teq5D-719D075C6JIuKeHTljXyQt5VTJV0hWJH2oo5e1sOAdNepD-80uBbjlFXzpbf4MvD3r4mqNuNqyJMGeKV-OepYxxqwWVR3LRAOtdLz3JkN2B__KJChIC9VrF0Hk2WUaCE5CjU06tmgYoMvb0yLS5K9kV6Bj7ZhDnEcn1gN4A5vlupGcRhmI3VY2B2qT6DLiw"}}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '46fe9ca6-72f9-11eb-9617-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '737',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '158'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe/decrypt', {"alg":"RSA1_5","value":"alRI4bCAI4EaPr_UtDvrgQvE8f5wZ-NeMPKGgLKiNIKMe-p3xWgzfecAzeSandP4l5iCsYo53rD_eexfZ4b6jkMXFREbonvX9DzLf66LezWs8NSgBoK4K96Yvf4S49xodWEoYbZP0oIZ-bUJ1u61XMuLUvA_35DJ9Mz2dkThCnX94bsgmk6CtPn4UIhVL_FsTPcfpyxQKpyUwkfTViHdjuAvGTkK5AEXYPYrS07RmJpe9KnOK1YOSbE7BRIqZk3I5mkeAwupfCCKMKsheKSk_pV3vTvnp1JmFsmcYS7wqKoQoDEpWEEQ5HF5963NDuPXB7L2FNwtsfDpAq8rPZRl4A"})
+  .query(true)
+  .reply(200, {"alg":"RSA1_5","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIFJTQQ"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '199',
+  'x-ms-request-id',
+  '472f5a08-72f9-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '2',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613770052,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613770052},"deletedDate":1613770053,"key":{"e":"AQAB","key_ops":["wrapKey","encrypt","decrypt","unwrapKey","sign","verify"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe","kty":"RSA-HSM","n":"qUWERKm5LqLVY355ZHrjgsl9HYVS8atcIPtXy18-j_CItxHlcwaEXsGX-FBDbQiQPmy0ORGM9vFOY9AELmVBHhls00LsytobzNCzmv20zb86QYqMvTMaM5py9BeNiLhIq3Q3OWmQ41igY9HC7Teq5D-719D075C6JIuKeHTljXyQt5VTJV0hWJH2oo5e1sOAdNepD-80uBbjlFXzpbf4MvD3r4mqNuNqyJMGeKV-OepYxxqwWVR3LRAOtdLz3JkN2B__KJChIC9VrF0Hk2WUaCE5CjU06tmgYoMvb0yLS5K9kV6Bj7ZhDnEcn1gN4A5vlupGcRhmI3VY2B2qT6DLiw"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621546053}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '905',
+  'x-ms-request-id',
+  '47484b8a-72f9-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '92',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613770052,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613770052},"deletedDate":1613770053,"key":{"e":"AQAB","key_ops":["verify","sign","unwrapKey","encrypt","decrypt","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c24de25ece2a477fa5c5f0d9944d37fe","kty":"RSA-HSM","n":"qUWERKm5LqLVY355ZHrjgsl9HYVS8atcIPtXy18-j_CItxHlcwaEXsGX-FBDbQiQPmy0ORGM9vFOY9AELmVBHhls00LsytobzNCzmv20zb86QYqMvTMaM5py9BeNiLhIq3Q3OWmQ41igY9HC7Teq5D-719D075C6JIuKeHTljXyQt5VTJV0hWJH2oo5e1sOAdNepD-80uBbjlFXzpbf4MvD3r4mqNuNqyJMGeKV-OepYxxqwWVR3LRAOtdLz3JkN2B__KJChIC9VrF0Hk2WUaCE5CjU06tmgYoMvb0yLS5K9kV6Bj7ZhDnEcn1gN4A5vlupGcRhmI3VY2B2qT6DLiw"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621546053}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '476f70de-72f9-11eb-9617-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '905',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '37'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '478e0bca-72f9-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '113',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
@@ -1,0 +1,325 @@
+let nock = require('nock');
+
+module.exports.hash = "7f019cb2f2bc3d2aab41a5758a39bea7";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '108dd3e2-7314-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2b41fa0d-ce56-4a8a-b663-26909b043400',
+  'x-ms-ests-server',
+  '2.1.11496.7 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAgAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Sat, 20 Feb 2021 00:39:17 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781558,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781558},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '361',
+  'x-ms-request-id',
+  '10b8561c-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '412',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714')
+  .query(true)
+  .reply(401, "OK", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '2',
+  'x-ms-request-id',
+  '111107d0-7314-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'cache-control',
+  'no-cache',
+  'x-ms-server-latency',
+  '0'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2fdfd5b5-31e4-4e5c-94c9-82cfab430800',
+  'x-ms-ests-server',
+  '2.1.11513.13 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAwAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:18 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Sat, 20 Feb 2021 00:39:18 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781558,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781558},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","kty":"oct-HSM"}}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '1135165c-7314-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '361',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '99'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714/encrypt', {"alg":"A256CBCPAD","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM","iv":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"})
+  .query(true)
+  .reply(200, {"alg":"A256CBCPAD","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","value":"Li1NeuPScXooCc64kcQwA4PBNIN_8ZPZEHIBsADplZ5vAIdRTrqop2zgANyzwKiB"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '225',
+  'x-ms-request-id',
+  '115cbdba-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714/decrypt', {"alg":"A256CBCPAD","value":"Li1NeuPScXooCc64kcQwA4PBNIN_8ZPZEHIBsADplZ5vAIdRTrqop2zgANyzwKiB","iv":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"})
+  .query(true)
+  .reply(200, {"alg":"A256CBCPAD","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '208',
+  'x-ms-request-id',
+  '1176d984-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '0',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781558,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781558},"deletedDate":1613781559,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557559}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '529',
+  'x-ms-request-id',
+  '1190f882-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '87',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781558,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781558},"deletedDate":1613781559,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8869cd9d22a84a183666e129ff17b714","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557559}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '11b70a0e-7314-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '529',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '30'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '11d4334a-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '127',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
@@ -1,0 +1,325 @@
+let nock = require('nock');
+
+module.exports.hash = "4b644a3a4de1b95ee31429b07ed2eaf1";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '0f33277c-7314-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '2b41fa0d-ce56-4a8a-b663-26906c043400',
+  'x-ms-ests-server',
+  '2.1.11496.7 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAQAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:15 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Sat, 20 Feb 2021 00:39:15 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '360',
+  'x-ms-request-id',
+  '0f6569b2-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '170',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8')
+  .query(true)
+  .reply(401, "OK", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '2',
+  'x-ms-request-id',
+  '0f9837ac-7314-11eb-bf79-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'cache-control',
+  'no-cache',
+  'x-ms-server-latency',
+  '0'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'e6cb8b30-23f1-46b9-a8bc-99fc35af0f00',
+  'x-ms-ests-server',
+  '2.1.11496.7 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAgAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:16 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Sat, 20 Feb 2021 00:39:15 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"}}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '0fc495f4-7314-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '360',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '113'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8/encrypt', {"alg":"A256GCM","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"})
+  .query(true)
+  .reply(200, {"alg":"A256GCM","iv":"U5Oz8CUYBD3mK0ocAAAAAA","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","tag":"S5sBQE2Y1k63OkvAbJXo2Q","value":"EtnsQUDCwjeEOSWtRT4PJ5iACWox_DOZoEPhtOUaBLMl-t0"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '265',
+  'x-ms-request-id',
+  '0fee63ac-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '1',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8/decrypt', {"alg":"A256GCM","value":"EtnsQUDCwjeEOSWtRT4PJ5iACWox_DOZoEPhtOUaBLMl-t0","iv":"U5Oz8CUYBD3mK0ocAAAAAA","tag":"S5sBQE2Y1k63OkvAbJXo2Q"})
+  .query(true)
+  .reply(200, {"alg":"A256GCM","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '204',
+  'x-ms-request-id',
+  '10072752-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '1',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"deletedDate":1613781557,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557557}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '527',
+  'x-ms-request-id',
+  '101fe738-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '77',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"deletedDate":1613781557,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557557}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '10440fb4-7314-11eb-bf79-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '527',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '32'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/cryptography-client-test')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '10627198-7314-11eb-bf79-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '110',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.js
@@ -1,0 +1,178 @@
+let nock = require('nock');
+
+module.exports.hash = "03df4f9906bd7a40099d7eea3c16c3d8";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '19784542-731d-11eb-9617-0242ac120006',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '667cf5ca-4faf-4d16-8d48-0efb940a3c00',
+  'x-ms-ests-server',
+  '2.1.11496.7 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Aku4h6oc5D1IieMG-eZr9NH8QxJoAQAAAF5gwtcOAAAA; expires=Mon, 22-Mar-2021 01:43:58 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Sat, 20 Feb 2021 01:43:58 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create', {"kty":"oct-HSM","attributes":{}})
+  .query(true)
+  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '377',
+  'x-ms-request-id',
+  '19cb413e-731d-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '195',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"deletedDate":1613785439,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1621561439}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '561',
+  'x-ms-request-id',
+  '1a01fbfc-731d-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '183',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"deletedDate":1613785439,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1621561439}, [
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-request-id',
+  '1a36776a-731d-11eb-9617-0242ac120006',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'content-length',
+  '561',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-build-version',
+  '1.0.20210204-1-c9f88df4-develop',
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '36'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
+  .query(true)
+  .reply(204, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '1a54be6e-731d-11eb-9617-0242ac120006',
+  'x-ms-keyvault-region',
+  'westeurope',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-ms-keyvault-network-info',
+  'addr=50.35.231.105',
+  'x-ms-server-latency',
+  '120',
+  'cache-control',
+  'no-cache',
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -59,6 +59,10 @@ export class CryptographyClient {
     constructor(key: JsonWebKey);
     decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
     encrypt(algorithm: EncryptionAlgorithm, plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
+    // Warning: (ae-forgotten-export) The symbol "EncryptParameters" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    encrypt(encryptParameters: EncryptParameters, options?: CryptographyOptions): Promise<EncryptResult>;
     get keyId(): string | undefined;
     sign(algorithm: SignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;
     signData(algorithm: SignatureAlgorithm, data: Uint8Array, options?: SignOptions): Promise<SignResult>;

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -58,11 +58,16 @@ export class CryptographyClient {
     constructor(key: string | KeyVaultKey, credential: TokenCredential, pipelineOptions?: CryptographyClientOptions);
     constructor(key: JsonWebKey);
     decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
-    encrypt(algorithm: EncryptionAlgorithm, plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
+    // Warning: (ae-forgotten-export) The symbol "DecryptParameters" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    decrypt(decryptParameters: DecryptParameters, options?: DecryptOptions): Promise<DecryptResult>;
     // Warning: (ae-forgotten-export) The symbol "EncryptParameters" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    encrypt(encryptParameters: EncryptParameters, options?: CryptographyOptions): Promise<EncryptResult>;
+    encrypt(encryptParameters: EncryptParameters, options?: EncryptOptions): Promise<EncryptResult>;
+    encrypt(algorithm: EncryptionAlgorithm, // ask: consider refining without an object...
+    plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
     get keyId(): string | undefined;
     sign(algorithm: SignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;
     signData(algorithm: SignatureAlgorithm, data: Uint8Array, options?: SignOptions): Promise<SignResult>;
@@ -118,7 +123,10 @@ export interface EncryptOptions extends KeyOperationsOptions {
 
 // @public
 export interface EncryptResult {
+    additionalAuthenticatedData?: Uint8Array;
     algorithm: EncryptionAlgorithm;
+    authenticationTag?: Uint8Array;
+    iv?: Uint8Array;
     keyID?: string;
     result: Uint8Array;
 }
@@ -198,9 +206,6 @@ export type KeyOperation = string;
 
 // @public
 export interface KeyOperationsOptions extends CryptographyOptions {
-    readonly additionalAuthenticatedData?: Uint8Array;
-    iv?: Uint8Array;
-    tag?: Uint8Array;
 }
 
 // @public
@@ -265,20 +270,35 @@ export const enum KnownDeletionRecoveryLevel {
 
 // @public
 export const enum KnownEncryptionAlgorithms {
+    // (undocumented)
     A128CBC = "A128CBC",
+    // (undocumented)
     A128Cbcpad = "A128CBCPAD",
+    // (undocumented)
     A128GCM = "A128GCM",
+    // (undocumented)
     A128KW = "A128KW",
+    // (undocumented)
     A192CBC = "A192CBC",
+    // (undocumented)
     A192Cbcpad = "A192CBCPAD",
+    // (undocumented)
     A192GCM = "A192GCM",
+    // (undocumented)
     A192KW = "A192KW",
+    // (undocumented)
     A256CBC = "A256CBC",
+    // (undocumented)
     A256Cbcpad = "A256CBCPAD",
+    // (undocumented)
     A256GCM = "A256GCM",
+    // (undocumented)
     A256KW = "A256KW",
+    // (undocumented)
     RSA15 = "RSA1_5",
+    // (undocumented)
     RSAOaep = "RSA-OAEP",
+    // (undocumented)
     RSAOaep256 = "RSA-OAEP-256"
 }
 
@@ -292,13 +312,19 @@ export const enum KnownKeyCurveNames {
 
 // @public
 export const enum KnownKeyOperations {
+    // (undocumented)
     Decrypt = "decrypt",
+    // (undocumented)
     Encrypt = "encrypt",
-    Export = "export",
+    // (undocumented)
     Import = "import",
+    // (undocumented)
     Sign = "sign",
+    // (undocumented)
     UnwrapKey = "unwrapKey",
+    // (undocumented)
     Verify = "verify",
+    // (undocumented)
     WrapKey = "wrapKey"
 }
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -13,6 +13,36 @@ import { PollOperationState } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-http';
 
 // @public
+export interface AesCbcDecryptParameters {
+    algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+    ciphertext: Uint8Array;
+    iv?: Uint8Array;
+}
+
+// @public
+export interface AesCbcEncryptParameters {
+    algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+    iv?: Uint8Array;
+    plaintext: Uint8Array;
+}
+
+// @public
+export interface AesGcmDecryptParameters {
+    additionalAuthenticatedData?: Uint8Array;
+    algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+    authenticationTag?: Uint8Array;
+    ciphertext: Uint8Array;
+    iv?: Uint8Array;
+}
+
+// @public
+export interface AesGcmEncryptParameters {
+    additionalAuthenticatedData?: Uint8Array;
+    algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+    plaintext: Uint8Array;
+}
+
+// @public
 export interface BackupKeyOptions extends coreHttp.OperationOptions {
 }
 
@@ -57,17 +87,12 @@ export interface CreateRsaKeyOptions extends CreateKeyOptions {
 export class CryptographyClient {
     constructor(key: string | KeyVaultKey, credential: TokenCredential, pipelineOptions?: CryptographyClientOptions);
     constructor(key: JsonWebKey);
-    decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
-    // Warning: (ae-forgotten-export) The symbol "DecryptParameters" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     decrypt(decryptParameters: DecryptParameters, options?: DecryptOptions): Promise<DecryptResult>;
-    // Warning: (ae-forgotten-export) The symbol "EncryptParameters" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
+    // @deprecated
+    decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
     encrypt(encryptParameters: EncryptParameters, options?: EncryptOptions): Promise<EncryptResult>;
-    encrypt(algorithm: EncryptionAlgorithm, // ask: consider refining without an object...
-    plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
+    // @deprecated
+    encrypt(algorithm: EncryptionAlgorithm, plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
     get keyId(): string | undefined;
     sign(algorithm: SignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;
     signData(algorithm: SignatureAlgorithm, data: Uint8Array, options?: SignOptions): Promise<SignResult>;
@@ -89,6 +114,9 @@ export interface CryptographyOptions extends coreHttp.OperationOptions {
 // @public
 export interface DecryptOptions extends KeyOperationsOptions {
 }
+
+// @public
+export type DecryptParameters = RsaDecryptParameters | AesGcmDecryptParameters | AesCbcDecryptParameters;
 
 // @public
 export interface DecryptResult {
@@ -120,6 +148,9 @@ export type EncryptionAlgorithm = string;
 // @public
 export interface EncryptOptions extends KeyOperationsOptions {
 }
+
+// @public
+export type EncryptParameters = RsaEncryptParameters | AesGcmEncryptParameters | AesCbcEncryptParameters;
 
 // @public
 export interface EncryptResult {
@@ -270,35 +301,20 @@ export const enum KnownDeletionRecoveryLevel {
 
 // @public
 export const enum KnownEncryptionAlgorithms {
-    // (undocumented)
     A128CBC = "A128CBC",
-    // (undocumented)
     A128Cbcpad = "A128CBCPAD",
-    // (undocumented)
     A128GCM = "A128GCM",
-    // (undocumented)
     A128KW = "A128KW",
-    // (undocumented)
     A192CBC = "A192CBC",
-    // (undocumented)
     A192Cbcpad = "A192CBCPAD",
-    // (undocumented)
     A192GCM = "A192GCM",
-    // (undocumented)
     A192KW = "A192KW",
-    // (undocumented)
     A256CBC = "A256CBC",
-    // (undocumented)
     A256Cbcpad = "A256CBCPAD",
-    // (undocumented)
     A256GCM = "A256GCM",
-    // (undocumented)
     A256KW = "A256KW",
-    // (undocumented)
     RSA15 = "RSA1_5",
-    // (undocumented)
     RSAOaep = "RSA-OAEP",
-    // (undocumented)
     RSAOaep256 = "RSA-OAEP-256"
 }
 
@@ -312,19 +328,12 @@ export const enum KnownKeyCurveNames {
 
 // @public
 export const enum KnownKeyOperations {
-    // (undocumented)
     Decrypt = "decrypt",
-    // (undocumented)
     Encrypt = "encrypt",
-    // (undocumented)
     Import = "import",
-    // (undocumented)
     Sign = "sign",
-    // (undocumented)
     UnwrapKey = "unwrapKey",
-    // (undocumented)
     Verify = "verify",
-    // (undocumented)
     WrapKey = "wrapKey"
 }
 
@@ -387,6 +396,18 @@ export interface PurgeDeletedKeyOptions extends coreHttp.OperationOptions {
 
 // @public
 export interface RestoreKeyBackupOptions extends coreHttp.OperationOptions {
+}
+
+// @public
+export interface RsaDecryptParameters {
+    algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+    ciphertext: Uint8Array;
+}
+
+// @public
+export interface RsaEncryptParameters {
+    algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+    plaintext: Uint8Array;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -16,13 +16,13 @@ import { TokenCredential } from '@azure/core-http';
 export interface AesCbcDecryptParameters {
     algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
     ciphertext: Uint8Array;
-    iv?: Uint8Array;
+    iv: Uint8Array;
 }
 
 // @public
 export interface AesCbcEncryptParameters {
     algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
-    iv?: Uint8Array;
+    iv: Uint8Array;
     plaintext: Uint8Array;
 }
 
@@ -32,7 +32,7 @@ export interface AesGcmDecryptParameters {
     algorithm: "A128GCM" | "A192GCM" | "A256GCM";
     authenticationTag?: Uint8Array;
     ciphertext: Uint8Array;
-    iv?: Uint8Array;
+    iv: Uint8Array;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/samples/javascript/cryptography.js
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/cryptography.js
@@ -27,8 +27,9 @@ async function main() {
   let myWorkKey = await client.createKey(keyName, "RSA");
 
   const cryptoClient = new CryptographyClient(
-    myWorkKey // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
-  , credential);
+    myWorkKey, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
+    credential
+  );
 
   // Sign and Verify
   const signatureValue = "MySignature";
@@ -45,10 +46,13 @@ async function main() {
   console.log("verify result: ", verifyResult);
 
   // Encrypt and decrypt
-  const encrypt = await cryptoClient.encrypt("RSA1_5", Buffer.from("My Message"));
+  const encrypt = await cryptoClient.encrypt({
+    algorithm: "RSA1_5",
+    plaintext: Buffer.from("My Message")
+  });
   console.log("encrypt result: ", encrypt);
 
-  const decrypt = await cryptoClient.decrypt("RSA1_5", encrypt.result);
+  const decrypt = await cryptoClient.decrypt({ algorithm: "RSA1_5", ciphertext: encrypt.result });
   console.log("decrypt: ", decrypt.result.toString());
 
   // Wrap and unwrap

--- a/sdk/keyvault/keyvault-keys/samples/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/package.json
@@ -7,7 +7,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsc",
     "prebuild": "rimraf dist/"
   },
   "repository": {

--- a/sdk/keyvault/keyvault-keys/samples/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/package.json
@@ -7,7 +7,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p .",
     "prebuild": "rimraf dist/"
   },
   "repository": {

--- a/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
@@ -3,7 +3,7 @@
 
 import { createHash } from "crypto";
 
-import { KeyClient, CryptographyClient, KnownEncryptionAlgorithms } from "../../../";
+import { KeyClient, CryptographyClient } from "../../../";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
@@ -26,119 +26,36 @@ export async function main(): Promise<void> {
   const keyName = `key${uniqueString}`;
 
   // Connection to Azure Key Vault Cryptography functionality
-  let myWorkKey = await client.createKey(keyName, "RSA");
+  const myWorkKey = await client.createKey(keyName, "RSA");
 
-  let cryptoClient = new CryptographyClient(
+  const cryptoClient = new CryptographyClient(
     myWorkKey.id!, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
     credential
   );
 
   // Sign and Verify
-  // const signatureValue = "MySignature";
-  // let hash = createHash("sha256");
+  const signatureValue = "MySignature";
+  let hash = createHash("sha256");
 
-  // hash.update(signatureValue);
-  // let digest = hash.digest();
-  // console.log("digest: ", digest);
+  hash.update(signatureValue);
+  let digest = hash.digest();
+  console.log("digest: ", digest);
 
-  // const signature = await cryptoClient.sign("RS256", digest);
-  // console.log("sign result: ", signature);
+  const signature = await cryptoClient.sign("RS256", digest);
+  console.log("sign result: ", signature);
 
-  // const verifyResult = await cryptoClient.verify("RS256", digest, signature.result);
-  // console.log("verify result: ", verifyResult);
+  const verifyResult = await cryptoClient.verify("RS256", digest, signature.result);
+  console.log("verify result: ", verifyResult);
 
-  // // Encrypt and decrypt
-  // let encrypt = await cryptoClient.encrypt("RSA1_5", Buffer.from("My Message"));
-  // console.log("encrypt result: ", encrypt);
+  // Encrypt and decrypt
+  const encrypt = await cryptoClient.encrypt({
+    algorithm: "RSA1_5",
+    plaintext: Buffer.from("My Message")
+  });
+  console.log("encrypt result: ", encrypt);
 
-  // let decrypt = await cryptoClient.decrypt("RSA1_5", encrypt.result);
-  // console.log("decrypt: ", decrypt.result.toString());
-
-  // Encrypt and decrypt using options
-  // console.log(
-  //   await cryptoClient.encrypt({ algorithm: "RSA1_5", plaintext: Buffer.from("My Message") })
-  // );
-  // console.log(
-  //   await cryptoClient.encrypt({ algorithm: "RSA-OAEP", plaintext: Buffer.from("My Message") })
-  // );
-  // console.log(
-  //   await cryptoClient.encrypt({ algorithm: "RSA-OAEP-256", plaintext: Buffer.from("My Message") })
-  // );
-
-  // Connection to Azure Key Vault Cryptography functionality
-  myWorkKey = await client.createKey(keyName, "AES", { keySize: 256 });
-
-  cryptoClient = new CryptographyClient(
-    myWorkKey.id!, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
-    credential
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A192GCM",
-      plaintext: Buffer.from("My Message"),
-      additionalAuthenticatedData: Buffer.from("iv")
-    })
-  );
-  return;
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A192GCM",
-      plaintext: Buffer.from("My Message")
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A256GCM",
-      plaintext: Buffer.from("My Message")
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A128CBC",
-      plaintext: Buffer.from("My Message"),
-      iv: Buffer.from("iv") // TODO: is iv optional or required?
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A192CBC",
-      plaintext: Buffer.from("My Message")
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt(
-      {
-        algorithm: "A256CBC",
-        plaintext: Buffer.from("My Message WITH ABORT SIGNAL")
-      },
-      {
-        requestOptions: {
-          timeout: 499
-        }
-      }
-    )
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A128CBCPAD",
-      plaintext: Buffer.from("My Message"),
-      iv: Buffer.from("iv")
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A256CBCPAD",
-      plaintext: Buffer.from("My Message"),
-      iv: Buffer.from("iv")
-    })
-  );
-  console.log(
-    await cryptoClient.encrypt({
-      algorithm: "A192CBCPAD",
-      plaintext: Buffer.from("My Message"),
-      iv: Buffer.from("iv")
-    })
-  );
+  const decrypt = await cryptoClient.decrypt({ algorithm: "RSA1_5", ciphertext: encrypt.result });
+  console.log("decrypt: ", decrypt.result.toString());
 
   // Wrap and unwrap
   const wrapped = await cryptoClient.wrapKey("RSA-OAEP", Buffer.from("My Message"));

--- a/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
@@ -3,7 +3,7 @@
 
 import { createHash } from "crypto";
 
-import { KeyClient, CryptographyClient } from "@azure/keyvault-keys";
+import { KeyClient, CryptographyClient, KnownEncryptionAlgorithms } from "../../../";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
@@ -26,33 +26,119 @@ export async function main(): Promise<void> {
   const keyName = `key${uniqueString}`;
 
   // Connection to Azure Key Vault Cryptography functionality
-  const myWorkKey = await client.createKey(keyName, "RSA");
+  let myWorkKey = await client.createKey(keyName, "RSA");
 
-  const cryptoClient = new CryptographyClient(
+  let cryptoClient = new CryptographyClient(
     myWorkKey.id!, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
     credential
   );
 
   // Sign and Verify
-  const signatureValue = "MySignature";
-  let hash = createHash("sha256");
+  // const signatureValue = "MySignature";
+  // let hash = createHash("sha256");
 
-  hash.update(signatureValue);
-  let digest = hash.digest();
-  console.log("digest: ", digest);
+  // hash.update(signatureValue);
+  // let digest = hash.digest();
+  // console.log("digest: ", digest);
 
-  const signature = await cryptoClient.sign("RS256", digest);
-  console.log("sign result: ", signature);
+  // const signature = await cryptoClient.sign("RS256", digest);
+  // console.log("sign result: ", signature);
 
-  const verifyResult = await cryptoClient.verify("RS256", digest, signature.result);
-  console.log("verify result: ", verifyResult);
+  // const verifyResult = await cryptoClient.verify("RS256", digest, signature.result);
+  // console.log("verify result: ", verifyResult);
 
-  // Encrypt and decrypt
-  const encrypt = await cryptoClient.encrypt("RSA1_5", Buffer.from("My Message"));
-  console.log("encrypt result: ", encrypt);
+  // // Encrypt and decrypt
+  // let encrypt = await cryptoClient.encrypt("RSA1_5", Buffer.from("My Message"));
+  // console.log("encrypt result: ", encrypt);
 
-  const decrypt = await cryptoClient.decrypt("RSA1_5", encrypt.result);
-  console.log("decrypt: ", decrypt.result.toString());
+  // let decrypt = await cryptoClient.decrypt("RSA1_5", encrypt.result);
+  // console.log("decrypt: ", decrypt.result.toString());
+
+  // Encrypt and decrypt using options
+  // console.log(
+  //   await cryptoClient.encrypt({ algorithm: "RSA1_5", plaintext: Buffer.from("My Message") })
+  // );
+  // console.log(
+  //   await cryptoClient.encrypt({ algorithm: "RSA-OAEP", plaintext: Buffer.from("My Message") })
+  // );
+  // console.log(
+  //   await cryptoClient.encrypt({ algorithm: "RSA-OAEP-256", plaintext: Buffer.from("My Message") })
+  // );
+
+  // Connection to Azure Key Vault Cryptography functionality
+  myWorkKey = await client.createKey(keyName, "AES", { keySize: 256 });
+
+  cryptoClient = new CryptographyClient(
+    myWorkKey.id!, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
+    credential
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A192GCM",
+      plaintext: Buffer.from("My Message"),
+      additionalAuthenticatedData: Buffer.from("iv")
+    })
+  );
+  return;
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A192GCM",
+      plaintext: Buffer.from("My Message")
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A256GCM",
+      plaintext: Buffer.from("My Message")
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A128CBC",
+      plaintext: Buffer.from("My Message"),
+      iv: Buffer.from("iv") // TODO: is iv optional or required?
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A192CBC",
+      plaintext: Buffer.from("My Message")
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt(
+      {
+        algorithm: "A256CBC",
+        plaintext: Buffer.from("My Message WITH ABORT SIGNAL")
+      },
+      {
+        requestOptions: {
+          timeout: 499
+        }
+      }
+    )
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A128CBCPAD",
+      plaintext: Buffer.from("My Message"),
+      iv: Buffer.from("iv")
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A256CBCPAD",
+      plaintext: Buffer.from("My Message"),
+      iv: Buffer.from("iv")
+    })
+  );
+  console.log(
+    await cryptoClient.encrypt({
+      algorithm: "A192CBCPAD",
+      plaintext: Buffer.from("My Message"),
+      iv: Buffer.from("iv")
+    })
+  );
 
   // Wrap and unwrap
   const wrapped = await cryptoClient.wrapKey("RSA-OAEP", Buffer.from("My Message"));

--- a/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
@@ -3,7 +3,7 @@
 
 import { createHash } from "crypto";
 
-import { KeyClient, CryptographyClient } from "../../../";
+import { KeyClient, CryptographyClient } from "@azure/keyvault-keys";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists

--- a/sdk/keyvault/keyvault-keys/samples/typescript/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/tsconfig.json
@@ -2,13 +2,14 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
+    "target": "ES2015",
 
     "lib": ["dom", "dom.iterable", "esnext.asynciterable"],
 
     "allowSyntheticDefaultImports": true,
 
-    "outDir": "dist",
-    "rootDir": "src"
+    "outDir": "dist"
+    // "rootDir": "src",
   },
   "include": ["src/**.ts"],
   "exclude": ["node_modules"]

--- a/sdk/keyvault/keyvault-keys/samples/typescript/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/tsconfig.json
@@ -2,14 +2,13 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES2015",
 
     "lib": ["dom", "dom.iterable", "esnext.asynciterable"],
 
     "allowSyntheticDefaultImports": true,
 
-    "outDir": "dist"
-    // "rootDir": "src",
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src/**.ts"],
   "exclude": ["node_modules"]

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -212,7 +212,7 @@ export class CryptographyClient {
    * @param algorithm - The algorithm to use.
    * @param ciphertext - The text to decrypt.
    * @param options - Additional options.
-   * @deprecated Use `decrypt({ algorithm, ciphertext }, options) instead.
+   * @deprecated Use `decrypt({ algorithm, ciphertext }, options)` instead.
    */
   public async decrypt(
     algorithm: EncryptionAlgorithm,

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -143,8 +143,7 @@ export class CryptographyClient {
    * @deprecated Use `encrypt({ algorithm, plaintext }, options)` instead.
    */
   public async encrypt(
-    // consider @deprecate and possibly reorder?
-    algorithm: EncryptionAlgorithm, // ask: consider refining without an object...
+    algorithm: EncryptionAlgorithm,
     plaintext: Uint8Array,
     options?: EncryptOptions
   ): Promise<EncryptResult>;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -112,6 +112,19 @@ export class CryptographyClient {
     return false;
   }
 
+  /**
+   * Encrypts the given plaintext with the specified encryption parameters.
+   * Depending on the algorithm set in the encryption parameters, the set of possible encryption parameters will change.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new CryptographyClient(keyVaultKey, credentials);
+   * let result = await client.encrypt({ algorithm: "RSA1_5", plaintext: Buffer.from("My Message")});
+   * let result = await client.encrypt({ algorithm: "A256GCM", plaintext: Buffer.from("My Message"), additionalAuthenticatedData: Buffer.from("My authenticated data")});
+   * ```
+   * @param encryptParameters - The encryption parameters, keyed on the encryption algorithm chosen.
+   * @param options - Additional options.
+   */
   public async encrypt(
     encryptParameters: EncryptParameters,
     options?: EncryptOptions
@@ -127,6 +140,7 @@ export class CryptographyClient {
    * @param algorithm - The algorithm to use.
    * @param plaintext - The text to encrypt.
    * @param options - Additional options.
+   * @deprecated Use `encrypt({ algorithm, plaintext }, options)` instead.
    */
   public async encrypt(
     // consider @deprecate and possibly reorder?
@@ -157,6 +171,7 @@ export class CryptographyClient {
     args: [EncryptParameters, EncryptOptions?] | [string, Uint8Array, EncryptOptions?]
   ): [EncryptParameters, EncryptOptions?] {
     if (typeof args[0] === "string") {
+      // Sample shape: ["RSA1_5", buffer, options]
       return [
         {
           algorithm: args[0],
@@ -165,10 +180,28 @@ export class CryptographyClient {
         args[2]
       ];
     } else {
+      // Sample shape: [{ algorithm: "RSA1_5", plaintext: buffer }, options]
       return [args[0], args[1] as EncryptOptions];
     }
   }
 
+  /**
+   * Decrypts the given ciphertext with the specified decryption parameters.
+   * Depending on the algorithm used in the decryption parameters, the set of possible decryption parameters will change.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new CryptographyClient(keyVaultKey, credentials);
+   * let result = await client.decrypt({ algorithm: "RSA1_5", ciphertext: encryptedBuffer });
+   * let result = await client.decrypt({ algorithm: "A256GCM", iv: ivFromEncryptResult, authenticationTag: tagFromEncryptResult });
+   * ```
+   * @param decryptParameters - The decryption parameters.
+   * @param options - Additional options.
+   */
+  public async decrypt(
+    decryptParameters: DecryptParameters,
+    options?: DecryptOptions
+  ): Promise<DecryptResult>;
   /**
    * Decrypts the given ciphertext with the specified cryptography algorithm
    *
@@ -180,14 +213,11 @@ export class CryptographyClient {
    * @param algorithm - The algorithm to use.
    * @param ciphertext - The text to decrypt.
    * @param options - Additional options.
+   * @deprecated Use `decrypt({ algorithm, ciphertext }, options) instead.
    */
   public async decrypt(
     algorithm: EncryptionAlgorithm,
     ciphertext: Uint8Array,
-    options?: DecryptOptions
-  ): Promise<DecryptResult>;
-  public async decrypt(
-    decryptParameters: DecryptParameters,
     options?: DecryptOptions
   ): Promise<DecryptResult>;
   public async decrypt(
@@ -207,6 +237,7 @@ export class CryptographyClient {
     args: [DecryptParameters, DecryptOptions?] | [string, Uint8Array, DecryptOptions?]
   ): [DecryptParameters, DecryptOptions?] {
     if (typeof args[0] === "string") {
+      // Sample shape: ["RSA1_5", encryptedBuffer, options]
       return [
         {
           algorithm: args[0],
@@ -215,6 +246,7 @@ export class CryptographyClient {
         args[2]
       ];
     } else {
+      // Sample shape: [{ algorithm: "RSA1_5", ciphertext: encryptedBuffer }, options]
       return [args[0], args[1] as DecryptOptions];
     }
   }

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -126,7 +126,8 @@ export class CryptographyClient {
    * @param options - Additional options.
    */
   public async encrypt(
-    algorithm: EncryptionAlgorithm,
+    // consider @deprecate and possibly reorder?
+    algorithm: EncryptionAlgorithm, // ask: consider refining without an object...
     plaintext: Uint8Array,
     options?: EncryptOptions
   ): Promise<EncryptResult>;
@@ -136,7 +137,7 @@ export class CryptographyClient {
   ): Promise<EncryptResult>;
   public async encrypt(
     algorithmOrParameters: EncryptionAlgorithm | EncryptParameters,
-    ...plainTextOrOptions: [CryptographyOptions?] | [Uint8Array, EncryptOptions?]
+    ...plainTextOrOptions: [CryptographyOptions?] | [Uint8Array, EncryptOptions?] // todo: what version of TS is required vs what we support...
   ): Promise<EncryptResult> {
     const { algorithm, plaintext, options } = this.disambiguateEncryptArguments(
       algorithmOrParameters,
@@ -151,7 +152,8 @@ export class CryptographyClient {
       }
       return this.concreteClient.client.encrypt(
         algorithm as LocalSupportedAlgorithmName,
-        plaintext
+        plaintext,
+        options
       );
     }
   }
@@ -171,7 +173,7 @@ export class CryptographyClient {
       return {
         algorithm,
         plaintext,
-        options: Object.assign({}, plainTextOrOptions[0] || {}, rest) as EncryptOptions
+        options: Object.assign({}, plainTextOrOptions[0] || {}, rest) as EncryptOptions // {...plainTextOrOptions[0], ...rest}
       };
     }
   }
@@ -207,6 +209,9 @@ export class CryptographyClient {
       cipherTextOrOptions
     );
     if (this.concreteClient.kind === "remote") {
+      console.log("algorithm", algorithm);
+      console.log("ciphertext", ciphertext);
+      console.log("options", options);
       return this.concreteClient.client.decrypt(algorithm, ciphertext, options);
     } else {
       throw new Error("Decrypting using a local JsonWebKey is not supported.");

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -61,7 +61,6 @@ export interface EncryptResult {
    */
   additionalAuthenticatedData?: Uint8Array;
 }
-// TODO: test the additional values set above
 
 /**
  * Result of the {@link wrap} operation.

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -183,65 +183,129 @@ export interface WrapKeyOptions extends KeyOperationsOptions {}
  */
 export interface UnwrapKeyOptions extends KeyOperationsOptions {}
 
-interface BaseEncryptionParameters {
+/**
+ * Encryption parameters for RSA encryption algorithms.
+ */
+export interface RsaEncryptParameters {
   /**
-   *
+   * The encryption algorithm to use.
+   */
+  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+  /**
+   * The plain text to encrypt.
    */
   plaintext: Uint8Array;
 }
 
-export interface RsaEncryptionParameters extends BaseEncryptionParameters {
-  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
-}
-
-export interface AesGcmEncryptionParameters extends BaseEncryptionParameters {
+/**
+ * Encryption parameters for AES-GCM encryption algorithms.
+ */
+export interface AesGcmEncryptParameters {
+  /**
+   * The encryption algorithm to use.
+   */
   algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+  /**
+   * The plain text to encrypt.
+   */
+  plaintext: Uint8Array;
+  /**
+   * Optional data that is authenticated but not encrypted.
+   */
   additionalAuthenticatedData?: Uint8Array;
 }
 
-export interface AesCbcEncryptionParameters extends BaseEncryptionParameters {
-  algorithm: "A128CBC" | "A192CBC" | "A256CBC";
+/**
+ * Encryption parameters for AES-CBC encryption algorithms.
+ */
+export interface AesCbcEncryptParameters {
+  /**
+   * The encryption algorithm to use.
+   */
+  algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+  /**
+   * The plain text to encrypt.
+   */
+  plaintext: Uint8Array;
+  /**
+   * Optional initialization vector. If omitted, the service will generate and return a secure nonce in {@see EncryptResult}.
+   */
   iv?: Uint8Array;
 }
 
-export interface AesCbcPadEncryptionParameters extends BaseEncryptionParameters {
-  algorithm: "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
-  iv?: Uint8Array;
-}
-
+/**
+ * A type representing all currently supported encryption parameters as they apply to different encryption algorithms.
+ */
 export type EncryptParameters =
-  | RsaEncryptionParameters
-  | AesGcmEncryptionParameters
-  | AesCbcEncryptionParameters
-  | AesCbcPadEncryptionParameters;
+  | RsaEncryptParameters
+  | AesGcmEncryptParameters
+  | AesCbcEncryptParameters;
 
-interface BaseDecryptionParameters {
+/**
+ * Decryption parameters for RSA encryption algorithms.
+ */
+export interface RsaDecryptParameters {
+  /**
+   * The encryption algorithm to use.
+   */
+  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+  /**
+   * The ciphertext to decrypt.
+   */
   ciphertext: Uint8Array;
 }
 
-export interface RsaDecryptionParameters extends BaseDecryptionParameters {
-  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
-}
-
-export interface AesGcmDecryptionParameters extends BaseDecryptionParameters {
+/**
+ * Decryption parameters for AES-GCM encryption algorithms.
+ */
+export interface AesGcmDecryptParameters {
+  /**
+   * The encryption algorithm to use.
+   */
   algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+  /**
+   * The ciphertext to decrypt.
+   */
+  ciphertext: Uint8Array;
+  /**
+   * The initialization vector (or nonce) generated during encryption.
+   */
   iv?: Uint8Array;
+  /**
+   * The authentication tag generated during encryption.
+   */
   authenticationTag?: Uint8Array;
+  /**
+   * Optional data that is authenticated but not encrypted.
+   */
   additionalAuthenticatedData?: Uint8Array;
 }
 
-export interface AesCbcDecryptionParameters extends BaseDecryptionParameters {
-  algorithm: "A128CBC" | "A192CBC" | "A256CBC";
+/**
+ * Decryption parameters for AES-CBC encryption algorithms.
+ */
+export interface AesCbcDecryptParameters {
+  /**
+   * The encryption algorithm to use.
+   */
+  algorithm: "A128CBC" | "A192CBC" | "A256CBC" | "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+  /**
+   * The initialization vector used during encryption.
+   */
+  /**
+   * The ciphertext to decrypt.
+   */
+  ciphertext: Uint8Array;
+  /**
+   * The initialization vector generated during encryption.
+   */
   iv?: Uint8Array;
 }
 
-export interface AesCbcPadDecryptionParameters extends BaseDecryptionParameters {
-  algorithm: "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
-  iv?: Uint8Array;
-}
-
+/**
+ * A type representing all currently supported decryption parameters as they apply to different encryption algorithms.
+ */
 export type DecryptParameters =
-  | RsaDecryptionParameters
-  | AesGcmDecryptionParameters
-  | AesCbcDecryptionParameters
-  | AesCbcPadDecryptionParameters;
+  | RsaDecryptParameters
+  | AesGcmDecryptParameters
+  | AesCbcDecryptParameters;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -228,9 +228,9 @@ export interface AesCbcEncryptParameters {
    */
   plaintext: Uint8Array;
   /**
-   * Optional initialization vector. If omitted, the service will generate and return a secure nonce in {@see EncryptResult}.
+   * The initialization vector used for encryption.
    */
-  iv?: Uint8Array;
+  iv: Uint8Array;
 }
 
 /**
@@ -270,7 +270,7 @@ export interface AesGcmDecryptParameters {
   /**
    * The initialization vector (or nonce) generated during encryption.
    */
-  iv?: Uint8Array;
+  iv: Uint8Array;
   /**
    * The authentication tag generated during encryption.
    */
@@ -299,7 +299,7 @@ export interface AesCbcDecryptParameters {
   /**
    * The initialization vector generated during encryption.
    */
-  iv?: Uint8Array;
+  iv: Uint8Array;
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -55,7 +55,7 @@ export interface EncryptResult {
   /**
    * The authentication tag resulting from encryption with a symmetric key including A128GCM, A192GCM, and A256GCM.
    */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
   /**
    * Additional data that is authenticated during decryption but not encrypted.
    */
@@ -151,21 +151,7 @@ export interface VerifyResult {
 /**
  * Common optional properties for encrypt, decrypt, wrap and unwrap.
  */
-export interface KeyOperationsOptions extends CryptographyOptions {
-  /**
-   * Initialization vector for symmetric algorithms.
-   */
-  iv?: Uint8Array;
-  /**
-   * Additional data to authenticate but not encrypt/decrypt when using authenticated crypto
-   * algorithms.
-   */
-  readonly additionalAuthenticatedData?: Uint8Array;
-  /**
-   * The tag to authenticate when performing decryption with an authenticated algorithm.
-   */
-  tag?: Uint8Array;
-}
+export interface KeyOperationsOptions extends CryptographyOptions {}
 
 /**
  * Options for {@link encrypt}.
@@ -240,7 +226,7 @@ export interface RsaDecryptionParameters extends BaseDecryptionParameters {
 export interface AesGcmDecryptionParameters extends BaseDecryptionParameters {
   algorithm: "A128GCM" | "A192GCM" | "A256GCM";
   iv?: Uint8Array;
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
   additionalAuthenticatedData?: Uint8Array;
 }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -55,7 +55,7 @@ export interface EncryptResult {
   /**
    * The authentication tag resulting from encryption with a symmetric key including A128GCM, A192GCM, and A256GCM.
    */
-  authenticationTag?: Uint8Array;
+  tag?: Uint8Array;
   /**
    * Additional data that is authenticated during decryption but not encrypted.
    */
@@ -239,19 +239,19 @@ export interface RsaDecryptionParameters extends BaseDecryptionParameters {
 
 export interface AesGcmDecryptionParameters extends BaseDecryptionParameters {
   algorithm: "A128GCM" | "A192GCM" | "A256GCM";
-  iv: Uint8Array;
-  authenticationTag: Uint8Array;
+  iv?: Uint8Array;
+  tag?: Uint8Array;
   additionalAuthenticatedData?: Uint8Array;
 }
 
 export interface AesCbcDecryptionParameters extends BaseDecryptionParameters {
   algorithm: "A128CBC" | "A192CBC" | "A256CBC";
-  iv: Uint8Array;
+  iv?: Uint8Array;
 }
 
 export interface AesCbcPadDecryptionParameters extends BaseDecryptionParameters {
   algorithm: "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
-  iv: Uint8Array;
+  iv?: Uint8Array;
 }
 
 export type DecryptParameters =

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -183,3 +183,33 @@ export interface WrapKeyOptions extends KeyOperationsOptions {}
  * Options for {@link unwrapKey}.
  */
 export interface UnwrapKeyOptions extends KeyOperationsOptions {}
+
+export interface BaseEncryptionParameters {
+  plaintext: Uint8Array;
+}
+
+export interface RsaEncryptionParameters extends BaseEncryptionParameters {
+  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+}
+
+export interface AesGcmEncryptionParameters extends BaseEncryptionParameters {
+  algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+  additionalAuthenticatedData?: Uint8Array;
+}
+
+export interface AesCbcEncryptionParameters extends BaseEncryptionParameters {
+  algorithm: "A128CBC" | "A192CBC" | "A256CBC";
+  iv?: Uint8Array;
+}
+
+export interface AesCbcPadEncryptionParameters extends BaseEncryptionParameters {
+  algorithm: "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+  iv?: Uint8Array;
+}
+
+// TODO: what about Pad??
+export type EncryptParameters =
+  | RsaEncryptionParameters
+  | AesGcmEncryptionParameters
+  | AesCbcEncryptionParameters
+  | AesCbcPadEncryptionParameters;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -48,7 +48,20 @@ export interface EncryptResult {
    * The ID of the Key Vault Key used to encrypt the data.
    */
   keyID?: string;
+  /**
+   * The initialization vector used for encryption.
+   */
+  iv?: Uint8Array;
+  /**
+   * The authentication tag resulting from encryption with a symmetric key including A128GCM, A192GCM, and A256GCM.
+   */
+  authenticationTag?: Uint8Array;
+  /**
+   * Additional data that is authenticated during decryption but not encrypted.
+   */
+  additionalAuthenticatedData?: Uint8Array;
 }
+// TODO: test the additional values set above
 
 /**
  * Result of the {@link wrap} operation.
@@ -184,7 +197,10 @@ export interface WrapKeyOptions extends KeyOperationsOptions {}
  */
 export interface UnwrapKeyOptions extends KeyOperationsOptions {}
 
-export interface BaseEncryptionParameters {
+interface BaseEncryptionParameters {
+  /**
+   *
+   */
   plaintext: Uint8Array;
 }
 
@@ -207,9 +223,39 @@ export interface AesCbcPadEncryptionParameters extends BaseEncryptionParameters 
   iv?: Uint8Array;
 }
 
-// TODO: what about Pad??
 export type EncryptParameters =
   | RsaEncryptionParameters
   | AesGcmEncryptionParameters
   | AesCbcEncryptionParameters
   | AesCbcPadEncryptionParameters;
+
+interface BaseDecryptionParameters {
+  ciphertext: Uint8Array;
+}
+
+export interface RsaDecryptionParameters extends BaseDecryptionParameters {
+  algorithm: "RSA1_5" | "RSA-OAEP" | "RSA-OAEP-256";
+}
+
+export interface AesGcmDecryptionParameters extends BaseDecryptionParameters {
+  algorithm: "A128GCM" | "A192GCM" | "A256GCM";
+  iv: Uint8Array;
+  authenticationTag: Uint8Array;
+  additionalAuthenticatedData?: Uint8Array;
+}
+
+export interface AesCbcDecryptionParameters extends BaseDecryptionParameters {
+  algorithm: "A128CBC" | "A192CBC" | "A256CBC";
+  iv: Uint8Array;
+}
+
+export interface AesCbcPadDecryptionParameters extends BaseDecryptionParameters {
+  algorithm: "A128CBCPAD" | "A192CBCPAD" | "A256CBCPAD";
+  iv: Uint8Array;
+}
+
+export type DecryptParameters =
+  | RsaDecryptionParameters
+  | AesGcmDecryptionParameters
+  | AesCbcDecryptionParameters
+  | AesCbcPadDecryptionParameters;

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -896,7 +896,7 @@ const encryptOperationSpec: coreHttp.OperationSpec = {
       value: ["value"],
       iv: ["options", "iv"],
       additionalAuthenticatedData: ["options", "additionalAuthenticatedData"],
-      tag: ["options", "tag"]
+      authenticationTag: ["options", "authenticationTag"]
     },
     mapper: Mappers.KeyOperationsParameters
   },
@@ -927,7 +927,7 @@ const decryptOperationSpec: coreHttp.OperationSpec = {
       value: ["value"],
       iv: ["options", "iv"],
       additionalAuthenticatedData: ["options", "additionalAuthenticatedData"],
-      tag: ["options", "tag"]
+      authenticationTag: ["options", "authenticationTag"]
     },
     mapper: Mappers.KeyOperationsParameters
   },
@@ -1012,7 +1012,7 @@ const wrapKeyOperationSpec: coreHttp.OperationSpec = {
       value: ["value"],
       iv: ["options", "iv"],
       additionalAuthenticatedData: ["options", "additionalAuthenticatedData"],
-      tag: ["options", "tag"]
+      authenticationTag: ["options", "authenticationTag"]
     },
     mapper: Mappers.KeyOperationsParameters
   },
@@ -1043,7 +1043,7 @@ const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
       value: ["value"],
       iv: ["options", "iv"],
       additionalAuthenticatedData: ["options", "additionalAuthenticatedData"],
-      tag: ["options", "tag"]
+      authenticationTag: ["options", "authenticationTag"]
     },
     mapper: Mappers.KeyOperationsParameters
   },

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -41,7 +41,6 @@ import {
   KeyVaultClientWrapKeyResponse,
   KeyVaultClientUnwrapKeyOptionalParams,
   KeyVaultClientUnwrapKeyResponse,
-  KeyVaultClientExportKeyResponse,
   KeyVaultClientGetDeletedKeysOptionalParams,
   KeyVaultClientGetDeletedKeysResponse,
   KeyVaultClientGetDeletedKeyResponse,
@@ -524,35 +523,6 @@ export class KeyVaultClient extends KeyVaultClientContext {
   }
 
   /**
-   * The export key operation is applicable to all key types. The target key must be marked exportable.
-   * This operation requires the keys/export permission.
-   * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
-   * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
-   * @param environment The target environment assertion.
-   * @param options The options parameters.
-   */
-  exportKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    environment: string,
-    options?: coreHttp.OperationOptions
-  ): Promise<KeyVaultClientExportKeyResponse> {
-    const operationArguments: coreHttp.OperationArguments = {
-      vaultBaseUrl,
-      keyName,
-      keyVersion,
-      environment,
-      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
-    };
-    return this.sendOperationRequest(
-      operationArguments,
-      exportKeyOperationSpec
-    ) as Promise<KeyVaultClientExportKeyResponse>;
-  }
-
-  /**
    * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public
    * part of a deleted key. This operation includes deletion-specific information. The Get Deleted Keys
    * operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on
@@ -739,8 +709,7 @@ const createKeyOperationSpec: coreHttp.OperationSpec = {
       keyOps: ["options", "keyOps"],
       keyAttributes: ["options", "keyAttributes"],
       tags: ["options", "tags"],
-      curve: ["options", "curve"],
-      releasePolicy: ["options", "releasePolicy"]
+      curve: ["options", "curve"]
     },
     mapper: Mappers.KeyCreateParameters
   },
@@ -766,8 +735,7 @@ const importKeyOperationSpec: coreHttp.OperationSpec = {
       hsm: ["options", "hsm"],
       key: ["key"],
       keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"],
-      releasePolicy: ["options", "releasePolicy"]
+      tags: ["options", "tags"]
     },
     mapper: Mappers.KeyImportParameters
   },
@@ -808,8 +776,7 @@ const updateKeyOperationSpec: coreHttp.OperationSpec = {
     parameterPath: {
       keyOps: ["options", "keyOps"],
       keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"],
-      releasePolicy: ["options", "releasePolicy"]
+      tags: ["options", "tags"]
     },
     mapper: Mappers.KeyUpdateParameters
   },
@@ -1079,31 +1046,6 @@ const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
       tag: ["options", "tag"]
     },
     mapper: Mappers.KeyOperationsParameters
-  },
-  queryParameters: [Parameters.apiVersion],
-  urlParameters: [
-    Parameters.vaultBaseUrl,
-    Parameters.keyName1,
-    Parameters.keyVersion
-  ],
-  headerParameters: [Parameters.contentType, Parameters.accept],
-  mediaType: "json",
-  serializer
-};
-const exportKeyOperationSpec: coreHttp.OperationSpec = {
-  path: "/keys/{key-name}/{key-version}/export",
-  httpMethod: "POST",
-  responses: {
-    200: {
-      bodyMapper: Mappers.KeyBundle
-    },
-    default: {
-      bodyMapper: Mappers.KeyVaultError
-    }
-  },
-  requestBody: {
-    parameterPath: { environment: ["environment"] },
-    mapper: Mappers.KeyExportParameters
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -23,8 +23,6 @@ export interface KeyCreateParameters {
   tags?: { [propertyName: string]: string };
   /** Elliptic curve name. For valid values, see JsonWebKeyCurveName. */
   curve?: JsonWebKeyCurveName;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The object attributes managed by the KeyVault service. */
@@ -47,26 +45,6 @@ export interface Attributes {
   readonly updated?: Date;
 }
 
-export interface KeyReleasePolicy {
-  /** key release policy version */
-  version?: KeyReleasePolicyVersion;
-  anyOf?: KeyReleaseAuthority[];
-}
-
-export interface KeyReleaseAuthority {
-  /** Base URL of the attestation service. */
-  authorityURL?: string;
-  allOf?: KeyReleaseCondition[];
-}
-
-export interface KeyReleaseCondition {
-  /** claim type name */
-  claimType?: string;
-  /** condition to test */
-  claimCondition?: KeyReleaseConditionCondition;
-  value?: string;
-}
-
 /** A KeyBundle consisting of a WebKey plus its attributes. */
 export interface KeyBundle {
   /** The Json web key. */
@@ -80,8 +58,6 @@ export interface KeyBundle {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly managed?: boolean;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18 */
@@ -125,7 +101,7 @@ export interface KeyVaultError {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly error?: ErrorModel;
+  readonly error?: ErrorModel | null;
 }
 
 /** The key vault server error. */
@@ -144,7 +120,7 @@ export interface ErrorModel {
    * The key vault server error.
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
-  readonly innerError?: ErrorModel;
+  readonly innerError?: ErrorModel | null;
 }
 
 /** The key import parameters. */
@@ -157,8 +133,6 @@ export interface KeyImportParameters {
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The key update parameters. */
@@ -169,8 +143,6 @@ export interface KeyUpdateParameters {
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** The key list result. */
@@ -239,6 +211,12 @@ export interface KeyOperationResult {
   readonly kid?: string;
   /** NOTE: This property will not be serialized. It can only be populated by the server. */
   readonly result?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly iv?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly authenticationTag?: Uint8Array;
+  /** NOTE: This property will not be serialized. It can only be populated by the server. */
+  readonly additionalAuthenticatedData?: Uint8Array;
 }
 
 /** The key operations parameters. */
@@ -267,12 +245,6 @@ export interface KeyVerifyResult {
   readonly value?: boolean;
 }
 
-/** The export key parameters. */
-export interface KeyExportParameters {
-  /** The target environment assertion. */
-  environment: string;
-}
-
 /** A list of keys that have been deleted in this vault. */
 export interface DeletedKeyListResult {
   /**
@@ -289,8 +261,6 @@ export interface DeletedKeyListResult {
 
 /** Properties of the key pair backing a certificate. */
 export interface KeyProperties {
-  /** Indicates if the private key can be exported. */
-  exportable?: boolean;
   /** The type of key pair to be used for the certificate. */
   keyType?: JsonWebKeyType;
   /** The key size in bits. For example: 2048, 3072, or 4096 for RSA. */
@@ -313,8 +283,6 @@ export type KeyAttributes = Attributes & {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly recoveryLevel?: DeletionRecoveryLevel;
-  /** Indicates if the private key can be exported. */
-  exportable?: boolean;
 };
 
 /** A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info */
@@ -396,22 +364,13 @@ export type JsonWebKeyType = string;
 
 /** Known values of {@link JsonWebKeyOperation} that the service accepts. */
 export const enum KnownJsonWebKeyOperation {
-  /** Key operation - encrypt */
   Encrypt = "encrypt",
-  /** Key operation - decrypt */
   Decrypt = "decrypt",
-  /** Key operation - sign */
   Sign = "sign",
-  /** Key operation - verify */
   Verify = "verify",
-  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
-  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
-  /** Key operation - import */
-  Import = "import",
-  /** Key operation - export */
-  Export = "export"
+  Import = "import"
 }
 
 /**
@@ -425,8 +384,7 @@ export const enum KnownJsonWebKeyOperation {
  * **verify** \
  * **wrapKey** \
  * **unwrapKey** \
- * **import** \
- * **export**
+ * **import**
  */
 export type JsonWebKeyOperation = string;
 
@@ -487,67 +445,22 @@ export const enum KnownJsonWebKeyCurveName {
  */
 export type JsonWebKeyCurveName = string;
 
-/** Known values of {@link KeyReleasePolicyVersion} that the service accepts. */
-export const enum KnownKeyReleasePolicyVersion {
-  /** Schema version 0.2 */
-  Zero2 = "0.2"
-}
-
-/**
- * Defines values for KeyReleasePolicyVersion. \
- * {@link KnownKeyReleasePolicyVersion} can be used interchangeably with KeyReleasePolicyVersion,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **0.2**: Schema version 0.2
- */
-export type KeyReleasePolicyVersion = string;
-
-/** Known values of {@link KeyReleaseConditionCondition} that the service accepts. */
-export const enum KnownKeyReleaseConditionCondition {
-  /** equals comparison. */
-  Equals = "equals"
-}
-
-/**
- * Defines values for KeyReleaseConditionCondition. \
- * {@link KnownKeyReleaseConditionCondition} can be used interchangeably with KeyReleaseConditionCondition,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **equals**: equals comparison.
- */
-export type KeyReleaseConditionCondition = string;
-
 /** Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts. */
 export const enum KnownJsonWebKeyEncryptionAlgorithm {
-  /** Encryption Algorithm - RSA-OAEP */
   RSAOaep = "RSA-OAEP",
-  /** Encryption Algorithm - RSA-OAEP-256 */
   RSAOaep256 = "RSA-OAEP-256",
-  /** Encryption Algorithm - RSA1_5 */
   RSA15 = "RSA1_5",
-  /** Encryption Algorithm - A128GCM */
   A128GCM = "A128GCM",
-  /** Encryption Algorithm - A192GCM */
   A192GCM = "A192GCM",
-  /** Encryption Algorithm - A256GCM */
   A256GCM = "A256GCM",
-  /** Encryption Algorithm - A128KW */
   A128KW = "A128KW",
-  /** Encryption Algorithm - A192KW */
   A192KW = "A192KW",
-  /** Encryption Algorithm - A256KW */
   A256KW = "A256KW",
-  /** Encryption Algorithm - A128CBC */
   A128CBC = "A128CBC",
-  /** Encryption Algorithm - A192CBC */
   A192CBC = "A192CBC",
-  /** Encryption Algorithm - A256CBC */
   A256CBC = "A256CBC",
-  /** Encryption Algorithm - A128CBCPAD */
   A128Cbcpad = "A128CBCPAD",
-  /** Encryption Algorithm - A192CBCPAD */
   A192Cbcpad = "A192CBCPAD",
-  /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD"
 }
 
@@ -634,8 +547,6 @@ export interface KeyVaultClientCreateKeyOptionalParams
   tags?: { [propertyName: string]: string };
   /** Elliptic curve name. For valid values, see JsonWebKeyCurveName. */
   curve?: JsonWebKeyCurveName;
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the createKey operation. */
@@ -659,8 +570,6 @@ export interface KeyVaultClientImportKeyOptionalParams
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the importKey operation. */
@@ -696,8 +605,6 @@ export interface KeyVaultClientUpdateKeyOptionalParams
   keyAttributes?: KeyAttributes;
   /** Application specific metadata in the form of key-value pairs. */
   tags?: { [propertyName: string]: string };
-  /** The policy rules under which the key can be exported. */
-  releasePolicy?: KeyReleasePolicy;
 }
 
 /** Contains response data for the updateKey operation. */
@@ -899,18 +806,6 @@ export type KeyVaultClientUnwrapKeyResponse = KeyOperationResult & {
 
     /** The response body as parsed JSON or XML */
     parsedBody: KeyOperationResult;
-  };
-};
-
-/** Contains response data for the exportKey operation. */
-export type KeyVaultClientExportKeyResponse = KeyBundle & {
-  /** The underlying HTTP response. */
-  _response: coreHttp.HttpResponse & {
-    /** The response body as text (string format) */
-    bodyAsText: string;
-
-    /** The response body as parsed JSON or XML */
-    parsedBody: KeyBundle;
   };
 };
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -364,12 +364,19 @@ export type JsonWebKeyType = string;
 
 /** Known values of {@link JsonWebKeyOperation} that the service accepts. */
 export const enum KnownJsonWebKeyOperation {
+  /** Key operation - encrypt */
   Encrypt = "encrypt",
+  /** Key operation - decrypt */
   Decrypt = "decrypt",
+  /** Key operation - sign */
   Sign = "sign",
+  /** Key operation - verify */
   Verify = "verify",
+  /** Key operation - wrapKey */
   WrapKey = "wrapKey",
+  /** Key operation - unwrapKey */
   UnwrapKey = "unwrapKey",
+  /** Key operation - import */
   Import = "import"
 }
 
@@ -447,20 +454,35 @@ export type JsonWebKeyCurveName = string;
 
 /** Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts. */
 export const enum KnownJsonWebKeyEncryptionAlgorithm {
+  /** Encryption Algorithm - RSA-OAEP */
   RSAOaep = "RSA-OAEP",
+  /** Encryption Algorithm - RSA-OAEP-256 */
   RSAOaep256 = "RSA-OAEP-256",
+  /** Encryption Algorithm - RSA1_5 */
   RSA15 = "RSA1_5",
+  /** Encryption Algorithm - A128GCM */
   A128GCM = "A128GCM",
+  /** Encryption Algorithm - A192GCM */
   A192GCM = "A192GCM",
+  /** Encryption Algorithm - A256GCM */
   A256GCM = "A256GCM",
+  /** Encryption Algorithm - A128KW */
   A128KW = "A128KW",
+  /** Encryption Algorithm - A192KW */
   A192KW = "A192KW",
+  /** Encryption Algorithm - A256KW */
   A256KW = "A256KW",
+  /** Encryption Algorithm - A128CBC */
   A128CBC = "A128CBC",
+  /** Encryption Algorithm - A192CBC */
   A192CBC = "A192CBC",
+  /** Encryption Algorithm - A256CBC */
   A256CBC = "A256CBC",
+  /** Encryption Algorithm - A128CBCPAD */
   A128Cbcpad = "A128CBCPAD",
+  /** Encryption Algorithm - A192CBCPAD */
   A192Cbcpad = "A192CBCPAD",
+  /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD"
 }
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -199,7 +199,7 @@ export interface KeyOperationsParameters {
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
   additionalAuthenticatedData?: Uint8Array;
   /** The tag to authenticate when performing decryption with an authenticated algorithm. */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
 }
 
 /** The key operation result. */
@@ -701,7 +701,7 @@ export interface KeyVaultClientEncryptOptionalParams
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
   additionalAuthenticatedData?: Uint8Array;
   /** The tag to authenticate when performing decryption with an authenticated algorithm. */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
 }
 
 /** Contains response data for the encrypt operation. */
@@ -724,7 +724,7 @@ export interface KeyVaultClientDecryptOptionalParams
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
   additionalAuthenticatedData?: Uint8Array;
   /** The tag to authenticate when performing decryption with an authenticated algorithm. */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
 }
 
 /** Contains response data for the decrypt operation. */
@@ -771,7 +771,7 @@ export interface KeyVaultClientWrapKeyOptionalParams
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
   additionalAuthenticatedData?: Uint8Array;
   /** The tag to authenticate when performing decryption with an authenticated algorithm. */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
 }
 
 /** Contains response data for the wrapKey operation. */
@@ -794,7 +794,7 @@ export interface KeyVaultClientUnwrapKeyOptionalParams
   /** Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms. */
   additionalAuthenticatedData?: Uint8Array;
   /** The tag to authenticate when performing decryption with an authenticated algorithm. */
-  tag?: Uint8Array;
+  authenticationTag?: Uint8Array;
 }
 
 /** Contains response data for the unwrapKey operation. */

--- a/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
@@ -62,13 +62,6 @@ export const KeyCreateParameters: coreHttp.CompositeMapper = {
         type: {
           name: "String"
         }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
-        }
       }
     }
   }
@@ -115,93 +108,6 @@ export const Attributes: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyReleasePolicy: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleasePolicy",
-    modelProperties: {
-      version: {
-        serializedName: "version",
-        type: {
-          name: "String"
-        }
-      },
-      anyOf: {
-        serializedName: "anyOf",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "KeyReleaseAuthority"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const KeyReleaseAuthority: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleaseAuthority",
-    modelProperties: {
-      authorityURL: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "authority",
-        type: {
-          name: "String"
-        }
-      },
-      allOf: {
-        serializedName: "allOf",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "KeyReleaseCondition"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const KeyReleaseCondition: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyReleaseCondition",
-    modelProperties: {
-      claimType: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "claim",
-        type: {
-          name: "String"
-        }
-      },
-      claimCondition: {
-        serializedName: "condition",
-        type: {
-          name: "String"
-        }
-      },
-      value: {
-        serializedName: "value",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const KeyBundle: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
@@ -233,13 +139,6 @@ export const KeyBundle: coreHttp.CompositeMapper = {
         readOnly: true,
         type: {
           name: "Boolean"
-        }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
         }
       }
     }
@@ -433,13 +332,6 @@ export const KeyImportParameters: coreHttp.CompositeMapper = {
           name: "Dictionary",
           value: { type: { name: "String" } }
         }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
-        }
       }
     }
   }
@@ -473,13 +365,6 @@ export const KeyUpdateParameters: coreHttp.CompositeMapper = {
         type: {
           name: "Dictionary",
           value: { type: { name: "String" } }
-        }
-      },
-      releasePolicy: {
-        serializedName: "release_policy",
-        type: {
-          name: "Composite",
-          className: "KeyReleasePolicy"
         }
       }
     }
@@ -642,6 +527,27 @@ export const KeyOperationResult: coreHttp.CompositeMapper = {
         type: {
           name: "Base64Url"
         }
+      },
+      iv: {
+        serializedName: "iv",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
+      },
+      authenticationTag: {
+        serializedName: "tag",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
+      },
+      additionalAuthenticatedData: {
+        serializedName: "aad",
+        readOnly: true,
+        type: {
+          name: "Base64Url"
+        }
       }
     }
   }
@@ -716,25 +622,6 @@ export const KeyVerifyResult: coreHttp.CompositeMapper = {
   }
 };
 
-export const KeyExportParameters: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "KeyExportParameters",
-    modelProperties: {
-      environment: {
-        constraints: {
-          MinLength: 1
-        },
-        serializedName: "env",
-        required: true,
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
 export const DeletedKeyListResult: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
@@ -769,12 +656,6 @@ export const KeyProperties: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "KeyProperties",
     modelProperties: {
-      exportable: {
-        serializedName: "exportable",
-        type: {
-          name: "Boolean"
-        }
-      },
       keyType: {
         serializedName: "kty",
         type: {
@@ -821,12 +702,6 @@ export const KeyAttributes: coreHttp.CompositeMapper = {
         readOnly: true,
         type: {
           name: "String"
-        }
-      },
-      exportable: {
-        serializedName: "exportable",
-        type: {
-          name: "Boolean"
         }
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/mappers.ts
@@ -499,7 +499,7 @@ export const KeyOperationsParameters: coreHttp.CompositeMapper = {
           name: "Base64Url"
         }
       },
-      tag: {
+      authenticationTag: {
         serializedName: "tag",
         type: {
           name: "Base64Url"

--- a/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
@@ -213,8 +213,8 @@ export const additionalAuthenticatedData: OperationParameter = {
   mapper: KeyOperationsParametersMapper
 };
 
-export const tag: OperationParameter = {
-  parameterPath: ["options", "tag"],
+export const authenticationTag: OperationParameter = {
+  parameterPath: ["options", "authenticationTag"],
   mapper: KeyOperationsParametersMapper
 };
 

--- a/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/parameters.ts
@@ -18,8 +18,7 @@ import {
   KeyRestoreParameters as KeyRestoreParametersMapper,
   KeyOperationsParameters as KeyOperationsParametersMapper,
   KeySignParameters as KeySignParametersMapper,
-  KeyVerifyParameters as KeyVerifyParametersMapper,
-  KeyExportParameters as KeyExportParametersMapper
+  KeyVerifyParameters as KeyVerifyParametersMapper
 } from "../models/mappers";
 
 export const contentType: OperationParameter = {
@@ -81,11 +80,6 @@ export const curve: OperationParameter = {
   mapper: KeyCreateParametersMapper
 };
 
-export const releasePolicy: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
-  mapper: KeyCreateParametersMapper
-};
-
 export const vaultBaseUrl: OperationURLParameter = {
   parameterPath: "vaultBaseUrl",
   mapper: {
@@ -143,11 +137,6 @@ export const tags1: OperationParameter = {
   mapper: KeyImportParametersMapper
 };
 
-export const releasePolicy1: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
-  mapper: KeyImportParametersMapper
-};
-
 export const keyName1: OperationURLParameter = {
   parameterPath: "keyName",
   mapper: {
@@ -171,11 +160,6 @@ export const keyAttributes2: OperationParameter = {
 
 export const tags2: OperationParameter = {
   parameterPath: ["options", "tags"],
-  mapper: KeyUpdateParametersMapper
-};
-
-export const releasePolicy2: OperationParameter = {
-  parameterPath: ["options", "releasePolicy"],
   mapper: KeyUpdateParametersMapper
 };
 
@@ -257,11 +241,6 @@ export const digest: OperationParameter = {
 export const signature: OperationParameter = {
   parameterPath: "signature",
   mapper: KeyVerifyParametersMapper
-};
-
-export const environment: OperationParameter = {
-  parameterPath: "environment",
-  mapper: KeyExportParametersMapper
 };
 
 export const nextLink: OperationURLParameter = {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -97,7 +97,9 @@ import {
   SignOptions,
   UnwrapKeyOptions,
   VerifyOptions,
-  WrapKeyOptions
+  WrapKeyOptions,
+  EncryptParameters,
+  DecryptParameters
 } from "./cryptographyClientModels";
 
 import { parseKeyVaultKeyId, KeyVaultKeyId } from "./identifier";
@@ -115,11 +117,13 @@ export {
   CreateOctKeyOptions,
   CryptographyClient,
   CryptographyOptions,
+  DecryptParameters,
   DecryptOptions,
   DecryptResult,
   DeletedKey,
   DeletionRecoveryLevel,
   KnownDeletionRecoveryLevel,
+  EncryptParameters,
   EncryptOptions,
   EncryptResult,
   GetDeletedKeyOptions,

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -99,7 +99,13 @@ import {
   VerifyOptions,
   WrapKeyOptions,
   EncryptParameters,
-  DecryptParameters
+  DecryptParameters,
+  RsaEncryptParameters,
+  AesCbcEncryptParameters,
+  AesGcmEncryptParameters,
+  AesCbcDecryptParameters,
+  AesGcmDecryptParameters,
+  RsaDecryptParameters
 } from "./cryptographyClientModels";
 
 import { parseKeyVaultKeyId, KeyVaultKeyId } from "./identifier";
@@ -117,12 +123,18 @@ export {
   CreateOctKeyOptions,
   CryptographyClient,
   CryptographyOptions,
+  RsaDecryptParameters,
+  AesGcmDecryptParameters,
+  AesCbcDecryptParameters,
   DecryptParameters,
   DecryptOptions,
   DecryptResult,
   DeletedKey,
   DeletionRecoveryLevel,
   KnownDeletionRecoveryLevel,
+  RsaEncryptParameters,
+  AesGcmEncryptParameters,
+  AesCbcEncryptParameters,
   EncryptParameters,
   EncryptOptions,
   EncryptResult,

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -137,6 +137,10 @@ export class KeyVaultCryptographyClient {
     plaintext: Uint8Array,
     options: EncryptOptions = {}
   ): Promise<EncryptResult> {
+    console.log("ENCRYPT CALL AFTER MAPPING");
+    console.log("algorithm", algorithm);
+    console.log("plaintext", plaintext);
+    console.log("options", options);
     const localCryptographyClient = await this.getLocalCryptographyClient();
     const requestOptions = operationOptionsToRequestOptionsBase(options);
     const span = this.createSpan("encrypt", requestOptions);

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -150,7 +150,11 @@ export class KeyVaultCryptographyClient {
 
     if (localCryptographyClient && isLocallySupported(algorithm)) {
       try {
-        return localCryptographyClient.encrypt(algorithm as LocalSupportedAlgorithmName, plaintext);
+        return localCryptographyClient.encrypt(
+          algorithm as LocalSupportedAlgorithmName,
+          plaintext,
+          options
+        );
       } catch (e) {
         if (e.name !== "LocalCryptographyUnsupportedError") {
           span.end();
@@ -175,7 +179,15 @@ export class KeyVaultCryptographyClient {
       span.end();
     }
 
-    return { result: result.result!, algorithm, keyID: this.getKeyID() };
+    return {
+      algorithm,
+      result: result.result!,
+      keyID: this.getKeyID(),
+      additionalAuthenticatedData:
+        options.additionalAuthenticatedData || result.additionalAuthenticatedData,
+      tag: result.authenticationTag,
+      iv: options.iv || result.iv
+    };
   }
 
   /**
@@ -197,6 +209,7 @@ export class KeyVaultCryptographyClient {
     options: DecryptOptions = {}
   ): Promise<DecryptResult> {
     const requestOptions = operationOptionsToRequestOptionsBase(options);
+    console.log("requestOptions", requestOptions);
     const span = this.createSpan("decrypt", requestOptions);
 
     await this.checkPermissions("decrypt");

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -191,7 +191,6 @@ export class KeyVaultCryptographyClient {
   ): Promise<DecryptResult> {
     const { algorithm, ciphertext, ...params } = decryptParameters;
     const requestOptions = { ...operationOptionsToRequestOptionsBase(options), ...params };
-    console.log("requestOptions", requestOptions);
     const span = this.createSpan("decrypt", requestOptions);
 
     await this.checkPermissions("decrypt");

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -145,7 +145,7 @@ export class KeyVaultCryptographyClient {
     const localCryptographyClient = await this.getLocalCryptographyClient();
     checkKeyValidity(this.getKeyID(), this.keyBundle);
 
-    if (localCryptographyClient && isLocallySupported(encryptParameters.algorithm)) {
+    if (localCryptographyClient && isLocallySupported(algorithm)) {
       try {
         return localCryptographyClient.encrypt(encryptParameters, options);
       } catch (e) {
@@ -176,7 +176,6 @@ export class KeyVaultCryptographyClient {
       algorithm: encryptParameters.algorithm,
       result: result.result!,
       keyID: this.getKeyID(),
-      // TODO: Should we be passing back aad, tag, iv if the service didnt return them but the user passed them in?
       additionalAuthenticatedData:
         result.additionalAuthenticatedData ||
         (encryptParameters as any).additionalAuthenticatedData,

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -172,16 +172,16 @@ export class KeyVaultCryptographyClient {
       span.end();
     }
 
-    // Todo: figure out how to get iv, aad, and tag if present in params...
     return {
       algorithm: encryptParameters.algorithm,
       result: result.result!,
       keyID: this.getKeyID(),
+      // TODO: Should we be passing back aad, tag, iv if the service didnt return them but the user passed them in?
       additionalAuthenticatedData:
         result.additionalAuthenticatedData ||
         (encryptParameters as any).additionalAuthenticatedData,
-      authenticationTag: result.authenticationTag,
-      iv: result.iv
+      authenticationTag: result.authenticationTag || (encryptParameters as any).authenticationTag,
+      iv: result.iv || (encryptParameters as any).iv
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/keyVaultCryptographyClient.ts
@@ -176,11 +176,9 @@ export class KeyVaultCryptographyClient {
       algorithm: encryptParameters.algorithm,
       result: result.result!,
       keyID: this.getKeyID(),
-      additionalAuthenticatedData:
-        result.additionalAuthenticatedData ||
-        (encryptParameters as any).additionalAuthenticatedData,
-      authenticationTag: result.authenticationTag || (encryptParameters as any).authenticationTag,
-      iv: result.iv || (encryptParameters as any).iv
+      additionalAuthenticatedData: result.additionalAuthenticatedData,
+      authenticationTag: result.authenticationTag,
+      iv: result.iv
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -16,7 +16,7 @@ import {
   EncryptResult
 } from "./cryptographyClientModels";
 import { runOperation } from "./localCryptography/runOperation";
-import { EncryptionAlgorithm } from ".";
+import { EncryptionAlgorithm, EncryptOptions } from ".";
 
 /**
  * A client used to perform local cryptographic operations with JSON Web Keys.
@@ -40,7 +40,8 @@ export class LocalCryptographyClient {
    */
   public async encrypt(
     algorithm: LocalSupportedAlgorithmName,
-    plaintext: Uint8Array
+    plaintext: Uint8Array,
+    options: EncryptOptions = {}
   ): Promise<EncryptResult> {
     if (!isNode) {
       throw new LocalCryptographyUnsupportedError("Encryption is only available in NodeJS");
@@ -52,7 +53,14 @@ export class LocalCryptographyClient {
       Buffer.from(plaintext)
     )) as Buffer;
     const keyID = this.key.kid;
-    return { result, algorithm: algorithm as EncryptionAlgorithm, keyID };
+    return {
+      result,
+      algorithm: algorithm as EncryptionAlgorithm,
+      keyID,
+      additionalAuthenticatedData: options.additionalAuthenticatedData,
+      tag: options.tag,
+      iv: options.iv
+    };
   }
 
   /**

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -56,10 +56,7 @@ export class LocalCryptographyClient {
     return {
       result,
       algorithm: encryptParameters.algorithm as EncryptionAlgorithm,
-      keyID,
-      additionalAuthenticatedData: (encryptParameters as any).additionalAuthenticatedData,
-      authenticationTag: (encryptParameters as any).authenticationTag,
-      iv: (encryptParameters as any).iv
+      keyID
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -57,7 +57,6 @@ export class LocalCryptographyClient {
       result,
       algorithm: encryptParameters.algorithm as EncryptionAlgorithm,
       keyID,
-      // TODO: is this right? Doesn't feel right since we don't support the AES crypto algorithms locally anyway
       additionalAuthenticatedData: (encryptParameters as any).additionalAuthenticatedData,
       authenticationTag: (encryptParameters as any).authenticationTag,
       iv: (encryptParameters as any).iv

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -13,7 +13,8 @@ import {
   WrapResult,
   VerifyResult,
   KeyWrapAlgorithm,
-  EncryptResult
+  EncryptResult,
+  EncryptParameters
 } from "./cryptographyClientModels";
 import { runOperation } from "./localCryptography/runOperation";
 import { EncryptionAlgorithm, EncryptOptions } from ".";
@@ -39,9 +40,8 @@ export class LocalCryptographyClient {
    * @param plaintext - The text to encrypt.
    */
   public async encrypt(
-    algorithm: LocalSupportedAlgorithmName,
-    plaintext: Uint8Array,
-    options: EncryptOptions = {}
+    encryptParameters: EncryptParameters,
+    _options: EncryptOptions = {}
   ): Promise<EncryptResult> {
     if (!isNode) {
       throw new LocalCryptographyUnsupportedError("Encryption is only available in NodeJS");
@@ -49,17 +49,14 @@ export class LocalCryptographyClient {
     const result = (await runOperation(
       this.key,
       "encrypt",
-      algorithm,
-      Buffer.from(plaintext)
+      encryptParameters.algorithm as LocalSupportedAlgorithmName,
+      Buffer.from(encryptParameters.plaintext)
     )) as Buffer;
     const keyID = this.key.kid;
     return {
       result,
-      algorithm: algorithm as EncryptionAlgorithm,
-      keyID,
-      additionalAuthenticatedData: options.additionalAuthenticatedData,
-      tag: options.tag,
-      iv: options.iv
+      algorithm: encryptParameters.algorithm as EncryptionAlgorithm,
+      keyID
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/localCryptographyClient.ts
@@ -56,7 +56,11 @@ export class LocalCryptographyClient {
     return {
       result,
       algorithm: encryptParameters.algorithm as EncryptionAlgorithm,
-      keyID
+      keyID,
+      // TODO: is this right? Doesn't feel right since we don't support the AES crypto algorithms locally anyway
+      additionalAuthenticatedData: (encryptParameters as any).additionalAuthenticatedData,
+      authenticationTag: (encryptParameters as any).authenticationTag,
+      iv: (encryptParameters as any).iv
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -11,7 +11,7 @@ azure-arm: false
 generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f9caf92527ccff06c5b66380e6f2b4f50f5e82b3/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/612f78afd05911d0e1e82ba72b41781f655dbffb/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -33,4 +33,8 @@ directive:
     where: $.definitions.KeyOperationsParameters.properties.aad
     transform: >
       $["x-ms-client-name"] = "additionalAuthenticatedData";
+  - from: swagger-document
+    where: $.definitions.KeyOperationsParameters.properties.tag
+    transform: >
+      $["x-ms-client-name"] = "authenticationTag"
 ```

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -1,40 +1,139 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { DefaultAzureCredential } from "@azure/identity";
 import * as assert from "assert";
+import sinon from "sinon";
+import { CryptographyClient } from "../../src";
 import { checkKeyValidity } from "../../src/keyVaultCryptographyClient";
+import { stringToUint8Array } from "../utils/crypto";
 
-describe("checkKeyValidity", () => {
-  it("Checking that the key's notBefore is respected", async function() {
-    const keyBundle = {
-      attributes: {
-        notBefore: new Date(Date.now() + 60 * 1000 * 60 * 24) // Now + 24h
+describe.only("internal crypto tests", () => {
+  describe("checkKeyValidity", () => {
+    it("Checking that the key's notBefore is respected", async function() {
+      const keyBundle = {
+        attributes: {
+          notBefore: new Date(Date.now() + 60 * 1000 * 60 * 24) // Now + 24h
+        }
+      };
+      let error: Error | undefined = undefined;
+      try {
+        await checkKeyValidity("1", keyBundle);
+      } catch (e) {
+        error = e;
       }
-    };
-    let error: Error | undefined = undefined;
-    try {
-      await checkKeyValidity("1", keyBundle);
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(
-      error?.message,
-      `Key 1 can't be used before ${keyBundle.attributes.notBefore.toISOString()}`
-    );
+      assert.equal(
+        error?.message,
+        `Key 1 can't be used before ${keyBundle.attributes.notBefore.toISOString()}`
+      );
+    });
+
+    it("Checking that the key's expires is respected", async function() {
+      const keyBundle = {
+        attributes: {
+          expires: new Date(Date.now() - 60 * 1000 * 60 * 24) // Now - 24h
+        }
+      };
+      let error: Error | undefined = undefined;
+      try {
+        await checkKeyValidity("1", keyBundle);
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(
+        error?.message,
+        `Key 1 expired at ${keyBundle.attributes.expires.toISOString()}`
+      );
+    });
   });
 
-  it("Checking that the key's expires is respected", async function() {
-    const keyBundle = {
-      attributes: {
-        expires: new Date(Date.now() - 60 * 1000 * 60 * 24) // Now - 24h
-      }
-    };
-    let error: Error | undefined = undefined;
-    try {
-      await checkKeyValidity("1", keyBundle);
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error?.message, `Key 1 expired at ${keyBundle.attributes.expires.toISOString()}`);
+  describe("Parameter passing to encrypt / decrypt", function() {
+    let client: CryptographyClient;
+    let mockConcreteClient: sinon.SinonMock;
+
+    beforeEach(() => {
+      client = new CryptographyClient(
+        {
+          name: "keyName",
+          key: {
+            kid: "https://keyvault.vault.azure.net/keys/foobar/123"
+          },
+          properties: {
+            name: "keyName",
+            vaultUrl: "https://keyvault.vault.azure.net"
+          }
+        },
+        new DefaultAzureCredential()
+      );
+      mockConcreteClient = sinon.mock(client["concreteClient"].client);
+    });
+
+    afterEach(() => {
+      mockConcreteClient?.restore();
+    });
+
+    describe("Encrypt parameter mapping", async function() {
+      it("maps parameters correctly when using the previous API", async function() {
+        const text = stringToUint8Array(this.test!.title!);
+
+        mockConcreteClient.expects("encrypt").calledOnceWithExactly(
+          { algorithm: "RSA1_5", plaintext: text },
+          {
+            requestOptions: { timeout: 5 }
+          }
+        );
+
+        await client.encrypt("RSA1_5", text, { requestOptions: { timeout: 5 } });
+        mockConcreteClient.verify();
+      });
+
+      it("maps parameters correctly when using the current API", async function() {
+        const text = stringToUint8Array(this.test!.title!);
+
+        mockConcreteClient.expects("encrypt").calledOnceWithExactly(
+          { algorithm: "RSA1_5", plaintext: text },
+          {
+            requestOptions: { timeout: 5 }
+          }
+        );
+
+        await client.encrypt(
+          { algorithm: "RSA1_5", plaintext: text },
+          { requestOptions: { timeout: 5 } }
+        );
+        mockConcreteClient.verify();
+      });
+    });
+
+    describe("Decrypt parameter mapping", async function() {
+      it("maps parameters correctly when using the previous API", async function() {
+        const text = stringToUint8Array(this.test!.title!);
+        mockConcreteClient.expects("decrypt").calledOnceWithExactly(
+          { algorithm: "RSA1_5", ciphertext: text },
+          {
+            requestOptions: { timeout: 5 }
+          }
+        );
+
+        await client.decrypt("RSA1_5", text, { requestOptions: { timeout: 5 } });
+        mockConcreteClient.verify();
+      });
+
+      it("maps parameters correctly when using the current API", async function() {
+        const text = stringToUint8Array(this.test!.title!);
+        mockConcreteClient.expects("decrypt").calledOnceWithExactly(
+          { algorithm: "RSA1_5", ciphertext: text },
+          {
+            requestOptions: { timeout: 5 }
+          }
+        );
+
+        await client.decrypt(
+          { algorithm: "RSA1_5", ciphertext: text },
+          { requestOptions: { timeout: 5 } }
+        );
+        mockConcreteClient.verify();
+      });
+    });
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -50,8 +50,10 @@ describe("internal crypto tests", () => {
   describe("Parameter passing to encrypt / decrypt", function() {
     let client: CryptographyClient;
     let mockConcreteClient: sinon.SinonMock;
+    let mockCredential;
 
     beforeEach(() => {
+      mockCredential = sinon.createStubInstance(DefaultAzureCredential);
       client = new CryptographyClient(
         {
           name: "keyName",
@@ -63,7 +65,7 @@ describe("internal crypto tests", () => {
             vaultUrl: "https://keyvault.vault.azure.net"
           }
         },
-        new DefaultAzureCredential()
+        mockCredential
       );
       mockConcreteClient = sinon.mock(client["concreteClient"].client);
     });

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -8,7 +8,7 @@ import { CryptographyClient } from "../../src";
 import { checkKeyValidity } from "../../src/keyVaultCryptographyClient";
 import { stringToUint8Array } from "../utils/crypto";
 
-describe.only("internal crypto tests", () => {
+describe("internal crypto tests", () => {
   describe("checkKeyValidity", () => {
     it("Checking that the key's notBefore is respected", async function() {
       const keyBundle = {

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { env, Recorder } from "@azure/test-utils-recorder";
+
+import { KeyClient } from "../../src";
+import { authenticate } from "../utils/testAuthentication";
+import TestClient from "../utils/testClient";
+import { CreateOctKeyOptions } from "../../src/keysModels";
+
+describe("Keys client - create, read, update and delete operations for managed HSM", () => {
+  const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
+  let keySuffix: string;
+  let hsmClient: KeyClient;
+  let testClient: TestClient;
+  let recorder: Recorder;
+
+  beforeEach(async function() {
+    const authentication = await authenticate(this);
+    recorder = authentication.recorder;
+
+    if (!authentication.hsmClient) {
+      // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
+      // This is only necessary while Managed HSM is in preview.
+      this.skip();
+    }
+
+    hsmClient = authentication.hsmClient;
+    keySuffix = authentication.keySuffix;
+    testClient = new TestClient(hsmClient);
+  });
+
+  afterEach(async function() {
+    await recorder.stop();
+  });
+
+  it("can create an OCT key with options", async function() {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    const options: CreateOctKeyOptions = {
+      hsm: true
+    };
+    const result = await hsmClient.createOctKey(keyName, options);
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
+    assert.equal(result.keyType, "oct-HSM");
+    await testClient.flushKey(keyName);
+  });
+});

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -28,7 +28,7 @@ describe("Keys client - create, read, update and delete operations for managed H
 
     hsmClient = authentication.hsmClient;
     keySuffix = authentication.keySuffix;
-    testClient = new TestClient(hsmClient);
+    testClient = new TestClient(authentication.hsmClient);
   });
 
   afterEach(async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import { RestError } from "@azure/core-http";
 import { AbortController } from "@azure/abort-controller";
-import { env, isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
+import { env, Recorder } from "@azure/test-utils-recorder";
 
 import {
   KeyClient,
@@ -16,7 +16,6 @@ import { assertThrowsAbortError } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
-import { CreateOctKeyOptions } from "../../src/keysModels";
 
 describe("Keys client - create, read, update and delete operations", () => {
   const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
@@ -158,21 +157,6 @@ describe("Keys client - create, read, update and delete operations", () => {
         }
       });
     });
-  });
-
-  it("can create an OCT key with options", async function() {
-    if (!isPlaybackMode()) {
-      // oct key types are only supported in HSM instances, so avoid running this in a live setting until KeyVault supports them as well.
-      this.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    const options: CreateOctKeyOptions = {
-      hsm: true
-    };
-    const result = await client.createOctKey(keyName, options);
-    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
-    assert.equal(result.keyType, "oct-HSM");
-    await testClient.flushKey(keyName);
   });
 
   it("can create a disabled key", async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -73,12 +73,16 @@ describe("CryptographyClient for managed HSM (skipped if MHSM is not deployed)",
         plaintext: stringToUint8Array(text),
         iv: stringToUint8Array(text)
       });
-      assert.exists(encryptResult.iv);
+      // There is a service-level issue where `iv` is not returned
+      // from the service as part of the result. Until it's resolved
+      // we have to pend this and just pass the same iv
+      // back to decrypt for now.
+      // assert.exists(encryptResult.iv);
 
       const decryptResult = await cryptoClient.decrypt({
         algorithm: "A256CBCPAD",
         ciphertext: encryptResult.result!,
-        iv: encryptResult.iv!
+        iv: stringToUint8Array(text) // Replace with `encryptResult.iv!` once ADO 9361749 is resolved.
       });
       assert.equal(uint8ArrayToString(decryptResult.result), text);
     });

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { Recorder } from "@azure/test-utils-recorder";
+import { ClientSecretCredential } from "@azure/identity";
+// import { isNode } from "@azure/core-http";
+
+import { CryptographyClient, KeyVaultKey, KeyClient } from "../../src";
+import { authenticate } from "../utils/testAuthentication";
+import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
+import TestClient from "../utils/testClient";
+
+describe.only("CryptographyClient for managed HSM (all decrypts happen remotely)", () => {
+  let hsmClient: KeyClient;
+  let testClient: TestClient;
+  let cryptoClient: CryptographyClient;
+  let recorder: Recorder;
+  let credential: ClientSecretCredential;
+  let keyName: string;
+  let keyVaultKey: KeyVaultKey;
+  let keySuffix: string;
+
+  beforeEach(async function() {
+    const authentication = await authenticate(this);
+    recorder = authentication.recorder;
+
+    if (!authentication.hsmClient) {
+      // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
+      // This is only necessary while Managed HSM is in preview.
+      this.skip();
+    }
+
+    hsmClient = authentication.hsmClient;
+    testClient = new TestClient(hsmClient);
+    credential = authentication.credential;
+    keySuffix = authentication.keySuffix;
+    keyName = testClient.formatName("cryptography-client-test" + keySuffix);
+  });
+
+  afterEach(async function() {
+    if (!this.currentTest?.isPending()) {
+      await testClient?.flushKey(keyName);
+    }
+    await recorder.stop();
+  });
+
+  describe("with AES crypto algorithms", async function() {
+    it("encrypts and decrypts using AES-GCM", async function() {
+      keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+      cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
+      const text = this.test!.title;
+      const encryptResult = await cryptoClient.encrypt({
+        algorithm: "A256GCM",
+        plaintext: stringToUint8Array(text)
+      });
+      assert.exists(encryptResult.iv);
+      assert.exists(encryptResult.authenticationTag);
+
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "A256GCM",
+        ciphertext: encryptResult.result!,
+        iv: encryptResult.iv!,
+        authenticationTag: encryptResult.authenticationTag
+      });
+      assert.equal(text, uint8ArrayToString(decryptResult.result));
+    });
+
+    it("encrypts and decrypts using AES-CBC", async function() {
+      keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+      cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
+      const text = this.test!.title;
+      const encryptResult = await cryptoClient.encrypt({
+        algorithm: "A256CBCPAD",
+        plaintext: stringToUint8Array(text),
+        iv: stringToUint8Array(text)
+      });
+      assert.exists(encryptResult.iv);
+
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "A256CBCPAD",
+        ciphertext: encryptResult.result!,
+        iv: encryptResult.iv!
+      });
+      assert.equal(uint8ArrayToString(decryptResult.result), text);
+    });
+  });
+});

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -11,7 +11,7 @@ import { authenticate } from "../utils/testAuthentication";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import TestClient from "../utils/testClient";
 
-describe.only("CryptographyClient for managed HSM (all decrypts happen remotely)", () => {
+describe("CryptographyClient for managed HSM (skipped if MHSM is not deployed)", () => {
   let hsmClient: KeyClient;
   let testClient: TestClient;
   let cryptoClient: CryptographyClient;
@@ -39,9 +39,7 @@ describe.only("CryptographyClient for managed HSM (all decrypts happen remotely)
   });
 
   afterEach(async function() {
-    if (!this.currentTest?.isPending()) {
-      await testClient?.flushKey(keyName);
-    }
+    await testClient?.flushKey(keyName);
     await recorder.stop();
   });
 

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -32,7 +32,7 @@ describe("CryptographyClient for managed HSM (skipped if MHSM is not deployed)",
     }
 
     hsmClient = authentication.hsmClient;
-    testClient = new TestClient(hsmClient);
+    testClient = new TestClient(authentication.hsmClient);
     credential = authentication.credential;
     keySuffix = authentication.keySuffix;
     keyName = testClient.formatName("cryptography-client-test" + keySuffix);

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -51,18 +51,6 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
 
   // The tests follow
 
-  it("returns the additional parameters in encryptResult", async function() {
-    const text = stringToUint8Array(this.test!.title);
-    const encryptResult = await cryptoClient.encrypt("RSA1_5", text, {
-      additionalAuthenticatedData: text,
-      tag: text,
-      iv: text
-    });
-    assert.equal(encryptResult.additionalAuthenticatedData, text);
-    assert.equal(encryptResult.iv, text);
-    assert.equal(encryptResult.tag, text);
-  });
-
   if (isRecordMode()) {
     it("encrypt & decrypt with RSA1_5", async function() {
       const text = this.test!.title;
@@ -149,7 +137,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
         algorithm: "A128GCM",
         ciphertext: encryptResult.result,
         iv: encryptResult.iv!,
-        tag: encryptResult.tag!,
+        authenticationTag: encryptResult.authenticationTag!,
         additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
       });
       const decryptedText = uint8ArrayToString(decryptResult.result);
@@ -219,7 +207,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       await testClient.flushKey(hsmKeyName);
     });
 
-    it.only("encrypt & decrypt with an AES key", async function() {
+    it("encrypt & decrypt with an AES key", async function() {
       const hsmKeyName = keyName + "2";
       const hsmKey = await client.createKey(hsmKeyName, "AES", { keySize: 256 });
       const hsmCryptoClient = new CryptographyClient(hsmKey.id!, credential);
@@ -233,11 +221,12 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       console.log("encryptResult", encryptResult);
       const decryptResult = await hsmCryptoClient.decrypt({
         algorithm: "A256GCM",
-        tag: encryptResult.tag,
+        authenticationTag: encryptResult.authenticationTag,
         ciphertext: encryptResult.result,
         iv: encryptResult.iv,
         additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
       });
+
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
       await testClient.flushKey(hsmKeyName);

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -186,31 +186,6 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       assert.equal(text, decryptedText);
       await testClient.flushKey(hsmKeyName);
     });
-
-    it("encrypt & decrypt with an AES key", async function() {
-      const hsmKeyName = keyName + "2";
-      const hsmKey = await client.createKey(hsmKeyName, "AES", { keySize: 256 });
-      const hsmCryptoClient = new CryptographyClient(hsmKey.id!, credential);
-      const text = this.test!.title;
-      const encryptResult = await hsmCryptoClient.encrypt({
-        algorithm: "A256GCM",
-        plaintext: stringToUint8Array(text),
-        additionalAuthenticatedData: stringToUint8Array(text)
-      });
-      assert.exists(encryptResult.iv);
-      console.log("encryptResult", encryptResult);
-      const decryptResult = await hsmCryptoClient.decrypt({
-        algorithm: "A256GCM",
-        authenticationTag: encryptResult.authenticationTag,
-        ciphertext: encryptResult.result,
-        iv: encryptResult.iv!,
-        additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
-      });
-
-      const decryptedText = uint8ArrayToString(decryptResult.result);
-      assert.equal(text, decryptedText);
-      await testClient.flushKey(hsmKeyName);
-    });
   }
 
   it("wrap and unwrap with RSA-OAEP on a RSA-HSM key", async function() {

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -54,8 +54,14 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   if (isRecordMode()) {
     it("encrypt & decrypt with RSA1_5", async function() {
       const text = this.test!.title;
-      const encryptResult = await cryptoClient.encrypt("RSA1_5", stringToUint8Array(text));
-      const decryptResult = await cryptoClient.decrypt("RSA1_5", encryptResult.result);
+      const encryptResult = await cryptoClient.encrypt({
+        algorithm: "RSA1_5",
+        plaintext: stringToUint8Array(text)
+      });
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "RSA1_5",
+        ciphertext: encryptResult.result
+      });
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
     });
@@ -65,15 +71,24 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const keyPEM = convertJWKtoPEM(keyVaultKey.key!);
       const padded: any = { key: keyPEM, padding: constants.RSA_PKCS1_PADDING };
       const encrypted = publicEncrypt(padded, Buffer.from(text));
-      const decryptResult = await cryptoClient.decrypt("RSA1_5", encrypted);
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "RSA1_5",
+        ciphertext: encrypted
+      });
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
     });
 
     it("encrypt & decrypt with RSA-OAEP", async function() {
       const text = this.test!.title;
-      const encryptResult = await cryptoClient.encrypt("RSA-OAEP", stringToUint8Array(text));
-      const decryptResult = await cryptoClient.decrypt("RSA-OAEP", encryptResult.result);
+      const encryptResult = await cryptoClient.encrypt({
+        algorithm: "RSA-OAEP",
+        plaintext: stringToUint8Array(text)
+      });
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "RSA-OAEP",
+        ciphertext: encryptResult.result
+      });
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
     });
@@ -83,7 +98,10 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       // Encrypting outside the client since the client will intentionally
       const keyPEM = convertJWKtoPEM(keyVaultKey.key!);
       const encrypted = publicEncrypt(keyPEM, Buffer.from(text));
-      const decryptResult = await cryptoClient.decrypt("RSA-OAEP", encrypted);
+      const decryptResult = await cryptoClient.decrypt({
+        algorithm: "RSA-OAEP",
+        ciphertext: encrypted
+      });
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
     });
@@ -94,25 +112,10 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const cryptoClientFromKey = new CryptographyClient(customKeyVaultKey, credential);
 
       const text = this.test!.title;
-      const encryptResult = await cryptoClientFromKey.encrypt("RSA1_5", stringToUint8Array(text));
-      const decryptResult = await cryptoClientFromKey.decrypt("RSA1_5", encryptResult.result);
-      const decryptedText = uint8ArrayToString(decryptResult.result);
-      assert.equal(text, decryptedText);
-    });
-  }
-
-  describe.skip("algorithm specific encryption parameters", async function() {
-    it("defines encryption and decryption parameters for RSA keys", async function() {
-      const customKeyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const customKeyVaultKey = await client.createKey(customKeyName, "RSA", { keySize: 128 });
-      const cryptoClientFromKey = new CryptographyClient(customKeyVaultKey, credential);
-
-      const text = this.test!.title;
       const encryptResult = await cryptoClientFromKey.encrypt({
         algorithm: "RSA1_5",
         plaintext: stringToUint8Array(text)
       });
-      console.log("encryptResult", encryptResult);
       const decryptResult = await cryptoClientFromKey.decrypt({
         algorithm: "RSA1_5",
         ciphertext: encryptResult.result
@@ -120,30 +123,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
     });
-
-    it("defines encryption and decryption parameters for AES keys", async function() {
-      const customKeyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const customKeyVaultKey = await client.createKey(customKeyName, "AES", { keySize: 128 });
-      const cryptoClientFromKey = new CryptographyClient(customKeyVaultKey, credential);
-
-      const text = this.test!.title;
-      const encryptResult = await cryptoClientFromKey.encrypt({
-        algorithm: "A128GCM",
-        plaintext: stringToUint8Array(text),
-        additionalAuthenticatedData: stringToUint8Array(text)
-      });
-      console.log("encryptResult", encryptResult);
-      const decryptResult = await cryptoClientFromKey.decrypt({
-        algorithm: "A128GCM",
-        ciphertext: encryptResult.result,
-        iv: encryptResult.iv!,
-        authenticationTag: encryptResult.authenticationTag!,
-        additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
-      });
-      const decryptedText = uint8ArrayToString(decryptResult.result);
-      assert.equal(text, decryptedText);
-    });
-  });
+  }
 
   // Local encryption is only supported in NodeJS.
   it("sign and verify with RS256", async function(): Promise<void> {
@@ -223,7 +203,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
         algorithm: "A256GCM",
         authenticationTag: encryptResult.authenticationTag,
         ciphertext: encryptResult.result,
-        iv: encryptResult.iv,
+        iv: encryptResult.iv!,
         additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
       });
 

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -51,6 +51,18 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
 
   // The tests follow
 
+  it("returns the additional parameters in encryptResult", async function() {
+    const text = stringToUint8Array(this.test!.title);
+    const encryptResult = await cryptoClient.encrypt("RSA1_5", text, {
+      additionalAuthenticatedData: text,
+      tag: text,
+      iv: text
+    });
+    assert.equal(encryptResult.additionalAuthenticatedData, text);
+    assert.equal(encryptResult.iv, text);
+    assert.equal(encryptResult.tag, text);
+  });
+
   if (isRecordMode()) {
     it("encrypt & decrypt with RSA1_5", async function() {
       const text = this.test!.title;
@@ -101,7 +113,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
     });
   }
 
-  describe.only("algorithm specific encryption parameters", async function() {
+  describe.skip("algorithm specific encryption parameters", async function() {
     it("defines encryption and decryption parameters for RSA keys", async function() {
       const customKeyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
       const customKeyVaultKey = await client.createKey(customKeyName, "RSA", { keySize: 128 });
@@ -121,7 +133,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       assert.equal(text, decryptedText);
     });
 
-    it.only("defines encryption and decryption parameters for AES keys", async function() {
+    it("defines encryption and decryption parameters for AES keys", async function() {
       const customKeyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
       const customKeyVaultKey = await client.createKey(customKeyName, "AES", { keySize: 128 });
       const cryptoClientFromKey = new CryptographyClient(customKeyVaultKey, credential);
@@ -137,7 +149,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
         algorithm: "A128GCM",
         ciphertext: encryptResult.result,
         iv: encryptResult.iv!,
-        authenticationTag: encryptResult.authenticationTag!,
+        tag: encryptResult.tag!,
         additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
       });
       const decryptedText = uint8ArrayToString(decryptResult.result);
@@ -202,6 +214,30 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
       const text = this.test!.title;
       const encryptResult = await hsmCryptoClient.encrypt("RSA1_5", stringToUint8Array(text));
       const decryptResult = await hsmCryptoClient.decrypt("RSA1_5", encryptResult.result);
+      const decryptedText = uint8ArrayToString(decryptResult.result);
+      assert.equal(text, decryptedText);
+      await testClient.flushKey(hsmKeyName);
+    });
+
+    it.only("encrypt & decrypt with an AES key", async function() {
+      const hsmKeyName = keyName + "2";
+      const hsmKey = await client.createKey(hsmKeyName, "AES", { keySize: 256 });
+      const hsmCryptoClient = new CryptographyClient(hsmKey.id!, credential);
+      const text = this.test!.title;
+      const encryptResult = await hsmCryptoClient.encrypt({
+        algorithm: "A256GCM",
+        plaintext: stringToUint8Array(text),
+        additionalAuthenticatedData: stringToUint8Array(text)
+      });
+      assert.exists(encryptResult.iv);
+      console.log("encryptResult", encryptResult);
+      const decryptResult = await hsmCryptoClient.decrypt({
+        algorithm: "A256GCM",
+        tag: encryptResult.tag,
+        ciphertext: encryptResult.result,
+        iv: encryptResult.iv,
+        additionalAuthenticatedData: encryptResult.additionalAuthenticatedData
+      });
       const decryptedText = uint8ArrayToString(decryptResult.result);
       assert.equal(text, decryptedText);
       await testClient.flushKey(hsmKeyName);

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -10,6 +10,16 @@ import { Context } from "mocha";
 
 // Adding this to the source would change the public API.
 type ApiVersions = "7.0" | "7.1" | "7.2";
+
+export interface TestHelpers {
+  recorder: Recorder;
+  client: KeyClient;
+  credential: ClientSecretCredential;
+  testClient: TestClient;
+  hsmClient?: KeyClient;
+  keySuffix: string;
+}
+
 export async function authenticate(that: Context, version?: string): Promise<TestHelpers> {
   const keySuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
@@ -52,13 +62,4 @@ export async function authenticate(that: Context, version?: string): Promise<Tes
   }
 
   return { recorder, client, credential, testClient, hsmClient, keySuffix };
-}
-
-export interface TestHelpers {
-  recorder: Recorder;
-  client: KeyClient;
-  credential: ClientSecretCredential;
-  testClient: TestClient;
-  hsmClient?: KeyClient;
-  keySuffix: string;
 }

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -3,14 +3,14 @@
 
 import { ClientSecretCredential } from "@azure/identity";
 import { KeyClient } from "../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
+import { env, record, Recorder, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 
 // Adding this to the source would change the public API.
 type ApiVersions = "7.0" | "7.1" | "7.2";
-export async function authenticate(that: Context, version?: string): Promise<any> {
+export async function authenticate(that: Context, version?: string): Promise<TestHelpers> {
   const keySuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
@@ -52,4 +52,13 @@ export async function authenticate(that: Context, version?: string): Promise<any
   }
 
   return { recorder, client, credential, testClient, hsmClient, keySuffix };
+}
+
+export interface TestHelpers {
+  recorder: Recorder;
+  client: KeyClient;
+  credential: ClientSecretCredential;
+  testClient: TestClient;
+  hsmClient?: KeyClient;
+  keySuffix: string;
 }

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -3,7 +3,7 @@
 
 import { ClientSecretCredential } from "@azure/identity";
 import { KeyClient } from "../../src";
-import { env, record, Recorder, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
+import { env, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
@@ -11,16 +11,7 @@ import { Context } from "mocha";
 // Adding this to the source would change the public API.
 type ApiVersions = "7.0" | "7.1" | "7.2";
 
-export interface TestHelpers {
-  recorder: Recorder;
-  client: KeyClient;
-  credential: ClientSecretCredential;
-  testClient: TestClient;
-  hsmClient?: KeyClient;
-  keySuffix: string;
-}
-
-export async function authenticate(that: Context, version?: string): Promise<TestHelpers> {
+export async function authenticate(that: Context, version?: string): Promise<any> {
   const keySuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -18,7 +18,8 @@ export async function authenticate(that: Context, version?: string): Promise<any
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
       KEYVAULT_NAME: "keyvault_name",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net"
+      KEYVAULT_URI: "https://keyvault_name.vault.azure.net",
+      AZURE_MANAGEDHSM_URI: "https://azure_managedhsm.managedhsm.azure.net"
     },
     customizationsOnRecordings: [
       (recording: any): any =>
@@ -45,5 +46,10 @@ export async function authenticate(that: Context, version?: string): Promise<any
   });
   const testClient = new TestClient(client);
 
-  return { recorder, client, credential, testClient, keySuffix };
+  let hsmClient: KeyClient | undefined = undefined;
+  if (env.AZURE_MANAGEDHSM_URI) {
+    hsmClient = new KeyClient(env.AZURE_MANAGEDHSM_URI, credential);
+  }
+
+  return { recorder, client, credential, testClient, hsmClient, keySuffix };
 }


### PR DESCRIPTION
## What

- Add overloads to lead customers down the right path when encrypting / decrypting using AES algorithms
- Add Managed HSM specific test files and coverage
- Remove iv, aad, and tag from Encrypt/Decrypt Options
- Rename tag to authenticationTag
- Add iv, aad, and tag to EncryptResult

## Why

- AES algorithms have a bunch of specific requirements for encryption / decryption and it's a lot to put on the consumer to figure out what needs to get sent with each algorithm., We explored a few approaches and settled cross language on passing a set of algorithm specific encrypt parameters to the method. For TS our implementation uses a discriminated union.
- To test these changes correctly we should start running KV tests against Managed HSM (some algorithms are only supported in Managed HSM). For now we're only running the subset of tests conditionally but once more changes come in I want to make it run all the tests against the MHSM in a single configuration. 

Resolves #13843
Resolves #13129

## Callouts

- This snowballed into a huge PR, unfortunately. Sorry about that - if you want a guided tour reach out to me
- Eventually what I want to do, once #13886 is merged in, is to have an additional config where we run _all_ tests against the MHSM. 



![encryptparams](https://user-images.githubusercontent.com/753570/108577131-c80f2100-72d4-11eb-9507-9d0c42e8b07c.gif)
