### PR TITLE
[KeyVault] - Replace `keyId: URL` with `certificateKeyId: string` 

### DIFF
--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.0-beta.3 (Unreleased)
 
 - Updated the Latest service version to 7.2.
+- Added a `certificateKeyId?: string` certificate property to use instead of the deprecated `keyId?: URL` and removed `"lib": ["dom"]` from `tsconfig.json`
 
 ## 4.2.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.2.0-beta.3 (Unreleased)
 
 - Updated the Latest service version to 7.2.
-- Added a `certificateKeyId?: string` certificate property to use instead of the deprecated `keyId?: URL` and removed `"lib": ["dom"]` from `tsconfig.json`
+- Added a `certificateKeyId?: string` secret property to use instead of the deprecated `keyId?: URL` and removed `"lib": ["dom"]` from `tsconfig.json`
 
 ## 4.2.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -144,7 +144,7 @@ export interface SecretProperties {
     readonly expiresOn?: Date;
     id?: string;
     // @deprecated
-    readonly keyId?: any;
+    readonly keyId?: unknown;
     readonly managed?: boolean;
     name: string;
     readonly notBefore?: Date;

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -144,7 +144,7 @@ export interface SecretProperties {
     readonly expiresOn?: Date;
     id?: string;
     // @deprecated
-    readonly keyId?: URL;
+    readonly keyId?: unknown;
     readonly managed?: boolean;
     name: string;
     readonly notBefore?: Date;

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -144,7 +144,7 @@ export interface SecretProperties {
     readonly expiresOn?: Date;
     id?: string;
     // @deprecated
-    readonly keyId?: unknown;
+    readonly keyId?: any;
     readonly managed?: boolean;
     name: string;
     readonly notBefore?: Date;

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -137,11 +137,13 @@ export interface SecretPollerOptions extends coreHttp.OperationOptions {
 
 // @public
 export interface SecretProperties {
+    readonly certificateKeyId?: string;
     contentType?: string;
     readonly createdOn?: Date;
     enabled?: boolean;
     readonly expiresOn?: Date;
     id?: string;
+    // @deprecated
     readonly keyId?: URL;
     readonly managed?: boolean;
     name: string;

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -83,7 +83,7 @@ export interface SecretProperties {
    * this field specifies the corresponding key backing the KV certificate.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
-   * @deprecated Please use {@see SecretProperties.certificateKeyId} instead. This field will always be undefined.
+   * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
   readonly keyId?: unknown;
 

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -85,7 +85,7 @@ export interface SecretProperties {
    * the server.**
    * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
-  readonly keyId?: any;
+  readonly keyId?: unknown;
 
   /**
    * If this is a secret backing a KV certificate, then

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -89,7 +89,7 @@ export interface SecretProperties {
 
   /**
    * If this is a secret backing a KV certificate, then
-   * this field specifies the corresponding key backing the KV certificate.
+   * this field specifies the identifier of the corresponding key backing the KV certificate.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -85,7 +85,7 @@ export interface SecretProperties {
    * the server.**
    * @deprecated Please use {@see SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
-  readonly keyId?: any;
+  readonly keyId?: unknown;
 
   /**
    * If this is a secret backing a KV certificate, then

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -85,7 +85,7 @@ export interface SecretProperties {
    * the server.**
    * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
-  readonly keyId?: unknown;
+  readonly keyId?: any;
 
   /**
    * If this is a secret backing a KV certificate, then

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -85,7 +85,7 @@ export interface SecretProperties {
    * the server.**
    * @deprecated Please use {@see SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
-  readonly keyId?: URL;
+  readonly keyId?: any;
 
   /**
    * If this is a secret backing a KV certificate, then

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -83,8 +83,18 @@ export interface SecretProperties {
    * this field specifies the corresponding key backing the KV certificate.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
+   * @deprecated Please use {@see SecretProperties.certificateKeyId} instead. This field will always be undefined.
    */
   readonly keyId?: URL;
+
+  /**
+   * If this is a secret backing a KV certificate, then
+   * this field specifies the corresponding key backing the KV certificate.
+   * **NOTE: This property will not be serialized. It can only be populated by
+   * the server.**
+   */
+  readonly certificateKeyId?: string;
+
   /**
    * True if the secret's lifetime is managed by
    * key vault. If this is a secret backing a certificate, then managed will be

--- a/sdk/keyvault/keyvault-secrets/src/transformations.ts
+++ b/sdk/keyvault/keyvault-secrets/src/transformations.ts
@@ -38,7 +38,8 @@ export function getSecretFromSecretBundle(
 
       vaultUrl: parsedId.vaultUrl,
       version: parsedId.version,
-      name: parsedId.name
+      name: parsedId.name,
+      certificateKeyId: secretBundle.kid
     }
   };
 

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -50,7 +50,8 @@ describe("Transformations", () => {
         managed: true,
         vaultUrl: "https://azure_keyvault.vault.azure.net",
         version: "1",
-        name: "abc123"
+        name: "abc123",
+        certificateKeyId: "test_kid"
       }
     };
 

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],


### PR DESCRIPTION
## what

- Deprecate `secretProperties.keyId` and replace it with `secretProperties.certificateKeyId`
- Remove `dom` from tsconfig

## why

`secretProperties.keyId` being a URL is the only reason we need `dom` lib in this library.
Even though it has never been populated we cannot remove it because we might break 
someone's compilation (although it would have never worked at runtime). 

Instead we'll deprecate it, note that it will always be undefined, and make it an any so
we can remove the dependency on `dom`. 

Refer to #9639 for previous work in this area.

Resolves #10726