### PR TITLE
Disable TestMinMax

### DIFF
--- a/sdk/mixedreality/mixedreality-authentication/tests.yml
+++ b/sdk/mixedreality/mixedreality-authentication/tests.yml
@@ -5,5 +5,4 @@ extends:
   parameters:
     PackageName: "@azure/mixedreality-authentication"
     ResourceServiceDirectory: mixedreality
-    TestMinMax: true
     ResourceGroupLocation: eastus2


### PR DESCRIPTION
  - The TestMinMax flag causes a couple of extra jobs to be run that fail due to bad configuration. I don't see most other libraries enabling it, so I'm going to disable it. I don't feel too bad about this since both the min and max jobs appear to run against Node 12, which we already have a test job to validate.