### PR TITLE
[app-config] Use createSpan from core-tracing

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -8,7 +8,6 @@ import { AppConfigCredential } from "./appConfigCredential";
 import { AppConfiguration } from "./generated/src/appConfiguration";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 import {
-  operationOptionsToRequestOptionsBase,
   isTokenCredential,
   exponentialRetryPolicy,
   systemErrorRetryPolicy,
@@ -54,7 +53,7 @@ import {
   formatFieldsForSelect
 } from "./internal/helpers";
 import { tracingPolicy } from "@azure/core-http";
-import { Spanner } from "./internal/tracingHelpers";
+import { trace as traceFromTracingHelpers } from "./internal/tracingHelpers";
 import {
   AppConfigurationGetKeyValuesResponse,
   AppConfigurationOptionalParams as GeneratedAppConfigurationClientOptions
@@ -116,7 +115,8 @@ export interface InternalAppConfigurationClientOptions extends AppConfigurationC
  */
 export class AppConfigurationClient {
   private client: AppConfiguration;
-  private spanner: Spanner<AppConfigurationClient>;
+  // (for tests)
+  private _trace = traceFromTracingHelpers;
 
   /**
    * Initializes a new instance of the AppConfigurationClient class.
@@ -172,8 +172,6 @@ export class AppConfigurationClient {
       apiVersion,
       getGeneratedClientOptions(appConfigEndpoint, syncTokens, appConfigOptions)
     );
-
-    this.spanner = new Spanner<AppConfigurationClient>("Azure.Data.AppConfiguration");
   }
 
   /**
@@ -191,8 +189,7 @@ export class AppConfigurationClient {
     configurationSetting: AddConfigurationSettingParam,
     options: AddConfigurationSettingOptions = {}
   ): Promise<AddConfigurationSettingResponse> {
-    const opts = operationOptionsToRequestOptionsBase(options);
-    return this.spanner.trace("addConfigurationSetting", opts, async (newOptions) => {
+    return this._trace("addConfigurationSetting", options, async (newOptions) => {
       const originalResponse = await this.client.putKeyValue(configurationSetting.key, {
         ifNoneMatch: "*",
         label: configurationSetting.label,
@@ -218,8 +215,7 @@ export class AppConfigurationClient {
     id: ConfigurationSettingId,
     options: DeleteConfigurationSettingOptions = {}
   ): Promise<DeleteConfigurationSettingResponse> {
-    const opts = operationOptionsToRequestOptionsBase(options);
-    return this.spanner.trace("deleteConfigurationSetting", opts, async (newOptions) => {
+    return this._trace("deleteConfigurationSetting", options, async (newOptions) => {
       const originalResponse = await this.client.deleteKeyValue(id.key, {
         label: id.label,
         ...newOptions,
@@ -244,8 +240,7 @@ export class AppConfigurationClient {
     id: ConfigurationSettingId,
     options: GetConfigurationSettingOptions = {}
   ): Promise<GetConfigurationSettingResponse> {
-    const requestOptions = operationOptionsToRequestOptionsBase(options);
-    return this.spanner.trace("getConfigurationSetting", requestOptions, async (newOptions) => {
+    return this._trace("getConfigurationSetting", options, async (newOptions) => {
       const originalResponse = await this.client.getKeyValue(id.key, {
         ...newOptions,
         label: id.label,
@@ -316,10 +311,9 @@ export class AppConfigurationClient {
   private async *listConfigurationSettingsByPage(
     options: ListConfigurationSettingsOptions = {}
   ): AsyncIterableIterator<ListConfigurationSettingPage> {
-    const requestOptions = operationOptionsToRequestOptionsBase(options);
-    let currentResponse = await this.spanner.trace(
+    let currentResponse = await this._trace(
       "listConfigurationSettings",
-      requestOptions,
+      options,
       async (newOptions) => {
         const response = await this.client.getKeyValues({
           ...newOptions,
@@ -334,9 +328,9 @@ export class AppConfigurationClient {
     yield* this.createListConfigurationPageFromResponse(currentResponse);
 
     while (currentResponse.nextLink) {
-      currentResponse = await this.spanner.trace(
+      currentResponse = await this._trace(
         "listConfigurationSettings",
-        requestOptions,
+        options,
         // TODO: same code up above. Unify.
         async (newOptions) => {
           const response = await this.client.getKeyValues({
@@ -410,20 +404,15 @@ export class AppConfigurationClient {
   private async *listRevisionsByPage(
     options: ListRevisionsOptions = {}
   ): AsyncIterableIterator<ListRevisionsPage> {
-    const requestOptions = operationOptionsToRequestOptionsBase(options);
-    let currentResponse = await this.spanner.trace(
-      "listRevisions",
-      requestOptions,
-      async (newOptions) => {
-        const response = await this.client.getRevisions({
-          ...newOptions,
-          ...formatAcceptDateTime(options),
-          ...formatFiltersAndSelect(newOptions)
-        });
+    let currentResponse = await this._trace("listRevisions", options, async (newOptions) => {
+      const response = await this.client.getRevisions({
+        ...newOptions,
+        ...formatAcceptDateTime(options),
+        ...formatFiltersAndSelect(newOptions)
+      });
 
-        return response;
-      }
-    );
+      return response;
+    });
 
     yield {
       ...currentResponse,
@@ -431,7 +420,7 @@ export class AppConfigurationClient {
     };
 
     while (currentResponse.nextLink) {
-      currentResponse = await this.spanner.trace("listRevisions", requestOptions, (newOptions) => {
+      currentResponse = await this._trace("listRevisions", options, (newOptions) => {
         return this.client.getRevisions({
           ...newOptions,
           ...formatAcceptDateTime(options),
@@ -466,9 +455,7 @@ export class AppConfigurationClient {
     configurationSetting: SetConfigurationSettingParam,
     options: SetConfigurationSettingOptions = {}
   ): Promise<SetConfigurationSettingResponse> {
-    const requestOptions = operationOptionsToRequestOptionsBase(options);
-
-    return this.spanner.trace("setConfigurationSetting", requestOptions, async (newOptions) => {
+    return this._trace("setConfigurationSetting", options, async (newOptions) => {
       const response = await this.client.putKeyValue(configurationSetting.key, {
         ...newOptions,
         label: configurationSetting.label,
@@ -489,9 +476,7 @@ export class AppConfigurationClient {
     readOnly: boolean,
     options: SetReadOnlyOptions = {}
   ): Promise<SetReadOnlyResponse> {
-    const opts = operationOptionsToRequestOptionsBase(options);
-
-    return this.spanner.trace("setReadOnly", opts, async (newOptions) => {
+    return this._trace("setReadOnly", options, async (newOptions) => {
       if (readOnly) {
         const response = await this.client.putLock(id.key, {
           ...newOptions,

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -1,100 +1,51 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getTracer } from "@azure/core-tracing";
-import { Span, SpanKind, CanonicalCode } from "@opentelemetry/api";
-import { SpanOptions } from "@azure/core-tracing";
+import { Span, CanonicalCode } from "@opentelemetry/api";
 
-import { RestError } from "@azure/core-http";
+import { RestError, OperationOptions } from "@azure/core-http";
+import { createSpanFunction } from "@azure/core-tracing";
+import { AppConfigurationClient } from "../appConfigurationClient";
+
+/** @internal */
+export const createSpan = createSpanFunction({
+  namespace: "Microsoft.AppConfiguration",
+  packagePrefix: "Azure.Data.AppConfiguration"
+});
 
 /**
+ * Traces an operation and properly handles reporting start, end and errors for a given span
+ *
+ * @param operationName - Name of a method in the TClient type
+ * @param options - An options class, typically derived from \@azure/core-http/RequestOptionsBase
+ * @param fn - The function to call with an options class that properly propagates the span context
+ *
  * @internal
  */
-export interface Spannable {
-  spanOptions?: SpanOptions;
+export async function trace<ReturnT>(
+  operationName: keyof AppConfigurationClient,
+  options: OperationOptions,
+  fn: (options: OperationOptions, span: Span) => Promise<ReturnT>,
+  createSpanFn = createSpan
+): Promise<ReturnT> {
+  const { updatedOptions, span } = createSpanFn(operationName, options);
+
+  try {
+    // NOTE: we really do need to await on this function here so we can handle any exceptions thrown and properly
+    // close the span.
+    return await fn(updatedOptions, span);
+  } catch (err) {
+    span.setStatus({
+      code: CanonicalCode.INTERNAL, // TODO: StatusCode.ERROR in otel 0.16+
+      message: err.message
+    });
+    throw err;
+  } finally {
+    span.end();
+  }
 }
 
-/**
- * @internal
- */
-export class Spanner<TClient> {
-  constructor(private baseOperationName: string) {}
-
-  /**
-   * Traces an operation and properly handles reporting start, end and errors for a given span
-   *
-   * @param operationName - Name of a method in the TClient type
-   * @param options - An options class, typically derived from \@azure/core-http/RequestOptionsBase
-   * @param fn - The function to call with an options class that properly propagates the span context
-   * @param translateToCanonicalCodeFn - An optional function to translate thrown errors into a CanonicalCode for the span
-   */
-  async trace<OptionsT extends Spannable, ReturnT>(
-    operationName: keyof TClient,
-    options: OptionsT,
-    fn: (options: OptionsT, span: Span) => Promise<ReturnT>,
-    translateToCanonicalCodeFn: (err: Error) => CanonicalCode = Spanner.getCanonicalCode
-  ): Promise<ReturnT> {
-    const { newOptions, span } = this.createSpan<OptionsT>(options, operationName);
-
-    try {
-      return await fn(newOptions, span);
-    } catch (err) {
-      span.setStatus({
-        code: translateToCanonicalCodeFn(err),
-        message: err.message
-      });
-      throw err;
-    } finally {
-      span.end();
-    }
-  }
-
-  private createSpan<T extends Spannable>(options: T, operationName: keyof TClient) {
-    const span = getTracer().startSpan(`${this.baseOperationName}.${operationName}`, {
-      ...options.spanOptions,
-      kind: SpanKind.INTERNAL
-    });
-    span.setAttribute("az.namespace", "Microsoft.AppConfiguration");
-
-    let newOptions = options;
-
-    if (span.isRecording()) {
-      newOptions = Spanner.addParentToOptions<T>(options, span);
-    }
-    return { span, newOptions };
-  }
-
-  static getCanonicalCode(err: Error): CanonicalCode {
-    if (Spanner.isRestError(err)) {
-      switch (err.statusCode) {
-        case 401:
-          return CanonicalCode.PERMISSION_DENIED;
-        case 404:
-          return CanonicalCode.NOT_FOUND;
-        case 412:
-          return CanonicalCode.FAILED_PRECONDITION;
-      }
-    }
-
-    return CanonicalCode.UNKNOWN;
-  }
-
-  static isRestError(err: Error): err is RestError {
-    return err instanceof RestError;
-  }
-
-  static addParentToOptions<T extends Spannable>(options: T, span: Span): T {
-    const spanOptions = options.spanOptions || {};
-    return {
-      ...options,
-      spanOptions: {
-        ...spanOptions,
-        parent: span.context(),
-        attributes: {
-          ...spanOptions.attributes,
-          "az.namespace": "Microsoft.AppConfiguration"
-        }
-      }
-    };
-  }
+/** @internal */
+export function isRestError(err: Error): err is RestError {
+  return err instanceof RestError;
 }

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -33,7 +33,13 @@ export async function trace<ReturnT>(
   try {
     // NOTE: we really do need to await on this function here so we can handle any exceptions thrown and properly
     // close the span.
-    return await fn(updatedOptions, span);
+    const result = await fn(updatedOptions, span);
+
+    // otel 0.16+ needs this or else the code ends up being set as UNSET
+    span.setStatus({
+      code: CanonicalCode.OK
+    });
+    return result;
   } catch (err) {
     span.setStatus({
       code: CanonicalCode.INTERNAL, // TODO: StatusCode.ERROR in otel 0.16+

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -41,16 +41,15 @@ describe("tracingHelpers", () => {
       {
         tracingOptions: {}
       },
-      async (_newOptions, _span) => {},
+      async (_newOptions, _span) => { },
       fakeCreateSpan
     );
 
-    assert.equal(
-      setStatusStub?.called,
-      false,
-      "if nothing fails we don't explicitly set the status (uses the default status)"
-    );
+    assert.equal(setStatusStub?.called, true);
 
+    const [status] = setStatusStub!.args[0];
+
+    assert.equal(status.code, CanonicalCode.OK);
     assert.equal(endStub?.called, true);
   });
 
@@ -98,7 +97,7 @@ describe("tracingHelpers", () => {
     assert.equal(
       setStatusStub?.args[0][0].code,
       CanonicalCode.INTERNAL,
-      "Any thrown exception causes the span to be set to StatusCode.ERROR"
+      "Any thrown exception causes the span status to be set to an error"
     );
 
     assert.equal(endStub?.called, true);

--- a/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/tracingHelpers.spec.ts
@@ -1,58 +1,185 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Spanner } from "../../src/internal/tracingHelpers";
-import { RestError } from "@azure/core-http";
-import { getTracer } from "@azure/core-tracing";
-import { SpanKind, CanonicalCode } from "@opentelemetry/api";
-import { SpanOptions } from "@azure/core-tracing";
+import { createSpan, trace } from "../../src/internal/tracingHelpers";
+import { Span, Status, CanonicalCode } from "@opentelemetry/api";
 
 import * as assert from "assert";
-
-interface FakeOptions {
-  name: string;
-  spanOptions: SpanOptions;
-}
+import sinon from "sinon";
+import { AppConfigurationClient } from "../../src/appConfigurationClient";
+import { AbortSignalLike, OperationOptions } from "@azure/core-http";
+import { OperationTracingOptions } from "@azure/core-tracing";
 
 describe("tracingHelpers", () => {
-  it("addParentToOptions", () => {
-    const fakeOptions: FakeOptions = {
-      name: "fakeName",
-      spanOptions: {
-        attributes: {
-          testAttribute: "testAttributeValue"
-        }
+  it("trace OK", async () => {
+    let setStatusStub: sinon.SinonStub<[Status], Span> | undefined;
+    let endStub: sinon.SinonStub | undefined;
+
+    const fakeCreateSpan = <
+      T extends {
+        tracingOptions?: OperationTracingOptions | undefined;
       }
+    >(
+      operationName: string,
+      operationOptions: T | undefined
+    ): {
+      span: Span;
+      updatedOptions: T;
+    } => {
+      assert.deepEqual(operationName, "addConfigurationSetting");
+
+      const createdSpan = createSpan(operationName, operationOptions);
+
+      setStatusStub = sinon.stub(createdSpan.span, "setStatus");
+      endStub = sinon.stub(createdSpan.span, "end");
+
+      return createdSpan;
     };
 
-    const parentSpan = getTracer().startSpan("test", {
-      kind: SpanKind.PRODUCER
-    });
+    await trace(
+      "addConfigurationSetting",
+      {
+        tracingOptions: {}
+      },
+      async (_newOptions, _span) => {},
+      fakeCreateSpan
+    );
 
-    const newOptions = Spanner["addParentToOptions"](fakeOptions, parentSpan);
+    assert.equal(
+      setStatusStub?.called,
+      false,
+      "if nothing fails we don't explicitly set the status (uses the default status)"
+    );
 
-    assert.equal("fakeName", newOptions.name);
-    assert.deepEqual(parentSpan.context(), newOptions.spanOptions.parent);
-    assert.ok(newOptions.spanOptions.attributes, "Should have attributes set");
-    if (newOptions.spanOptions.attributes) {
-      assert.equal("Microsoft.AppConfiguration", newOptions.spanOptions.attributes["az.namespace"]);
-      assert.equal("testAttributeValue", newOptions.spanOptions.attributes["testAttribute"]);
-    }
+    assert.equal(endStub?.called, true);
   });
 
-  it("getCanonicalCode", () => {
+  it("trace ERROR", async () => {
+    let setStatusStub: sinon.SinonStub<[Status], Span> | undefined;
+    let endStub: sinon.SinonStub | undefined;
+
+    try {
+      await trace(
+        "addConfigurationSetting",
+        {
+          tracingOptions: {}
+        },
+        async (_options: any, _span: Span) => {
+          throw new Error("Purposefully thrown error");
+        },
+        <
+          T extends {
+            tracingOptions?: OperationTracingOptions | undefined;
+          }
+        >(
+          operationName: string,
+          operationOptions: T | undefined
+        ): {
+          span: Span;
+          updatedOptions: T;
+        } => {
+          assert.deepEqual(operationName, "addConfigurationSetting");
+
+          const createdSpan = createSpan(operationName, operationOptions);
+
+          setStatusStub = sinon.stub(createdSpan.span, "setStatus");
+          endStub = sinon.stub(createdSpan.span, "end");
+
+          return createdSpan;
+        }
+      );
+
+      assert.fail("Exception should have been thrown from `trace` since the inner action threw");
+    } catch (err) {
+      assert.equal(err.message, "Purposefully thrown error");
+    }
+
+    assert.ok(setStatusStub, "setStatus should have been called");
     assert.equal(
-      CanonicalCode.PERMISSION_DENIED,
-      Spanner.getCanonicalCode(new RestError("hello", "", 401))
+      setStatusStub?.args[0][0].code,
+      CanonicalCode.INTERNAL,
+      "Any thrown exception causes the span to be set to StatusCode.ERROR"
     );
-    assert.equal(
-      CanonicalCode.NOT_FOUND,
-      Spanner.getCanonicalCode(new RestError("hello", "", 404))
+
+    assert.equal(endStub?.called, true);
+  });
+
+  it("tracing is set up for all methods", async () => {
+    const appConfigurationClient = new AppConfigurationClient(
+      "Endpoint=endpoint;Id=id;Secret=secret"
     );
-    assert.equal(CanonicalCode.UNKNOWN, Spanner.getCanonicalCode(new RestError("hello", "", 409)));
-    assert.equal(
-      CanonicalCode.FAILED_PRECONDITION,
-      Spanner.getCanonicalCode(new RestError("hello", "", 412))
+
+    let traceData = {
+      operationName: "",
+      options: undefined as OperationOptions | undefined
+    };
+
+    appConfigurationClient["_trace"] = async (operationName, options, _fn) => {
+      traceData.operationName = operationName;
+      traceData.options = options;
+      return {} as any;
+    };
+
+    const operationOptions: OperationOptions = {
+      abortSignal: ({} as any) as AbortSignalLike,
+      tracingOptions: {
+        hello: "world"
+      } as OperationTracingOptions
+    };
+
+    await appConfigurationClient.addConfigurationSetting(
+      { key: "ignored", value: "ignored" },
+      operationOptions
     );
+    assert.deepEqual(traceData, {
+      operationName: "addConfigurationSetting",
+      options: operationOptions
+    });
+
+    await appConfigurationClient.setConfigurationSetting(
+      { key: "ignored", value: "ignored" },
+      operationOptions
+    );
+    assert.deepEqual(traceData, {
+      operationName: "setConfigurationSetting",
+      options: operationOptions
+    });
+
+    await appConfigurationClient.getConfigurationSetting({ key: "ignored" }, operationOptions);
+    assert.deepEqual(traceData, {
+      operationName: "getConfigurationSetting",
+      options: operationOptions
+    });
+
+    await appConfigurationClient.setReadOnly({ key: "ignored" }, true, operationOptions);
+    assert.deepEqual(traceData, {
+      operationName: "setReadOnly",
+      options: operationOptions
+    });
+
+    await appConfigurationClient.deleteConfigurationSetting({ key: "ignored" }, operationOptions);
+    assert.deepEqual(traceData, {
+      operationName: "deleteConfigurationSetting",
+      options: operationOptions
+    });
+
+    const it = appConfigurationClient.listConfigurationSettings({
+      keyFilter: "ignored",
+      ...operationOptions
+    });
+    await it.next();
+
+    assert.deepEqual(traceData, {
+      operationName: "listConfigurationSettings",
+      options: { ...operationOptions, keyFilter: "ignored" }
+    });
+
+    const it2 = appConfigurationClient.listRevisions({ keyFilter: "ignored", ...operationOptions });
+    await it2.next();
+
+    assert.deepEqual(traceData, {
+      operationName: "listRevisions",
+      options: { ...operationOptions, keyFilter: "ignored" }
+    });
   });
 });


### PR DESCRIPTION
Updating AppConfiguration to point to core-tracing and remove all code that was attempting to manage span parenting.

This also mean I could finally gut Spanner<T> - it's now down to just being a single trace<> function that wraps calling a function and handling calling .setSpanStatus() on error.