### PR TITLE
[Service Bus] (minor) Bug Fix: `getNumberOfReceivers` helper method

### DIFF
--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -173,10 +173,10 @@ async function callOnDetachedOnReceivers(
  * @internal
  * Helper method to get the number of receivers of specified type from the connectionContext.
  */
-async function getNumberOfReceivers(
+function getNumberOfReceivers(
   connectionContext: Pick<ConnectionContext, "messageReceivers" | "messageSessions">,
   receiverType: ReceiverType
-): Promise<number> {
+): number {
   if (receiverType === "session") {
     const receivers = connectionContext.messageSessions;
     return Object.keys(receivers).length;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/13990
"Number of receivers" returned is not a number. It was not a fatal bug since we only relied on its existence.