### PR TITLE
[core-client] Unify PipelineOptions and ServiceClientOptions

### DIFF
--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -360,10 +360,8 @@ export interface ServiceClientOptions extends CommonClientOptions {
     baseUri?: string;
     credential?: TokenCredential;
     credentialScopes?: string | string[];
-    parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
     pipeline?: Pipeline;
     requestContentType?: string;
-    stringifyXML?: (obj: any, opts?: XmlOptions) => string;
 }
 
 // @public (undocumented)

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -10,6 +10,7 @@ import { HttpsClient } from '@azure/core-https';
 import { InternalPipelineOptions } from '@azure/core-https';
 import { OperationTracingOptions } from '@azure/core-tracing';
 import { Pipeline } from '@azure/core-https';
+import { PipelineOptions } from '@azure/core-https';
 import { PipelinePolicy } from '@azure/core-https';
 import { PipelineRequest } from '@azure/core-https';
 import { PipelineResponse } from '@azure/core-https';
@@ -36,13 +37,8 @@ export interface BaseMapper {
 }
 
 // @public
-export interface ClientPipelineOptions extends InternalPipelineOptions {
-    credentialOptions?: {
-        credentialScopes: string | string[];
-        credential: TokenCredential;
-    };
-    deserializationOptions?: DeserializationPolicyOptions;
-    serializationOptions?: SerializationPolicyOptions;
+export interface CommonClientOptions extends PipelineOptions {
+    httpsClient?: HttpsClient;
 }
 
 // @public (undocumented)
@@ -70,7 +66,7 @@ export interface CompositeMapperType {
 }
 
 // @public
-export function createClientPipeline(options?: ClientPipelineOptions): Pipeline;
+export function createClientPipeline(options?: InternalClientPipelineOptions): Pipeline;
 
 // @public
 export function createSerializer(modelMappers?: {
@@ -139,6 +135,16 @@ export interface FullOperationResponse extends PipelineResponse {
         [key: string]: unknown;
     };
     request: OperationRequest;
+}
+
+// @public
+export interface InternalClientPipelineOptions extends InternalPipelineOptions {
+    credentialOptions?: {
+        credentialScopes: string | string[];
+        credential: TokenCredential;
+    };
+    deserializationOptions?: DeserializationPolicyOptions;
+    serializationOptions?: SerializationPolicyOptions;
 }
 
 // @public (undocumented)
@@ -344,16 +350,16 @@ export interface SerializerOptions {
 // @public
 export class ServiceClient {
     constructor(options?: ServiceClientOptions);
+    readonly pipeline: Pipeline;
     sendOperationRequest<T>(operationArguments: OperationArguments, operationSpec: OperationSpec): Promise<T>;
     sendRequest(request: PipelineRequest): Promise<PipelineResponse>;
 }
 
 // @public
-export interface ServiceClientOptions {
+export interface ServiceClientOptions extends CommonClientOptions {
     baseUri?: string;
     credential?: TokenCredential;
     credentialScopes?: string | string[];
-    httpsClient?: HttpsClient;
     parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
     pipeline?: Pipeline;
     requestContentType?: string;

--- a/sdk/core/core-client/src/index.ts
+++ b/sdk/core/core-client/src/index.ts
@@ -4,7 +4,7 @@
 export { createSerializer, MapperTypeNames } from "./serializer";
 export { createSpanFunction } from "./createSpan";
 export { ServiceClient, ServiceClientOptions } from "./serviceClient";
-export { createClientPipeline, ClientPipelineOptions } from "./pipeline";
+export { createClientPipeline, InternalClientPipelineOptions } from "./pipeline";
 export {
   OperationSpec,
   OperationArguments,
@@ -39,7 +39,8 @@ export {
   XML_CHARKEY,
   XmlOptions,
   SerializerOptions,
-  RawResponseCallback
+  RawResponseCallback,
+  CommonClientOptions
 } from "./interfaces";
 export {
   deserializationPolicy,

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -7,7 +7,9 @@ import {
   HttpMethods,
   PipelineResponse,
   TransferProgressEvent,
-  PipelineRequest
+  PipelineRequest,
+  PipelineOptions,
+  HttpsClient
 } from "@azure/core-https";
 
 /**
@@ -536,4 +538,14 @@ export interface SpanConfig {
    * Service namespace
    */
   namespace: string;
+}
+
+/**
+ * The common set of options that high level clients are expected to expose.
+ */
+export interface CommonClientOptions extends PipelineOptions {
+  /**
+   * The HttpClient that will be used to send HTTP requests.
+   */
+  httpsClient?: HttpsClient;
 }

--- a/sdk/core/core-client/src/pipeline.ts
+++ b/sdk/core/core-client/src/pipeline.ts
@@ -16,7 +16,7 @@ import { serializationPolicy, SerializationPolicyOptions } from "./serialization
  * Mostly for customizing the auth policy (if using token auth) or
  * the deserialization options when using XML.
  */
-export interface ClientPipelineOptions extends InternalPipelineOptions {
+export interface InternalClientPipelineOptions extends InternalPipelineOptions {
   /**
    * Options to customize bearerTokenAuthenticationPolicy.
    */
@@ -37,7 +37,7 @@ export interface ClientPipelineOptions extends InternalPipelineOptions {
  * Also adds in bearerTokenAuthenticationPolicy if passed a TokenCredential.
  * @param options - Options to customize the created pipeline.
  */
-export function createClientPipeline(options: ClientPipelineOptions = {}): Pipeline {
+export function createClientPipeline(options: InternalClientPipelineOptions = {}): Pipeline {
   const pipeline = createPipelineFromOptions(options ?? {});
   if (options.credentialOptions) {
     pipeline.addPolicy(

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -13,7 +13,6 @@ import {
   OperationArguments,
   OperationSpec,
   OperationRequest,
-  XmlOptions,
   CommonClientOptions
 } from "./interfaces";
 import { getStreamingResponseStatusCodes } from "./interfaceHelpers";
@@ -50,16 +49,6 @@ export interface ServiceClientOptions extends CommonClientOptions {
    * A customized pipeline to use, otherwise a default one will be created.
    */
   pipeline?: Pipeline;
-
-  /**
-   * A method that is able to turn an XML object model into a string.
-   */
-  stringifyXML?: (obj: any, opts?: XmlOptions) => string;
-
-  /**
-   * A method that is able to parse XML.
-   */
-  parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
 }
 
 /**
@@ -215,13 +204,7 @@ function createDefaultPipeline(options: ServiceClientOptions): Pipeline {
 
   return createClientPipeline({
     ...options,
-    credentialOptions,
-    deserializationOptions: {
-      parseXML: options.parseXML
-    },
-    serializationOptions: {
-      stringifyXML: options.stringifyXML
-    }
+    credentialOptions
   });
 }
 

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -9,7 +9,13 @@ import {
   Pipeline,
   createPipelineRequest
 } from "@azure/core-https";
-import { OperationArguments, OperationSpec, OperationRequest, XmlOptions } from "./interfaces";
+import {
+  OperationArguments,
+  OperationSpec,
+  OperationRequest,
+  XmlOptions,
+  CommonClientOptions
+} from "./interfaces";
 import { getStreamingResponseStatusCodes } from "./interfaceHelpers";
 import { getRequestUrl } from "./urlHelpers";
 import { flattenResponse } from "./utils";
@@ -21,7 +27,7 @@ import { createClientPipeline } from "./pipeline";
 /**
  * Options to be provided while creating the client.
  */
-export interface ServiceClientOptions {
+export interface ServiceClientOptions extends CommonClientOptions {
   /**
    * If specified, this is the base URI that requests will be made against for this ServiceClient.
    * If it is not specified, then all OperationSpecs must contain a baseUrl property.
@@ -44,10 +50,6 @@ export interface ServiceClientOptions {
    * A customized pipeline to use, otherwise a default one will be created.
    */
   pipeline?: Pipeline;
-  /**
-   * The HttpClient that will be used to send HTTP requests.
-   */
-  httpsClient?: HttpsClient;
 
   /**
    * A method that is able to turn an XML object model into a string.
@@ -81,7 +83,10 @@ export class ServiceClient {
    */
   private readonly _httpsClient: HttpsClient;
 
-  private readonly _pipeline: Pipeline;
+  /**
+   * The pipeline used by this client to make requests
+   */
+  public readonly pipeline: Pipeline;
 
   /**
    * The ServiceClient constructor
@@ -92,22 +97,15 @@ export class ServiceClient {
     this._requestContentType = options.requestContentType;
     this._baseUri = options.baseUri;
     this._httpsClient = options.httpsClient || getCachedDefaultHttpsClient();
-    const credentialScopes = getCredentialScopes(options);
-    this._pipeline =
-      options.pipeline ||
-      createDefaultPipeline({
-        credentialScopes,
-        credential: options.credential,
-        parseXML: options.parseXML,
-        stringifyXML: options.stringifyXML
-      });
+
+    this.pipeline = options.pipeline || createDefaultPipeline(options);
   }
 
   /**
    * Send the provided httpRequest.
    */
   async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
-    return this._pipeline.sendRequest(this._httpsClient, request);
+    return this.pipeline.sendRequest(this._httpsClient, request);
   }
 
   /**
@@ -208,20 +206,15 @@ export class ServiceClient {
   }
 }
 
-function createDefaultPipeline(
-  options: {
-    credentialScopes?: string | string[];
-    credential?: TokenCredential;
-    parseXML?: (str: string, opts?: XmlOptions) => Promise<any>;
-    stringifyXML?: (obj: any, opts?: XmlOptions) => string;
-  } = {}
-): Pipeline {
+function createDefaultPipeline(options: ServiceClientOptions): Pipeline {
+  const credentialScopes = getCredentialScopes(options);
   const credentialOptions =
-    options.credential && options.credentialScopes
-      ? { credentialScopes: options.credentialScopes, credential: options.credential }
+    options.credential && credentialScopes
+      ? { credentialScopes, credential: options.credential }
       : undefined;
 
   return createClientPipeline({
+    ...options,
     credentialOptions,
     deserializationOptions: {
       parseXML: options.parseXML

--- a/sdk/eventgrid/eventgrid/review/eventgrid.api.md
+++ b/sdk/eventgrid/eventgrid/review/eventgrid.api.md
@@ -6,9 +6,9 @@
 
 import { AzureKeyCredential } from '@azure/core-auth';
 import { AzureSASCredential } from '@azure/core-auth';
+import { CommonClientOptions } from '@azure/core-client';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
-import { PipelineOptions } from '@azure/core-https';
 import { SASCredential } from '@azure/core-auth';
 
 // @public
@@ -346,7 +346,7 @@ export class EventGridPublisherClient<T extends InputSchema> {
 }
 
 // @public
-export type EventGridPublisherClientOptions = PipelineOptions;
+export type EventGridPublisherClientOptions = CommonClientOptions;
 
 // @public
 export interface EventHubCaptureFileCreatedEventData {

--- a/sdk/eventgrid/eventgrid/src/eventGridClient.ts
+++ b/sdk/eventgrid/eventgrid/src/eventGridClient.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 import { KeyCredential, SASCredential } from "@azure/core-auth";
-import { PipelineOptions } from "@azure/core-https";
-import { OperationOptions, createClientPipeline } from "@azure/core-client";
+import { OperationOptions, CommonClientOptions } from "@azure/core-client";
 
 import { eventGridCredentialPolicy } from "./eventGridAuthenticationPolicy";
 import { SDK_VERSION } from "./constants";
@@ -25,7 +24,7 @@ import { v4 as uuidv4 } from "uuid";
 /**
  * Options for the Event Grid Client.
  */
-export type EventGridPublisherClientOptions = PipelineOptions;
+export type EventGridPublisherClientOptions = CommonClientOptions;
 
 /**
  * Options for the send events operation.
@@ -121,12 +120,10 @@ export class EventGridPublisherClient<T extends InputSchema> {
       pipelineOptions.userAgentOptions.userAgentPrefix = libInfo;
     }
 
-    const pipeline = createClientPipeline(pipelineOptions);
+    this.client = new GeneratedClient(pipelineOptions);
     const authPolicy = eventGridCredentialPolicy(credential);
-    pipeline.addPolicy(authPolicy);
-    pipeline.addPolicy(cloudEventDistributedTracingEnricherPolicy());
-
-    this.client = new GeneratedClient({ pipeline });
+    this.client.pipeline.addPolicy(authPolicy);
+    this.client.pipeline.addPolicy(cloudEventDistributedTracingEnricherPolicy());
     this.apiVersion = this.client.apiVersion;
   }
 

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
+import { CommonClientOptions } from '@azure/core-client';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
-import { PipelineOptions } from '@azure/core-https';
 import { PipelinePolicy } from '@azure/core-https';
 
 // @public
@@ -433,7 +433,7 @@ export class TableServiceClient {
     }
 
 // @public
-export type TableServiceClientOptions = PipelineOptions & {
+export type TableServiceClientOptions = CommonClientOptions & {
     endpoint?: string;
     version?: string;
 };

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -50,7 +50,7 @@ import { CanonicalCode } from "@opentelemetry/api";
 import { TableBatchImpl, createInnerBatchRequest } from "./TableBatch";
 import { InternalBatchClientOptions } from "./utils/internalModels";
 import { Uuid } from "./utils/uuid";
-import { parseXML } from "@azure/core-xml";
+import { parseXML, stringifyXML } from "@azure/core-xml";
 
 /**
  * A TableClient represents a Client to the Azure Tables service allowing you
@@ -161,6 +161,9 @@ export class TableClient {
           },
           deserializationOptions: {
             parseXML
+          },
+          serializationOptions: {
+            stringifyXML
           }
         }
       };

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -27,7 +27,10 @@ import {
   UpsertEntityResponse,
   DeleteTableEntityResponse
 } from "./generatedModels";
-import { QueryOptions as GeneratedQueryOptions } from "./generated/models";
+import {
+  GeneratedClientOptionalParams,
+  QueryOptions as GeneratedQueryOptions
+} from "./generated/models";
 import { getClientParamsFromConnectionString } from "./utils/connectionString";
 import {
   TablesSharedKeyCredential,
@@ -40,12 +43,7 @@ import { GeneratedClient, TableDeleteEntityOptionalParams } from "./generated";
 import { deserialize, deserializeObjectsArray, serialize } from "./serialization";
 import { Table } from "./generated/operations";
 import { LIB_INFO, TablesLoggingAllowedHeaderNames } from "./utils/constants";
-import { Pipeline } from "@azure/core-https";
-import {
-  ClientPipelineOptions,
-  createClientPipeline,
-  FullOperationResponse
-} from "@azure/core-client";
+import { FullOperationResponse } from "@azure/core-client";
 import { logger } from "./logger";
 import { createSpan } from "./utils/tracing";
 import { CanonicalCode } from "@opentelemetry/api";
@@ -146,15 +144,15 @@ export class TableClient {
       clientOptions.userAgentOptions.userAgentPrefix = LIB_INFO;
     }
 
-    let pipeline: Pipeline;
+    let generatedClientOptions: GeneratedClientOptionalParams = {};
 
     if (isInternalClientOptions(clientOptions)) {
       // The client is meant to be an intercept client, so we need to create only the intercepting
       // pipelines.
-      pipeline = clientOptions.innerBatchRequest.createPipeline();
+      generatedClientOptions.pipeline = clientOptions.innerBatchRequest.createPipeline();
     } else {
       // The client is meant to be a regular service client, so we need to create the regular set of pipelines
-      const internalPipelineOptions: ClientPipelineOptions = {
+      generatedClientOptions = {
         ...clientOptions,
         ...{
           loggingOptions: {
@@ -166,17 +164,15 @@ export class TableClient {
           }
         }
       };
-      pipeline = createClientPipeline(internalPipelineOptions);
-
-      if (credential) {
-        pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
-      }
     }
 
     this.tableName = tableName;
     this.credential = credential;
-    const { table } = new GeneratedClient(url, { pipeline });
-    this.table = table;
+    const generatedClient = new GeneratedClient(url, generatedClientOptions);
+    if (credential) {
+      generatedClient.pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
+    }
+    this.table = generatedClient.table;
   }
 
   /**

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -38,7 +38,7 @@ import { InternalClientPipelineOptions } from "@azure/core-client";
 import { CanonicalCode } from "@opentelemetry/api";
 import { createSpan } from "./utils/tracing";
 import { tablesSharedKeyCredentialPolicy } from "./TablesSharedKeyCredentialPolicy";
-import { parseXML } from "@azure/core-xml";
+import { parseXML, stringifyXML } from "@azure/core-xml";
 
 /**
  * A TableServiceClient represents a Client to the Azure Tables service allowing you
@@ -126,6 +126,9 @@ export class TableServiceClient {
         },
         deserializationOptions: {
           parseXML
+        },
+        serializationOptions: {
+          stringifyXML
         }
       }
     };

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -34,7 +34,7 @@ import "@azure/core-paging";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { LIB_INFO, TablesLoggingAllowedHeaderNames } from "./utils/constants";
 import { logger } from "./logger";
-import { createClientPipeline, ClientPipelineOptions } from "@azure/core-client";
+import { InternalClientPipelineOptions } from "@azure/core-client";
 import { CanonicalCode } from "@opentelemetry/api";
 import { createSpan } from "./utils/tracing";
 import { tablesSharedKeyCredentialPolicy } from "./TablesSharedKeyCredentialPolicy";
@@ -117,7 +117,7 @@ export class TableServiceClient {
       clientOptions.userAgentOptions.userAgentPrefix = LIB_INFO;
     }
 
-    const internalPipelineOptions: ClientPipelineOptions = {
+    const internalPipelineOptions: InternalClientPipelineOptions = {
       ...clientOptions,
       ...{
         loggingOptions: {
@@ -130,12 +130,10 @@ export class TableServiceClient {
       }
     };
 
-    const pipeline = createClientPipeline(internalPipelineOptions);
-
+    const client = new GeneratedClient(url, internalPipelineOptions);
     if (credential) {
-      pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
+      client.pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
     }
-    const client = new GeneratedClient(url, { pipeline });
     this.table = client.table;
     this.service = client.service;
   }

--- a/sdk/tables/data-tables/src/generated/generatedClientContext.ts
+++ b/sdk/tables/data-tables/src/generated/generatedClientContext.ts
@@ -7,7 +7,6 @@
  */
 
 import { ServiceClient } from "@azure/core-client";
-import { stringifyXML, parseXML } from "@azure/core-xml";
 import { GeneratedClientOptionalParams } from "./models";
 
 export class GeneratedClientContext extends ServiceClient {
@@ -26,9 +25,7 @@ export class GeneratedClientContext extends ServiceClient {
 
     const defaults: GeneratedClientOptionalParams = {
       baseUri: "{url}",
-      requestContentType: "application/json; charset=utf-8",
-      stringifyXML,
-      parseXML
+      requestContentType: "application/json; charset=utf-8"
     };
 
     const optionsWithDefaults = {

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -6,13 +6,12 @@ import {
   TableInsertEntityHeaders,
   TableCreateHeaders
 } from "./generated/models";
-import { PipelineOptions } from "@azure/core-https";
-import { OperationOptions } from "@azure/core-client";
+import { OperationOptions, CommonClientOptions } from "@azure/core-client";
 
 /**
  * Client options used to configure Tables Api requests
  */
-export type TableServiceClientOptions = PipelineOptions & {
+export type TableServiceClientOptions = CommonClientOptions & {
   endpoint?: string;
   version?: string;
 };


### PR DESCRIPTION
The two main changes here:

- Rename `ClientPipelineOptions` to `InternalClientPipelineOptions` to reflect that this extends the quasi-private `InternalPipelineOptions` interface.
- Create a new interface for convenience clients to use as their base options type: `CommonClientOptions`
- Have `ServiceClientOptions` extend `CommonClientOptions` so the two worlds can unify at last

The rest is just updating downstream packages.