### PR TITLE
[KeyVault] Replace KEYVAULT_NAME with KEYVAULT_URI in docs

### DIFF
--- a/sdk/keyvault/keyvault-admin/sample.env
+++ b/sdk/keyvault/keyvault-admin/sample.env
@@ -6,9 +6,6 @@ KEYVAULT_URI=<key-vault-uri>
 # At the moment only Azure Managed HSM supports administration operations.
 AZURE_MANAGEDHSM_URI=<managed-hsm-uri>
 
-# The name of the Key Vault.
-KEYVAULT_NAME=<key-vault-name>
-
 # URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 BLOB_STORAGE_URI=<blob-storage-uri>
 

--- a/sdk/keyvault/keyvault-admin/samples/javascript/README.md
+++ b/sdk/keyvault/keyvault-admin/samples/javascript/README.md
@@ -53,7 +53,7 @@ node backupRestoreHelloWorld.js
 Alternatively, run a single sample with the correct environment variables set (step 2 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env KEYVAULT_NAME="<key vault name>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" BLOB_STORAGE_URI="<blob-storage-uri>" BLOB_STORAGE_SAS_TOKEN="<blob-storage-sas-token>" CLIENT_OBJECT_ID="<client-object-id>" node backupRestoreHelloWorld.js
+npx cross-env KEYVAULT_URI="<key vault uri>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" BLOB_STORAGE_URI="<blob-storage-uri>" BLOB_STORAGE_SAS_TOKEN="<blob-storage-sas-token>" CLIENT_OBJECT_ID="<client-object-id>" node backupRestoreHelloWorld.js
 ```
 
 These samples add and remove roles to and from the application, tenant or principal specified by the `CLIENT_OBJECT_ID` environment variable. **Do not use the same Object Id of the application, tenant or principal you're using to authenticate the client.**

--- a/sdk/keyvault/keyvault-admin/samples/javascript/sample.env
+++ b/sdk/keyvault/keyvault-admin/samples/javascript/sample.env
@@ -2,9 +2,6 @@
 # Create a Key Vault in the Azure Portal and enter its URI (e.g. https://mytest.vault.azure.net/) here.
 KEYVAULT_URI=<key-vault-uri>
 
-# The name of the Key Vault.
-KEYVAULT_NAME=<key-vault-name>
-
 # URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 BLOB_STORAGE_URI=<blob-storage-uri>
 

--- a/sdk/keyvault/keyvault-admin/samples/typescript/README.md
+++ b/sdk/keyvault/keyvault-admin/samples/typescript/README.md
@@ -65,7 +65,7 @@ node dist/backupRestoreHelloWorld.ts
 Alternatively, run a single sample with the correct environment variables set (step 2 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env KEYVAULT_NAME="<key vault name>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" BLOB_STORAGE_URI="<blob-storage-uri>" BLOB_STORAGE_SAS_TOKEN="<blob-storage-sas-token>" CLIENT_OBJECT_ID="<client-object-id>" node dist/backupRestoreHelloWorld.ts
+npx cross-env KEYVAULT_URI="<key vault uri>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" BLOB_STORAGE_URI="<blob-storage-uri>" BLOB_STORAGE_SAS_TOKEN="<blob-storage-sas-token>" CLIENT_OBJECT_ID="<client-object-id>" node dist/backupRestoreHelloWorld.ts
 ```
 
 These samples add and remove roles to and from the application, tenant or principal specified by the `CLIENT_OBJECT_ID` environment variable. **Do not use the same Object Id of the application, tenant or principal you're using to authenticate the client.**

--- a/sdk/keyvault/keyvault-admin/samples/typescript/sample.env
+++ b/sdk/keyvault/keyvault-admin/samples/typescript/sample.env
@@ -2,9 +2,6 @@
 # Create a Key Vault in the Azure Portal and enter its URI (e.g. https://mytest.vault.azure.net/) here.
 KEYVAULT_URI=<key-vault-uri>
 
-# The name of the Key Vault.
-KEYVAULT_NAME=<key-vault-name>
-
 # URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 BLOB_STORAGE_URI=<blob-storage-uri>
 

--- a/sdk/keyvault/keyvault-admin/test/README.md
+++ b/sdk/keyvault/keyvault-admin/test/README.md
@@ -15,7 +15,6 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
 - `KEYVAULT_URI`: The name of the key vault to use in the samples.
-- `KEYVAULT_NAME`: The name of the KeyVault to use.
 - `BLOB_STORAGE_URI`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `BLOB_STORAGE_SAS_TOKEN`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `CLIENT_OBJECT_ID`: Object ID of the application, tenant or principal to whom the role will be assigned to. These tests add and remove roles to and from this ID. **Do not use the same Object Id of the application, tenant or principal you're using to authenticate the client.**

--- a/sdk/keyvault/keyvault-certificates/test/README.md
+++ b/sdk/keyvault/keyvault-certificates/test/README.md
@@ -14,7 +14,7 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `KEYVAULT_NAME`: The name of the KeyVault to use.
+- `KEYVAULT_URI`: The uri of the KeyVault to use.
 
 The live tests in this project will create, modify and delete [certificates](https://docs.microsoft.com/azure/key-vault/certificates/about-certificates) inside of the provided Azure Key Vault.
 

--- a/sdk/keyvault/keyvault-keys/samples/javascript/README.md
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/README.md
@@ -53,7 +53,7 @@ node helloWorld.js
 Alternatively, run a single sample with the correct environment variables set (step 2 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env KEYVAULT_NAME="<key vault name>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node helloWorld.js
+npx cross-env KEYVAULT_URI="<key vault uri>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node helloWorld.js
 ```
 
 ## Next Steps

--- a/sdk/keyvault/keyvault-keys/samples/typescript/README.md
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/README.md
@@ -65,7 +65,7 @@ node dist/helloWorld.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env KEYVAULT_NAME="<key vault name>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node dist/helloWorld.js
+npx cross-env KEYVAULT_URI="<key vault uri>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node dist/helloWorld.js
 ```
 
 ## Next Steps

--- a/sdk/keyvault/keyvault-keys/test/README.md
+++ b/sdk/keyvault/keyvault-keys/test/README.md
@@ -14,7 +14,7 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `KEYVAULT_NAME`: The name of the KeyVault to use.
+- `KEYVAULT_URI`: The name of the KeyVault to use.
 
 The live tests in this project will create, modify and delete [keys](https://docs.microsoft.com/azure/key-vault/keys/about-keys) inside of the provided Azure Key Vault.
 

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/README.md
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/README.md
@@ -67,7 +67,7 @@ node dist/helloWorld.js
 Alternatively, run a single sample with the correct environment variables set (step 3 is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env KEYVAULT_NAME="<key vault name>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node dist/helloWorld.js
+npx cross-env KEYVAULT_URI="<key vault uri>" AZURE_TENANT_ID="<AAD tenant id>" AZURE_CLIENT_ID="<AAD client id>" AZURE_CLIENT_SECRET="<AAD client secret>" node dist/helloWorld.js
 ```
 
 ## Next Steps

--- a/sdk/keyvault/keyvault-secrets/test/README.md
+++ b/sdk/keyvault/keyvault-secrets/test/README.md
@@ -14,7 +14,7 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `KEYVAULT_NAME`: The name of the KeyVault to use.
+- `KEYVAULT_URI`: The URI of the KeyVault to use.
 
 The live tests in this project will create, modify and delete [secrets](https://docs.microsoft.com/azure/key-vault/secrets/about-secrets) inside of the provided Azure Key Vault.
 

--- a/sdk/test-utils/recorder/README.md
+++ b/sdk/test-utils/recorder/README.md
@@ -457,7 +457,7 @@ setReplaceableVariables({
   AZURE_CLIENT_ID: "azure_client_id",
   AZURE_CLIENT_SECRET: "azure_client_secret",
   AZURE_TENANT_ID: "azure_tenant_id",
-  KEYVAULT_NAME: "keyvault_name"
+  KEYVAULT_URI: "https://keyvault_name.vault.azure.net"
 });
 ```
 


### PR DESCRIPTION
To line up well with other services, and because Managed HSM has a different
URI pattern (but same client library) as KeyVault we started using KEYVAULT_URI
instead of KEYVAULT_NAME.

This commit just cleans up some of the documentation and instructions and removes
the now obsolete KEYVAULT_NAME.