### PR TITLE
[Event Hubs] Allow linter errs to break build

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -61,7 +61,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/internal/*.spec.js dist-esm/test/public/*.spec.js dist-esm/test/public/**/*.spec.js dist-esm/test/internal/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o event-hubs-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "perf-test:node": "tsc -p . --module \"commonjs\" && node dist-esm/test/perf/track-2/index.spec.js",
     "prebuild": "npm run clean",

--- a/sdk/eventhub/event-hubs/test/internal/utils.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/utils.spec.ts
@@ -324,7 +324,7 @@ function getAbortSignalWithTracking(
 ): AbortSignalLike & { ourListenersWereRemoved(): boolean } {
   const signal = (abortController.signal as any) as ReturnType<typeof getAbortSignalWithTracking>;
 
-  const allFunctions = new Set<Function>();
+  const allFunctions = new Set();
 
   const origAddEventListener = signal.addEventListener;
   const origRemoveEventListener = signal.removeEventListener;

--- a/sdk/eventhub/event-hubs/test/public/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testUtils.ts
@@ -9,7 +9,7 @@ import { NoOpTracer, TestTracer, setTracer } from "@azure/core-tracing";
 
 dotenv.config();
 
-declare const window: any;
+declare const self: any;
 
 export const isNode =
   !!process && !!process.version && !!process.versions && !!process.versions.node;
@@ -26,7 +26,7 @@ function getEnvVarValue(name: string): string | undefined {
   if (isNode) {
     return process.env[name];
   } else {
-    return window.__env__[name];
+    return self.__env__[name];
   }
 }
 


### PR DESCRIPTION
Fixes the last error in Event Hubs package and allows future linter errors to break the build.

We need to fix up the checkpoint store package before we can close the related issue #10777