### PR TITLE
[Core] Use internal instead of hidden where applicable

### DIFF
--- a/sdk/core/core-amqp/src/log.ts
+++ b/sdk/core/core-amqp/src/log.ts
@@ -13,7 +13,7 @@ export const logger = createClientLogger("core-amqp");
 /**
  * Logs the error's stack trace to "verbose" if a stack trace is available.
  * @param error - Error containing a stack trace.
- * @hidden
+ * @internal
  */
 export function logErrorStackTrace(error: unknown): void {
   if (isObjectWithProperties(error, ["stack"])) {

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -11,7 +11,7 @@ import { checkNetworkConnection } from "./util/checkNetworkConnection";
 
 /**
  * Determines whether the object is a Delivery object.
- * @hidden
+ * @internal
  */
 function isDelivery(obj: any): boolean {
   let result: boolean = false;
@@ -117,7 +117,7 @@ export interface RetryConfig<T> {
 
 /**
  * Validates the retry config.
- * @hidden
+ * @internal
  */
 function validateRetryConfig<T>(config: RetryConfig<T>): void {
   if (!config.operation) {

--- a/sdk/core/core-amqp/src/util/checkNetworkConnection.browser.ts
+++ b/sdk/core/core-amqp/src/util/checkNetworkConnection.browser.ts
@@ -3,7 +3,6 @@
 
 /**
  * Checks whether a network connection is detected.
- * @hidden
  * @internal
  */
 export function checkNetworkConnection(): Promise<boolean> {

--- a/sdk/core/core-amqp/src/util/checkNetworkConnection.ts
+++ b/sdk/core/core-amqp/src/util/checkNetworkConnection.ts
@@ -6,7 +6,6 @@ import { logger } from "../log";
 
 /**
  * Checks whether a network connection is detected.
- * @hidden
  * @internal
  */
 export function checkNetworkConnection(host: string): Promise<boolean> {

--- a/sdk/core/core-amqp/src/util/runtimeInfo.browser.ts
+++ b/sdk/core/core-amqp/src/util/runtimeInfo.browser.ts
@@ -23,7 +23,6 @@ interface Navigator {
 
 /**
  * Returns information about the platform this function is being run on.
- * @hidden
  * @internal
  */
 export function getPlatformInfo(): string {
@@ -32,7 +31,6 @@ export function getPlatformInfo(): string {
 
 /**
  * Returns information about Node.js this function is being run on.
- * @hidden
  * @internal
  */
 export function getFrameworkInfo(): string {

--- a/sdk/core/core-amqp/src/util/runtimeInfo.ts
+++ b/sdk/core/core-amqp/src/util/runtimeInfo.ts
@@ -5,7 +5,6 @@ import * as os from "os";
 
 /**
  * Returns information about the platform this function is being run on.
- * @hidden
  * @internal
  */
 export function getPlatformInfo(): string {
@@ -14,7 +13,6 @@ export function getPlatformInfo(): string {
 
 /**
  * Returns information about Node.js this function is being run on.
- * @hidden
  * @internal
  */
 export function getFrameworkInfo(): string {

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -294,7 +294,6 @@ export function isIotHubConnectionString(connectionString: string): boolean {
 }
 
 /**
- * @hidden
  * @internal
  */
 export function isString(s: unknown): s is string {
@@ -302,7 +301,6 @@ export function isString(s: unknown): s is string {
 }
 
 /**
- * @hidden
  * @internal
  */
 export function isNumber(n: unknown): n is number {

--- a/sdk/core/core-client/src/base64.ts
+++ b/sdk/core/core-client/src/base64.ts
@@ -4,7 +4,7 @@
 /**
  * Encodes a string in base64 format.
  * @param value - the string to encode
- * @internal @hidden
+ * @internal
  */
 export function encodeString(value: string): string {
   return Buffer.from(value).toString("base64");
@@ -13,7 +13,7 @@ export function encodeString(value: string): string {
 /**
  * Encodes a byte array in base64 format.
  * @param value - the Uint8Aray to encode
- * @internal @hidden
+ * @internal
  */
 export function encodeByteArray(value: Uint8Array): string {
   // Buffer.from accepts <ArrayBuffer> | <SharedArrayBuffer>-- the TypeScript definition is off here
@@ -25,7 +25,7 @@ export function encodeByteArray(value: Uint8Array): string {
 /**
  * Decodes a base64 string into a byte array.
  * @param value - the base64 string to decode
- * @internal @hidden
+ * @internal
  */
 export function decodeString(value: string): Uint8Array {
   return Buffer.from(value, "base64");

--- a/sdk/core/core-client/src/interfaceHelpers.ts
+++ b/sdk/core/core-client/src/interfaceHelpers.ts
@@ -6,7 +6,7 @@ import { OperationSpec, OperationParameter } from "./interfaces";
 
 /**
  * Gets the list of status codes for streaming responses.
- * @internal @hidden
+ * @internal
  */
 export function getStreamingResponseStatusCodes(operationSpec: OperationSpec): Set<number> {
   const result = new Set<number>();
@@ -26,7 +26,7 @@ export function getStreamingResponseStatusCodes(operationSpec: OperationSpec): S
  * Get the path to this parameter's value as a dotted string (a.b.c).
  * @param parameter - The parameter to get the path string for.
  * @returns The path to this parameter's value as a dotted string.
- * @internal @hidden
+ * @internal
  */
 export function getPathStringFromParameter(parameter: OperationParameter): string {
   const { parameterPath, mapper } = parameter;

--- a/sdk/core/core-client/src/operationHelpers.ts
+++ b/sdk/core/core-client/src/operationHelpers.ts
@@ -12,7 +12,7 @@ import {
 } from "./interfaces";
 
 /**
- * @internal @hidden
+ * @internal
  * Retrieves the value to use for a given operation argument
  * @param operationArguments - The arguments passed from the generated client
  * @param parameter - The parameter description

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -94,7 +94,7 @@ function serializeHeaders(
 }
 
 /**
- * @internal @hidden
+ * @internal
  */
 export function serializeRequestBody(
   request: OperationRequest,

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -7,7 +7,7 @@ import { CompositeMapper, FullOperationResponse, OperationResponseMap } from "./
  * Returns true if the given value is a basic/primitive type
  * (string, number, boolean, null, undefined).
  * @param value - Value to test
- * @hidden @internal
+ * @internal
  */
 export function isPrimitiveType(value: unknown): boolean {
   return (typeof value !== "object" && typeof value !== "function") || value === null;
@@ -18,7 +18,7 @@ const validateISODuration = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?
 /**
  * Returns true if the given string is in ISO 8601 format.
  * @param value - The value to be validated for ISO 8601 duration format.
- * @hidden @internal
+ * @internal
  */
 export function isDuration(value: string): boolean {
   return validateISODuration.test(value);
@@ -31,7 +31,7 @@ const validUuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F
  *
  * @param uuid - The uuid that needs to be validated.
  *
- * @hidden @internal
+ * @internal
  */
 export function isValidUuid(uuid: string): boolean {
   return validUuidRegex.test(uuid);

--- a/sdk/core/core-crypto/src/sha256.browser.ts
+++ b/sdk/core/core-crypto/src/sha256.browser.ts
@@ -11,7 +11,6 @@ let subtleCrypto: SubtleCrypto | undefined;
 
 /**
  * Returns a cached reference to the Web API crypto.subtle object.
- * @hidden
  * @internal
  */
 function getCrypto(): SubtleCrypto {

--- a/sdk/core/core-crypto/src/utils/base64.browser.ts
+++ b/sdk/core/core-crypto/src/utils/base64.browser.ts
@@ -6,7 +6,6 @@
 /**
  * Converts a base64 string into a byte array.
  * @param content - The base64 string to convert.
- * @hidden
  * @internal
  */
 export function base64ToBytes(content: string): Uint8Array {
@@ -26,7 +25,6 @@ export function base64ToBytes(content: string): Uint8Array {
 /**
  * Converts an ArrayBuffer to base64 string.
  * @param buffer - Raw binary data.
- * @hidden
  * @internal
  */
 export function bufferToBase64(buffer: ArrayBuffer): string {

--- a/sdk/core/core-crypto/src/utils/hex.ts
+++ b/sdk/core/core-crypto/src/utils/hex.ts
@@ -4,7 +4,6 @@
 /**
  * Converts an ArrayBuffer to a hexadecimal string.
  * @param buffer - Raw binary data.
- * @hidden
  * @internal
  */
 export function bufferToHex(buffer: ArrayBuffer): string {
@@ -15,7 +14,6 @@ export function bufferToHex(buffer: ArrayBuffer): string {
 /**
  * Converts a byte to a hexadecimal string.
  * @param byte - An integer representation of a byte.
- * @hidden
  * @internal
  */
 function byteToHex(byte: number): string {

--- a/sdk/core/core-crypto/src/utils/utf8.browser.ts
+++ b/sdk/core/core-crypto/src/utils/utf8.browser.ts
@@ -7,7 +7,6 @@ let encoder: TextEncoder | undefined;
 
 /**
  * Returns a cached TextEncoder.
- * @hidden
  * @internal
  */
 function getTextEncoder(): TextEncoder {
@@ -26,7 +25,6 @@ function getTextEncoder(): TextEncoder {
 /**
  * Converts a utf8 string into a byte array.
  * @param content - The utf8 string to convert.
- * @hidden
  * @internal
  */
 export function utf8ToBytes(content: string): Uint8Array {

--- a/sdk/core/core-http/src/operationSpec.ts
+++ b/sdk/core/core-http/src/operationSpec.ts
@@ -97,7 +97,7 @@ export interface OperationSpec {
 
 /**
  * Gets the list of status codes for streaming responses.
- * @internal @hidden
+ * @internal
  */
 export function getStreamResponseStatusCodes(operationSpec: OperationSpec): Set<number> {
   const result = new Set<number>();

--- a/sdk/core/core-https/src/util/helpers.ts
+++ b/sdk/core/core-https/src/util/helpers.ts
@@ -24,7 +24,7 @@ export function delay<T>(t: number, value?: T): Promise<T | void> {
  * this for any kind of security purpose, find a better source of random.
  * @param min - The smallest integer value allowed.
  * @param max - The largest integer value allowed.
- * @hidden @internal
+ * @internal
  */
 export function getRandomIntegerInclusive(min: number, max: number): number {
   // Make sure inputs are integers.

--- a/sdk/core/core-https/src/util/sanitizer.ts
+++ b/sdk/core/core-https/src/util/sanitizer.ts
@@ -4,7 +4,7 @@
 import { URL } from "./url";
 
 /**
- * @hidden @internal
+ * @internal
  */
 export interface SanitizerOptions {
   /**
@@ -23,7 +23,7 @@ export interface SanitizerOptions {
 }
 
 /**
- * @hidden @internal
+ * @internal
  */
 export type UnknownObject = { [s: string]: unknown };
 
@@ -74,7 +74,7 @@ const defaultAllowedHeaderNames = [
 const defaultAllowedQueryParameters: string[] = ["api-version"];
 
 /**
- * @hidden @internal
+ * @internal
  */
 export class Sanitizer {
   private allowedHeaderNames: Set<string>;

--- a/sdk/core/core-https/src/util/userAgent.ts
+++ b/sdk/core/core-https/src/util/userAgent.ts
@@ -14,14 +14,14 @@ function getUserAgentString(telemetryInfo: Map<string, string>): string {
 }
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function getUserAgentHeaderName(): string {
   return getHeaderName();
 }
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function getUserAgentValue(prefix?: string): string {
   const runtimeInfo = new Map<string, string>();

--- a/sdk/core/core-https/src/util/userAgentPlatform.browser.ts
+++ b/sdk/core/core-https/src/util/userAgentPlatform.browser.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function getHeaderName(): string {
   return "x-ms-useragent";
@@ -18,7 +18,7 @@ interface NavigatorEx extends Navigator {
 }
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function setPlatformSpecificData(map: Map<string, string>): void {
   const navigator = self.navigator as NavigatorEx;

--- a/sdk/core/core-https/src/util/userAgentPlatform.ts
+++ b/sdk/core/core-https/src/util/userAgentPlatform.ts
@@ -4,14 +4,14 @@
 import * as os from "os";
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function getHeaderName(): string {
   return "User-Agent";
 }
 
 /**
- * @hidden @internal
+ * @internal
  */
 export function setPlatformSpecificData(map: Map<string, string>): void {
   map.set("Node", process.version);

--- a/sdk/core/core-lro/src/poller.ts
+++ b/sdk/core/core-lro/src/poller.ts
@@ -287,7 +287,6 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
 
   /**
    * @internal
-   * @hidden
    * Starts a loop that will break only if the poller is done
    * or if the poller is stopped.
    */
@@ -303,7 +302,6 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
 
   /**
    * @internal
-   * @hidden
    * pollOnce does one polling, by calling to the update method of the underlying
    * poll operation to make any relevant change effective.
    *
@@ -338,7 +336,6 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
 
   /**
    * @internal
-   * @hidden
    * fireProgress calls the functions passed in via onProgress the method of the poller.
    *
    * It loops over all of the callbacks received from onProgress, and executes them, sending them
@@ -354,7 +351,6 @@ export abstract class Poller<TState extends PollOperationState<TResult>, TResult
 
   /**
    * @internal
-   * @hidden
    * Invokes the underlying operation's cancel method, and rejects the
    * pollUntilDone promise.
    */

--- a/sdk/core/core-tracing/src/tracers/opencensus/openCensusTraceStateWrapper.ts
+++ b/sdk/core/core-tracing/src/tracers/opencensus/openCensusTraceStateWrapper.ts
@@ -4,7 +4,6 @@
 import { TraceState } from "@opentelemetry/api";
 
 /**
- * @hidden
  * @internal
  */
 export class OpenCensusTraceStateWrapper implements TraceState {

--- a/sdk/core/logger/review/logger.api.md
+++ b/sdk/core/logger/review/logger.api.md
@@ -21,9 +21,7 @@ export interface AzureLogger {
 // @public
 export type AzureLogLevel = "verbose" | "info" | "warning" | "error";
 
-// Warning: (ae-internal-missing-underscore) The name "createClientLogger" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @public
 export function createClientLogger(namespace: string): AzureLogger;
 
 // @public

--- a/sdk/core/logger/review/logger.api.md
+++ b/sdk/core/logger/review/logger.api.md
@@ -21,7 +21,9 @@ export interface AzureLogger {
 // @public
 export type AzureLogLevel = "verbose" | "info" | "warning" | "error";
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "createClientLogger" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export function createClientLogger(namespace: string): AzureLogger;
 
 // @public

--- a/sdk/core/logger/src/index.ts
+++ b/sdk/core/logger/src/index.ts
@@ -123,7 +123,7 @@ export interface AzureLogger {
 /**
  * Creates a logger for use by the Azure SDKs that inherits from `AzureLogger`.
  * @param namespace - The name of the SDK package.
- * @internal
+ * @hidden
  */
 export function createClientLogger(namespace: string): AzureLogger {
   const clientRootLogger: AzureClientLogger = AzureLogger.extend(namespace);

--- a/sdk/core/logger/src/index.ts
+++ b/sdk/core/logger/src/index.ts
@@ -123,7 +123,7 @@ export interface AzureLogger {
 /**
  * Creates a logger for use by the Azure SDKs that inherits from `AzureLogger`.
  * @param namespace - The name of the SDK package.
- * @hidden
+ * @internal
  */
 export function createClientLogger(namespace: string): AzureLogger {
   const clientRootLogger: AzureClientLogger = AzureLogger.extend(namespace);


### PR DESCRIPTION
This PR has the below changes related to #13449
- Remove `@hidden` tag where `@internal` is already used
- Replace `@hidden` with `@internal` for members not exported from index.ts