### PR TITLE
[core-https] Fix proxy issue

### DIFF
--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.2 (Unreleased)
 
 - Changed from exposing `DefaultHttpsClient` as a class directly, to providing `createDefaultHttpsClient()` to instantiate the appropriate runtime class.
+- Fix an issue when passing in proxy hosts. There's some difference between the previous `tunnel.HttpsOverHttpsOptions` and `HttpsProxyAgentOptions`, in particular the former's `host` property includes both the protocol and the host parts, while the later have separate `host` and `protocol` properties.
 
 ## 1.0.0-beta.1 (2021-02-04)
 

--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-beta.2 (Unreleased)
 
 - Changed from exposing `DefaultHttpsClient` as a class directly, to providing `createDefaultHttpsClient()` to instantiate the appropriate runtime class.
-- Fix an issue when passing in proxy hosts. There's some difference between the previous `tunnel.HttpsOverHttpsOptions` and `HttpsProxyAgentOptions`, in particular the former's `host` property includes both the protocol and the host parts, while the later have separate `host` and `protocol` properties.
+- Fix an issue when passing in proxy hosts. [PR 13911](https://github.com/Azure/azure-sdk-for-js/pull/13911)
 
 ## 1.0.0-beta.1 (2021-02-04)
 

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -198,9 +198,15 @@ class NodeHttpsClient implements HttpsClient {
     const proxySettings = request.proxySettings;
     if (proxySettings) {
       if (!this.proxyAgent) {
-        const parsedUrl = new URL(proxySettings.host);
+        let parsedUrl: URL;
+        try {
+          parsedUrl = new URL(proxySettings.host);
+        } catch (_error) {
+          throw new RangeError("Expecting a valid host string in proxy settings.");
+        }
+
         const proxyAgentOptions: HttpsProxyAgentOptions = {
-          host: parsedUrl.host,
+          hostname: parsedUrl.hostname,
           port: proxySettings.port,
           protocol: parsedUrl.protocol,
           headers: request.headers.toJSON()

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -202,7 +202,7 @@ class NodeHttpsClient implements HttpsClient {
         try {
           parsedUrl = new URL(proxySettings.host);
         } catch (_error) {
-          throw new RangeError("Expecting a valid host string in proxy settings.");
+          throw new RangeError(`Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`);
         }
 
         const proxyAgentOptions: HttpsProxyAgentOptions = {

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -202,7 +202,7 @@ class NodeHttpsClient implements HttpsClient {
         try {
           parsedUrl = new URL(proxySettings.host);
         } catch (_error) {
-          throw new RangeError(`Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`);
+          throw new Error(`Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`);
         }
 
         const proxyAgentOptions: HttpsProxyAgentOptions = {

--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -198,9 +198,11 @@ class NodeHttpsClient implements HttpsClient {
     const proxySettings = request.proxySettings;
     if (proxySettings) {
       if (!this.proxyAgent) {
+        const parsedUrl = new URL(proxySettings.host);
         const proxyAgentOptions: HttpsProxyAgentOptions = {
-          host: proxySettings.host,
+          host: parsedUrl.host,
           port: proxySettings.port,
+          protocol: parsedUrl.protocol,
           headers: request.headers.toJSON()
         };
         if (proxySettings.username && proxySettings.password) {


### PR DESCRIPTION
There's some difference between the previous `tunnel.HttpsOverHttpsOptions` and
current `HttpsProxyAgentOptions`, in particular the former's `host` property
includes both the protocol and the host parts, while the later have separate
`host` and `protocol` properties.