### PR TITLE
[core-abort-controller] pack downlevel dts files

### DIFF
--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.3 (Unreleased)
 
+- Support Typescript version < 3.6 by down-leveling the type definition files. ([PR 12793](https://github.com/Azure/azure-sdk-for-js/pull/12793))
 
 ## 1.0.2 (2020-01-07)
 

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -50,6 +50,7 @@
     "dist-esm/src/",
     "shims-public.d.ts",
     "types/src",
+    "types/3.1",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
PR #12793 adds downlevel dts files but didn't pack them. This PR fixed that.