### PR TITLE
Fix Prepare-Release script

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -13,7 +13,7 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory, $pkgNa
   {
     $projectJson = Get-Content $projectPath | ConvertFrom-Json
     $jsStylePkgName = $projectJson.name.Replace("@", "").Replace("/", "-")
-    if ($pkgName -eq "$jsStylePkgName")
+    if ($pkgName -eq "$jsStylePkgName" -or $pkgName -eq $projectJson.name)
     {
       $pkgProp = [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceDirectory)
       $pkgProp.SdkType = $projectJson.psobject.properties['sdk-type'].value
@@ -22,7 +22,7 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory, $pkgNa
         $pkgProp.SdkType = "mgmt"
       }
       $pkgProp.IsNewSdk = $pkgProp.SdkType -eq "client"
-      $pkgProp.ArtifactName = $pkgName  # pkgName variable actually stores artifact name
+      $pkgProp.ArtifactName = $jsStylePkgName
       return $pkgProp
     }
   }
@@ -114,8 +114,8 @@ function Publish-javascript-GithubIODocs ($DocLocation, $PublicArtifactLocation)
 {
   $PublishedDocs = Get-ChildItem "$($DocLocation)/documentation" | Where-Object -FilterScript { $_.Name.EndsWith(".zip") }
 
-  foreach ($Item in $PublishedDocs) 
-  {    
+  foreach ($Item in $PublishedDocs)
+  {
     Expand-Archive -Force -Path "$($DocLocation)/documentation/$($Item.Name)" -DestinationPath "$($DocLocation)/documentation/$($Item.BaseName)"
     $dirList = Get-ChildItem "$($DocLocation)/documentation/$($Item.BaseName)/$($Item.BaseName)" -Attributes Directory
 
@@ -126,7 +126,7 @@ function Publish-javascript-GithubIODocs ($DocLocation, $PublicArtifactLocation)
       # set default package name
       $PkgName = "azure-$($Item.BaseName)"
       if ($pkgs -and $pkgs.Count -eq 1)
-      {        
+      {
         $parsedPackage = Get-javascript-PackageInfoFromPackageFile $pkgs[0] $PublicArtifactLocation
         $PkgName = $parsedPackage.PackageId.Replace("@", "").Replace("/", "-")
       }
@@ -165,7 +165,7 @@ function Get-javascript-GithubIoDocIndex()
 function Update-javascript-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $monikerId = $null)
 {
   $pkgJsonLoc = (Join-Path -Path $ciRepo -ChildPath $locationInDocRepo)
-  
+
   if (-not (Test-Path $pkgJsonLoc))
   {
     Write-Error "Unable to locate package json at location $pkgJsonLoc, exiting."
@@ -200,7 +200,7 @@ function Update-javascript-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $moniker
     }
     else
     {
-      $newItem = New-Object PSObject -Property @{ 
+      $newItem = New-Object PSObject -Property @{
         name = $name
       }
 
@@ -248,7 +248,8 @@ function SetPackageVersion ($PackageName, $Version, $ServiceDirectory = $null, $
   }
   Push-Location "$EngDir/tools/versioning"
   npm install
-  node ./set-version.js --artifact-name $PackageName --new-version $Version --release-date $ReleaseDate --repo-root $RepoRoot
+  $artifactName = $PackageName.Replace("@", "").Replace("/", "-")
+  node ./set-version.js --artifact-name $artifactName --new-version $Version --release-date $ReleaseDate --repo-root $RepoRoot
   Pop-Location
 }
 

--- a/eng/tools/versioning/VersionUtils.js
+++ b/eng/tools/versioning/VersionUtils.js
@@ -60,14 +60,21 @@ function updateChangelog(
     args.push(releaseDate);
   }
   child = spawnSync("pwsh", args);
-  console.log("Powershell Data: " + child.stdout);
-  console.log("Powershell Errors: " + child.stderr);
+  const out = child.stdout.toString();
+  const err = child.stderr.toString();
+
+  if (out != "") {
+    console.log(out);
+  }
+
+  if (err != "") {
+    console.log(err);
+  }
 
   if (child.error) {
     console.error("Child process failed - ", child.error);
     return false;
   }
-  console.log("Powershell script finished with exit code - ", child.status);
   if (child.status === 0) {
     return true;
   }


### PR DESCRIPTION
This PR fixes the JS script so it can correctly take a
package name and find it as well as update the associated
versions.

Also updated the script to clean-up some of the ouptut
from the changelog script it calls on the behalf of the user.