### PR TITLE
[Storage] Fix the self vs window rule in storage packages

### DIFF
--- a/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
@@ -96,7 +96,7 @@ export class SimpleTokenCredential implements TokenCredential {
 }
 
 export function isBrowser(): boolean {
-  return typeof window !== "undefined";
+  return typeof self !== "undefined";
 }
 
 export function getUniqueName(prefix: string): string {

--- a/sdk/storage/storage-blob/test/encrytion.spec.ts
+++ b/sdk/storage/storage-blob/test/encrytion.spec.ts
@@ -33,8 +33,8 @@ describe("Encryption Scope", function() {
       encryptionScopeName1 = process.env[encryptionScopeEnvVar1];
       encryptionScopeName2 = process.env[encryptionScopeEnvVar2];
     } else {
-      encryptionScopeName1 = (window as any).__env__[encryptionScopeEnvVar1];
-      encryptionScopeName2 = (window as any).__env__[encryptionScopeEnvVar2];
+      encryptionScopeName1 = (self as any).__env__[encryptionScopeEnvVar1];
+      encryptionScopeName2 = (self as any).__env__[encryptionScopeEnvVar2];
     }
 
     if ((!encryptionScopeName1 || !encryptionScopeName2) && !isPlaybackMode()) {

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -113,7 +113,7 @@ export class SimpleTokenCredential implements TokenCredential {
 }
 
 export function isBrowser(): boolean {
-  return typeof window !== "undefined";
+  return typeof self !== "undefined";
 }
 
 export function getUniqueName(prefix: string): string {

--- a/sdk/storage/storage-file-datalake/test/utils/index.browser.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/index.browser.ts
@@ -19,7 +19,7 @@ export function getTokenCredential(): TokenCredential {
   const accountTokenEnvVar = `DFS_ACCOUNT_TOKEN`;
   let accountToken: string | undefined;
 
-  accountToken = (window as any).__env__[accountTokenEnvVar];
+  accountToken = (self as any).__env__[accountTokenEnvVar];
 
   if (!accountToken || accountToken === "") {
     throw new Error(`${accountTokenEnvVar} environment variables not specified.`);
@@ -37,8 +37,8 @@ export function getGenericDataLakeServiceClient(
 
   let accountName: string | undefined;
   let accountSAS: string | undefined;
-  accountName = (window as any).__env__[accountNameEnvVar];
-  accountSAS = (window as any).__env__[accountSASEnvVar];
+  accountName = (self as any).__env__[accountNameEnvVar];
+  accountSAS = (self as any).__env__[accountSASEnvVar];
 
   if (!accountName || !accountSAS || accountName === "" || accountSAS === "") {
     throw new Error(
@@ -64,7 +64,7 @@ export function getTokenDataLakeServiceClient(): DataLakeServiceClient {
 
   let accountName: string | undefined;
 
-  accountName = (window as any).__env__[accountNameEnvVar];
+  accountName = (self as any).__env__[accountNameEnvVar];
 
   if (!accountName || accountName === "") {
     throw new Error(`${accountNameEnvVar} environment variables not specified.`);
@@ -146,7 +146,7 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
 }
 
 export function isIE(): boolean {
-  const sAgent = window.navigator.userAgent;
+  const sAgent = self.navigator.userAgent;
   const Idx = sAgent.indexOf("MSIE");
 
   // If IE, return version number.
@@ -176,6 +176,6 @@ export function getBrowserFile(name: string, size: number): File {
 }
 
 export function getSASConnectionStringFromEnvironment(): string {
-  const env = (window as any).__env__;
+  const env = (self as any).__env__;
   return `BlobEndpoint=https://${env.DFS_ACCOUNT_NAME}.blob.core.windows.net/;QueueEndpoint=https://${env.DFS_ACCOUNT_NAME}.queue.core.windows.net/;FileEndpoint=https://${env.DFS_ACCOUNT_NAME}.file.core.windows.net/;TableEndpoint=https://${env.DFS_ACCOUNT_NAME}.table.core.windows.net/;SharedAccessSignature=${env.DFS_ACCOUNT_SAS}`;
 }

--- a/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
@@ -99,7 +99,7 @@ export class SimpleTokenCredential implements TokenCredential {
 }
 
 export function isBrowser(): boolean {
-  return typeof window !== "undefined";
+  return typeof self !== "undefined";
 }
 
 export function getUniqueName(prefix: string): string {

--- a/sdk/storage/storage-file-share/test/utils/index.browser.ts
+++ b/sdk/storage/storage-file-share/test/utils/index.browser.ts
@@ -16,8 +16,8 @@ export function getGenericBSU(
 
   let accountName: string | undefined;
   let accountSAS: string | undefined;
-  accountName = (window as any).__env__[accountNameEnvVar];
-  accountSAS = (window as any).__env__[accountSASEnvVar];
+  accountName = (self as any).__env__[accountNameEnvVar];
+  accountSAS = (self as any).__env__[accountSASEnvVar];
 
   if (!accountName || !accountSAS || accountName === "" || accountSAS === "") {
     throw new Error(
@@ -109,7 +109,7 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
 }
 
 export function isIE(): boolean {
-  const sAgent = window.navigator.userAgent;
+  const sAgent = self.navigator.userAgent;
   const Idx = sAgent.indexOf("MSIE");
 
   // If IE, return version number.
@@ -139,7 +139,7 @@ export function getBrowserFile(name: string, size: number): File {
 }
 
 export function getSASConnectionStringFromEnvironment(): string {
-  const env = (window as any).__env__;
+  const env = (self as any).__env__;
   return `BlobEndpoint=https://${env.ACCOUNT_NAME}.blob.core.windows.net/;QueueEndpoint=https://${env.ACCOUNT_NAME}.queue.core.windows.net/;FileEndpoint=https://${env.ACCOUNT_NAME}.file.core.windows.net/;TableEndpoint=https://${env.ACCOUNT_NAME}.table.core.windows.net/;SharedAccessSignature=${env.ACCOUNT_SAS}`;
 }
 

--- a/sdk/storage/storage-file-share/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-share/test/utils/testutils.common.ts
@@ -5,7 +5,7 @@ import { padStart } from "../../src/utils/utils.common";
 import { env, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 
 export function isBrowser(): boolean {
-  return typeof window !== "undefined";
+  return typeof self !== "undefined";
 }
 
 const mockAccountName = "fakestorageaccount";

--- a/sdk/storage/storage-queue/test/node/emulator-tests.spec.ts
+++ b/sdk/storage/storage-queue/test/node/emulator-tests.spec.ts
@@ -12,7 +12,7 @@ describe("Emulator Tests", () => {
   const messageContent = "Hello World";
   let queueName: string;
   let queueClient: QueueClient;
-  const env = isBrowser() ? (window as any).__env__ : process.env;
+  const env = isBrowser() ? (self as any).__env__ : process.env;
   beforeEach(async function() {
     if (!env.STORAGE_CONNECTION_STRING.startsWith("UseDevelopmentStorage=true")) {
       this.skip();

--- a/sdk/storage/storage-queue/test/utils/index.browser.ts
+++ b/sdk/storage/storage-queue/test/utils/index.browser.ts
@@ -15,8 +15,8 @@ export function getGenericQSU(
 
   let accountName: string | undefined;
   let accountSAS: string | undefined;
-  accountName = (window as any).__env__[accountNameEnvVar];
-  accountSAS = (window as any).__env__[accountSASEnvVar];
+  accountName = (self as any).__env__[accountNameEnvVar];
+  accountSAS = (self as any).__env__[accountSASEnvVar];
 
   if (!accountName || !accountSAS || accountName === "" || accountSAS === "") {
     throw new Error(
@@ -104,7 +104,7 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
 }
 
 export function isIE(): boolean {
-  const sAgent = window.navigator.userAgent;
+  const sAgent = self.navigator.userAgent;
   const Idx = sAgent.indexOf("MSIE");
 
   // If IE, return version number.
@@ -134,7 +134,7 @@ export function getBrowserFile(name: string, size: number): File {
 }
 
 export function getSASConnectionStringFromEnvironment(): string {
-  const env = (window as any).__env__;
+  const env = (self as any).__env__;
   return `BlobEndpoint=https://${env.ACCOUNT_NAME}.blob.core.windows.net/;QueueEndpoint=https://${
     env.ACCOUNT_NAME
   }.queue.core.windows.net/;FileEndpoint=https://${

--- a/sdk/storage/storage-queue/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-queue/test/utils/testutils.common.ts
@@ -5,7 +5,7 @@ import { padStart } from "../../src/utils/utils.common";
 import { env, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 
 export function isBrowser(): boolean {
-  return typeof window !== "undefined";
+  return typeof self !== "undefined";
 }
 
 const mockAccountName = "fakestorageaccount";


### PR DESCRIPTION
This PR fixes up the latest linter rule we added to our linter.
Found this when running the `lint:fix` script on the storage packages

More details are in #13873
Related to #10782