### PR TITLE
[service-bus][test] extract key values into constants

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
@@ -20,6 +20,7 @@ import { TopicResourceSerializer } from "../../../src/serializers/topicResourceS
 import { SubscriptionResourceSerializer } from "../../../src/serializers/subscriptionResourceSerializer";
 import { RuleResourceSerializer } from "../../../src/serializers/ruleResourceSerializer";
 import { getXMLNSPrefix, isJSONLikeObject } from "../../../src/util/utils";
+import { TestConstants } from "./testConstants";
 
 const queueProperties = [
   Constants.LOCK_DURATION,
@@ -210,8 +211,8 @@ describe("ATOM Serializers", () => {
               accessRights: ["Manage", "Send", "Listen"]
             },
             keyName: "allClaims_v2",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           },
           {
             claimType: "SharedAccessKey",
@@ -219,8 +220,8 @@ describe("ATOM Serializers", () => {
               accessRights: ["Manage", "Send", "Listen"]
             },
             keyName: "allClaims_v3",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           }
         ],
         enablePartitioning: true
@@ -267,8 +268,8 @@ describe("ATOM Serializers", () => {
               accessRights: ["Manage", "Send", "Listen"]
             },
             keyName: "allClaims_v2",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           },
           {
             claimType: "SharedAccessKey",
@@ -276,8 +277,8 @@ describe("ATOM Serializers", () => {
               accessRights: ["Manage", "Send", "Listen"]
             },
             keyName: "allClaims_v3",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           }
         ]
       };

--- a/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/atomXml.spec.ts
@@ -20,7 +20,7 @@ import { TopicResourceSerializer } from "../../../src/serializers/topicResourceS
 import { SubscriptionResourceSerializer } from "../../../src/serializers/subscriptionResourceSerializer";
 import { RuleResourceSerializer } from "../../../src/serializers/ruleResourceSerializer";
 import { getXMLNSPrefix, isJSONLikeObject } from "../../../src/util/utils";
-import { TestConstants } from "./testConstants";
+import { TestConstants } from "../../public/testConstants";
 
 const queueProperties = [
   Constants.LOCK_DURATION,

--- a/sdk/servicebus/service-bus/test/internal/unit/testConstants.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/testConstants.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export const TestConstants = {
-  primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-  secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
-};

--- a/sdk/servicebus/service-bus/test/internal/unit/testConstants.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/testConstants.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const TestConstants = {
+  primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
+  secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+};

--- a/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
@@ -18,6 +18,7 @@ import { EntityStatus, EntityAvailabilityStatus } from "../../src";
 import { EnvVarNames, getEnvVars } from "./utils/envVarUtils";
 import { recreateQueue, recreateSubscription, recreateTopic } from "./utils/managementUtils";
 import { EntityNames } from "./utils/testUtils";
+import { TestConstants } from "./testConstants";
 
 chai.use(chaiAsPromised);
 chai.use(chaiExclude);
@@ -1570,15 +1571,15 @@ describe(`createSubscription() using different variations to the input parameter
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v2",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         },
         {
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v3",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         }
       ],
       enablePartitioning: true,
@@ -1602,15 +1603,15 @@ describe(`createSubscription() using different variations to the input parameter
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v2",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         },
         {
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v3",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         }
       ],
       enablePartitioning: true,
@@ -1875,15 +1876,15 @@ describe(`createRule() using different variations to the input parameter "ruleOp
           claimType: "SharedAccessKey",
           accessRights: ["Send"] as AccessRights,
           keyName: "allClaims_v2",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         },
         {
           claimType: "SharedAccessKey",
           accessRights: ["Listen"] as AccessRights,
           keyName: "allClaims_v3",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         }
       ],
       enablePartitioning: true,
@@ -1905,15 +1906,15 @@ describe(`createRule() using different variations to the input parameter "ruleOp
           claimType: "SharedAccessKey",
           accessRights: ["Send"] as AccessRights,
           keyName: "allClaims_v2",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         },
         {
           claimType: "SharedAccessKey",
           accessRights: ["Listen"] as AccessRights,
           keyName: "allClaims_v3",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         }
       ],
       maxDeliveryCount: 5,
@@ -1947,15 +1948,15 @@ describe(`createRule() using different variations to the input parameter "ruleOp
             claimType: "SharedAccessKey",
             accessRights: ["Manage", "Send", "Listen"],
             keyName: "allClaims_v2",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           },
           {
             claimType: "SharedAccessKey",
             accessRights: ["Manage", "Send", "Listen"],
             keyName: "allClaims_v3",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           }
         ],
         enablePartitioning: true,
@@ -2012,15 +2013,15 @@ describe(`createRule() using different variations to the input parameter "ruleOp
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v2",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         },
         {
           claimType: "SharedAccessKey",
           accessRights: ["Manage", "Send", "Listen"] as AccessRights,
           keyName: "allClaims_v3",
-          primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-          secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+          primaryKey: TestConstants.primaryKey,
+          secondaryKey: TestConstants.secondaryKey
         }
       ],
 
@@ -2429,8 +2430,8 @@ async function createEntity(
             claimType: "SharedAccessKey",
             accessRights: ["Manage", "Send", "Listen"],
             keyName: "allClaims_v1",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           }
         ]
       };
@@ -2676,8 +2677,8 @@ async function updateEntity(
             claimType: "SharedAccessKey",
             accessRights: ["Manage", "Send", "Listen"],
             keyName: "allClaims_v1",
-            primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
-            secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+            primaryKey: TestConstants.primaryKey,
+            secondaryKey: TestConstants.secondaryKey
           }
         ]
       };

--- a/sdk/servicebus/service-bus/test/public/testConstants.ts
+++ b/sdk/servicebus/service-bus/test/public/testConstants.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const TestConstants = {
+  primaryKey: "pNSRzKKm2vfdbCuTXMa9gOMHD66NwCTxJi4KWJX/TDc=",
+  secondaryKey: "UreXLPWiP6Murmsq2HYiIXs23qAvWa36ZOL3gb9rXLs="
+};


### PR DESCRIPTION
CredScan is computing hashes to identify locations of possible sensitive data.
Changes unrelated to the key values can cause the hashes to change. This PR
extracts key values into constants in a separate file so the scan results remain
stable which would make suppression easier.