### PR TITLE
[Tables] Fix and enable Batch browser tests

### DIFF
--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -9,7 +9,8 @@
     "./dist-esm/src/TablesSharedKeyCredential.js": "./dist-esm/src/TablesSharedKeyCredential.browser.js",
     "./dist-esm/src/utils/accountConnectionString.js": "./dist-esm/src/utils/accountConnectionString.browser.js",
     "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",
-    "./dist-esm/src/utils/bufferSerializer.js": "./dist-esm/src/utils/bufferSerializer.browser.js"
+    "./dist-esm/src/utils/bufferSerializer.js": "./dist-esm/src/utils/bufferSerializer.browser.js",
+    "./dist-esm/src/utils/batchHeaders.js": "./dist-esm/src/utils/batchHeaders.browser.js"
   },
   "types": "types/latest/data-tables.d.ts",
   "scripts": {

--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_handle_sub_request_error.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_handle_sub_request_error.json
@@ -1,0 +1,47 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/Tables",
+   "query": {},
+   "requestBody": "{\"TableName\":\"batchTableTestbrowser\"}",
+   "status": 409,
+   "response": "{\"odata.error\":{\"code\":\"TableAlreadyExists\",\"message\":{\"lang\":\"en-US\",\"value\":\"The table specified already exists.\\nRequestId:df35a3bf-f002-000f-046a-0a2505000000\\nTime:2021-02-24T05:04:16.1816847Z\"}}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "a8aac0c8-d02c-47db-a2a0-9b6d860cdb3d",
+    "x-ms-request-id": "df35a3bf-f002-000f-046a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/noExistingTable HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"1\",\"name\":\"first\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/noExistingTable HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"2\",\"name\":\"second\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/noExistingTable HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"3\",\"name\":\"third\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_117240cd-968b-4840-8851-57ccb2d36591\r\nContent-Type: multipart/mixed; boundary=changesetresponse_e4fa8fb7-a8f0-428b-8d27-59f737dd6e0f\r\n\r\n--changesetresponse_e4fa8fb7-a8f0-428b-8d27-59f737dd6e0f\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 404 Not Found\r\nX-Content-Type-Options: nosniff\r\nDataServiceVersion: 3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n\r\n{\"odata.error\":{\"code\":\"TableNotFound\",\"message\":{\"lang\":\"en-US\",\"value\":\"0:The table specified does not exist.\\nRequestId:df35a3c3-f002-000f-066a-0a2505000000\\nTime:2021-02-24T05:04:16.2507340Z\"}}}\r\n--changesetresponse_e4fa8fb7-a8f0-428b-8d27-59f737dd6e0f--\r\n--batchresponse_117240cd-968b-4840-8851-57ccb2d36591--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_117240cd-968b-4840-8851-57ccb2d36591",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "e6c438f6-a93d-4618-8785-61068fbd1c34",
+    "x-ms-request-id": "df35a3c3-f002-000f-066a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "235eaf5a6e7b9149c7d7e6f949e67e29"
+}

--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_create_batch_operations.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_create_batch_operations.json
@@ -1,0 +1,48 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/Tables",
+   "query": {},
+   "requestBody": "{\"TableName\":\"batchTableTestbrowser\"}",
+   "status": 201,
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#Tables/@Element\",\"TableName\":\"batchTableTestbrowser\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "location": "https://fakestorageaccount.table.core.windows.net/Tables('batchTableTestbrowser')",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "48d0f240-b690-4048-9810-cc9f28a5001a",
+    "x-ms-request-id": "df35a3a4-f002-000f-6e6a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"1\",\"name\":\"first\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"2\",\"name\":\"second\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"3\",\"name\":\"third\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_689ce39e-e7a7-4653-b409-9f5937ca391f\r\nContent-Type: multipart/mixed; boundary=changesetresponse_a3008e9e-7454-4794-a7ef-85ad748d8faf\r\n\r\n--changesetresponse_a3008e9e-7454-4794-a7ef-85ad748d8faf\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='1')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='1')\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.6583138Z'\"\r\n\r\n\r\n--changesetresponse_a3008e9e-7454-4794-a7ef-85ad748d8faf\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='2')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='2')\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.6583138Z'\"\r\n\r\n\r\n--changesetresponse_a3008e9e-7454-4794-a7ef-85ad748d8faf\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='3')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='3')\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.6583138Z'\"\r\n\r\n\r\n--changesetresponse_a3008e9e-7454-4794-a7ef-85ad748d8faf--\r\n--batchresponse_689ce39e-e7a7-4653-b409-9f5937ca391f--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_689ce39e-e7a7-4653-b409-9f5937ca391f",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "8b17262b-f671-484e-9a63-5997a27c3c26",
+    "x-ms-request-id": "df35a3aa-f002-000f-736a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "2b289dac33ea39abee8938a81efd0ebd"
+}

--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_delete_batch_operations.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_delete_batch_operations.json
@@ -1,0 +1,47 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/Tables",
+   "query": {},
+   "requestBody": "{\"TableName\":\"batchTableTestbrowser\"}",
+   "status": 409,
+   "response": "{\"odata.error\":{\"code\":\"TableAlreadyExists\",\"message\":{\"lang\":\"en-US\",\"value\":\"The table specified already exists.\\nRequestId:df35a3b8-f002-000f-7f6a-0a2505000000\\nTime:2021-02-24T05:04:16.0165677Z\"}}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "92a17292-3eb8-4466-8c50-1aa947943111",
+    "x-ms-request-id": "df35a3b8-f002-000f-7f6a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nDELETE https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='1') HTTP/1.1\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nif-match: *\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nDELETE https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='2') HTTP/1.1\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nif-match: *\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nDELETE https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='3') HTTP/1.1\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nif-match: *\r\n\r\n\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_932e086b-eace-486b-8742-2dcd67b5edc3\r\nContent-Type: multipart/mixed; boundary=changesetresponse_ed732383-6daf-40ea-ad1e-6f5ee601c6f1\r\n\r\n--changesetresponse_ed732383-6daf-40ea-ad1e-6f5ee601c6f1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\n\r\n\r\n--changesetresponse_ed732383-6daf-40ea-ad1e-6f5ee601c6f1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\n\r\n\r\n--changesetresponse_ed732383-6daf-40ea-ad1e-6f5ee601c6f1\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\n\r\n\r\n--changesetresponse_ed732383-6daf-40ea-ad1e-6f5ee601c6f1--\r\n--batchresponse_932e086b-eace-486b-8742-2dcd67b5edc3--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_932e086b-eace-486b-8742-2dcd67b5edc3",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "50ad4202-ea62-41ac-af13-7553db8937e3",
+    "x-ms-request-id": "df35a3b9-f002-000f-806a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "08cb27a81c1c6415c14985417d28a110"
+}

--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_update_batch_operations.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_a_set_of_update_batch_operations.json
@@ -1,0 +1,68 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/Tables",
+   "query": {},
+   "requestBody": "{\"TableName\":\"batchTableTestbrowser\"}",
+   "status": 409,
+   "response": "{\"odata.error\":{\"code\":\"TableAlreadyExists\",\"message\":{\"lang\":\"en-US\",\"value\":\"The table specified already exists.\\nRequestId:df35a3af-f002-000f-766a-0a2505000000\\nTime:2021-02-24T05:04:15.7573848Z\"}}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "2b8fa82e-6bcd-4685-8120-b94a15ca4e59",
+    "x-ms-request-id": "df35a3af-f002-000f-766a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPUT https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='1') HTTP/1.1\r\ncontent-type: application/json\r\ndataserviceversion: 3.0\r\naccept: application/json\r\nif-match: *\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"1\",\"name\":\"updated\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPUT https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='2') HTTP/1.1\r\ncontent-type: application/json\r\ndataserviceversion: 3.0\r\naccept: application/json\r\nif-match: *\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"2\",\"name\":\"updated\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPUT https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='batchTest',RowKey='3') HTTP/1.1\r\ncontent-type: application/json\r\ndataserviceversion: 3.0\r\naccept: application/json\r\nif-match: *\r\n\r\n\r\n{\"PartitionKey\":\"batchTest\",\"RowKey\":\"3\",\"name\":\"updated\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_0f2c2c66-c830-4552-b7d5-405370201d1d\r\nContent-Type: multipart/mixed; boundary=changesetresponse_ff527524-552c-43a9-828c-066561ac058f\r\n\r\n--changesetresponse_ff527524-552c-43a9-828c-066561ac058f\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\"\r\n\r\n\r\n--changesetresponse_ff527524-552c-43a9-828c-066561ac058f\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\"\r\n\r\n\r\n--changesetresponse_ff527524-552c-43a9-828c-066561ac058f\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion: 1.0;\r\nETag: W/\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\"\r\n\r\n\r\n--changesetresponse_ff527524-552c-43a9-828c-066561ac058f--\r\n--batchresponse_0f2c2c66-c830-4552-b7d5-405370201d1d--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_0f2c2c66-c830-4552-b7d5-405370201d1d",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "31fc616a-6d7a-4813-9570-478fd98f47ea",
+    "x-ms-request-id": "df35a3b1-f002-000f-786a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser()",
+   "query": {
+    "$filter": "PartitionKey eq 'batchTest'"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#batchTableTestbrowser\",\"value\":[{\"odata.etag\":\"W/\\\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\\\"\",\"PartitionKey\":\"batchTest\",\"RowKey\":\"1\",\"Timestamp\":\"2021-02-24T05:04:15.8438729Z\",\"name\":\"updated\"},{\"odata.etag\":\"W/\\\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\\\"\",\"PartitionKey\":\"batchTest\",\"RowKey\":\"2\",\"Timestamp\":\"2021-02-24T05:04:15.8438729Z\",\"name\":\"updated\"},{\"odata.etag\":\"W/\\\"datetime'2021-02-24T05%3A04%3A15.8438729Z'\\\"\",\"PartitionKey\":\"batchTest\",\"RowKey\":\"3\",\"Timestamp\":\"2021-02-24T05:04:15.8438729Z\",\"name\":\"updated\"}]}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Wed, 24 Feb 2021 05:04:15 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "e874f9ca-2f62-40ff-b51e-c45843acd513",
+    "x-ms-request-id": "df35a3b5-f002-000f-7c6a-0a2505000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "074eaec8b1034359a5f895008028808a"
+}

--- a/sdk/tables/data-tables/src/TableBatch.ts
+++ b/sdk/tables/data-tables/src/TableBatch.ts
@@ -5,7 +5,6 @@ import {
   createHttpHeaders,
   PipelineRequest,
   createPipelineRequest,
-  RawHttpHeaders,
   PipelineResponse,
   RestError,
   createEmptyPipeline
@@ -29,6 +28,7 @@ import { createSpan } from "./utils/tracing";
 import { CanonicalCode } from "@opentelemetry/api";
 import { URL } from "./utils/url";
 import { TableServiceErrorOdataError } from "./generated";
+import { getBatchHeaders } from "./utils/batchHeaders";
 
 /**
  * TableBatch collects sub-operations that can be submitted together via submitBatch
@@ -138,15 +138,7 @@ export class TableBatchImpl implements TableBatch {
     await Promise.all(this.pendingOperations);
     const body = this.batchRequest.getHttpRequestBody();
     const client = new ServiceClient();
-    const headers: RawHttpHeaders = {
-      accept: "application/json",
-      "x-ms-version": "2019-02-02",
-      "Accept-Charset": "UTF-8",
-      DataServiceVersion: "3.0;",
-      MaxDataServiceVersion: "3.0;NetFx",
-      "Content-Type": `multipart/mixed; boundary=batch_${this.batchGuid}`,
-      Connection: "Keep-Alive"
-    };
+    const headers = getBatchHeaders(this.batchGuid);
 
     const { span, updatedOptions } = createSpan("TableBatch-submitBatch", {} as OperationOptions);
     const request = createPipelineRequest({

--- a/sdk/tables/data-tables/src/utils/baseBatchHeaders.ts
+++ b/sdk/tables/data-tables/src/utils/baseBatchHeaders.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RawHttpHeaders } from "@azure/core-https";
+
+/**
+ * @internal
+ * Builds an object with the required headers for a Batch request. For both Node and Browser
+ */
+export function getBaseBatchHeaders(batchGuid: string): RawHttpHeaders {
+  return {
+    accept: "application/json",
+    "x-ms-version": "2019-02-02",
+    DataServiceVersion: "3.0;",
+    MaxDataServiceVersion: "3.0;NetFx",
+    "Content-Type": `multipart/mixed; boundary=batch_${batchGuid}`
+  };
+}

--- a/sdk/tables/data-tables/src/utils/batchHeaders.browser.ts
+++ b/sdk/tables/data-tables/src/utils/batchHeaders.browser.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getBaseBatchHeaders } from "./baseBatchHeaders";
+
+/**
+ * @internal
+ * Builds an object with the required headers for a Batch request. For the Browser
+ */
+export const getBatchHeaders = getBaseBatchHeaders;

--- a/sdk/tables/data-tables/src/utils/batchHeaders.ts
+++ b/sdk/tables/data-tables/src/utils/batchHeaders.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RawHttpHeaders } from "@azure/core-https";
+import { getBaseBatchHeaders } from "./baseBatchHeaders";
+
+/**
+ * @internal
+ * Builds an object with the required headers for a Batch request. For Node
+ */
+export function getBatchHeaders(batchGuid: string): RawHttpHeaders {
+  const baseHeaders = getBaseBatchHeaders(batchGuid);
+  return {
+    ...baseHeaders,
+    // The below headers are not supported in the browser as they are flagged as "unsafe headers"
+    "Accept-Charset": "UTF-8",
+    Connection: "Keep-Alive"
+  };
+}

--- a/sdk/tables/data-tables/test/integration/batch.spec.ts
+++ b/sdk/tables/data-tables/test/integration/batch.spec.ts
@@ -9,117 +9,113 @@ import { isNode } from "../testUtils";
 import { Uuid } from "../../src/utils/uuid";
 import * as sinon from "sinon";
 
-if (isNode || isLiveMode()) {
-  describe("batch operations", () => {
-    let client: TableClient;
-    let recorder: Recorder;
-    const suffix = isNode ? "node" : "browser";
-    const tableName = `batchTableTest${suffix}`;
+describe("batch operations", () => {
+  let client: TableClient;
+  let recorder: Recorder;
+  const suffix = isNode ? "node" : "browser";
+  const tableName = `batchTableTest${suffix}`;
 
-    const partitionKey = "batchTest";
-    const testEntities = [
-      { partitionKey, rowKey: "1", name: "first" },
-      { partitionKey, rowKey: "2", name: "second" },
-      { partitionKey, rowKey: "3", name: "third" }
-    ];
+  const partitionKey = "batchTest";
+  const testEntities = [
+    { partitionKey, rowKey: "1", name: "first" },
+    { partitionKey, rowKey: "2", name: "second" },
+    { partitionKey, rowKey: "3", name: "third" }
+  ];
 
-    // Cannot use SharedKey auth when using recordings since the signature uses the current date
-    // which wouldn't match the recorded one. Fallingback to SAS for recorded tests.
-    const authMode = !isNode || !isLiveMode() ? "SASConnectionString" : "AccountConnectionString";
+  // Cannot use SharedKey auth when using recordings since the signature uses the current date
+  // which wouldn't match the recorded one. Fallingback to SAS for recorded tests.
+  const authMode = !isNode || !isLiveMode() ? "SASConnectionString" : "AccountConnectionString";
 
-    beforeEach(async function() {
-      sinon.stub(Uuid, "generateUuid").returns("fakeId");
-      // eslint-disable-next-line no-invalid-this
-      recorder = record(this, recordedEnvironmentSetup);
-      client = createTableClient(tableName, authMode);
+  beforeEach(async function() {
+    sinon.stub(Uuid, "generateUuid").returns("fakeId");
+    // eslint-disable-next-line no-invalid-this
+    recorder = record(this, recordedEnvironmentSetup);
+    client = createTableClient(tableName, authMode);
 
-      try {
-        if (!isPlaybackMode()) {
-          await client.create();
-        }
-      } catch {
-        console.warn("Table already exists");
+    try {
+      if (!isPlaybackMode()) {
+        await client.create();
       }
-    });
+    } catch {
+      console.warn("Table already exists");
+    }
+  });
 
-    afterEach(async function() {
-      sinon.restore();
-      await recorder.stop();
-    });
+  afterEach(async function() {
+    sinon.restore();
+    await recorder.stop();
+  });
 
-    after(async () => {
-      try {
-        if (!isPlaybackMode()) {
-          await client.delete();
-        }
-      } catch {
-        console.warn("Table was not deleted");
+  after(async () => {
+    try {
+      if (!isPlaybackMode()) {
+        await client.delete();
       }
-    });
+    } catch {
+      console.warn("Table was not deleted");
+    }
+  });
 
-    it("should send a set of create batch operations", async () => {
-      const batch = client.createBatch(partitionKey);
+  it("should send a set of create batch operations", async () => {
+    const batch = client.createBatch(partitionKey);
 
-      await batch.createEntities(testEntities);
-      const result = await batch.submitBatch();
-      assert.equal(result.status, 202);
-      assert.lengthOf(result.subResponses, 3);
-      testEntities.forEach((entity) => {
-        const subResponse = result.getResponseForEntity(entity.rowKey);
-        assert.equal(subResponse?.status, 204);
-        // Etags should be in the following format W/"datetime'2020-10-01T18%3A07%3A48.4010495Z'"
-        assert.isTrue(subResponse?.etag?.indexOf(`W/"datetime'`) !== -1);
-      });
-    });
-
-    it("should send a set of update batch operations", async () => {
-      const batch = client.createBatch(partitionKey);
-
-      testEntities.forEach((entity) =>
-        batch.updateEntity({ ...entity, name: "updated" }, "Replace")
-      );
-
-      const batchResult = await batch.submitBatch();
-      const updatedEntities = client.listEntities<{ name: string }>({
-        queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
-      });
-
-      assert.equal(batchResult.status, 202);
-      assert.lengthOf(batchResult.subResponses, 3);
-      batchResult.subResponses.forEach((subResponse) => {
-        assert.equal(subResponse?.status, 204);
-      });
-
-      for await (const entity of updatedEntities) {
-        assert.equal(entity.name, "updated");
-      }
-    });
-
-    it("should send a set of delete batch operations", async () => {
-      const batch = client.createBatch(partitionKey);
-
-      testEntities.forEach((entity) => batch.deleteEntity(entity.partitionKey, entity.rowKey));
-      const result = await batch.submitBatch();
-      assert.equal(result.status, 202);
-      assert.lengthOf(result.subResponses, 3);
-      result.subResponses.forEach((subResponse) => {
-        assert.equal(subResponse?.status, 204);
-      });
-    });
-
-    it("should handle sub request error", async () => {
-      const testClient = createTableClient("noExistingTable", authMode);
-      const batch = testClient.createBatch(partitionKey);
-      batch.createEntities(testEntities);
-
-      try {
-        await batch.submitBatch();
-        assert.fail("Expected submitBatch to throw");
-      } catch (error) {
-        assert.equal(error.code, "TableNotFound");
-        assert.equal(error.statusCode, 404);
-        assert.isString(error.message);
-      }
+    await batch.createEntities(testEntities);
+    const result = await batch.submitBatch();
+    assert.equal(result.status, 202);
+    assert.lengthOf(result.subResponses, 3);
+    testEntities.forEach((entity) => {
+      const subResponse = result.getResponseForEntity(entity.rowKey);
+      assert.equal(subResponse?.status, 204);
+      // Etags should be in the following format W/"datetime'2020-10-01T18%3A07%3A48.4010495Z'"
+      assert.isTrue(subResponse?.etag?.indexOf(`W/"datetime'`) !== -1);
     });
   });
-}
+
+  it("should send a set of update batch operations", async () => {
+    const batch = client.createBatch(partitionKey);
+
+    testEntities.forEach((entity) => batch.updateEntity({ ...entity, name: "updated" }, "Replace"));
+
+    const batchResult = await batch.submitBatch();
+    const updatedEntities = client.listEntities<{ name: string }>({
+      queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
+    });
+
+    assert.equal(batchResult.status, 202);
+    assert.lengthOf(batchResult.subResponses, 3);
+    batchResult.subResponses.forEach((subResponse) => {
+      assert.equal(subResponse?.status, 204);
+    });
+
+    for await (const entity of updatedEntities) {
+      assert.equal(entity.name, "updated");
+    }
+  });
+
+  it("should send a set of delete batch operations", async () => {
+    const batch = client.createBatch(partitionKey);
+
+    testEntities.forEach((entity) => batch.deleteEntity(entity.partitionKey, entity.rowKey));
+    const result = await batch.submitBatch();
+    assert.equal(result.status, 202);
+    assert.lengthOf(result.subResponses, 3);
+    result.subResponses.forEach((subResponse) => {
+      assert.equal(subResponse?.status, 204);
+    });
+  });
+
+  it("should handle sub request error", async () => {
+    const testClient = createTableClient("noExistingTable", authMode);
+    const batch = testClient.createBatch(partitionKey);
+    batch.createEntities(testEntities);
+
+    try {
+      await batch.submitBatch();
+      assert.fail("Expected submitBatch to throw");
+    } catch (error) {
+      assert.equal(error.code, "TableNotFound");
+      assert.equal(error.statusCode, 404);
+      assert.isString(error.message);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #11603

`Accept-Charset` and `Connection` headers are marked as `unsafe` in some browsers. Fixing this issue by only adding them if running in Node