### PR TITLE
[core-https] Small improvement to the exponentialRetryPolicy

### DIFF
--- a/sdk/core/core-https/src/nodeHttpsClient.ts
+++ b/sdk/core/core-https/src/nodeHttpsClient.ts
@@ -202,7 +202,9 @@ class NodeHttpsClient implements HttpsClient {
         try {
           parsedUrl = new URL(proxySettings.host);
         } catch (_error) {
-          throw new Error(`Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`);
+          throw new Error(
+            `Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`
+          );
         }
 
         const proxyAgentOptions: HttpsProxyAgentOptions = {

--- a/sdk/core/core-https/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-https/src/policies/exponentialRetryPolicy.ts
@@ -17,6 +17,13 @@ const DEFAULT_CLIENT_RETRY_COUNT = 10;
 const DEFAULT_CLIENT_RETRY_INTERVAL = 1000;
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1000 * 64;
 
+const retryHttpStatusCodes: number[] = [
+  // Client error responses
+  408, // Request timeout
+  425, // Too early
+  429 // Too many requests
+];
+
 interface RetryData {
   retryCount: number;
   retryInterval: number;
@@ -73,9 +80,9 @@ export function exponentialRetryPolicy(
   function shouldRetry(statusCode: number | undefined, retryData: RetryData): boolean {
     if (
       statusCode === undefined ||
-      (statusCode < 500 && statusCode !== 408) ||
-      statusCode === 501 ||
-      statusCode === 505
+      (statusCode < 500 && retryHttpStatusCodes.indexOf(statusCode) === -1) ||
+      statusCode === 501 || // Not implemented
+      statusCode === 505 // HTTP version not supported
     ) {
       return false;
     }

--- a/sdk/core/core-https/test/exponentialRetryPolicy.spec.ts
+++ b/sdk/core/core-https/test/exponentialRetryPolicy.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import * as sinon from "sinon";
+import {
+  createPipelineRequest,
+  SendRequest,
+  PipelineResponse,
+  createHttpHeaders,
+  exponentialRetryPolicy
+} from "../src";
+
+describe("exponentialRetryPolicy", () => {
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  it("It should retry when specific status codes are encountered", async () => {
+    const request = createPipelineRequest({
+      url: "https://bing.com"
+    });
+
+    const retryStatusCodes: number[] = [
+      // Client error responses
+      408, // Request timeout
+      425, // Too early
+      429, // Too many requests
+
+      // Server error responses
+      // Anything but 501 and 505
+      500, // Internal server error
+      503, // Service unavailable
+      504 // Gateway timeout
+    ];
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200
+    };
+
+    for (const status of retryStatusCodes) {
+      const retryResponse: PipelineResponse = {
+        headers: createHttpHeaders({
+          "Retry-After": "10"
+        }),
+        request,
+        status
+      };
+
+      const policy = exponentialRetryPolicy();
+      const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+      next.onFirstCall().resolves(retryResponse);
+      next.onSecondCall().resolves(retryResponse);
+      next.onThirdCall().resolves(successResponse);
+
+      const clock = sinon.useFakeTimers();
+
+      const promise = policy.sendRequest(request, next);
+      assert.isTrue(next.calledOnce);
+
+      await clock.nextAsync();
+      assert.isTrue(next.calledTwice);
+
+      await clock.nextAsync();
+      assert.isTrue(next.calledThrice);
+
+      const result = await promise;
+
+      assert.strictEqual(result, successResponse);
+      clock.restore();
+    }
+  });
+});


### PR DESCRIPTION
Thanks to a recent customer issue with the Track 1 core ([link](https://github.com/Azure/ms-rest-nodeauth/issues/114)), we were able to spot that the retry policy needs to be aware of more HTTP status codes, like: 429, "Too Many Requests".

I've used this opportunity to add some other status codes that I thought relevant, and to add tests.

Fixes #14010

Feedback appreciated ✨