### PR TITLE
Undeprecate existing encrypt and decrypt methods

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Updated the Latest service version to 7.2.
 - Added `curve` to `createKeyOptions` to be used when creating an `EC` key.
-- Deprecated the current `encrypt` and `decrypt` methods in favor of the more flexible overloads that take an `{Encrypt|Decrypt}Parameters` and allow passing in algorithm specific parameters. This enables support for the various AES algorithms used in Managed HSM. The deprecated methods continue to function and there's no timeline for their removal.
+- Added `EncryptParameters` and `DecryptParameters` which encapsulate algorithm specific parameter requirements.
+- Added `encrypt` and `decrypt` overload methods to `CryptographyClient` that accept `EncryptParameters` and `DecryptParameters` - allowing for AES encryption parameters to be passed in to the service.
 - Added `additionalAuthenticatedData`, `iv`, and `authenticationTag` to `EncryptResult` in order to support AES encryption and decryption.
 
 ## 4.2.0-beta.3 (2021-02-09)

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -88,10 +88,8 @@ export class CryptographyClient {
     constructor(key: string | KeyVaultKey, credential: TokenCredential, pipelineOptions?: CryptographyClientOptions);
     constructor(key: JsonWebKey);
     decrypt(decryptParameters: DecryptParameters, options?: DecryptOptions): Promise<DecryptResult>;
-    // @deprecated
     decrypt(algorithm: EncryptionAlgorithm, ciphertext: Uint8Array, options?: DecryptOptions): Promise<DecryptResult>;
     encrypt(encryptParameters: EncryptParameters, options?: EncryptOptions): Promise<EncryptResult>;
-    // @deprecated
     encrypt(algorithm: EncryptionAlgorithm, plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
     get keyId(): string | undefined;
     sign(algorithm: SignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -140,7 +140,6 @@ export class CryptographyClient {
    * @param algorithm - The algorithm to use.
    * @param plaintext - The text to encrypt.
    * @param options - Additional options.
-   * @deprecated Use `encrypt({ algorithm, plaintext }, options)` instead.
    */
   public async encrypt(
     algorithm: EncryptionAlgorithm,
@@ -212,7 +211,6 @@ export class CryptographyClient {
    * @param algorithm - The algorithm to use.
    * @param ciphertext - The text to decrypt.
    * @param options - Additional options.
-   * @deprecated Use `decrypt({ algorithm, ciphertext }, options)` instead.
    */
   public async decrypt(
     algorithm: EncryptionAlgorithm,


### PR DESCRIPTION
In #13889 I deprecated the existing `encrypt` and `decrypt` overloads in favor
of the more flexible counterparts. Heath made a good point about warnings
causing possible build errors. The existing methods are also perfectly suitable
for encrypting / decrypting using RSA so they don't need to be deprecated.

This commit just removes the deprecation doc comment and updates the 
CHANGELOG.