### PR TITLE
[Text Analytics] Regenerate using an updated swagger for StringIndexType

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -48,7 +48,7 @@ export interface EntitiesTask {
 
 export interface EntitiesTaskParameters {
   modelVersion?: string;
-  stringIndexType?: StringIndexTypeResponse;
+  stringIndexType?: StringIndexType;
 }
 
 export interface PiiTask {
@@ -60,7 +60,7 @@ export interface PiiTaskParameters {
   modelVersion?: string;
   /** (Optional) describes the PII categories to return */
   piiCategories?: PiiCategory[];
-  stringIndexType?: StringIndexTypeResponse;
+  stringIndexType?: StringIndexType;
 }
 
 export interface KeyPhrasesTask {
@@ -77,7 +77,7 @@ export interface EntityLinkingTask {
 
 export interface EntityLinkingTaskParameters {
   modelVersion?: string;
-  stringIndexType?: StringIndexTypeResponse;
+  stringIndexType?: StringIndexType;
 }
 
 export interface ErrorResponse {
@@ -586,8 +586,8 @@ export interface GeneratedClientHealthHeaders {
   operationLocation?: string;
 }
 
-/** Known values of {@link StringIndexTypeResponse} that the service accepts. */
-export const enum KnownStringIndexTypeResponse {
+/** Known values of {@link StringIndexType} that the service accepts. */
+export const enum KnownStringIndexType {
   /** Returned offset and length values will correspond to TextElements (Graphemes and Grapheme clusters) confirming to the Unicode 8.0.0 standard. Use this option if your application is written in .Net Framework or .Net Core and you will be using StringInfo. */
   TextElementsV8 = "TextElements_v8",
   /** Returned offset and length values will correspond to Unicode code points. Use this option if your application is written in a language that support Unicode, for example Python. */
@@ -597,15 +597,15 @@ export const enum KnownStringIndexTypeResponse {
 }
 
 /**
- * Defines values for StringIndexTypeResponse. \
- * {@link KnownStringIndexTypeResponse} can be used interchangeably with StringIndexTypeResponse,
+ * Defines values for StringIndexType. \
+ * {@link KnownStringIndexType} can be used interchangeably with StringIndexType,
  *  this enum contains the known values that the service supports.
  * ### Know values supported by the service
  * **TextElements_v8**: Returned offset and length values will correspond to TextElements (Graphemes and Grapheme clusters) confirming to the Unicode 8.0.0 standard. Use this option if your application is written in .Net Framework or .Net Core and you will be using StringInfo. \
  * **UnicodeCodePoint**: Returned offset and length values will correspond to Unicode code points. Use this option if your application is written in a language that support Unicode, for example Python. \
  * **Utf16CodeUnit**: Returned offset and length values will correspond to UTF-16 code units. Use this option if your application is written in a language that support Unicode, for example Java, JavaScript.
  */
-export type StringIndexTypeResponse = string;
+export type StringIndexType = string;
 
 /** Known values of {@link PiiTaskParametersDomain} that the service accepts. */
 export const enum KnownPiiTaskParametersDomain {
@@ -1080,27 +1080,6 @@ export const enum KnownRelationType {
  * **ValueOfExamination**
  */
 export type RelationType = string;
-
-/** Known values of {@link StringIndexType} that the service accepts. */
-export const enum KnownStringIndexType {
-  /** Returned offset and length values will correspond to TextElements (Graphemes and Grapheme clusters) confirming to the Unicode 8.0.0 standard. Use this option if your application is written in .Net Framework or .Net Core and you will be using StringInfo. */
-  TextElementsV8 = "TextElements_v8",
-  /** Returned offset and length values will correspond to Unicode code points. Use this option if your application is written in a language that support Unicode, for example Python. */
-  UnicodeCodePoint = "UnicodeCodePoint",
-  /** Returned offset and length values will correspond to UTF-16 code units. Use this option if your application is written in a language that support Unicode, for example Java, JavaScript. */
-  Utf16CodeUnit = "Utf16CodeUnit"
-}
-
-/**
- * Defines values for StringIndexType. \
- * {@link KnownStringIndexType} can be used interchangeably with StringIndexType,
- *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
- * **TextElements_v8**: Returned offset and length values will correspond to TextElements (Graphemes and Grapheme clusters) confirming to the Unicode 8.0.0 standard. Use this option if your application is written in .Net Framework or .Net Core and you will be using StringInfo. \
- * **UnicodeCodePoint**: Returned offset and length values will correspond to Unicode code points. Use this option if your application is written in a language that support Unicode, for example Python. \
- * **Utf16CodeUnit**: Returned offset and length values will correspond to UTF-16 code units. Use this option if your application is written in a language that support Unicode, for example Java, JavaScript.
- */
-export type StringIndexType = string;
 /** Defines values for ErrorCodeValue. */
 export type ErrorCodeValue =
   | "InvalidRequest"

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -176,7 +176,6 @@ export const EntitiesTaskParameters: coreHttp.CompositeMapper = {
         }
       },
       stringIndexType: {
-        defaultValue: "TextElements_v8",
         serializedName: "stringIndexType",
         type: {
           name: "String"
@@ -225,7 +224,7 @@ export const PiiTaskParameters: coreHttp.CompositeMapper = {
         constraints: {
           UniqueItems: true
         },
-        serializedName: "piiCategories",
+        serializedName: "pii-categories",
         type: {
           name: "Sequence",
           element: {
@@ -236,7 +235,6 @@ export const PiiTaskParameters: coreHttp.CompositeMapper = {
         }
       },
       stringIndexType: {
-        defaultValue: "TextElements_v8",
         serializedName: "stringIndexType",
         type: {
           name: "String"
@@ -307,7 +305,6 @@ export const EntityLinkingTaskParameters: coreHttp.CompositeMapper = {
         }
       },
       stringIndexType: {
-        defaultValue: "TextElements_v8",
         serializedName: "stringIndexType",
         type: {
           name: "String"

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/parameters.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/parameters.ts
@@ -137,7 +137,6 @@ export const modelVersion: OperationQueryParameter = {
 export const stringIndexType: OperationQueryParameter = {
   parameterPath: ["options", "stringIndexType"],
   mapper: {
-    defaultValue: "TextElements_v8",
     serializedName: "stringIndexType",
     type: {
       name: "String"

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d2982a8962885e8506b5ebc0b33cb8caf1dc7551/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json
 add-credentials: false
 package-version: 5.1.0-beta.5
 v3: true


### PR DESCRIPTION
Regenerate using the swagger in https://github.com/Azure/azure-rest-api-specs/pull/13209 that makes sure the naming for the `StringIndexType` is consistent between its uses as a method parameter and as an action description property.