### PR TITLE
Add Alternative Code Paths Depending on Parameters

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -8,7 +8,7 @@ $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=con
 
 function Confirm-NodeInstallation
 {
-  if ((Get-Command npm | Measure-Object).Count -eq 0 ) 
+  if (!(Get-Command npm -ErrorAction SilentlyContinue))
   {
     LogError "Could not locate npm. Install NodeJS (includes npm and npx) https://nodejs.org/en/download"
     exit 1


### PR DESCRIPTION
Add alternative code paths depending on parameters which allows for coming changes to common tools.
This change is solely intended to prevent breaking the build while making changes to common across various repos.

Sample Build https://dev.azure.com/azure-sdk/internal/_build/results?buildId=756241&view=results