### PR TITLE
[Text Analytics] Expose healthcare relationships

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 - We are now targeting the service's v3.1-preview.4 API as the default instead of v3.1-preview.3.
 - [Breaking] Aspects in opinions mining are now called targets and each individual opinion is now called an assessment. The new naming simplifies the naming of different parts of the response.
 - `beginAnalyzeBatchActions` can now process recognize linked entities actions.
+- `beginAnalyzeHealthcareEntities` returns `entityRelations` per document, a list of relations between healthcare entities.
 - `beginAnalyzeHealthcareEntities` entities now include `assertions` instead of `isNegated` which gives more context about the respective entity.
 
 ## 5.1.0-beta.4 (2021-02-10)

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_input_strings.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/api_key_textanalyticsclient_lros_health/recording_input_strings.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "11d012fe07c49f2345181c761be56d2b";
+module.exports.hash = "7530ad58e215d0fbbc87dc5ff41d007a";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -11,115 +11,95 @@ nock('https://endpoint', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'operation-location',
-  'https://endpoint/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33',
+  'https://endpoint/text/analytics/v3.1-preview.4/entities/health/jobs/3c2316e9-0a4a-4d9e-a00b-7c03261a435d',
   'x-envoy-upstream-service-time',
-  '216',
+  '2742',
   'apim-request-id',
-  '5dc8884f-beff-4a5a-b843-57731e07efd6',
+  '08d86b32-a4fb-4e3a-b2a8-fb463b100bc1',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:34:33 GMT'
+  'Mon, 01 Mar 2021 21:05:48 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33')
+  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/3c2316e9-0a4a-4d9e-a00b-7c03261a435d')
   .query(true)
-  .reply(200, {"jobId":"1a599e11-6202-49f6-9a4c-6a5808312a33","lastUpdateDateTime":"2021-02-23T19:34:33Z","createdDateTime":"2021-02-23T19:34:32Z","expirationDateTime":"2021-02-24T19:34:32Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"3c2316e9-0a4a-4d9e-a00b-7c03261a435d","lastUpdateDateTime":"2021-03-01T21:05:48Z","createdDateTime":"2021-03-01T21:05:46Z","expirationDateTime":"2021-03-02T21:05:46Z","status":"notStarted","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '972',
+  '610',
   'apim-request-id',
-  'bc7a15fd-4ce2-424e-8dd4-e1eded17cbad',
+  'ba81dcec-33e7-41a8-83e6-6230a3f15dbb',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:34:34 GMT'
+  'Mon, 01 Mar 2021 21:05:48 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33')
+  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/3c2316e9-0a4a-4d9e-a00b-7c03261a435d')
   .query(true)
-  .reply(200, {"jobId":"1a599e11-6202-49f6-9a4c-6a5808312a33","lastUpdateDateTime":"2021-02-23T19:34:33Z","createdDateTime":"2021-02-23T19:34:32Z","expirationDateTime":"2021-02-24T19:34:32Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"3c2316e9-0a4a-4d9e-a00b-7c03261a435d","lastUpdateDateTime":"2021-03-01T21:05:50Z","createdDateTime":"2021-03-01T21:05:46Z","expirationDateTime":"2021-03-02T21:05:46Z","status":"running","errors":[]}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '150',
+  '1775',
   'apim-request-id',
-  'a270bb7c-7bcd-48ea-a2b3-fdef28589612',
+  '89e2c1f5-a060-417c-bac4-a3b9ffd82f3c',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:34:34 GMT'
+  'Mon, 01 Mar 2021 21:05:50 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33')
+  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/3c2316e9-0a4a-4d9e-a00b-7c03261a435d')
   .query(true)
-  .reply(200, {"jobId":"1a599e11-6202-49f6-9a4c-6a5808312a33","lastUpdateDateTime":"2021-02-23T19:34:33Z","createdDateTime":"2021-02-23T19:34:32Z","expirationDateTime":"2021-02-24T19:34:32Z","status":"notStarted","errors":[]}, [
+  .reply(200, {"jobId":"3c2316e9-0a4a-4d9e-a00b-7c03261a435d","lastUpdateDateTime":"2021-03-01T21:05:51Z","createdDateTime":"2021-03-01T21:05:46Z","expirationDateTime":"2021-03-02T21:05:46Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"0","entities":[{"offset":29,"length":19,"text":"high blood pressure","category":"Diagnosis","confidenceScore":1,"assertion":{"certainty":"negative"},"links":[{"dataSource":"UMLS","id":"C0020538"},{"dataSource":"AOD","id":"0000023317"},{"dataSource":"BI","id":"BI00001"},{"dataSource":"CCPSS","id":"1017493"},{"dataSource":"CCS","id":"7.1"},{"dataSource":"CHV","id":"0000015800"},{"dataSource":"COSTAR","id":"397"},{"dataSource":"CSP","id":"0571-5243"},{"dataSource":"CST","id":"HYPERTENS"},{"dataSource":"DXP","id":"U002034"},{"dataSource":"HPO","id":"HP:0000822"},{"dataSource":"ICD10","id":"I10-I15.9"},{"dataSource":"ICD10AM","id":"I10-I15.9"},{"dataSource":"ICD10CM","id":"I10"},{"dataSource":"ICD9CM","id":"997.91"},{"dataSource":"ICPC2ICD10ENG","id":"MTHU035456"},{"dataSource":"ICPC2P","id":"K85004"},{"dataSource":"LCH","id":"U002317"},{"dataSource":"LCH_NW","id":"sh85063723"},{"dataSource":"LNC","id":"LA14293-7"},{"dataSource":"MDR","id":"10020772"},{"dataSource":"MEDCIN","id":"33288"},{"dataSource":"MEDLINEPLUS","id":"34"},{"dataSource":"MSH","id":"D006973"},{"dataSource":"MTH","id":"005"},{"dataSource":"MTHICD9","id":"997.91"},{"dataSource":"NANDA-I","id":"00905"},{"dataSource":"NCI","id":"C3117"},{"dataSource":"NCI_CPTAC","id":"C3117"},{"dataSource":"NCI_CTCAE","id":"E13785"},{"dataSource":"NCI_CTRP","id":"C3117"},{"dataSource":"NCI_FDA","id":"1908"},{"dataSource":"NCI_GDC","id":"C3117"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000458091"},{"dataSource":"NCI_NICHD","id":"C3117"},{"dataSource":"NOC","id":"060808"},{"dataSource":"OMIM","id":"MTHU002068"},{"dataSource":"PCDS","id":"PRB_11000.06"},{"dataSource":"PDQ","id":"CDR0000686951"},{"dataSource":"PSY","id":"23830"},{"dataSource":"RCD","id":"XE0Ub"},{"dataSource":"SNM","id":"F-70700"},{"dataSource":"SNMI","id":"D3-02000"},{"dataSource":"SNOMEDCT_US","id":"38341003"},{"dataSource":"WHO","id":"0210"}]}],"relations":[],"warnings":[]},{"id":"1","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":0.98},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1}],"relations":[{"relationType":"DosageOfMedication","entities":[{"ref":"#/results/documents/1/entities/0","role":"Attribute"},{"ref":"#/results/documents/1/entities/1","role":"Entity"}]},{"relationType":"FrequencyOfMedication","entities":[{"ref":"#/results/documents/1/entities/1","role":"Entity"},{"ref":"#/results/documents/1/entities/2","role":"Attribute"}]}],"warnings":[]}],"errors":[],"modelVersion":"2021-01-11"}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '108',
+  '1276',
   'apim-request-id',
-  'ffad790d-5b09-420c-a9d7-3a39bddbca48',
+  '4f066aad-326c-4250-8184-0c166dae7370',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:34:36 GMT'
+  'Mon, 01 Mar 2021 21:05:54 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33')
+  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/3c2316e9-0a4a-4d9e-a00b-7c03261a435d')
   .query(true)
-  .reply(200, {"jobId":"1a599e11-6202-49f6-9a4c-6a5808312a33","lastUpdateDateTime":"2021-02-23T19:34:37Z","createdDateTime":"2021-02-23T19:34:32Z","expirationDateTime":"2021-02-24T19:34:32Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"0","entities":[{"offset":29,"length":19,"text":"high blood pressure","category":"Diagnosis","confidenceScore":1,"assertion":{"certainty":"negative"},"links":[{"dataSource":"UMLS","id":"C0020538"},{"dataSource":"AOD","id":"0000023317"},{"dataSource":"BI","id":"BI00001"},{"dataSource":"CCPSS","id":"1017493"},{"dataSource":"CCS","id":"7.1"},{"dataSource":"CHV","id":"0000015800"},{"dataSource":"COSTAR","id":"397"},{"dataSource":"CSP","id":"0571-5243"},{"dataSource":"CST","id":"HYPERTENS"},{"dataSource":"DXP","id":"U002034"},{"dataSource":"HPO","id":"HP:0000822"},{"dataSource":"ICD10","id":"I10-I15.9"},{"dataSource":"ICD10AM","id":"I10-I15.9"},{"dataSource":"ICD10CM","id":"I10"},{"dataSource":"ICD9CM","id":"997.91"},{"dataSource":"ICPC2ICD10ENG","id":"MTHU035456"},{"dataSource":"ICPC2P","id":"K85004"},{"dataSource":"LCH","id":"U002317"},{"dataSource":"LCH_NW","id":"sh85063723"},{"dataSource":"LNC","id":"LA14293-7"},{"dataSource":"MDR","id":"10020772"},{"dataSource":"MEDCIN","id":"33288"},{"dataSource":"MEDLINEPLUS","id":"34"},{"dataSource":"MSH","id":"D006973"},{"dataSource":"MTH","id":"005"},{"dataSource":"MTHICD9","id":"997.91"},{"dataSource":"NANDA-I","id":"00905"},{"dataSource":"NCI","id":"C3117"},{"dataSource":"NCI_CPTAC","id":"C3117"},{"dataSource":"NCI_CTCAE","id":"E13785"},{"dataSource":"NCI_CTRP","id":"C3117"},{"dataSource":"NCI_FDA","id":"1908"},{"dataSource":"NCI_GDC","id":"C3117"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000458091"},{"dataSource":"NCI_NICHD","id":"C3117"},{"dataSource":"NOC","id":"060808"},{"dataSource":"OMIM","id":"MTHU002068"},{"dataSource":"PCDS","id":"PRB_11000.06"},{"dataSource":"PDQ","id":"CDR0000686951"},{"dataSource":"PSY","id":"23830"},{"dataSource":"RCD","id":"XE0Ub"},{"dataSource":"SNM","id":"F-70700"},{"dataSource":"SNMI","id":"D3-02000"},{"dataSource":"SNOMEDCT_US","id":"38341003"},{"dataSource":"WHO","id":"0210"}]}],"relations":[],"warnings":[]},{"id":"1","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":0.98},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1}],"relations":[{"relationType":"DosageOfMedication","entities":[{"ref":"#/results/documents/1/entities/0","role":"Attribute"},{"ref":"#/results/documents/1/entities/1","role":"Entity"}]},{"relationType":"FrequencyOfMedication","entities":[{"ref":"#/results/documents/1/entities/1","role":"Entity"},{"ref":"#/results/documents/1/entities/2","role":"Attribute"}]}],"warnings":[]}],"errors":[],"modelVersion":"2021-01-11"}}, [
+  .reply(200, {"jobId":"3c2316e9-0a4a-4d9e-a00b-7c03261a435d","lastUpdateDateTime":"2021-03-01T21:05:51Z","createdDateTime":"2021-03-01T21:05:46Z","expirationDateTime":"2021-03-02T21:05:46Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"0","entities":[{"offset":29,"length":19,"text":"high blood pressure","category":"Diagnosis","confidenceScore":1,"assertion":{"certainty":"negative"},"links":[{"dataSource":"UMLS","id":"C0020538"},{"dataSource":"AOD","id":"0000023317"},{"dataSource":"BI","id":"BI00001"},{"dataSource":"CCPSS","id":"1017493"},{"dataSource":"CCS","id":"7.1"},{"dataSource":"CHV","id":"0000015800"},{"dataSource":"COSTAR","id":"397"},{"dataSource":"CSP","id":"0571-5243"},{"dataSource":"CST","id":"HYPERTENS"},{"dataSource":"DXP","id":"U002034"},{"dataSource":"HPO","id":"HP:0000822"},{"dataSource":"ICD10","id":"I10-I15.9"},{"dataSource":"ICD10AM","id":"I10-I15.9"},{"dataSource":"ICD10CM","id":"I10"},{"dataSource":"ICD9CM","id":"997.91"},{"dataSource":"ICPC2ICD10ENG","id":"MTHU035456"},{"dataSource":"ICPC2P","id":"K85004"},{"dataSource":"LCH","id":"U002317"},{"dataSource":"LCH_NW","id":"sh85063723"},{"dataSource":"LNC","id":"LA14293-7"},{"dataSource":"MDR","id":"10020772"},{"dataSource":"MEDCIN","id":"33288"},{"dataSource":"MEDLINEPLUS","id":"34"},{"dataSource":"MSH","id":"D006973"},{"dataSource":"MTH","id":"005"},{"dataSource":"MTHICD9","id":"997.91"},{"dataSource":"NANDA-I","id":"00905"},{"dataSource":"NCI","id":"C3117"},{"dataSource":"NCI_CPTAC","id":"C3117"},{"dataSource":"NCI_CTCAE","id":"E13785"},{"dataSource":"NCI_CTRP","id":"C3117"},{"dataSource":"NCI_FDA","id":"1908"},{"dataSource":"NCI_GDC","id":"C3117"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000458091"},{"dataSource":"NCI_NICHD","id":"C3117"},{"dataSource":"NOC","id":"060808"},{"dataSource":"OMIM","id":"MTHU002068"},{"dataSource":"PCDS","id":"PRB_11000.06"},{"dataSource":"PDQ","id":"CDR0000686951"},{"dataSource":"PSY","id":"23830"},{"dataSource":"RCD","id":"XE0Ub"},{"dataSource":"SNM","id":"F-70700"},{"dataSource":"SNMI","id":"D3-02000"},{"dataSource":"SNOMEDCT_US","id":"38341003"},{"dataSource":"WHO","id":"0210"}]}],"relations":[],"warnings":[]},{"id":"1","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":0.98},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1}],"relations":[{"relationType":"DosageOfMedication","entities":[{"ref":"#/results/documents/1/entities/0","role":"Attribute"},{"ref":"#/results/documents/1/entities/1","role":"Entity"}]},{"relationType":"FrequencyOfMedication","entities":[{"ref":"#/results/documents/1/entities/1","role":"Entity"},{"ref":"#/results/documents/1/entities/2","role":"Attribute"}]}],"warnings":[]}],"errors":[],"modelVersion":"2021-01-11"}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '801',
+  '825',
   'apim-request-id',
-  'f81af111-fe4e-4460-b87e-2ecf5ca4a8f2',
+  'c1303dc4-fcd5-4b99-9ced-d9034fadd5f0',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:34:39 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/entities/health/jobs/1a599e11-6202-49f6-9a4c-6a5808312a33')
-  .query(true)
-  .reply(200, {"jobId":"1a599e11-6202-49f6-9a4c-6a5808312a33","lastUpdateDateTime":"2021-02-23T19:34:37Z","createdDateTime":"2021-02-23T19:34:32Z","expirationDateTime":"2021-02-24T19:34:32Z","status":"succeeded","errors":[],"results":{"documents":[{"id":"0","entities":[{"offset":29,"length":19,"text":"high blood pressure","category":"Diagnosis","confidenceScore":1,"assertion":{"certainty":"negative"},"links":[{"dataSource":"UMLS","id":"C0020538"},{"dataSource":"AOD","id":"0000023317"},{"dataSource":"BI","id":"BI00001"},{"dataSource":"CCPSS","id":"1017493"},{"dataSource":"CCS","id":"7.1"},{"dataSource":"CHV","id":"0000015800"},{"dataSource":"COSTAR","id":"397"},{"dataSource":"CSP","id":"0571-5243"},{"dataSource":"CST","id":"HYPERTENS"},{"dataSource":"DXP","id":"U002034"},{"dataSource":"HPO","id":"HP:0000822"},{"dataSource":"ICD10","id":"I10-I15.9"},{"dataSource":"ICD10AM","id":"I10-I15.9"},{"dataSource":"ICD10CM","id":"I10"},{"dataSource":"ICD9CM","id":"997.91"},{"dataSource":"ICPC2ICD10ENG","id":"MTHU035456"},{"dataSource":"ICPC2P","id":"K85004"},{"dataSource":"LCH","id":"U002317"},{"dataSource":"LCH_NW","id":"sh85063723"},{"dataSource":"LNC","id":"LA14293-7"},{"dataSource":"MDR","id":"10020772"},{"dataSource":"MEDCIN","id":"33288"},{"dataSource":"MEDLINEPLUS","id":"34"},{"dataSource":"MSH","id":"D006973"},{"dataSource":"MTH","id":"005"},{"dataSource":"MTHICD9","id":"997.91"},{"dataSource":"NANDA-I","id":"00905"},{"dataSource":"NCI","id":"C3117"},{"dataSource":"NCI_CPTAC","id":"C3117"},{"dataSource":"NCI_CTCAE","id":"E13785"},{"dataSource":"NCI_CTRP","id":"C3117"},{"dataSource":"NCI_FDA","id":"1908"},{"dataSource":"NCI_GDC","id":"C3117"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000458091"},{"dataSource":"NCI_NICHD","id":"C3117"},{"dataSource":"NOC","id":"060808"},{"dataSource":"OMIM","id":"MTHU002068"},{"dataSource":"PCDS","id":"PRB_11000.06"},{"dataSource":"PDQ","id":"CDR0000686951"},{"dataSource":"PSY","id":"23830"},{"dataSource":"RCD","id":"XE0Ub"},{"dataSource":"SNM","id":"F-70700"},{"dataSource":"SNMI","id":"D3-02000"},{"dataSource":"SNOMEDCT_US","id":"38341003"},{"dataSource":"WHO","id":"0210"}]}],"relations":[],"warnings":[]},{"id":"1","entities":[{"offset":11,"length":5,"text":"100mg","category":"Dosage","confidenceScore":0.98},{"offset":17,"length":9,"text":"ibuprofen","category":"MedicationName","confidenceScore":1,"links":[{"dataSource":"UMLS","id":"C0020740"},{"dataSource":"AOD","id":"0000019879"},{"dataSource":"ATC","id":"M01AE01"},{"dataSource":"CCPSS","id":"0046165"},{"dataSource":"CHV","id":"0000006519"},{"dataSource":"CSP","id":"2270-2077"},{"dataSource":"DRUGBANK","id":"DB01050"},{"dataSource":"GS","id":"1611"},{"dataSource":"LCH_NW","id":"sh97005926"},{"dataSource":"LNC","id":"LP16165-0"},{"dataSource":"MEDCIN","id":"40458"},{"dataSource":"MMSL","id":"d00015"},{"dataSource":"MSH","id":"D007052"},{"dataSource":"MTHSPL","id":"WK2XYI10QM"},{"dataSource":"NCI","id":"C561"},{"dataSource":"NCI_CTRP","id":"C561"},{"dataSource":"NCI_DCP","id":"00803"},{"dataSource":"NCI_DTP","id":"NSC0256857"},{"dataSource":"NCI_FDA","id":"WK2XYI10QM"},{"dataSource":"NCI_NCI-GLOSS","id":"CDR0000613511"},{"dataSource":"NDDF","id":"002377"},{"dataSource":"PDQ","id":"CDR0000040475"},{"dataSource":"RCD","id":"x02MO"},{"dataSource":"RXNORM","id":"5640"},{"dataSource":"SNM","id":"E-7772"},{"dataSource":"SNMI","id":"C-603C0"},{"dataSource":"SNOMEDCT_US","id":"387207008"},{"dataSource":"USP","id":"m39860"},{"dataSource":"USPMG","id":"MTHU000060"},{"dataSource":"VANDF","id":"4017840"}]},{"offset":34,"length":11,"text":"twice daily","category":"Frequency","confidenceScore":1}],"relations":[{"relationType":"DosageOfMedication","entities":[{"ref":"#/results/documents/1/entities/0","role":"Attribute"},{"ref":"#/results/documents/1/entities/1","role":"Entity"}]},{"relationType":"FrequencyOfMedication","entities":[{"ref":"#/results/documents/1/entities/1","role":"Entity"},{"ref":"#/results/documents/1/entities/2","role":"Attribute"}]}],"warnings":[]}],"errors":[],"modelVersion":"2021-01-11"}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '981',
-  'apim-request-id',
-  '4887bd7f-bae8-4bed-80d0-001f61addaf4',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:34:40 GMT'
+  'Mon, 01 Mar 2021 21:05:55 GMT'
 ]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -234,8 +234,11 @@ export interface HealthcareEntity extends Entity {
 // @public
 export interface HealthcareEntityRelation {
     roles: HealthcareRelationRole[];
-    type: RelationType;
+    type: HealthcareEntityRelationType;
 }
+
+// @public
+export type HealthcareEntityRelationType = string;
 
 // @public
 export interface HealthcareRelationRole {
@@ -459,9 +462,6 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
     readonly entities: PiiEntity[];
     redactedText: string;
 }
-
-// @public
-export type RelationType = string;
 
 // @public (undocumented)
 export interface SentenceAssessment {

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -240,7 +240,7 @@ export interface HealthcareEntityRelation {
 // @public
 export interface HealthcareEntityRelationRole {
     entity: HealthcareEntity;
-    role: HealthcareEntityRelationRoleType;
+    name: HealthcareEntityRelationRoleType;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -55,7 +55,7 @@ export interface AnalyzeHealthcareEntitiesResultArray extends Array<AnalyzeHealt
 // @public
 export interface AnalyzeHealthcareEntitiesSuccessResult extends TextAnalyticsSuccessResult {
     entities: HealthcareEntity[];
-    relationships: HealthcareEntityRelation[];
+    entityRelations: HealthcareEntityRelation[];
 }
 
 // @public
@@ -233,18 +233,21 @@ export interface HealthcareEntity extends Entity {
 
 // @public
 export interface HealthcareEntityRelation {
-    roles: HealthcareRelationRole[];
-    type: HealthcareEntityRelationType;
+    relationType: HealthcareEntityRelationType;
+    roles: HealthcareEntityRelationRole[];
 }
+
+// @public
+export interface HealthcareEntityRelationRole {
+    entity: HealthcareEntity;
+    role: HealthcareEntityRelationRoleType;
+}
+
+// @public
+export type HealthcareEntityRelationRoleType = string;
 
 // @public
 export type HealthcareEntityRelationType = string;
-
-// @public
-export interface HealthcareRelationRole {
-    entity: HealthcareEntity;
-    role: string;
-}
 
 // @public
 export type InnerErrorCodeValue = string;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -55,6 +55,7 @@ export interface AnalyzeHealthcareEntitiesResultArray extends Array<AnalyzeHealt
 // @public
 export interface AnalyzeHealthcareEntitiesSuccessResult extends TextAnalyticsSuccessResult {
     entities: HealthcareEntity[];
+    relationships: HealthcareEntityRelation[];
 }
 
 // @public
@@ -228,6 +229,18 @@ export interface HealthcareEntity extends Entity {
     assertion?: HealthcareAssertion;
     dataSources: EntityDataSource[];
     relatedEntities: Map<HealthcareEntity, string>;
+}
+
+// @public
+export interface HealthcareEntityRelation {
+    roles: HealthcareRelationRole[];
+    type: RelationType;
+}
+
+// @public
+export interface HealthcareRelationRole {
+    entity: HealthcareEntity;
+    role: string;
 }
 
 // @public
@@ -446,6 +459,9 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
     readonly entities: PiiEntity[];
     redactedText: string;
 }
+
+// @public
+export type RelationType = string;
 
 // @public (undocumented)
 export interface SentenceAssessment {

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
@@ -58,9 +58,14 @@ export interface HealthcareEntity extends Entity {
 }
 
 /**
+ * The type of different roles a healthcare entity can play in a relation.
+ */
+export type HealthcareEntityRelationRoleType = string;
+
+/**
  * A healthcare entity that plays a specific role in a relation.
  */
-export interface HealthcareRelationRole {
+export interface HealthcareEntityRelationRole {
   /**
    * A healthcare entity
    */
@@ -68,7 +73,7 @@ export interface HealthcareRelationRole {
   /**
    * The role of the healthcare entity in a particular relation.
    */
-  role: string;
+  role: HealthcareEntityRelationRoleType;
 }
 
 /**
@@ -78,11 +83,11 @@ export interface HealthcareEntityRelation {
   /**
    * The type of the healthcare relation.
    */
-  type: RelationType;
+  relationType: RelationType;
   /**
    * The list of healthcare entities and their roles in the healthcare relation.
    */
-  roles: HealthcareRelationRole[];
+  roles: HealthcareEntityRelationRole[];
 }
 
 /**
@@ -94,9 +99,9 @@ export interface AnalyzeHealthcareEntitiesSuccessResult extends TextAnalyticsSuc
    */
   entities: HealthcareEntity[];
   /**
-   * Relationships between healthcare entities.
+   * Relations between healthcare entities.
    */
-  relationships: HealthcareEntityRelation[];
+  entityRelations: HealthcareEntityRelation[];
 }
 
 /**
@@ -214,9 +219,9 @@ function makeHealthcareRelations(
 ): HealthcareEntityRelation[] {
   return relations.map(
     (relation: HealthcareRelation): HealthcareEntityRelation => ({
-      type: relation.relationType,
+      relationType: relation.relationType,
       roles: relation.entities.map(
-        (role: HealthcareRelationEntity): HealthcareRelationRole => ({
+        (role: HealthcareRelationEntity): HealthcareEntityRelationRole => ({
           entity: entities[parseHealthcareEntityIndex(role.ref)],
           role: role.role
         })
@@ -239,7 +244,7 @@ export function makeHealthcareEntitiesResult(
   return {
     ...makeTextAnalyticsSuccessResult(id, warnings, statistics),
     entities: newEntities,
-    relationships: makeHealthcareRelations(newEntities, relations)
+    entityRelations: makeHealthcareRelations(newEntities, relations)
   };
 }
 

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeHealthcareEntitiesResult.ts
@@ -73,7 +73,7 @@ export interface HealthcareEntityRelationRole {
   /**
    * The role of the healthcare entity in a particular relation.
    */
-  role: HealthcareEntityRelationRoleType;
+  name: HealthcareEntityRelationRoleType;
 }
 
 /**
@@ -223,7 +223,7 @@ function makeHealthcareRelations(
       roles: relation.entities.map(
         (role: HealthcareRelationEntity): HealthcareEntityRelationRole => ({
           entity: entities[parseHealthcareEntityIndex(role.ref)],
-          role: role.role
+          name: role.role
         })
       )
     })

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -86,7 +86,8 @@ export {
   HealthcareEntity,
   EntityDataSource,
   HealthcareEntityRelation,
-  HealthcareRelationRole
+  HealthcareEntityRelationRole,
+  HealthcareEntityRelationRoleType
 } from "./analyzeHealthcareEntitiesResult";
 export {
   PagedAnalyzeBatchActionsResult,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -142,5 +142,5 @@ export {
   Association,
   Certainty,
   Conditionality,
-  RelationType
+  RelationType as HealthcareEntityRelationType
 } from "./generated/models";

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -84,7 +84,9 @@ export {
   AnalyzeHealthcareEntitiesSuccessResult,
   AnalyzeHealthcareEntitiesErrorResult,
   HealthcareEntity,
-  EntityDataSource
+  EntityDataSource,
+  HealthcareEntityRelation,
+  HealthcareRelationRole
 } from "./analyzeHealthcareEntitiesResult";
 export {
   PagedAnalyzeBatchActionsResult,
@@ -139,5 +141,6 @@ export {
   PiiCategory,
   Association,
   Certainty,
-  Conditionality
+  Conditionality,
+  RelationType
 } from "./generated/models";

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -124,8 +124,8 @@ describe("[API Key] TextAnalyticsClient", function() {
           const doc2Entity1Edge1Label = doc2Entity1.relatedEntities.values().next().value;
           assert.equal(doc2Entity1Target1.text, "ibuprofen");
           assert.equal(doc2Entity1Edge1Label, "DosageOfMedication");
-          assert.deepEqual(doc2.relationships[0], {
-            type: "DosageOfMedication",
+          assert.deepEqual(doc2.entityRelations[0], {
+            relationType: "DosageOfMedication",
             roles: [
               {
                 entity: doc2.entities[0],
@@ -137,8 +137,8 @@ describe("[API Key] TextAnalyticsClient", function() {
               }
             ]
           });
-          assert.deepEqual(doc2.relationships[1], {
-            type: "FrequencyOfMedication",
+          assert.deepEqual(doc2.entityRelations[1], {
+            relationType: "FrequencyOfMedication",
             roles: [
               {
                 entity: doc2.entities[1],

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -129,11 +129,11 @@ describe("[API Key] TextAnalyticsClient", function() {
             roles: [
               {
                 entity: doc2.entities[0],
-                role: "Attribute"
+                name: "Attribute"
               },
               {
                 entity: doc2.entities[1],
-                role: "Entity"
+                name: "Entity"
               }
             ]
           });
@@ -142,11 +142,11 @@ describe("[API Key] TextAnalyticsClient", function() {
             roles: [
               {
                 entity: doc2.entities[1],
-                role: "Entity"
+                name: "Entity"
               },
               {
                 entity: doc2.entities[2],
-                role: "Attribute"
+                name: "Attribute"
               }
             ]
           });

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -94,7 +94,7 @@ describe("[API Key] TextAnalyticsClient", function() {
     });
 
     describe("#health", function() {
-      it("input strings", async function() {
+      it.only("input strings", async function() {
         const poller = await client.beginAnalyzeHealthcareEntities(
           [
             "Patient does not suffer from high blood pressure.",
@@ -124,6 +124,32 @@ describe("[API Key] TextAnalyticsClient", function() {
           const doc2Entity1Edge1Label = doc2Entity1.relatedEntities.values().next().value;
           assert.equal(doc2Entity1Target1.text, "ibuprofen");
           assert.equal(doc2Entity1Edge1Label, "DosageOfMedication");
+          assert.deepEqual(doc2.relationships[0], {
+            type: "DosageOfMedication",
+            roles: [
+              {
+                entity: doc2.entities[0],
+                role: "Attribute"
+              },
+              {
+                entity: doc2.entities[1],
+                role: "Entity"
+              }
+            ]
+          });
+          assert.deepEqual(doc2.relationships[1], {
+            type: "FrequencyOfMedication",
+            roles: [
+              {
+                entity: doc2.entities[1],
+                role: "Entity"
+              },
+              {
+                entity: doc2.entities[2],
+                role: "Attribute"
+              }
+            ]
+          });
 
           const doc2Entity2 = doc2.entities[1];
           assert.equal(doc2Entity2.text, "ibuprofen");

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -94,7 +94,7 @@ describe("[API Key] TextAnalyticsClient", function() {
     });
 
     describe("#health", function() {
-      it.only("input strings", async function() {
+      it("input strings", async function() {
         const poller = await client.beginAnalyzeHealthcareEntities(
           [
             "Patient does not suffer from high blood pressure.",


### PR DESCRIPTION
The service discovers relationships between healthcare entities and returns them as a list. This PR exposes this list after dereferencing the JSON pointers for healthcare entities.
Fixes https://github.com/Azure/azure-sdk-for-js/issues/14035