### PR TITLE
[Service Bus] Fix linting problems in test files

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
@@ -4,8 +4,17 @@
 import chai from "chai";
 import Long from "long";
 import chaiAsPromised from "chai-as-promised";
-import { ServiceBusMessage, delay, ProcessErrorArgs, ServiceBusSender, ServiceBusReceivedMessage } from "../../src";
-import { getAlreadyReceivingErrorMsg, InvalidOperationForPeekedMessage } from "../../src/util/errors";
+import {
+  ServiceBusMessage,
+  delay,
+  ProcessErrorArgs,
+  ServiceBusSender,
+  ServiceBusReceivedMessage
+} from "../../src";
+import {
+  getAlreadyReceivingErrorMsg,
+  InvalidOperationForPeekedMessage
+} from "../../src/util/errors";
 import { TestClientType, TestMessage } from "../public/utils/testUtils";
 import { ServiceBusReceiver, ServiceBusReceiverImpl } from "../../src/receivers/receiver";
 import {
@@ -34,9 +43,16 @@ let sender: ServiceBusSender;
 let receiver: ServiceBusReceiver;
 let deadLetterReceiver: ServiceBusReceiver;
 
-async function beforeEachTest(entityType: TestClientType): Promise<void> {
+async function beforeEachTest(
+  entityType: TestClientType,
+  receiveMode: "peekLock" | "receiveAndDelete" = "peekLock"
+): Promise<void> {
   entityNames = await serviceBusClient.test.createTestEntities(entityType);
-  receiver = await serviceBusClient.test.createPeekLockReceiver(entityNames);
+  if (receiveMode === "receiveAndDelete") {
+    receiver = await serviceBusClient.test.createReceiveAndDeleteReceiver(entityNames);
+  } else {
+    receiver = await serviceBusClient.test.createPeekLockReceiver(entityNames);
+  }
 
   sender = serviceBusClient.test.addToCleanup(
     serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
@@ -49,1102 +65,1073 @@ function afterEachTest(): Promise<void> {
   return serviceBusClient.test.afterEach();
 }
 
-describe("Batching Receiver", () => {
-  describe("Batch Receiver - Settle message", function(): void {
-    const maxDeliveryCount = 10;
+describe("Batch Receiver - Settle message", function(): void {
+  const maxDeliveryCount = 10;
 
-    before(() => {
-      serviceBusClient = createServiceBusClientForTests();
-    });
-
-    after(() => {
-      return serviceBusClient.test.after();
-    });
-
-    afterEach(async () => {
-      await afterEachTest();
-    });
-
-    async function sendReceiveMsg(
-      testMessages: ServiceBusMessage
-    ): Promise<ServiceBusReceivedMessage> {
-      await sender.sendMessages(testMessages);
-      const msgs = await receiver.receiveMessages(1);
-
-      should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
-      should.equal(msgs.length, 1, "Unexpected number of messages");
-      should.equal(msgs[0].body, testMessages.body, "MessageBody is different than expected");
-      should.equal(
-        msgs[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-      should.equal(msgs[0].deliveryCount, 0, "DeliveryCount is different than expected");
-
-      return msgs[0];
-    }
-
-    async function testComplete(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      const msg = await sendReceiveMsg(testMessages);
-
-      await receiver.completeMessage(msg);
-
-      await testPeekMsgsLength(receiver, 0);
-    }
-
-    it(noSessionTestClientType + ": complete() removes message", async function(): Promise<void> {
-      await beforeEachTest(noSessionTestClientType);
-      await testComplete();
-    });
-
-    it(withSessionTestClientType + ": complete() removes message", async function(): Promise<void> {
-      await beforeEachTest(withSessionTestClientType);
-      await testComplete();
-    });
-
-    async function testAbandon(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      const msg = await sendReceiveMsg(testMessages);
-      await receiver.abandonMessage(msg);
-
-      await testPeekMsgsLength(receiver, 1);
-
-      const messageBatch = await receiver.receiveMessages(1);
-
-      should.equal(messageBatch.length, 1, "Unexpected number of messages");
-      should.equal(messageBatch[0].deliveryCount, 1, "DeliveryCount is different than expected");
-      should.equal(
-        messageBatch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(messageBatch[0]);
-
-      await testPeekMsgsLength(receiver, 0);
-    }
-
-    it(
-      noSessionTestClientType + ": abandon() retains message with incremented deliveryCount",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testAbandon();
-      }
-    );
-
-    it(
-      withSessionTestClientType + ": abandon() retains message with incremented deliveryCount",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testAbandon();
-      }
-    );
-
-    async function testAbandonMsgsTillMaxDeliveryCount(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      await sender.sendMessages(testMessages);
-      let abandonMsgCount = 0;
-
-      while (abandonMsgCount < maxDeliveryCount) {
-        const batch = await receiver.receiveMessages(1);
-
-        should.equal(batch.length, 1, "Unexpected number of messages");
-        should.equal(
-          batch[0].messageId,
-          testMessages.messageId,
-          "MessageId is different than expected"
-        );
-        should.equal(
-          batch[0].deliveryCount,
-          abandonMsgCount,
-          "DeliveryCount is different than expected"
-        );
-        abandonMsgCount++;
-
-        await receiver.abandonMessage(batch[0]);
-      }
-
-      await testPeekMsgsLength(receiver, 0);
-
-      const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
-
-      should.equal(
-        Array.isArray(deadLetterMsgsBatch),
-        true,
-        "`ReceivedMessages` from Deadletter is not an array"
-      );
-      should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
-      should.equal(
-        deadLetterMsgsBatch[0].body,
-        testMessages.body,
-        "MessageBody is different than expected"
-      );
-      should.equal(
-        deadLetterMsgsBatch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(deadLetterMsgsBatch[0]);
-
-      await testPeekMsgsLength(deadLetterReceiver, 0);
-    }
-
-    it(
-      noSessionTestClientType + ": Multiple abandons until maxDeliveryCount.",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testAbandonMsgsTillMaxDeliveryCount();
-      }
-    );
-
-    it(
-      withSessionTestClientType + ": Multiple abandons until maxDeliveryCount.",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testAbandonMsgsTillMaxDeliveryCount();
-      }
-    );
-
-    async function testDefer(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      const msg = await sendReceiveMsg(testMessages);
-
-      if (!msg.sequenceNumber) {
-        throw "Sequence Number can not be null";
-      }
-      const sequenceNumber = msg.sequenceNumber;
-      await receiver.deferMessage(msg);
-
-      const [deferredMsg] = await receiver.receiveDeferredMessages(sequenceNumber);
-      if (!deferredMsg) {
-        throw "No message received for sequence number";
-      }
-      should.equal(deferredMsg.body, testMessages.body, "MessageBody is different than expected");
-      should.equal(
-        deferredMsg.messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-      should.equal(deferredMsg.deliveryCount, 1, "DeliveryCount is different than expected");
-
-      await receiver.completeMessage(deferredMsg);
-
-      await testPeekMsgsLength(receiver, 0);
-    }
-
-    it(
-      noSessionTestClientType + ": defer() moves message to deferred queue",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testDefer();
-      }
-    );
-
-    it(
-      withSessionTestClientType + ": defer() moves message to deferred queue",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testDefer();
-      }
-    );
-
-    async function testDeadletter(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      const msg = await sendReceiveMsg(testMessages);
-      await receiver.deadLetterMessage(msg);
-
-      await testPeekMsgsLength(receiver, 0);
-
-      const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
-
-      should.equal(
-        Array.isArray(deadLetterMsgsBatch),
-        true,
-        "`ReceivedMessages` from Deadletter is not an array"
-      );
-      should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
-      should.equal(
-        deadLetterMsgsBatch[0].body,
-        testMessages.body,
-        "MessageBody is different than expected"
-      );
-      should.equal(
-        deadLetterMsgsBatch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(deadLetterMsgsBatch[0]);
-
-      await testPeekMsgsLength(deadLetterReceiver, 0);
-    }
-
-    it(
-      noSessionTestClientType + ": deadLetter() moves message to deadletter queue",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testDeadletter();
-      }
-    );
-
-    it(
-      withSessionTestClientType + ": deadLetter() moves message to deadletter queue",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testDeadletter();
-      }
-    );
-
-    async function testPeek(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      await sender.sendMessages(testMessages);
-
-      const [peekedMsg] = await receiver.peekMessages(1);
-      if (!peekedMsg) {
-        // Sometimes the peek call does not return any messages :(
-        return;
-      }
-
-      should.equal(
-        !peekedMsg.lockToken,
-        true,
-        "Peeked msg was not meant to have lockToken! We use this assumption to differentiate between peeked msg and other messages."
-      );
-
-      const expectedErrorMsg = InvalidOperationForPeekedMessage;
-      try {
-        await receiver.completeMessage(peekedMsg);
-        assert.fail("completeMessage should have failed");
-      } catch (error) {
-        should.equal(error.message, expectedErrorMsg);
-      }
-      try {
-        await receiver.abandonMessage(peekedMsg);
-        assert.fail("abandonMessage should have failed");
-      } catch (error) {
-        should.equal(error.message, expectedErrorMsg);
-      }
-      try {
-        await receiver.deferMessage(peekedMsg);
-        assert.fail("deferMessage should have failed");
-      } catch (error) {
-        should.equal(error.message, expectedErrorMsg);
-      }
-      try {
-        await receiver.deadLetterMessage(peekedMsg);
-        assert.fail("deadLetterMessage should have failed");
-      } catch (error) {
-        should.equal(error.message, expectedErrorMsg);
-      }
-
-      await testPeekMsgsLength(receiver, 0);
-    }
-
-    it(noSessionTestClientType + ": cannot settle peeked message", async function(): Promise<void> {
-      await beforeEachTest(noSessionTestClientType);
-      await testPeek();
-    });
-
-    it(withSessionTestClientType + ": cannot settle peeked message", async function(): Promise<
-      void
-    > {
-      await beforeEachTest(withSessionTestClientType);
-      await testPeek();
-    });
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
   });
 
-  describe("Batch Receiver - Settle deadlettered message", function(): void {
-    before(() => {
-      serviceBusClient = createServiceBusClientForTests();
-    });
+  after(() => {
+    return serviceBusClient.test.after();
+  });
 
-    after(() => {
-      return serviceBusClient.test.after();
-    });
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-    afterEach(async () => {
-      await afterEachTest();
-    });
+  async function sendReceiveMsg(
+    testMessages: ServiceBusMessage
+  ): Promise<ServiceBusReceivedMessage> {
+    await sender.sendMessages(testMessages);
+    const msgs = await receiver.receiveMessages(1);
 
-    async function deadLetterMessage(
-      testMessage: ServiceBusMessage
-    ): Promise<ServiceBusReceivedMessage> {
-      await sender.sendMessages(testMessage);
+    should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
+    should.equal(msgs.length, 1, "Unexpected number of messages");
+    should.equal(msgs[0].body, testMessages.body, "MessageBody is different than expected");
+    should.equal(msgs[0].messageId, testMessages.messageId, "MessageId is different than expected");
+    should.equal(msgs[0].deliveryCount, 0, "DeliveryCount is different than expected");
+
+    return msgs[0];
+  }
+
+  async function testComplete(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    const msg = await sendReceiveMsg(testMessages);
+
+    await receiver.completeMessage(msg);
+
+    await testPeekMsgsLength(receiver, 0);
+  }
+
+  it(noSessionTestClientType + ": complete() removes message", async function(): Promise<void> {
+    await beforeEachTest(noSessionTestClientType);
+    await testComplete();
+  });
+
+  it(withSessionTestClientType + ": complete() removes message", async function(): Promise<void> {
+    await beforeEachTest(withSessionTestClientType);
+    await testComplete();
+  });
+
+  async function testAbandon(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    const msg = await sendReceiveMsg(testMessages);
+    await receiver.abandonMessage(msg);
+
+    await testPeekMsgsLength(receiver, 1);
+
+    const messageBatch = await receiver.receiveMessages(1);
+
+    should.equal(messageBatch.length, 1, "Unexpected number of messages");
+    should.equal(messageBatch[0].deliveryCount, 1, "DeliveryCount is different than expected");
+    should.equal(
+      messageBatch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await receiver.completeMessage(messageBatch[0]);
+
+    await testPeekMsgsLength(receiver, 0);
+  }
+
+  it(
+    noSessionTestClientType + ": abandon() retains message with incremented deliveryCount",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testAbandon();
+    }
+  );
+
+  it(
+    withSessionTestClientType + ": abandon() retains message with incremented deliveryCount",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testAbandon();
+    }
+  );
+
+  async function testAbandonMsgsTillMaxDeliveryCount(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    await sender.sendMessages(testMessages);
+    let abandonMsgCount = 0;
+
+    while (abandonMsgCount < maxDeliveryCount) {
       const batch = await receiver.receiveMessages(1);
 
       should.equal(batch.length, 1, "Unexpected number of messages");
-      should.equal(batch[0].body, testMessage.body, "MessageBody is different than expected");
       should.equal(
         batch[0].messageId,
-        testMessage.messageId,
-        "MessageId is different than expected"
-      );
-      should.equal(batch[0].deliveryCount, 0, "DeliveryCount is different than expected");
-
-      await receiver.deadLetterMessage(batch[0]);
-
-      await testPeekMsgsLength(receiver, 0);
-
-      const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
-
-      should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
-      should.equal(
-        deadLetterMsgsBatch[0].body,
-        testMessage.body,
-        "MessageBody is different than expected"
-      );
-      should.equal(
-        deadLetterMsgsBatch[0].messageId,
-        testMessage.messageId,
+        testMessages.messageId,
         "MessageId is different than expected"
       );
       should.equal(
-        deadLetterMsgsBatch[0].deliveryCount,
-        0,
+        batch[0].deliveryCount,
+        abandonMsgCount,
         "DeliveryCount is different than expected"
       );
+      abandonMsgCount++;
 
-      return deadLetterMsgsBatch[0];
+      await receiver.abandonMessage(batch[0]);
     }
 
-    async function completeDeadLetteredMessage(
-      testMessage: ServiceBusMessage,
-      deadletterClient: ServiceBusReceiver,
-      expectedDeliverCount: number
-    ): Promise<void> {
-      const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
+    await testPeekMsgsLength(receiver, 0);
 
-      should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
-      should.equal(
-        deadLetterMsgsBatch[0].body,
-        testMessage.body,
-        "MessageBody is different than expected"
-      );
-      should.equal(
-        deadLetterMsgsBatch[0].messageId,
-        testMessage.messageId,
-        "MessageId is different than expected"
-      );
-      should.equal(
-        deadLetterMsgsBatch[0].deliveryCount,
-        expectedDeliverCount,
-        "DeliveryCount is different than expected"
-      );
+    const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
 
-      await receiver.completeMessage(deadLetterMsgsBatch[0]);
-      await testPeekMsgsLength(deadletterClient, 0);
+    should.equal(
+      Array.isArray(deadLetterMsgsBatch),
+      true,
+      "`ReceivedMessages` from Deadletter is not an array"
+    );
+    should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
+    should.equal(
+      deadLetterMsgsBatch[0].body,
+      testMessages.body,
+      "MessageBody is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await receiver.completeMessage(deadLetterMsgsBatch[0]);
+
+    await testPeekMsgsLength(deadLetterReceiver, 0);
+  }
+
+  it(
+    noSessionTestClientType + ": Multiple abandons until maxDeliveryCount.",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testAbandonMsgsTillMaxDeliveryCount();
+    }
+  );
+
+  it(
+    withSessionTestClientType + ": Multiple abandons until maxDeliveryCount.",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testAbandonMsgsTillMaxDeliveryCount();
+    }
+  );
+
+  async function testDefer(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    const msg = await sendReceiveMsg(testMessages);
+
+    if (!msg.sequenceNumber) {
+      throw "Sequence Number can not be null";
+    }
+    const sequenceNumber = msg.sequenceNumber;
+    await receiver.deferMessage(msg);
+
+    const [deferredMsg] = await receiver.receiveDeferredMessages(sequenceNumber);
+    if (!deferredMsg) {
+      throw "No message received for sequence number";
+    }
+    should.equal(deferredMsg.body, testMessages.body, "MessageBody is different than expected");
+    should.equal(
+      deferredMsg.messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+    should.equal(deferredMsg.deliveryCount, 1, "DeliveryCount is different than expected");
+
+    await receiver.completeMessage(deferredMsg);
+
+    await testPeekMsgsLength(receiver, 0);
+  }
+
+  it(
+    noSessionTestClientType + ": defer() moves message to deferred queue",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testDefer();
+    }
+  );
+
+  it(
+    withSessionTestClientType + ": defer() moves message to deferred queue",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testDefer();
+    }
+  );
+
+  async function testDeadletter(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    const msg = await sendReceiveMsg(testMessages);
+    await receiver.deadLetterMessage(msg);
+
+    await testPeekMsgsLength(receiver, 0);
+
+    const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
+
+    should.equal(
+      Array.isArray(deadLetterMsgsBatch),
+      true,
+      "`ReceivedMessages` from Deadletter is not an array"
+    );
+    should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
+    should.equal(
+      deadLetterMsgsBatch[0].body,
+      testMessages.body,
+      "MessageBody is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await receiver.completeMessage(deadLetterMsgsBatch[0]);
+
+    await testPeekMsgsLength(deadLetterReceiver, 0);
+  }
+
+  it(
+    noSessionTestClientType + ": deadLetter() moves message to deadletter queue",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testDeadletter();
+    }
+  );
+
+  it(
+    withSessionTestClientType + ": deadLetter() moves message to deadletter queue",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testDeadletter();
+    }
+  );
+
+  async function testPeek(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    await sender.sendMessages(testMessages);
+
+    const [peekedMsg] = await receiver.peekMessages(1);
+    if (!peekedMsg) {
+      // Sometimes the peek call does not return any messages :(
+      return;
     }
 
-    async function testDeadletter(): Promise<void> {
-      const testMessage = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSessionSample();
-      const deadLetterMsg = await deadLetterMessage(testMessage);
-      let errorWasThrown = false;
+    should.equal(
+      !peekedMsg.lockToken,
+      true,
+      "Peeked msg was not meant to have lockToken! We use this assumption to differentiate between peeked msg and other messages."
+    );
 
-      await receiver.deadLetterMessage(deadLetterMsg).catch((err) => {
-        should.equal(err.code, "GeneralError", "Error code is different than expected");
-        errorWasThrown = true;
+    const expectedErrorMsg = InvalidOperationForPeekedMessage;
+    try {
+      await receiver.completeMessage(peekedMsg);
+      assert.fail("completeMessage should have failed");
+    } catch (error) {
+      should.equal(error.message, expectedErrorMsg);
+    }
+    try {
+      await receiver.abandonMessage(peekedMsg);
+      assert.fail("abandonMessage should have failed");
+    } catch (error) {
+      should.equal(error.message, expectedErrorMsg);
+    }
+    try {
+      await receiver.deferMessage(peekedMsg);
+      assert.fail("deferMessage should have failed");
+    } catch (error) {
+      should.equal(error.message, expectedErrorMsg);
+    }
+    try {
+      await receiver.deadLetterMessage(peekedMsg);
+      assert.fail("deadLetterMessage should have failed");
+    } catch (error) {
+      should.equal(error.message, expectedErrorMsg);
+    }
+
+    await testPeekMsgsLength(receiver, 0);
+  }
+
+  it(noSessionTestClientType + ": cannot settle peeked message", async function(): Promise<void> {
+    await beforeEachTest(noSessionTestClientType);
+    await testPeek();
+  });
+
+  it(withSessionTestClientType + ": cannot settle peeked message", async function(): Promise<void> {
+    await beforeEachTest(withSessionTestClientType);
+    await testPeek();
+  });
+});
+
+describe("Batch Receiver - Settle deadlettered message", function(): void {
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
+  });
+
+  after(() => {
+    return serviceBusClient.test.after();
+  });
+
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  async function deadLetterMessage(
+    testMessage: ServiceBusMessage
+  ): Promise<ServiceBusReceivedMessage> {
+    await sender.sendMessages(testMessage);
+    const batch = await receiver.receiveMessages(1);
+
+    should.equal(batch.length, 1, "Unexpected number of messages");
+    should.equal(batch[0].body, testMessage.body, "MessageBody is different than expected");
+    should.equal(batch[0].messageId, testMessage.messageId, "MessageId is different than expected");
+    should.equal(batch[0].deliveryCount, 0, "DeliveryCount is different than expected");
+
+    await receiver.deadLetterMessage(batch[0]);
+
+    await testPeekMsgsLength(receiver, 0);
+
+    const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
+
+    should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
+    should.equal(
+      deadLetterMsgsBatch[0].body,
+      testMessage.body,
+      "MessageBody is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].messageId,
+      testMessage.messageId,
+      "MessageId is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].deliveryCount,
+      0,
+      "DeliveryCount is different than expected"
+    );
+
+    return deadLetterMsgsBatch[0];
+  }
+
+  async function completeDeadLetteredMessage(
+    testMessage: ServiceBusMessage,
+    deadletterClient: ServiceBusReceiver,
+    expectedDeliverCount: number
+  ): Promise<void> {
+    const deadLetterMsgsBatch = await deadLetterReceiver.receiveMessages(1);
+
+    should.equal(deadLetterMsgsBatch.length, 1, "Unexpected number of messages");
+    should.equal(
+      deadLetterMsgsBatch[0].body,
+      testMessage.body,
+      "MessageBody is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].messageId,
+      testMessage.messageId,
+      "MessageId is different than expected"
+    );
+    should.equal(
+      deadLetterMsgsBatch[0].deliveryCount,
+      expectedDeliverCount,
+      "DeliveryCount is different than expected"
+    );
+
+    await receiver.completeMessage(deadLetterMsgsBatch[0]);
+    await testPeekMsgsLength(deadletterClient, 0);
+  }
+
+  async function testDeadletter(): Promise<void> {
+    const testMessage = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSessionSample();
+    const deadLetterMsg = await deadLetterMessage(testMessage);
+    let errorWasThrown = false;
+
+    await receiver.deadLetterMessage(deadLetterMsg).catch((err) => {
+      should.equal(err.code, "GeneralError", "Error code is different than expected");
+      errorWasThrown = true;
+    });
+
+    should.equal(errorWasThrown, true, "Error thrown flag must be true");
+
+    await completeDeadLetteredMessage(testMessage, deadLetterReceiver, 0);
+  }
+
+  it(
+    anyRandomTestClientType + ": Throws error when dead lettering a dead lettered message",
+    async function(): Promise<void> {
+      await beforeEachTest(anyRandomTestClientType);
+      await testDeadletter();
+    }
+  );
+
+  async function testAbandon(): Promise<void> {
+    const testMessage = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSessionSample();
+    const deadLetterMsg = await deadLetterMessage(testMessage);
+
+    await receiver.abandonMessage(deadLetterMsg);
+
+    await completeDeadLetteredMessage(testMessage, deadLetterReceiver, 0);
+  }
+
+  it(
+    anyRandomTestClientType + ": Abandon a message received from dead letter queue",
+    async function(): Promise<void> {
+      await beforeEachTest(anyRandomTestClientType);
+      await testAbandon();
+    }
+  );
+
+  async function testDefer(): Promise<void> {
+    const testMessage = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSessionSample();
+    const deadLetterMsg = await deadLetterMessage(testMessage);
+
+    if (!deadLetterMsg.sequenceNumber) {
+      throw "Sequence Number can not be null";
+    }
+
+    const sequenceNumber = deadLetterMsg.sequenceNumber;
+    await receiver.deferMessage(deadLetterMsg);
+
+    const [deferredMsg] = await deadLetterReceiver.receiveDeferredMessages(sequenceNumber);
+    if (!deferredMsg) {
+      throw "No message received for sequence number";
+    }
+    should.equal(deferredMsg.body, testMessage.body, "MessageBody is different than expected");
+    should.equal(
+      deferredMsg.messageId,
+      testMessage.messageId,
+      "MessageId is different than expected"
+    );
+
+    await deadLetterReceiver.completeMessage(deferredMsg);
+
+    await testPeekMsgsLength(receiver, 0);
+
+    await testPeekMsgsLength(deadLetterReceiver, 0);
+  }
+
+  // TODO: The below test for session enabled entity needs a higher timeout most of the time
+  // The rest of the time, it fails with "The service was unable to process the request; please retry the operation.".
+  // So, testing for non sessions at the moment, more investigation needed from service side.
+  it(
+    noSessionTestClientType + ": Defer a message received from dead letter queue",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testDefer();
+    }
+  );
+});
+
+describe("Batch Receiver - Multiple Receiver Operations", function(): void {
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
+  });
+
+  after(() => {
+    return serviceBusClient.test.after();
+  });
+
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  // We use an empty queue/topic here so that the first receiveMessages call takes time to return
+  async function testParallelReceiveCalls(): Promise<void> {
+    const firstBatchPromise = receiver.receiveMessages(1, { maxWaitTimeInMs: 10000 });
+    await delay(5000);
+
+    let errorMessage;
+    const expectedErrorMessage = getAlreadyReceivingErrorMsg(
+      receiver.entityPath,
+      entityNames.usesSessions ? TestMessage.sessionId : undefined
+    );
+
+    try {
+      await receiver.receiveMessages(1);
+    } catch (err) {
+      errorMessage = err && err.message;
+    }
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for receiveMessages"
+    );
+
+    let unexpectedError;
+    try {
+      receiver.subscribe({
+        async processMessage(): Promise<void> {
+          // process message here - it's basically a ServiceBusMessage minus any settlement related methods
+        },
+        async processError(args: ProcessErrorArgs): Promise<void> {
+          unexpectedError = args.error;
+        }
       });
-
-      should.equal(errorWasThrown, true, "Error thrown flag must be true");
-
-      await completeDeadLetteredMessage(testMessage, deadLetterReceiver, 0);
+    } catch (err) {
+      errorMessage = err && err.message;
     }
-
-    it(
-      anyRandomTestClientType + ": Throws error when dead lettering a dead lettered message",
-      async function(): Promise<void> {
-        await beforeEachTest(anyRandomTestClientType);
-        await testDeadletter();
-      }
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for registerMessageHandler"
+    );
+    should.equal(
+      unexpectedError,
+      undefined,
+      "Unexpected error found in errorHandler for registerMessageHandler"
     );
 
-    async function testAbandon(): Promise<void> {
-      const testMessage = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSessionSample();
-      const deadLetterMsg = await deadLetterMessage(testMessage);
+    await firstBatchPromise;
+  }
 
-      await receiver.abandonMessage(deadLetterMsg);
-
-      await completeDeadLetteredMessage(testMessage, deadLetterReceiver, 0);
+  it(
+    noSessionTestClientType +
+      ": Throws error when ReceiveBatch is called while the previous call is not done",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testParallelReceiveCalls();
     }
+  );
 
-    it(
-      anyRandomTestClientType + ": Abandon a message received from dead letter queue",
-      async function(): Promise<void> {
-        await beforeEachTest(anyRandomTestClientType);
-        await testAbandon();
-      }
+  it(
+    withSessionTestClientType +
+      ": Throws error when ReceiveBatch is called while the previous call is not done",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testParallelReceiveCalls();
+    }
+  );
+
+  const messages: ServiceBusMessage[] = [
+    {
+      body: "hello1",
+      messageId: `test message ${Math.random()}`,
+      partitionKey: "dummy" // partitionKey is only for partitioned queue/subscrption, Unpartitioned queue/subscrption do not care about partitionKey.
+    },
+    {
+      body: "hello2",
+      messageId: `test message ${Math.random()}`,
+      partitionKey: "dummy" // partitionKey is only for partitioned queue/subscrption, Unpartitioned queue/subscrption do not care about partitionKey.
+    }
+  ];
+  const messageWithSessions: ServiceBusMessage[] = [
+    {
+      body: "hello1",
+      messageId: `test message ${Math.random()}`,
+      sessionId: TestMessage.sessionId
+    },
+    {
+      body: "hello2",
+      messageId: `test message ${Math.random()}`,
+      sessionId: TestMessage.sessionId
+    }
+  ];
+
+  // We test for mutilple receiveMessages specifically to ensure that batchingRecevier on a client is reused
+  // See https://github.com/Azure/azure-service-bus-node/issues/31
+  async function testSequentialReceiveBatchCalls(): Promise<void> {
+    const testMessages = entityNames.usesSessions ? messageWithSessions : messages;
+    const batchMessageToSend = await sender.createMessageBatch();
+    for (const message of testMessages) {
+      batchMessageToSend.tryAddMessage(message);
+    }
+    await sender.sendMessages(batchMessageToSend);
+    const msgs1 = await receiver.receiveMessages(1);
+    const msgs2 = await receiver.receiveMessages(1);
+
+    // Results are checked after both receiveMessages are done to ensure that the second call doesnt
+    // affect the result from the first one.
+    should.equal(Array.isArray(msgs1), true, "`ReceivedMessages` is not an array");
+    should.equal(msgs1.length, 1, "Unexpected number of messages");
+
+    should.equal(Array.isArray(msgs2), true, "`ReceivedMessages` is not an array");
+    should.equal(msgs2.length, 1, "Unexpected number of messages");
+
+    should.equal(
+      testMessages.some((x) => x.messageId === msgs1[0].messageId),
+      true,
+      "MessageId is different than expected"
+    );
+    should.equal(
+      testMessages.some((x) => x.messageId === msgs2[0].messageId),
+      true,
+      "MessageId is different than expected"
     );
 
-    async function testDefer(): Promise<void> {
-      const testMessage = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSessionSample();
-      const deadLetterMsg = await deadLetterMessage(testMessage);
+    await receiver.completeMessage(msgs1[0]);
+    await receiver.completeMessage(msgs2[0]);
+  }
 
-      if (!deadLetterMsg.sequenceNumber) {
-        throw "Sequence Number can not be null";
-      }
-
-      const sequenceNumber = deadLetterMsg.sequenceNumber;
-      await receiver.deferMessage(deadLetterMsg);
-
-      const [deferredMsg] = await deadLetterReceiver.receiveDeferredMessages(sequenceNumber);
-      if (!deferredMsg) {
-        throw "No message received for sequence number";
-      }
-      should.equal(deferredMsg.body, testMessage.body, "MessageBody is different than expected");
-      should.equal(
-        deferredMsg.messageId,
-        testMessage.messageId,
-        "MessageId is different than expected"
-      );
-
-      await deadLetterReceiver.completeMessage(deferredMsg);
-
-      await testPeekMsgsLength(receiver, 0);
-
-      await testPeekMsgsLength(deadLetterReceiver, 0);
+  it(
+    noSessionTestClientType + ": Multiple sequential receiveMessages calls",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testSequentialReceiveBatchCalls();
     }
+  );
 
-    // TODO: The below test for session enabled entity needs a higher timeout most of the time
-    // The rest of the time, it fails with "The service was unable to process the request; please retry the operation.".
-    // So, testing for non sessions at the moment, more investigation needed from service side.
-    it(
-      noSessionTestClientType + ": Defer a message received from dead letter queue",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testDefer();
-      }
-    );
+  it(
+    withSessionTestClientType + ":  Multiple sequential receiveMessages calls",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testSequentialReceiveBatchCalls();
+    }
+  );
+});
+
+describe("Batch Receiver - Others", function(): void {
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
   });
 
-  describe("Batch Receiver - Multiple Receiver Operations", function(): void {
-    before(() => {
-      serviceBusClient = createServiceBusClientForTests();
-    });
-
-    after(() => {
-      return serviceBusClient.test.after();
-    });
-
-    afterEach(async () => {
-      await afterEachTest();
-    });
-
-    // We use an empty queue/topic here so that the first receiveMessages call takes time to return
-    async function testParallelReceiveCalls(): Promise<void> {
-      const firstBatchPromise = receiver.receiveMessages(1, { maxWaitTimeInMs: 10000 });
-      await delay(5000);
-
-      let errorMessage;
-      const expectedErrorMessage = getAlreadyReceivingErrorMsg(
-        receiver.entityPath,
-        entityNames.usesSessions ? TestMessage.sessionId : undefined
-      );
-
-      try {
-        await receiver.receiveMessages(1);
-      } catch (err) {
-        errorMessage = err && err.message;
-      }
-      should.equal(
-        errorMessage,
-        expectedErrorMessage,
-        "Unexpected error message for receiveMessages"
-      );
-
-      let unexpectedError;
-      try {
-        receiver.subscribe({
-          async processMessage(): Promise<void> {
-            // process message here - it's basically a ServiceBusMessage minus any settlement related methods
-          },
-          async processError(args: ProcessErrorArgs): Promise<void> {
-            unexpectedError = args.error;
-          }
-        });
-      } catch (err) {
-        errorMessage = err && err.message;
-      }
-      should.equal(
-        errorMessage,
-        expectedErrorMessage,
-        "Unexpected error message for registerMessageHandler"
-      );
-      should.equal(
-        unexpectedError,
-        undefined,
-        "Unexpected error found in errorHandler for registerMessageHandler"
-      );
-
-      await firstBatchPromise;
-    }
-
-    it(
-      noSessionTestClientType +
-        ": Throws error when ReceiveBatch is called while the previous call is not done",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testParallelReceiveCalls();
-      }
-    );
-
-    it(
-      withSessionTestClientType +
-        ": Throws error when ReceiveBatch is called while the previous call is not done",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testParallelReceiveCalls();
-      }
-    );
-
-    const messages: ServiceBusMessage[] = [
-      {
-        body: "hello1",
-        messageId: `test message ${Math.random()}`,
-        partitionKey: "dummy" // partitionKey is only for partitioned queue/subscrption, Unpartitioned queue/subscrption do not care about partitionKey.
-      },
-      {
-        body: "hello2",
-        messageId: `test message ${Math.random()}`,
-        partitionKey: "dummy" // partitionKey is only for partitioned queue/subscrption, Unpartitioned queue/subscrption do not care about partitionKey.
-      }
-    ];
-    const messageWithSessions: ServiceBusMessage[] = [
-      {
-        body: "hello1",
-        messageId: `test message ${Math.random()}`,
-        sessionId: TestMessage.sessionId
-      },
-      {
-        body: "hello2",
-        messageId: `test message ${Math.random()}`,
-        sessionId: TestMessage.sessionId
-      }
-    ];
-
-    // We test for mutilple receiveMessages specifically to ensure that batchingRecevier on a client is reused
-    // See https://github.com/Azure/azure-service-bus-node/issues/31
-    async function testSequentialReceiveBatchCalls(): Promise<void> {
-      const testMessages = entityNames.usesSessions ? messageWithSessions : messages;
-      const batchMessageToSend = await sender.createMessageBatch();
-      for (const message of testMessages) {
-        batchMessageToSend.tryAddMessage(message);
-      }
-      await sender.sendMessages(batchMessageToSend);
-      const msgs1 = await receiver.receiveMessages(1);
-      const msgs2 = await receiver.receiveMessages(1);
-
-      // Results are checked after both receiveMessages are done to ensure that the second call doesnt
-      // affect the result from the first one.
-      should.equal(Array.isArray(msgs1), true, "`ReceivedMessages` is not an array");
-      should.equal(msgs1.length, 1, "Unexpected number of messages");
-
-      should.equal(Array.isArray(msgs2), true, "`ReceivedMessages` is not an array");
-      should.equal(msgs2.length, 1, "Unexpected number of messages");
-
-      should.equal(
-        testMessages.some((x) => x.messageId === msgs1[0].messageId),
-        true,
-        "MessageId is different than expected"
-      );
-      should.equal(
-        testMessages.some((x) => x.messageId === msgs2[0].messageId),
-        true,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(msgs1[0]);
-      await receiver.completeMessage(msgs2[0]);
-    }
-
-    it(
-      noSessionTestClientType + ": Multiple sequential receiveMessages calls",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testSequentialReceiveBatchCalls();
-      }
-    );
-
-    it(
-      withSessionTestClientType + ":  Multiple sequential receiveMessages calls",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testSequentialReceiveBatchCalls();
-      }
-    );
+  after(() => {
+    return serviceBusClient.test.after();
   });
 
-  describe("Batch Receiver - Others", function(): void {
-    before(() => {
-      serviceBusClient = createServiceBusClientForTests();
-    });
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-    after(() => {
-      return serviceBusClient.test.after();
-    });
+  async function testNoSettlement(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    await sender.sendMessages(testMessages);
 
-    afterEach(async () => {
-      await afterEachTest();
-    });
-
-    async function testNoSettlement(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      await sender.sendMessages(testMessages);
-
-      // We need a receiver with lock renewal disabled so that
-      // the message lands back in the queue/subscription to be picked up again.
-      await receiver.close();
-      if (entityNames.usesSessions) {
-        receiver = await serviceBusClient.test.acceptSessionWithPeekLock(
-          entityNames,
-          testMessages.sessionId!,
-          {
-            maxAutoLockRenewalDurationInMs: 0
-          }
-        );
-      } else {
-        receiver = await serviceBusClient.test.createPeekLockReceiver(entityNames, {
+    // We need a receiver with lock renewal disabled so that
+    // the message lands back in the queue/subscription to be picked up again.
+    await receiver.close();
+    if (entityNames.usesSessions) {
+      receiver = await serviceBusClient.test.acceptSessionWithPeekLock(
+        entityNames,
+        testMessages.sessionId!,
+        {
           maxAutoLockRenewalDurationInMs: 0
-        });
-      }
-
-      let batch = await receiver.receiveMessages(1);
-
-      should.equal(batch.length, 1, "Unexpected number of messages");
-      should.equal(batch[0].deliveryCount, 0, "DeliveryCount is different than expected");
-      should.equal(
-        batch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
+        }
       );
+    } else {
+      receiver = await serviceBusClient.test.createPeekLockReceiver(entityNames, {
+        maxAutoLockRenewalDurationInMs: 0
+      });
+    }
 
-      await testPeekMsgsLength(receiver, 1);
+    let batch = await receiver.receiveMessages(1);
 
-      // If using sessions wait to lose the lock, then use a new receiver to get the message
-      // landed back in the queue/subscription.
-      if (entityNames.usesSessions) {
-        await delay(31000);
-        receiver = await serviceBusClient.test.acceptSessionWithPeekLock(
-          entityNames,
-          testMessages.sessionId!,
-          {
-            maxAutoLockRenewalDurationInMs: 0
-          }
+    should.equal(batch.length, 1, "Unexpected number of messages");
+    should.equal(batch[0].deliveryCount, 0, "DeliveryCount is different than expected");
+    should.equal(
+      batch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await testPeekMsgsLength(receiver, 1);
+
+    // If using sessions wait to lose the lock, then use a new receiver to get the message
+    // landed back in the queue/subscription.
+    if (entityNames.usesSessions) {
+      await delay(31000);
+      receiver = await serviceBusClient.test.acceptSessionWithPeekLock(
+        entityNames,
+        testMessages.sessionId!,
+        {
+          maxAutoLockRenewalDurationInMs: 0
+        }
+      );
+    }
+
+    batch = await receiver.receiveMessages(1);
+
+    should.equal(batch.length, 1, "Unexpected number of messages");
+    should.equal(batch[0].deliveryCount, 1, "DeliveryCount is different than expected");
+    should.equal(
+      batch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await receiver.completeMessage(batch[0]);
+  }
+
+  it(
+    noSessionTestClientType +
+      ": No settlement of the message is retained with incremented deliveryCount",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      await testNoSettlement();
+    }
+  );
+
+  it(
+    withSessionTestClientType +
+      ": No settlement of the message is retained with incremented deliveryCount",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      await testNoSettlement();
+    }
+  );
+
+  async function testAskForMore(): Promise<void> {
+    const testMessages = entityNames.usesSessions
+      ? TestMessage.getSessionSample()
+      : TestMessage.getSample();
+    await sender.sendMessages(testMessages);
+    const batch = await receiver.receiveMessages(2);
+
+    should.equal(batch.length, 1, "Unexpected number of messages");
+    should.equal(batch[0].body, testMessages.body, "MessageBody is different than expected");
+    should.equal(
+      batch[0].messageId,
+      testMessages.messageId,
+      "MessageId is different than expected"
+    );
+
+    await receiver.completeMessage(batch[0]);
+
+    await testPeekMsgsLength(receiver, 0);
+  }
+
+  it(
+    noSessionTestClientType + ": Receive n messages but queue only has m messages, where m < n",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+
+      await testAskForMore();
+    }
+  );
+
+  it(
+    withSessionTestClientType +
+      ": Receive n messages but subscription only has m messages, where m < n",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+
+      await testAskForMore();
+    }
+  );
+
+  it(
+    noSessionTestClientType + ": Abort receiveDeferredMessages request on the receiver",
+    async function(): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 1);
+      try {
+        await receiver.receiveDeferredMessages([Long.ZERO], {
+          abortSignal: controller.signal
+        });
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.equal(
+          "The receiveDeferredMessages operation has been cancelled by the user."
         );
       }
-
-      batch = await receiver.receiveMessages(1);
-
-      should.equal(batch.length, 1, "Unexpected number of messages");
-      should.equal(batch[0].deliveryCount, 1, "DeliveryCount is different than expected");
-      should.equal(
-        batch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(batch[0]);
     }
+  );
 
-    it(
-      noSessionTestClientType +
-        ": No settlement of the message is retained with incremented deliveryCount",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        await testNoSettlement();
+  it(
+    withSessionTestClientType + ": Abort receiveDeferredMessages request on the receiver",
+    async function(): Promise<void> {
+      await beforeEachTest(withSessionTestClientType);
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 1);
+      try {
+        await receiver.receiveDeferredMessages([Long.ZERO], {
+          abortSignal: controller.signal
+        });
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.equal(
+          "The receiveDeferredMessages operation has been cancelled by the user."
+        );
       }
-    );
-
-    it(
-      withSessionTestClientType +
-        ": No settlement of the message is retained with incremented deliveryCount",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        await testNoSettlement();
-      }
-    );
-
-    async function testAskForMore(): Promise<void> {
-      const testMessages = entityNames.usesSessions
-        ? TestMessage.getSessionSample()
-        : TestMessage.getSample();
-      await sender.sendMessages(testMessages);
-      const batch = await receiver.receiveMessages(2);
-
-      should.equal(batch.length, 1, "Unexpected number of messages");
-      should.equal(batch[0].body, testMessages.body, "MessageBody is different than expected");
-      should.equal(
-        batch[0].messageId,
-        testMessages.messageId,
-        "MessageId is different than expected"
-      );
-
-      await receiver.completeMessage(batch[0]);
-
-      await testPeekMsgsLength(receiver, 0);
     }
+  );
+});
 
-    it(
-      noSessionTestClientType + ": Receive n messages but queue only has m messages, where m < n",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-
-        await testAskForMore();
-      }
-    );
-
-    it(
-      withSessionTestClientType +
-        ": Receive n messages but subscription only has m messages, where m < n",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-
-        await testAskForMore();
-      }
-    );
-
-    it(
-      noSessionTestClientType + ": Abort receiveDeferredMessages request on the receiver",
-      async function(): Promise<void> {
-        await beforeEachTest(noSessionTestClientType);
-        const controller = new AbortController();
-        setTimeout(() => controller.abort(), 1);
-        try {
-          await receiver.receiveDeferredMessages([Long.ZERO], {
-            abortSignal: controller.signal
-          });
-          throw new Error(`Test failure`);
-        } catch (err) {
-          err.message.should.equal(
-            "The receiveDeferredMessages operation has been cancelled by the user."
-          );
-        }
-      }
-    );
-
-    it(
-      withSessionTestClientType + ": Abort receiveDeferredMessages request on the receiver",
-      async function(): Promise<void> {
-        await beforeEachTest(withSessionTestClientType);
-        const controller = new AbortController();
-        setTimeout(() => controller.abort(), 1);
-        try {
-          await receiver.receiveDeferredMessages([Long.ZERO], {
-            abortSignal: controller.signal
-          });
-          throw new Error(`Test failure`);
-        } catch (err) {
-          err.message.should.equal(
-            "The receiveDeferredMessages operation has been cancelled by the user."
-          );
-        }
-      }
-    );
+describe(noSessionTestClientType + ": Batch Receiver - disconnects", function(): void {
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
   });
 
-  describe(noSessionTestClientType + ": Batch Receiver - disconnects", function(): void {
-    let serviceBusClient: ServiceBusClientForTests;
-    let sender: ServiceBusSender;
-    let receiver: ServiceBusReceiver;
+  after(() => {
+    return serviceBusClient.test.after();
+  });
 
-    async function beforeEachTest(
-      receiveMode: "peekLock" | "receiveAndDelete" = "peekLock"
-    ): Promise<void> {
-      serviceBusClient = createServiceBusClientForTests();
-      const entityNames = await serviceBusClient.test.createTestEntities(noSessionTestClientType);
-      if (receiveMode == "receiveAndDelete") {
-        receiver = await serviceBusClient.test.createReceiveAndDeleteReceiver(entityNames);
-      } else {
-        receiver = await serviceBusClient.test.createPeekLockReceiver(entityNames);
-      }
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-      sender = serviceBusClient.test.addToCleanup(
-        serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
-      );
+  it("can receive and settle messages after a disconnect", async function(): Promise<void> {
+    // Create the sender and receiver.
+    await beforeEachTest(noSessionTestClientType);
+
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.sendMessages(TestMessage.getSample());
+
+    let settledMessageCount = 0;
+
+    const messages1 = await receiver.receiveMessages(1);
+    for (const message of messages1) {
+      await receiver.completeMessage(message);
+      settledMessageCount++;
     }
 
-    afterEach(async () => {
-      if (serviceBusClient) {
-        await serviceBusClient.test.afterEach();
-        await serviceBusClient.test.after();
-      }
-    });
+    settledMessageCount.should.equal(1, "Unexpected number of settled messages.");
 
-    it("can receive and settle messages after a disconnect", async function(): Promise<void> {
-      // Create the sender and receiver.
-      await beforeEachTest();
+    const connectionContext = (receiver as any)["_context"];
+    const refreshConnection = connectionContext.refreshConnection;
+    let refreshConnectionCalled = 0;
+    connectionContext.refreshConnection = function(...args: any) {
+      refreshConnectionCalled++;
+      refreshConnection.apply(this, args);
+    };
 
-      // Send a message so we can be sure when the receiver is open and active.
-      await sender.sendMessages(TestMessage.getSample());
+    // Simulate a disconnect being called with a non-retryable error.
+    (receiver as ServiceBusReceiverImpl)["_context"].connection["_connection"].idle();
 
-      let settledMessageCount = 0;
+    // send a second message to trigger the message handler again.
+    await sender.sendMessages(TestMessage.getSample());
 
-      const messages1 = await receiver.receiveMessages(1);
-      for (const message of messages1) {
-        await receiver.completeMessage(message);
-        settledMessageCount++;
-      }
+    // wait for the 2nd message to be received.
+    const messages2 = await (receiver as ServiceBusReceiver).receiveMessages(1);
+    for (const message of messages2) {
+      await receiver.completeMessage(message);
+      settledMessageCount++;
+    }
+    settledMessageCount.should.equal(2, "Unexpected number of settled messages.");
+    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
 
-      settledMessageCount.should.equal(1, "Unexpected number of settled messages.");
+  it("returns messages if drain is in progress (receiveAndDelete)", async function(): Promise<
+    void
+  > {
+    // Create the sender and receiver.
+    await beforeEachTest(noSessionTestClientType, "receiveAndDelete");
 
-      const connectionContext = (receiver as any)["_context"];
-      const refreshConnection = connectionContext.refreshConnection;
-      let refreshConnectionCalled = 0;
-      connectionContext.refreshConnection = function(...args: any) {
-        refreshConnectionCalled++;
-        refreshConnection.apply(this, args);
-      };
+    // The first time `receiveMessages` is called the receiver link is created.
+    // The `receiver_drained` handler is only added after the link is created,
+    // which is a non-blocking task.
+    await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
+    const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
+    const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
 
-      // Simulate a disconnect being called with a non-retryable error.
-      (receiver as ServiceBusReceiverImpl)["_context"].connection["_connection"].idle();
+    if (!batchingReceiver || !batchingReceiver.isOpen()) {
+      throw new Error(`Unable to initialize receiver link.`);
+    }
 
-      // send a second message to trigger the message handler again.
-      await sender.sendMessages(TestMessage.getSample());
+    // Send a message so we have something to receive.
+    await sender.sendMessages(TestMessage.getSample());
 
-      // wait for the 2nd message to be received.
-      const messages2 = await (receiver as ServiceBusReceiver).receiveMessages(1);
-      for (const message of messages2) {
-        await receiver.completeMessage(message);
-        settledMessageCount++;
-      }
-      settledMessageCount.should.equal(2, "Unexpected number of settled messages.");
-      refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
-    });
+    // Since the receiver has already been initialized,
+    // the `receiver_drained` handler is attached as soon
+    // as receiveMessages is invoked.
+    // We remove the `receiver_drained` timeout after `receiveMessages`
+    // does it's initial setup by wrapping it in a `setTimeout`.
+    // This triggers the `receiver_drained` handler removal on the next
+    // tick of the event loop; after the handler has been attached.
+    setTimeout(() => {
+      // remove `receiver_drained` event
+      batchingReceiver["link"]!.removeAllListeners(ReceiverEvents.receiverDrained);
+    }, 0);
 
-    it("returns messages if drain is in progress (receiveAndDelete)", async function(): Promise<
-      void
-    > {
-      // Create the sender and receiver.
-      await beforeEachTest("receiveAndDelete");
-
-      // The first time `receiveMessages` is called the receiver link is created.
-      // The `receiver_drained` handler is only added after the link is created,
-      // which is a non-blocking task.
-      await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
-      const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
-      const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
-
-      if (!batchingReceiver || !batchingReceiver.isOpen()) {
-        throw new Error(`Unable to initialize receiver link.`);
-      }
-
-      // Send a message so we have something to receive.
-      await sender.sendMessages(TestMessage.getSample());
-
-      // Since the receiver has already been initialized,
-      // the `receiver_drained` handler is attached as soon
-      // as receiveMessages is invoked.
-      // We remove the `receiver_drained` timeout after `receiveMessages`
-      // does it's initial setup by wrapping it in a `setTimeout`.
-      // This triggers the `receiver_drained` handler removal on the next
-      // tick of the event loop; after the handler has been attached.
-      setTimeout(() => {
-        // remove `receiver_drained` event
-        batchingReceiver["link"]!.removeAllListeners(ReceiverEvents.receiverDrained);
-      }, 0);
-
-      // We want to simulate a disconnect once the batching receiver is draining.
-      // We can detect when the receiver enters a draining state when `addCredit` is
-      // called while `drain` is set to true.
-      let didRequestDrain = false;
-      const addCredit = batchingReceiver["link"]!.addCredit;
-      batchingReceiver["link"]!.addCredit = function(credits) {
-        addCredit.call(this, credits);
-        if (batchingReceiver["link"]!.drain) {
-          didRequestDrain = true;
-          // Simulate a disconnect being called with a non-retryable error.
-          receiverContext.connection["_connection"].idle();
-        }
-      };
-
-      // Purposefully request more messages than what's available
-      // so that the receiver will have to drain.
-      const messages1 = await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
-
-      didRequestDrain.should.equal(true, "Drain was not requested.");
-      messages1.length.should.equal(1, "Unexpected number of messages received.");
-
-      // Make sure that a 2nd receiveMessages call still works
-      // by sending and receiving a single message again.
-      await sender.sendMessages(TestMessage.getSample());
-
-      // wait for the 2nd message to be received.
-      const messages2 = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
-
-      messages2.length.should.equal(1, "Unexpected number of messages received.");
-    });
-
-    it("throws an error if drain is in progress (peekLock)", async function(): Promise<void> {
-      // Create the sender and receiver.
-      await beforeEachTest();
-
-      // The first time `receiveMessages` is called the receiver link is created.
-      // The `receiver_drained` handler is only added after the link is created,
-      // which is a non-blocking task.
-      await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
-      const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
-      const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
-
-      if (!batchingReceiver || !batchingReceiver.isOpen()) {
-        throw new Error(`Unable to initialize receiver link.`);
-      }
-
-      // Send a message so we have something to receive.
-      await sender.sendMessages(TestMessage.getSample());
-
-      // Since the receiver has already been initialized,
-      // the `receiver_drained` handler is attached as soon
-      // as receiveMessages is invoked.
-      // We remove the `receiver_drained` timeout after `receiveMessages`
-      // does it's initial setup by wrapping it in a `setTimeout`.
-      // This triggers the `receiver_drained` handler removal on the next
-      // tick of the event loop; after the handler has been attached.
-      setTimeout(() => {
-        // remove `receiver_drained` event
-        batchingReceiver["link"]!.removeAllListeners(ReceiverEvents.receiverDrained);
-      }, 0);
-
-      // We want to simulate a disconnect once the batching receiver is draining.
-      // We can detect when the receiver enters a draining state when `addCredit` is
-      // called while `drain` is set to true.
-      let didRequestDrain = false;
-      const addCredit = batchingReceiver["link"]!.addCredit;
-      batchingReceiver["link"]!.addCredit = function(credits) {
+    // We want to simulate a disconnect once the batching receiver is draining.
+    // We can detect when the receiver enters a draining state when `addCredit` is
+    // called while `drain` is set to true.
+    let didRequestDrain = false;
+    const addCredit = batchingReceiver["link"]!.addCredit;
+    batchingReceiver["link"]!.addCredit = function(credits) {
+      addCredit.call(this, credits);
+      if (batchingReceiver["link"]!.drain) {
         didRequestDrain = true;
-        addCredit.call(this, credits);
-        if (batchingReceiver["link"]!.drain) {
-          // Simulate a disconnect being called with a non-retryable error.
-          receiverContext.connection["_connection"].idle();
-        }
-      };
-
-      // Purposefully request more messages than what's available
-      // so that the receiver will have to drain.
-      const testFailureMessage = "Test failure";
-      try {
-        await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
-        throw new Error(testFailureMessage);
-      } catch (err) {
-        err.message && err.message.should.not.equal(testFailureMessage);
+        // Simulate a disconnect being called with a non-retryable error.
+        receiverContext.connection["_connection"].idle();
       }
+    };
 
-      didRequestDrain.should.equal(true, "Drain was not requested.");
+    // Purposefully request more messages than what's available
+    // so that the receiver will have to drain.
+    const messages1 = await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
 
-      // Make sure that a 2nd receiveMessages call still works
-      // by sending and receiving a single message again.
-      await sender.sendMessages(TestMessage.getSample());
+    didRequestDrain.should.equal(true, "Drain was not requested.");
+    messages1.length.should.equal(1, "Unexpected number of messages received.");
 
-      // wait for the 2nd message to be received.
-      const messages = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
+    // Make sure that a 2nd receiveMessages call still works
+    // by sending and receiving a single message again.
+    await sender.sendMessages(TestMessage.getSample());
 
-      messages.length.should.equal(1, "Unexpected number of messages received.");
-    });
+    // wait for the 2nd message to be received.
+    const messages2 = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
 
-    it("returns messages if receive in progress (receiveAndDelete)", async function(): Promise<
-      void
-    > {
-      // Create the sender and receiver.
-      await beforeEachTest("receiveAndDelete");
+    messages2.length.should.equal(1, "Unexpected number of messages received.");
+  });
 
-      // The first time `receiveMessages` is called the receiver link is created.
-      // The `receiver_drained` handler is only added after the link is created,
-      // which is a non-blocking task.
-      await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
-      const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
-      const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
+  it("throws an error if drain is in progress (peekLock)", async function(): Promise<void> {
+    // Create the sender and receiver.
+    await beforeEachTest(noSessionTestClientType);
 
-      if (!batchingReceiver || !batchingReceiver.isOpen()) {
-        throw new Error(`Unable to initialize receiver link.`);
+    // The first time `receiveMessages` is called the receiver link is created.
+    // The `receiver_drained` handler is only added after the link is created,
+    // which is a non-blocking task.
+    await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
+    const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
+    const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
+
+    if (!batchingReceiver || !batchingReceiver.isOpen()) {
+      throw new Error(`Unable to initialize receiver link.`);
+    }
+
+    // Send a message so we have something to receive.
+    await sender.sendMessages(TestMessage.getSample());
+
+    // Since the receiver has already been initialized,
+    // the `receiver_drained` handler is attached as soon
+    // as receiveMessages is invoked.
+    // We remove the `receiver_drained` timeout after `receiveMessages`
+    // does it's initial setup by wrapping it in a `setTimeout`.
+    // This triggers the `receiver_drained` handler removal on the next
+    // tick of the event loop; after the handler has been attached.
+    setTimeout(() => {
+      // remove `receiver_drained` event
+      batchingReceiver["link"]!.removeAllListeners(ReceiverEvents.receiverDrained);
+    }, 0);
+
+    // We want to simulate a disconnect once the batching receiver is draining.
+    // We can detect when the receiver enters a draining state when `addCredit` is
+    // called while `drain` is set to true.
+    let didRequestDrain = false;
+    const addCredit = batchingReceiver["link"]!.addCredit;
+    batchingReceiver["link"]!.addCredit = function(credits) {
+      didRequestDrain = true;
+      addCredit.call(this, credits);
+      if (batchingReceiver["link"]!.drain) {
+        // Simulate a disconnect being called with a non-retryable error.
+        receiverContext.connection["_connection"].idle();
       }
+    };
 
-      // Send a message so we have something to receive.
-      await sender.sendMessages(TestMessage.getSample());
+    // Purposefully request more messages than what's available
+    // so that the receiver will have to drain.
+    const testFailureMessage = "Test failure";
+    try {
+      await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
+      throw new Error(testFailureMessage);
+    } catch (err) {
+      err.message && err.message.should.not.equal(testFailureMessage);
+    }
 
-      // Simulate a disconnect after a message has been received.
-      batchingReceiver["link"]!.once("message", function() {
-        setTimeout(() => {
-          // Simulate a disconnect being called with a non-retryable error.
-          receiverContext.connection["_connection"].idle();
-        }, 0);
-      });
+    didRequestDrain.should.equal(true, "Drain was not requested.");
 
-      // Purposefully request more messages than what's available
-      // so that the receiver will have to drain.
-      const messages1 = await receiver.receiveMessages(10, { maxWaitTimeInMs: 10000 });
+    // Make sure that a 2nd receiveMessages call still works
+    // by sending and receiving a single message again.
+    await sender.sendMessages(TestMessage.getSample());
 
-      messages1.length.should.equal(1, "Unexpected number of messages received.");
+    // wait for the 2nd message to be received.
+    const messages = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
 
-      // Make sure that a 2nd receiveMessages call still works
-      // by sending and receiving a single message again.
-      await sender.sendMessages(TestMessage.getSample());
+    messages.length.should.equal(1, "Unexpected number of messages received.");
+  });
 
-      // wait for the 2nd message to be received.
-      const messages2 = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
+  it("returns messages if receive in progress (receiveAndDelete)", async function(): Promise<void> {
+    // Create the sender and receiver.
+    await beforeEachTest(noSessionTestClientType, "receiveAndDelete");
 
-      messages2.length.should.equal(1, "Unexpected number of messages received.");
-    });
+    // The first time `receiveMessages` is called the receiver link is created.
+    // The `receiver_drained` handler is only added after the link is created,
+    // which is a non-blocking task.
+    await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
+    const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
+    const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
 
-    it("throws an error if receive is in progress (peekLock)", async function(): Promise<void> {
-      // Create the sender and receiver.
-      await beforeEachTest();
+    if (!batchingReceiver || !batchingReceiver.isOpen()) {
+      throw new Error(`Unable to initialize receiver link.`);
+    }
 
-      // The first time `receiveMessages` is called the receiver link is created.
-      // The `receiver_drained` handler is only added after the link is created,
-      // which is a non-blocking task.
-      await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
-      const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
-      const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
+    // Send a message so we have something to receive.
+    await sender.sendMessages(TestMessage.getSample());
 
-      if (!batchingReceiver || !batchingReceiver.isOpen()) {
-        throw new Error(`Unable to initialize receiver link.`);
-      }
-
-      // Simulate a disconnect
+    // Simulate a disconnect after a message has been received.
+    batchingReceiver["link"]!.once("message", function() {
       setTimeout(() => {
         // Simulate a disconnect being called with a non-retryable error.
         receiverContext.connection["_connection"].idle();
       }, 0);
-
-      // Purposefully request more messages than what's available
-      // so that the receiver will have to drain.
-      const testFailureMessage = "Test failure";
-      try {
-        const msgs = await receiver.receiveMessages(10, { maxWaitTimeInMs: 10000 });
-        console.log(msgs.length);
-        throw new Error(testFailureMessage);
-      } catch (err) {
-        err.message && err.message.should.not.equal(testFailureMessage);
-      }
-
-      // Make sure that a 2nd receiveMessages call still works
-      // by sending and receiving a single message again.
-      await sender.sendMessages(TestMessage.getSample());
-
-      // wait for the 2nd message to be received.
-      const messages = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
-
-      messages.length.should.equal(1, "Unexpected number of messages received.");
     });
+
+    // Purposefully request more messages than what's available
+    // so that the receiver will have to drain.
+    const messages1 = await receiver.receiveMessages(10, { maxWaitTimeInMs: 10000 });
+
+    messages1.length.should.equal(1, "Unexpected number of messages received.");
+
+    // Make sure that a 2nd receiveMessages call still works
+    // by sending and receiving a single message again.
+    await sender.sendMessages(TestMessage.getSample());
+
+    // wait for the 2nd message to be received.
+    const messages2 = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
+
+    messages2.length.should.equal(1, "Unexpected number of messages received.");
+  });
+
+  it("throws an error if receive is in progress (peekLock)", async function(): Promise<void> {
+    // Create the sender and receiver.
+    await beforeEachTest(noSessionTestClientType);
+
+    // The first time `receiveMessages` is called the receiver link is created.
+    // The `receiver_drained` handler is only added after the link is created,
+    // which is a non-blocking task.
+    await receiver.receiveMessages(1, { maxWaitTimeInMs: 1000 });
+    const receiverContext = (receiver as ServiceBusReceiverImpl)["_context"];
+    const batchingReceiver = (receiver as ServiceBusReceiverImpl)["_batchingReceiver"];
+
+    if (!batchingReceiver || !batchingReceiver.isOpen()) {
+      throw new Error(`Unable to initialize receiver link.`);
+    }
+
+    // Simulate a disconnect
+    setTimeout(() => {
+      // Simulate a disconnect being called with a non-retryable error.
+      receiverContext.connection["_connection"].idle();
+    }, 0);
+
+    // Purposefully request more messages than what's available
+    // so that the receiver will have to drain.
+    const testFailureMessage = "Test failure";
+    try {
+      const msgs = await receiver.receiveMessages(10, { maxWaitTimeInMs: 10000 });
+      console.log(msgs.length);
+      throw new Error(testFailureMessage);
+    } catch (err) {
+      err.message && err.message.should.not.equal(testFailureMessage);
+    }
+
+    // Make sure that a 2nd receiveMessages call still works
+    // by sending and receiving a single message again.
+    await sender.sendMessages(TestMessage.getSample());
+
+    // wait for the 2nd message to be received.
+    const messages = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5000 });
+
+    messages.length.should.equal(1, "Unexpected number of messages received.");
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/operationOptionsForATOM.spec.ts
@@ -31,7 +31,7 @@ describe("Operation Options", () => {
   // This describe block ensures that abort signal works as expected and
   // the OperationOptions are plugged in for all the methods
   describe("Abort Signal", () => {
-    async function verifyAbortError(func: Function): Promise<void> {
+    async function verifyAbortError(func: () => Promise<any>): Promise<void> {
       try {
         await func();
         assert.fail();

--- a/sdk/servicebus/service-bus/test/internal/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/renewLock.spec.ts
@@ -81,7 +81,7 @@ describe("Message Lock Renewal", () => {
       await checkWithTimeout(
         async () => {
           [peekedMsg] = await receiver.peekMessages(1);
-          return peekedMsg != undefined;
+          return peekedMsg !== undefined;
         },
         100,
         5000

--- a/sdk/servicebus/service-bus/test/internal/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/retries.spec.ts
@@ -57,7 +57,7 @@ describe("Retries - ManagementClient", () => {
   }
 
   function mockManagementClientToThrowError(): void {
-    const fakeFunction = async function() {
+    const fakeFunction = async function(): Promise<never> {
       numberOfTimesManagementClientInvoked++;
       throw new MessagingError("Hello there, I'm an error");
     };
@@ -72,7 +72,7 @@ describe("Retries - ManagementClient", () => {
     receiverMgmtClient["_makeManagementRequest"] = fakeFunction;
   }
 
-  async function mockManagementClientAndVerifyRetries(func: Function): Promise<void> {
+  async function mockManagementClientAndVerifyRetries(func: () => Promise<void>): Promise<void> {
     mockManagementClientToThrowError();
     let errorThrown = false;
     try {
@@ -235,7 +235,7 @@ describe("Retries - MessageSender", () => {
     (sender as ServiceBusSenderImpl)["_sender"]["open"] = fakeFunction;
   }
 
-  async function mockInitAndVerifyRetries(func: Function): Promise<void> {
+  async function mockInitAndVerifyRetries(func: () => Promise<void>): Promise<void> {
     mockInitToThrowError();
     let errorThrown = false;
     try {
@@ -338,7 +338,7 @@ describe("Retries - Receive methods", () => {
   }
 
   function mockBatchingReceiveToThrowError(): void {
-    const fakeFunction = async function() {
+    const fakeFunction = async function(): Promise<never> {
       numberOfTimesTried++;
       throw new MessagingError("Hello there, I'm an error");
     };
@@ -362,7 +362,7 @@ describe("Retries - Receive methods", () => {
     }
   }
 
-  async function mockReceiveAndVerifyRetries(func: Function): Promise<void> {
+  async function mockReceiveAndVerifyRetries(func: () => Promise<void>): Promise<void> {
     mockBatchingReceiveToThrowError();
     let errorThrown = false;
     try {

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -588,7 +588,9 @@ describe("ServiceBusClient live tests", () => {
       let errorReceiveStream: string = "";
       try {
         receiver.subscribe({
-          async processMessage() {},
+          async processMessage() {
+            /** Nothing to do here */
+          },
           async processError(e) {
             console.log(e);
           }
@@ -837,7 +839,7 @@ describe("ServiceBusClient live tests", () => {
   });
 });
 
-function reduceRetries(receiver: ServiceBusReceiver) {
+function reduceRetries(receiver: ServiceBusReceiver): void {
   // for some tests the important thing is just to run a single retry cycle (and then report)
   // the error. This reduces everything so we run a short retry cycle.
   //

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
@@ -167,7 +167,7 @@ describe("Streaming Receiver Tests", () => {
         body: "can stop and start a subscription message 1"
       });
 
-      const { subscription, msg: receivedMsg } = await new Promise<{
+      const { subscription: subscription1, msg: receivedMsg } = await new Promise<{
         subscription: { close(): Promise<void> };
         msg: string;
       }>((resolve, reject) => {
@@ -182,7 +182,7 @@ describe("Streaming Receiver Tests", () => {
       });
 
       receivedMsg.should.equal("can stop and start a subscription message 1");
-      await subscription.close();
+      await subscription1.close();
 
       await sender2.sendMessages({
         body: "can stop and start a subscription message 2"
@@ -982,7 +982,7 @@ export function createOnDetachedProcessErrorFake(): sinon.SinonSpy & {
     assertErrors: () => void;
   };
 
-  const assertErrors = () => {
+  const assertErrors = (): void => {
     const errors: string[] = [];
 
     for (const callArgs of processErrorFake.args) {

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiverSessions.spec.ts
@@ -172,7 +172,6 @@ describe("Streaming with sessions", () => {
             "MessageId is different than expected"
           );
           return Promise.resolve();
-          ``;
         },
         processError
       });
@@ -295,12 +294,11 @@ describe("Streaming with sessions", () => {
       receiver.subscribe(
         {
           async processMessage(msg: ServiceBusReceivedMessage) {
-            return receiver.abandonMessage(msg).then(() => {
+            return receiver.abandonMessage(msg).then(async () => {
               abandonFlag = 1;
               if ((receiver as ServiceBusSessionReceiverImpl)["_isReceivingMessages"]()) {
                 return receiver.close();
               }
-              return Promise.resolve();
             });
           },
           processError

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -205,7 +205,9 @@ describe("AbortSignal", () => {
 
       const sender = new MessageSender(
         createConnectionContextForTests({
-          onCreateAwaitableSenderCalled: () => {}
+          onCreateAwaitableSenderCalled: () => {
+            /** Nothing to do here */
+          }
         }),
         "fakeEntityPath",
         {}
@@ -242,7 +244,9 @@ describe("AbortSignal", () => {
       );
       closeables.push(sender);
 
-      sender["_negotiateClaim"] = async () => {};
+      sender["_negotiateClaim"] = async () => {
+        /** Nothing to do here */
+      };
 
       try {
         await sender.createBatch({ abortSignal: taggedAbortSignal });
@@ -316,7 +320,9 @@ describe("AbortSignal", () => {
       const messageReceiver = new StreamingReceiver(fakeContext, "fakeEntityPath", defaultOptions);
       closeables.push(messageReceiver);
 
-      messageReceiver["_negotiateClaim"] = async () => {};
+      messageReceiver["_negotiateClaim"] = async () => {
+        /** Nothing to do here */
+      };
 
       try {
         await messageReceiver["_init"]({} as ReceiverOptions, abortSignal);
@@ -354,7 +360,9 @@ describe("AbortSignal", () => {
 
         session.subscribe(
           {
-            processMessage: async (_msg) => {},
+            processMessage: async (_msg) => {
+              /** Nothing to do here */
+            },
             processError: async (args) => {
               receivedErrors.push(args.error);
             }
@@ -386,7 +394,9 @@ describe("AbortSignal", () => {
         await new Promise<void>((resolve) => {
           receiver.subscribe(
             {
-              processMessage: async (_msg: any) => {},
+              processMessage: async (_msg: any) => {
+                /** Nothing to do here */
+              },
               processError: async (args: ProcessErrorArgs) => {
                 resolve();
                 receivedErrors.push(args.error);

--- a/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
@@ -393,7 +393,7 @@ describe("ATOM Serializers", () => {
   }
 
   class MockSerializer implements AtomXmlSerializer {
-    serialize(resource: any): object {
+    serialize(resource: any): Record<string, unknown> {
       const property1 = "LockDuration";
       const property2 = "MaxSizeInMegabytes";
 

--- a/sdk/servicebus/service-bus/test/internal/unit/autoLockRenewer.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/autoLockRenewer.spec.ts
@@ -51,7 +51,9 @@ describe("autoLockRenewer unit tests", () => {
     } as ManagementClient;
 
     renewLockSpy = sinon.spy(managementClient, "renewLock");
-    onErrorFake = sinon.fake(async (_err: Error | MessagingError) => {});
+    onErrorFake = sinon.fake(async (_err: Error | MessagingError) => {
+      /** Nothing to do here */
+    });
 
     autoLockRenewer = LockRenewer.create(
       {

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -212,8 +212,12 @@ describe("Receiver unit tests", () => {
 
       const subscription = receiverImpl.subscribe(
         {
-          processError: async (_err) => {},
-          processMessage: async (_msg) => {}
+          processError: async (_err) => {
+            /** Nothing to do here */
+          },
+          processMessage: async (_msg) => {
+            /** Nothing to do here */
+          }
         },
         {
           abortSignal
@@ -222,8 +226,12 @@ describe("Receiver unit tests", () => {
 
       // subscription should just be auto-closed already
       const subscription2 = receiverImpl.subscribe({
-        processError: async (_err) => {},
-        processMessage: async (_msg) => {}
+        processError: async (_err) => {
+          /** Nothing to do here */
+        },
+        processMessage: async (_msg) => {
+          /** Nothing to do here */
+        }
       });
 
       await subscription.close(); // and closing it "out of order" shouldn't be an issue either.
@@ -244,7 +252,9 @@ describe("Receiver unit tests", () => {
           processError: async (err) => {
             reject(err);
           },
-          processMessage: async (_msg) => {}
+          processMessage: async (_msg) => {
+            /** Nothing to do here */
+          }
         } as InternalMessageHandlers);
       });
 
@@ -351,7 +361,9 @@ describe("Receiver unit tests", () => {
           initWasCalled = true;
           return;
         },
-        close: async () => {},
+        close: async () => {
+          /** Nothing to do here */
+        },
         name: "my pre-existing receiver"
       } as Pick<StreamingReceiver, "init" | "close" | "name">;
 
@@ -367,7 +379,9 @@ describe("Receiver unit tests", () => {
         lockRenewer: undefined,
         receiveMode: "peekLock",
         abortSignal: expectedAbortSignal,
-        onError: (_args) => {}
+        onError: (_args) => {
+          /** Nothing to do here */
+        }
       });
 
       assert.isTrue(initWasCalled, "initialize should be called on the original receiver");
@@ -386,7 +400,9 @@ describe("Receiver unit tests", () => {
       await impl["_createStreamingReceiver"]({
         lockRenewer: undefined,
         receiveMode: "peekLock",
-        onError: (_args) => {}
+        onError: (_args) => {
+          /** Nothing to do here */
+        }
       });
 
       assert.exists(impl["_streamingReceiver"], "new streaming receiver should be called");

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -58,7 +58,7 @@ describe("sender unit tests", () => {
 
       try {
         await sender.sendMessages(
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           invalidValue
         );
         assert.fail("You should not be seeing this.");
@@ -82,7 +82,7 @@ describe("sender unit tests", () => {
 
       try {
         batch.tryAddMessage(
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           invalidValue
         );
         assert.fail("You should not be seeing this.");
@@ -106,7 +106,7 @@ describe("sender unit tests", () => {
 
       try {
         await sender.scheduleMessages(
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           invalidValue,
           new Date()
         );

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusClient.spec.ts
@@ -16,7 +16,7 @@ import {
   ServiceBusSessionReceiver,
   ServiceBusSessionReceiverImpl
 } from "../../../src/receivers/sessionReceiver";
-import { AbortController } from "@azure/abort-controller";
+import { AbortController, AbortSignalLike } from "@azure/abort-controller";
 const assert = chai.assert;
 
 const allLockModes: ("peekLock" | "receiveAndDelete")[] = ["peekLock", "receiveAndDelete"];
@@ -341,7 +341,10 @@ describe("serviceBusClient unit tests", () => {
     });
   });
 });
-function createAbortSignal() {
+function createAbortSignal(): {
+  signal: AbortSignalLike;
+  abortedPropertyWasChecked: boolean;
+} {
   const abortSignal = new AbortController().signal;
   const result = {
     signal: abortSignal,

--- a/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
@@ -96,8 +96,12 @@ describe("StreamingReceiver unit tests", () => {
       );
 
       streamingReceiver.subscribe(
-        async (_msg) => {},
-        async (_err) => {}
+        async (_msg) => {
+          /** Nothing to do here */
+        },
+        async (_err) => {
+          /** Nothing to do here */
+        }
       );
 
       assert.equal(
@@ -133,8 +137,12 @@ describe("StreamingReceiver unit tests", () => {
       );
 
       streamingReceiver.subscribe(
-        async (_msg) => {},
-        async (_err) => {}
+        async (_msg) => {
+          /** Nothing to do here */
+        },
+        async (_err) => {
+          /** Nothing to do here */
+        }
       );
 
       assert.equal(
@@ -160,8 +168,12 @@ describe("StreamingReceiver unit tests", () => {
       defaultInitArgs.assert();
 
       streamingReceiver.subscribe(
-        async (_msg) => {},
-        async (_err) => {}
+        async (_msg) => {
+          /** Nothing to do here */
+        },
+        async (_err) => {
+          /** Nothing to do here */
+        }
       );
 
       assert.isTrue(streamingReceiver.isReceivingMessages);
@@ -186,8 +198,12 @@ describe("StreamingReceiver unit tests", () => {
       defaultInitArgs.assert();
 
       streamingReceiver.subscribe(
-        async (_msg) => {},
-        async (_err) => {}
+        async (_msg) => {
+          /** Nothing to do here */
+        },
+        async (_err) => {
+          /** Nothing to do here */
+        }
       );
 
       assert.isTrue(streamingReceiver.isReceivingMessages);
@@ -212,8 +228,12 @@ describe("StreamingReceiver unit tests", () => {
       defaultInitArgs.assert();
 
       streamingReceiver.subscribe(
-        async (_msg) => {},
-        async (_err) => {}
+        async (_msg) => {
+          /** Nothing to do here */
+        },
+        async (_err) => {
+          /** Nothing to do here */
+        }
       );
 
       assert.isTrue(

--- a/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
@@ -130,7 +130,9 @@ describe("Tracing tests", () => {
             throw new Error("This message failed when we tried to process it");
           }
         },
-        processError: async (_err) => {}
+        processError: async (_err) => {
+          /** Nothing to do here */
+        }
       },
       {
         tracingOptions
@@ -187,7 +189,9 @@ describe("Tracing tests", () => {
             throw new Error("This message failed when we tried to process it");
           }
         },
-        processError: async (_err) => {}
+        processError: async (_err) => {
+          /** Nothing to do here */
+        }
       },
       {
         tracingOptions
@@ -258,7 +262,11 @@ describe("Tracing tests", () => {
     });
   });
 
-  function stubCreateProcessingSpan(receiver: any) {
+  function stubCreateProcessingSpan(
+    receiver: any
+  ): {
+    span?: TestSpan;
+  } {
     const data: {
       span?: TestSpan;
     } = {};
@@ -358,7 +366,9 @@ describe("Tracing tests", () => {
       const tracer = new TestTracer();
       const span = tracer.startSpan("whatever");
 
-      await trace(async () => {}, span);
+      await trace(async () => {
+        /** Nothing to do here */
+      }, span);
 
       span.status!.code.should.equal(CanonicalCode.OK);
       span.endCalled.should.be.ok;
@@ -382,10 +392,6 @@ describe("Tracing tests", () => {
 class TestTracer2 extends TestTracer {
   public spanOptions: SpanOptions | undefined;
   public spanName: string | undefined;
-
-  constructor() {
-    super();
-  }
 
   startSpan(nameArg: string, optionsArg?: SpanOptions): TestSpan {
     this.spanName = nameArg;

--- a/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/tracing.spec.ts
@@ -263,7 +263,7 @@ describe("Tracing tests", () => {
   });
 
   function stubCreateProcessingSpan(
-    receiver: any
+    receiverToStub: any
   ): {
     span?: TestSpan;
   } {
@@ -286,7 +286,7 @@ describe("Tracing tests", () => {
       return data.span;
     };
 
-    receiver["_createProcessingSpan"] = fakeCreateProcessingSpan;
+    receiverToStub["_createProcessingSpan"] = fakeCreateProcessingSpan;
     return data;
   }
 
@@ -363,7 +363,6 @@ describe("Tracing tests", () => {
     });
 
     it("trace - normal", async () => {
-      const tracer = new TestTracer();
       const span = tracer.startSpan("whatever");
 
       await trace(async () => {
@@ -375,7 +374,6 @@ describe("Tracing tests", () => {
     });
 
     it("trace - throws", async () => {
-      const tracer = new TestTracer();
       const span = tracer.startSpan("whatever");
 
       await trace(async () => {

--- a/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
@@ -40,7 +40,9 @@ export function createConnectionContextForTests(
   let initWasCalled = false;
 
   const fakeConnectionContext = {
-    async readyToOpenLink(): Promise<void> {},
+    async readyToOpenLink(): Promise<void> {
+      /** Nothing to do here */
+    },
     isConnectionClosing(): boolean {
       return false;
     },
@@ -86,7 +88,9 @@ export function createConnectionContextForTests(
         (receiver as any).connection = { id: "connection-id" };
         return receiver;
       },
-      async close(): Promise<void> {}
+      async close(): Promise<void> {
+        /** Nothing to do here */
+      }
     },
     tokenCredential: {
       getToken() {
@@ -100,8 +104,12 @@ export function createConnectionContextForTests(
       async init() {
         initWasCalled = true;
       },
-      async negotiateClaim(): Promise<void> {},
-      async close(): Promise<void> {}
+      async negotiateClaim(): Promise<void> {
+        /** Nothing to do here */
+      },
+      async close(): Promise<void> {
+        /** Nothing to do here */
+      }
     },
     initWasCalled
   };

--- a/sdk/servicebus/service-bus/test/perf/track-2/sbBase.spec.ts
+++ b/sdk/servicebus/service-bus/test/perf/track-2/sbBase.spec.ts
@@ -21,11 +21,11 @@ export abstract class ServiceBusTest<TOptions> extends PerfStressTest<TOptions> 
     this.sbClient = sbClient;
   }
 
-  public async globalSetup() {
+  public async globalSetup(): Promise<void> {
     await ServiceBusTest.sbAdminClient.createQueue(ServiceBusTest.queueName);
   }
 
-  public async globalCleanup() {
+  public async globalCleanup(): Promise<void> {
     await ServiceBusTest.sbAdminClient.deleteQueue(ServiceBusTest.queueName);
     await this.sbClient.close();
   }

--- a/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
@@ -147,7 +147,7 @@ describe("Listing methods - PagedAsyncIterableIterator", function(): void {
     "listSubscriptionsRuntimeProperties",
     "listRules"
   ].forEach((methodName) => {
-    describe(`${methodName}`, () => {
+    describe(`${methodName}`, (): void => {
       function getIter() {
         let iterator;
         if (methodName.includes("Subscription")) {
@@ -744,9 +744,9 @@ describe("Atom management - Authentication", function(): void {
       const name = testCase.entityType === EntityType.SUBSCRIPTION ? "subscriptionName" : "name";
       const paramsToExclude = ["createdAt", "accessedAt", "modifiedAt"];
       for (const info of response) {
-        if (info[name] == testCase[1].alwaysBeExistingEntity) {
+        if (info[name] === testCase[1].alwaysBeExistingEntity) {
           assert.deepEqualExcluding(info, testCase[1].output, paramsToExclude);
-        } else if (info[name] == testCase[2].alwaysBeExistingEntity) {
+        } else if (info[name] === testCase[2].alwaysBeExistingEntity) {
           assert.deepEqualExcluding(info, testCase[2].output, paramsToExclude);
         }
       }
@@ -2383,7 +2383,7 @@ describe(`updateRule() using different variations to the input parameter "ruleOp
   });
 });
 
-function checkForValidErrorScenario(err: any, expectedtestOutput: any) {
+function checkForValidErrorScenario(err: any, expectedtestOutput: any): void {
   let isErrorExpected = false;
 
   if (expectedtestOutput.testErrorMessage) {
@@ -2421,7 +2421,7 @@ async function createEntity(
   ruleOptions?: Omit<Required<CreateSubscriptionOptions>["defaultRuleOptions"], "name">
 ): Promise<any> {
   if (!overrideOptions) {
-    if (queueOptions == undefined) {
+    if (queueOptions === undefined) {
       queueOptions = {
         lockDuration: "PT1M",
         authorizationRules: [
@@ -2436,19 +2436,19 @@ async function createEntity(
       };
     }
 
-    if (topicOptions == undefined) {
+    if (topicOptions === undefined) {
       topicOptions = {
         status: "Active"
       };
     }
 
-    if (subscriptionOptions == undefined) {
+    if (subscriptionOptions === undefined) {
       subscriptionOptions = {
         lockDuration: "PT1M"
       };
     }
 
-    if (ruleOptions == undefined) {
+    if (ruleOptions === undefined) {
       ruleOptions = {
         filter: {
           sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
@@ -2460,17 +2460,19 @@ async function createEntity(
   }
 
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient.createQueue(entityPath, {
         ...queueOptions
       });
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient.createTopic(entityPath, {
         ...topicOptions
       });
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2484,7 +2486,8 @@ async function createEntity(
         }
       );
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: Topic path AND subscription path must be passed when invoking tests on rules"
@@ -2498,6 +2501,7 @@ async function createEntity(
         ruleOptions?.action!
       );
       return ruleResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2509,13 +2513,15 @@ async function getEntity(
   subscriptionPath?: string
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient.getQueue(entityPath);
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient.getTopic(entityPath);
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2526,7 +2532,8 @@ async function getEntity(
         entityPath
       );
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: Topic path AND subscription path must be passed when invoking tests on rules"
@@ -2538,6 +2545,7 @@ async function getEntity(
         entityPath
       );
       return ruleResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2548,17 +2556,19 @@ async function getEntityRuntimeProperties(
   topicPath?: string
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient.getQueueRuntimeProperties(
         entityPath
       );
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient.getTopicRuntimeProperties(
         entityPath
       );
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2569,6 +2579,7 @@ async function getEntityRuntimeProperties(
         entityPath
       );
       return subscriptionResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2578,13 +2589,15 @@ async function getEntitiesRuntimeProperties(
   topicPath?: string
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient["getQueuesRuntimeProperties"]();
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient["getTopicsRuntimeProperties"]();
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2594,6 +2607,7 @@ async function getEntitiesRuntimeProperties(
         "getSubscriptionsRuntimeProperties"
       ](topicPath);
       return subscriptionResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2605,13 +2619,15 @@ async function entityExists(
   subscriptionPath?: string
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient.queueExists(entityPath);
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient.topicExists(entityPath);
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2622,7 +2638,8 @@ async function entityExists(
         entityPath
       );
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: topic path and subscription path must be passed when invoking tests on rules"
@@ -2634,6 +2651,7 @@ async function entityExists(
         entityPath
       );
       return ruleResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2650,7 +2668,7 @@ async function updateEntity(
   ruleOptions?: Omit<RuleProperties, "name">
 ): Promise<any> {
   if (!overrideOptions) {
-    if (queueOptions == undefined) {
+    if (queueOptions === undefined) {
       queueOptions = {
         lockDuration: "PT1M",
         authorizationRules: [
@@ -2665,19 +2683,19 @@ async function updateEntity(
       };
     }
 
-    if (topicOptions == undefined) {
+    if (topicOptions === undefined) {
       topicOptions = {
         status: "Active"
       };
     }
 
-    if (subscriptionOptions == undefined) {
+    if (subscriptionOptions === undefined) {
       subscriptionOptions = {
         lockDuration: "PT1M"
       };
     }
 
-    if (ruleOptions == undefined) {
+    if (ruleOptions === undefined) {
       ruleOptions = {
         filter: {
           sqlExpression: "stringValue = @stringParam AND intValue = @intParam",
@@ -2692,21 +2710,23 @@ async function updateEntity(
   }
 
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const getQueueResponse = await serviceBusAtomManagementClient.getQueue(entityPath);
       const queueResponse = await serviceBusAtomManagementClient.updateQueue({
         ...getQueueResponse,
         ...queueOptions
       });
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const getTopicResponse = await serviceBusAtomManagementClient.getTopic(entityPath);
       const topicResponse = await serviceBusAtomManagementClient.updateTopic({
         ...getTopicResponse,
         ...topicOptions
       });
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2721,7 +2741,8 @@ async function updateEntity(
         ...subscriptionOptions
       });
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: Topic path AND subscription path must be passed when invoking tests on rules"
@@ -2741,6 +2762,7 @@ async function updateEntity(
         }
       );
       return ruleResponse;
+    }
   }
 }
 
@@ -2751,13 +2773,15 @@ async function deleteEntity(
   subscriptionPath?: string
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient.deleteQueue(entityPath);
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient.deleteTopic(entityPath);
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2768,7 +2792,8 @@ async function deleteEntity(
         entityPath
       );
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: Topic path AND subscription path must be passed when invoking tests on rules"
@@ -2780,6 +2805,7 @@ async function deleteEntity(
         entityPath
       );
       return ruleResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }
@@ -2792,19 +2818,21 @@ async function listEntities(
   maxCount?: number
 ): Promise<any> {
   switch (testEntityType) {
-    case EntityType.QUEUE:
+    case EntityType.QUEUE: {
       const queueResponse = await serviceBusAtomManagementClient["getQueues"]({
         skip,
         maxCount
       });
       return queueResponse;
-    case EntityType.TOPIC:
+    }
+    case EntityType.TOPIC: {
       const topicResponse = await serviceBusAtomManagementClient["getTopics"]({
         skip,
         maxCount
       });
       return topicResponse;
-    case EntityType.SUBSCRIPTION:
+    }
+    case EntityType.SUBSCRIPTION: {
       if (!topicPath) {
         throw new Error(
           "TestError: Topic path must be passed when invoking tests on subscriptions"
@@ -2814,7 +2842,8 @@ async function listEntities(
         "getSubscriptions"
       ](topicPath, { skip, maxCount });
       return subscriptionResponse;
-    case EntityType.RULE:
+    }
+    case EntityType.RULE: {
       if (!topicPath || !subscriptionPath) {
         throw new Error(
           "TestError: Topic path AND subscription path must be passed when invoking tests on rules"
@@ -2826,6 +2855,7 @@ async function listEntities(
         { skip, maxCount }
       );
       return ruleResponse;
+    }
   }
   throw new Error("TestError: Unrecognized EntityType");
 }

--- a/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
@@ -79,7 +79,7 @@ describe("invalid parameters", () => {
         void
       > {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.receiveMessages(inputValue);
           chai.assert.fail("This should not have passed.");
         } catch (error) {
@@ -96,7 +96,7 @@ describe("invalid parameters", () => {
         void
       > {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.peekMessages(inputValue);
           chai.assert.fail("This should not have passed.");
         } catch (error) {
@@ -113,7 +113,7 @@ describe("invalid parameters", () => {
         void
       > {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.peekMessages(inputValue, {
             fromSequenceNumber: Long.ZERO
           });
@@ -224,7 +224,7 @@ describe("invalid parameters", () => {
     it("Receiver: Invalid ReceiveMode", async function(): Promise<void> {
       let errorCaught: string = "";
       try {
-        // @ts-expect-error
+        // @ts-expect-error We are trying invalid values on purpose to test the error thrown
         sbClient.createReceiver("dummyQueue", { receiveMode: 123 });
       } catch (error) {
         errorCaught = error.message;
@@ -239,7 +239,7 @@ describe("invalid parameters", () => {
     it("Receiver: Invalid SubQueue", async function(): Promise<void> {
       let errorCaught: string = "";
       try {
-        // @ts-expect-error
+        // @ts-expect-error We are trying invalid values on purpose to test the error thrown
         sbClient.createReceiver("dummyQueue", { subQueueType: 123 });
       } catch (error) {
         errorCaught = error.message;
@@ -256,7 +256,7 @@ describe("invalid parameters", () => {
         void
       > {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.receiveMessages(inputValue);
           chai.assert.fail("This should not have passed.");
         } catch (error) {
@@ -271,7 +271,7 @@ describe("invalid parameters", () => {
     invalidMessageCounts.forEach((inputValue) => {
       it(`Peek: ${inputValue} as maxMessageCount in Receiver`, async function(): Promise<void> {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.peekMessages(inputValue);
           chai.assert.fail("This should not have passed.");
         } catch (error) {
@@ -288,7 +288,7 @@ describe("invalid parameters", () => {
         void
       > {
         try {
-          // @ts-expect-error
+          // @ts-expect-error We are trying invalid types on purpose to test the error thrown
           await receiver.peekMessages(inputValue, {
             fromSequenceNumber: Long.ZERO
           });

--- a/sdk/servicebus/service-bus/test/public/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/propsToModify.spec.ts
@@ -51,7 +51,7 @@ describe("dead lettering", () => {
 
     const receivedMessages = await receiver.receiveMessages(1);
 
-    if (receivedMessages.length == 0) {
+    if (receivedMessages.length === 0) {
       throw new Error("No messages were received");
     }
 
@@ -198,7 +198,7 @@ describe("abandoning", () => {
 
     const receivedMessages = await receiver.receiveMessages(1);
 
-    if (receivedMessages.length == 0) {
+    if (receivedMessages.length === 0) {
       throw new Error("No messages were received");
     }
 
@@ -321,7 +321,7 @@ describe("deferring", () => {
 
     const receivedMessages = await receiver.receiveMessages(1);
 
-    if (receivedMessages.length == 0) {
+    if (receivedMessages.length === 0) {
       throw new Error("No messages were received");
     }
 

--- a/sdk/servicebus/service-bus/test/public/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/renewLockSessions.spec.ts
@@ -79,7 +79,7 @@ describe("Session Lock Renewal", () => {
     testClientType + ": Batch Receiver: complete() after lock expiry with throws error",
     async function(): Promise<void> {
       await beforeEachTest(0);
-      await testBatchReceiverManualLockRenewalErrorOnLockExpiry(testClientType, sender, receiver);
+      await testBatchReceiverManualLockRenewalErrorOnLockExpiry(testClientType);
     }
   );
 
@@ -87,7 +87,7 @@ describe("Session Lock Renewal", () => {
     testClientType + ": Streaming Receiver: renewLock() resets lock duration each time",
     async function(): Promise<void> {
       await beforeEachTest(0);
-      await testStreamingReceiverManualLockRenewalHappyCase(sender, receiver);
+      await testStreamingReceiverManualLockRenewalHappyCase();
     }
   );
 
@@ -102,7 +102,7 @@ describe("Session Lock Renewal", () => {
       };
 
       await beforeEachTest(options.maxAutoRenewLockDurationInMs);
-      await testAutoLockRenewalConfigBehavior(sender, receiver, options);
+      await testAutoLockRenewalConfigBehavior(options);
     }
   );
 
@@ -116,7 +116,7 @@ describe("Session Lock Renewal", () => {
       };
 
       await beforeEachTest(options.maxAutoRenewLockDurationInMs);
-      await testAutoLockRenewalConfigBehavior(sender, receiver, options);
+      await testAutoLockRenewalConfigBehavior(options);
     }
   );
 
@@ -176,9 +176,7 @@ describe("Session Lock Renewal", () => {
    * Test settling of message from Batch Receiver fails after session lock expires
    */
   async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
-    entityType: TestClientType,
-    sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver
+    entityType: TestClientType
   ): Promise<void> {
     const testMessage = getTestMessage();
     testMessage.body = `testBatchReceiverManualLockRenewalErrorOnLockExpiry-${Date.now().toString()}`;
@@ -215,10 +213,7 @@ describe("Session Lock Renewal", () => {
   /**
    * Test manual renewLock() using Streaming Receiver with autoLockRenewal disabled
    */
-  async function testStreamingReceiverManualLockRenewalHappyCase(
-    sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver
-  ): Promise<void> {
+  async function testStreamingReceiverManualLockRenewalHappyCase(): Promise<void> {
     let numOfMessagesReceived = 0;
     const testMessage = getTestMessage();
     testMessage.body = `testStreamingReceiverManualLockRenewalHappyCase-${Date.now().toString()}`;
@@ -292,8 +287,6 @@ describe("Session Lock Renewal", () => {
   }
 
   async function testAutoLockRenewalConfigBehavior(
-    sender: ServiceBusSender,
-    receiver: ServiceBusSessionReceiver,
     options: AutoLockRenewalTestOptions
   ): Promise<void> {
     let numOfMessagesReceived = 0;

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -248,7 +248,7 @@ describe("Sender Tests", () => {
 
     // Wait until we are sure we have passed the schedule time
     await delay(30000);
-    await testReceivedMsgsLength(receiver, 0);
+    await testReceivedMsgsLength(0);
   }
 
   async function testCancelMultipleScheduleMessages(): Promise<void> {
@@ -268,7 +268,7 @@ describe("Sender Tests", () => {
 
     // Wait until we are sure we have passed the schedule time
     await delay(30000);
-    await testReceivedMsgsLength(receiver, 0);
+    await testReceivedMsgsLength(0);
   }
 
   it(
@@ -320,7 +320,7 @@ describe("Sender Tests", () => {
 
     function compareSequenceNumbers(sequenceNumber1: Long.Long, sequenceNumber2: Long.Long): void {
       should.equal(
-        sequenceNumber1.compare(sequenceNumber2) != 0,
+        sequenceNumber1.compare(sequenceNumber2) !== 0,
         true,
         "Returned sequence numbers for parallel requests are the same"
       );
@@ -333,7 +333,7 @@ describe("Sender Tests", () => {
         ({ sequenceNumber }) => sequenceNumber?.comp(seqNum) === 0
       );
       should.equal(
-        msgWithSeqNum == undefined,
+        msgWithSeqNum === undefined,
         false,
         `Sequence number ${seqNum} is not found in the received messages!`
       );
@@ -348,10 +348,7 @@ describe("Sender Tests", () => {
     await testPeekMsgsLength(receiver, 0);
   });
 
-  async function testReceivedMsgsLength(
-    receiver: ServiceBusReceiver,
-    expectedReceivedMsgsLength: number
-  ): Promise<void> {
+  async function testReceivedMsgsLength(expectedReceivedMsgsLength: number): Promise<void> {
     const receivedMsgs = await receiver.receiveMessages(expectedReceivedMsgsLength + 1, {
       maxWaitTimeInMs: 5000
     });

--- a/sdk/servicebus/service-bus/test/public/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sessionsTests.spec.ts
@@ -64,6 +64,7 @@ describe("session tests", () => {
   }
 
   afterEach(async () => {
+    unexpectedError = undefined;
     await serviceBusClient.test.afterEach();
     await serviceBusClient.test.after();
   });
@@ -73,7 +74,6 @@ describe("session tests", () => {
       void
     > {
       let expectedErrorThrown = false;
-      let unexpectedError;
       try {
         await beforeEachTest();
       } catch (error) {
@@ -99,7 +99,6 @@ describe("session tests", () => {
       void
     > {
       let expectedErrorThrown = false;
-      let unexpectedError;
       await beforeEachTest("boo");
       try {
         await serviceBusClient.test.acceptSessionWithPeekLock(

--- a/sdk/servicebus/service-bus/test/public/utils/envVarUtils.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/envVarUtils.ts
@@ -34,7 +34,7 @@ let envVars: any;
  * or create and return one from configured values if not existing.
  */
 export function getEnvVars(): { [key in EnvVarNames]: string } {
-  if (envVars != undefined) {
+  if (envVars !== undefined) {
     return envVars;
   }
 

--- a/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/managementUtils.ts
@@ -18,7 +18,7 @@ let client: ServiceBusAdministrationClient;
  * a new instance constructed based on the connection string configured in environment.
  */
 function getManagementClient(): ServiceBusAdministrationClient {
-  if (client == undefined) {
+  if (client === undefined) {
     const env = getEnvVars();
     client = new ServiceBusAdministrationClient(env[EnvVarNames.SERVICEBUS_CONNECTION_STRING]);
   }
@@ -60,7 +60,7 @@ async function retry(
   }
 
   if (!succeeded) {
-    if (lastKnownError != undefined) {
+    if (lastKnownError !== undefined) {
       lastKnownError.message = operationDescription + " : " + lastKnownError.message;
       throw lastKnownError;
     } else {

--- a/sdk/servicebus/service-bus/test/public/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/testutils2.ts
@@ -331,7 +331,7 @@ export class ServiceBusTestHelpers {
       // session ID for your receiver.
       // if you want to get more specific use the `getPeekLockSessionReceiver` method
       // instead.
-      return await this.acceptSessionWithPeekLock(entityNames, TestMessage.sessionId, options);
+      return this.acceptSessionWithPeekLock(entityNames, TestMessage.sessionId, options);
     }
 
     return this.addToCleanup(

--- a/sdk/servicebus/service-bus/test/public/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/testutils2.ts
@@ -125,12 +125,10 @@ async function createTestEntities(
 }
 
 export async function drainAllMessages(receiver: ServiceBusReceiver): Promise<void> {
-  while (true) {
+  let pendingMsgs = true;
+  while (pendingMsgs) {
     const messages = await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
-
-    if (messages.length === 0) {
-      break;
-    }
+    pendingMsgs = messages.length > 0;
   }
 
   await receiver.close();
@@ -506,19 +504,17 @@ export function createServiceBusClientForTests(
 
 export async function drainReceiveAndDeleteReceiver(receiver: ServiceBusReceiver): Promise<void> {
   try {
-    while (true) {
+    let pendingMsgs = true;
+    while (pendingMsgs) {
       const messages = await receiver.receiveMessages(10, { maxWaitTimeInMs: 1000 });
-
-      if (messages.length === 0) {
-        break;
-      }
+      pendingMsgs = messages.length > 0;
     }
   } finally {
     await receiver.close();
   }
 }
 
-export function getConnectionString() {
+export function getConnectionString(): string {
   if (env[EnvVarNames.SERVICEBUS_CONNECTION_STRING] == null) {
     throw new Error(
       `No service bus connection string defined in ${EnvVarNames.SERVICEBUS_CONNECTION_STRING}. If you're in a unit test you should not be depending on the deployed environment!`


### PR DESCRIPTION
This PR fixes about 150 linter errors and warnings in the test files of the Service Bus package.
Use `Hide whitespace changes" option to look at the real impacting changes
Related to #10781