### PR TITLE
Update the Logic for retrieving Package Properties

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -56,8 +56,7 @@ steps:
   - ${{ each artifact in parameters.Artifacts }}:
       - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
         parameters:
-          PackageName: ${{artifact.name}}
-          ServiceName: ${{parameters.ServiceDirectory}}
+          ArtifactName: ${{artifact.name}}
           ForRelease: false
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -236,15 +236,22 @@ function Find-javascript-Artifacts-For-Apireview($artifactDir, $packageName = ""
   return $packages
 }
 
-function SetPackageVersion ($PackageName, $Version, $ServiceDirectory = $null, $ReleaseDate, $BuildType = $null, $GroupId = $null)
+function SetPackageVersion ($ArtifactName, $Version, $ServiceDirectory = $null, $ReleaseDate, $BuildType = $null, $GroupId = $null)
 {
   if ($null -eq $ReleaseDate)
   {
     $ReleaseDate = Get-Date -Format "yyyy-MM-dd"
   }
   Push-Location "$EngDir/tools/versioning"
+
+  if ((Get-Command npm | Measure-Object).Count -eq 0 ) 
+  {
+    LogError "Could not locate npm. Install NodeJS (includes npm and npx) https://nodejs.org/en/download"
+    exit 1
+  }
+
   npm install
-  node ./set-version.js --artifact-name $PackageName --new-version $Version --release-date $ReleaseDate --repo-root $RepoRoot
+  node ./set-version.js --artifact-name $ArtifactName --new-version $Version --release-date $ReleaseDate --repo-root $RepoRoot
   Pop-Location
 }
 

--- a/eng/tools/versioning/VersionUtils.js
+++ b/eng/tools/versioning/VersionUtils.js
@@ -33,31 +33,25 @@ function buildSemverRegex(prefix) {
 }
 
 function updateChangelog(
-  targetPackagePath,
-  packageName,
+  artifactName,
   repoRoot,
   newVersion,
   unreleased,
   replaceLatestVersionTitle,
   releaseDate = null
 ) {
-  const service = path.basename(path.dirname(targetPackagePath));
   const updateChangelogPath = path.resolve(
     path.join(repoRoot, "eng/common/scripts/Update-ChangeLog.ps1")
   );
   let args = [
     updateChangelogPath,
-    "--Version",
-    newVersion,
-    "--ServiceDirectory",
-    service,
-    "--PackageName",
-    packageName,
+    "--Version:" + newVersion,
+    "--ArtifactName:" + artifactName,
     "--Unreleased:$" + unreleased,
     "--ReplaceLatestEntryTitle:$" + replaceLatestVersionTitle
   ];
   if (releaseDate != null) {
-    args.push(releaseDate);
+    args.push("--ReleaseDate:" + releaseDate);
   }
   child = spawnSync("pwsh", args);
   console.log("Powershell Data: " + child.stdout);

--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -64,7 +64,6 @@ async function main(argv) {
 
   await versionUtils.updatePackageConstants(targetPackagePath, packageJsonContents, newVersion);
   const updateStatus = versionUtils.updateChangelog(
-    targetPackagePath,
     artifactName,
     repoRoot,
     newVersion,

--- a/eng/tools/versioning/set-version.js
+++ b/eng/tools/versioning/set-version.js
@@ -68,7 +68,6 @@ async function main(argv) {
   await versionUtils.updatePackageConstants(targetPackagePath, packageJsonContents, newVersion);
 
   const updateStatus = versionUtils.updateChangelog(
-    targetPackagePath,
     artifactName,
     repoRoot,
     newVersion,


### PR DESCRIPTION
Updates to `Get-javascript-PackageInfoFromRepo`
Fix  mix-up between `ArtifactName` and `PackageName`
Depends on https://github.com/Azure/azure-sdk-tools/pull/1418