### PR TITLE
[abort-controller] listeners that self-remove from abortSignal when invoked no longer prevent other listeners from being invoked

### DIFF
--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.4 (Unreleased)
 
+Fixes issue [13985](https://github.com/Azure/azure-sdk-for-js/issues/13985) where abort event listeners that removed themselves when invoked
+could prevent other event listeners from being invoked.
 
 ## 1.0.3 (2021-02-23)
 

--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.0.4 (Unreleased)
 
-Fixes issue [13985](https://github.com/Azure/azure-sdk-for-js/issues/13985) where abort event listeners that removed themselves when invoked
-could prevent other event listeners from being invoked.
+Fixes issue [13985](https://github.com/Azure/azure-sdk-for-js/issues/13985) where abort event listeners that removed themselves when invoked could prevent other event listeners from being invoked.
 
 ## 1.0.3 (2021-02-23)
 

--- a/sdk/core/abort-controller/src/AbortSignal.ts
+++ b/sdk/core/abort-controller/src/AbortSignal.ts
@@ -155,7 +155,10 @@ export function abortSignal(signal: AbortSignal): void {
 
   const listeners = listenersMap.get(signal)!;
   if (listeners) {
-    listeners.forEach((listener) => {
+    // Create a copy of listeners so mutations to the array
+    // (e.g. via removeListener calls) don't affect the listeners
+    // we invoke.
+    [...listeners].forEach((listener) => {
       listener.call(signal, { type: "abort" });
     });
   }

--- a/sdk/core/abort-controller/src/AbortSignal.ts
+++ b/sdk/core/abort-controller/src/AbortSignal.ts
@@ -158,7 +158,7 @@ export function abortSignal(signal: AbortSignal): void {
     // Create a copy of listeners so mutations to the array
     // (e.g. via removeListener calls) don't affect the listeners
     // we invoke.
-    [...listeners].forEach((listener) => {
+    listeners.slice().forEach((listener) => {
       listener.call(signal, { type: "abort" });
     });
   }


### PR DESCRIPTION
Fixes #13985

See the issue linked above for a RCA on the bug this fixes.

## Issue
When using the @azure/abort-controller package, attaching event listeners to an abortSignal that remove themselves after being invoked can prevent other listeners attached to the same signal from being invoked.

## Solution
With this update, when abort() is called, we create a copy of the listeners array that isn't mutated when removeListener() is called on the abortSignal. This ensures that listeners are invoked in the same order they were added.