### PR TITLE
[service-bus] Don't create unneeded empty spans when linking in message batches.

### DIFF
--- a/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/instrumentServiceBusMessage.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { extractSpanContextFromTraceParentHeader, getTraceParentHeader } from "@azure/core-tracing";
+import { extractSpanContextFromTraceParentHeader } from "@azure/core-tracing";
 import { CanonicalCode, Link, Span, SpanContext, SpanKind } from "@opentelemetry/api";
 import { ConnectionContext } from "../connectionContext";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
@@ -13,34 +13,6 @@ import { createServiceBusSpan } from "./tracing";
  * @hidden
  */
 export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
-
-/**
- * Populates the `ServiceBusMessage` with `SpanContext` info to support trace propagation.
- * Creates and returns a copy of the passed in `ServiceBusMessage` unless the `ServiceBusMessage`
- * has already been instrumented.
- * @param message - The `ServiceBusMessage` to instrument.
- * @param span - The `Span` containing the context to propagate tracing information.
- * @hidden
- * @internal
- */
-export function instrumentServiceBusMessage(
-  message: ServiceBusMessage,
-  span: Span
-): ServiceBusMessage {
-  if (message.applicationProperties && message.applicationProperties[TRACEPARENT_PROPERTY]) {
-    return message;
-  }
-
-  // create a copy so the original isn't modified
-  message = { ...message, applicationProperties: { ...message.applicationProperties } };
-
-  const traceParent = getTraceParentHeader(span.context());
-  if (traceParent) {
-    message.applicationProperties![TRACEPARENT_PROPERTY] = traceParent;
-  }
-
-  return message;
-}
 
 /**
  * Extracts the `SpanContext` from an `ServiceBusMessage` if the context exists.

--- a/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
@@ -2,8 +2,14 @@
 // Licensed under the MIT license.
 
 import { OperationOptions, RestError } from "@azure/core-http";
-import { CanonicalCode, Span, SpanKind } from "@opentelemetry/api";
-import { createSpanFunction, SpanOptions } from "@azure/core-tracing";
+import { CanonicalCode, Span, SpanContext, SpanKind } from "@opentelemetry/api";
+import {
+  createSpanFunction,
+  extractSpanContextFromTraceParentHeader,
+  getTraceParentHeader,
+  SpanOptions
+} from "@azure/core-tracing";
+import { ServiceBusMessage } from "../serviceBusMessage";
 
 /**
  * Creates a span using the global tracer.
@@ -74,4 +80,102 @@ export function createServiceBusSpan(
     span,
     updatedOptions
   };
+}
+
+/**
+ * @internal
+ */
+export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
+
+/**
+ * @hidden
+ */
+export interface InstrumentableMessage {
+  /**
+   * The application specific properties which can be
+   * used for custom message metadata.
+   */
+  applicationProperties?: { [key: string]: number | boolean | string | Date };
+}
+
+/**
+ * Instruments an AMQP message with a proper `Diagnostic-Id` for tracing.
+ *
+ * @hidden
+ */
+export function instrumentMessage<T extends InstrumentableMessage>(
+  message: T,
+  options: OperationOptions,
+  entityPath: string,
+  host: string
+): {
+  /**
+   * If instrumentation was done, a copy of the message with
+   * message.applicationProperties['Diagnostic-Id'] filled
+   * out appropriately.
+   */
+  message: T;
+
+  /**
+   * A valid SpanContext if this message should be linked to a parent span, or undefined otherwise.
+   */
+  spanContext: SpanContext | undefined;
+} {
+  const previouslyInstrumented = Boolean(
+    message.applicationProperties && message.applicationProperties[TRACEPARENT_PROPERTY]
+  );
+
+  if (previouslyInstrumented) {
+    return {
+      message,
+      spanContext: undefined
+    };
+  }
+
+  const { span: messageSpan } = createMessageSpan(options, entityPath, host);
+
+  try {
+    if (!messageSpan.isRecording()) {
+      return {
+        message,
+        spanContext: undefined
+      };
+    }
+
+    const traceParent = getTraceParentHeader(messageSpan.context());
+
+    if (traceParent) {
+      // create a copy so the original isn't modified
+      message = {
+        ...message,
+        applicationProperties: {
+          ...message.applicationProperties,
+          [TRACEPARENT_PROPERTY]: traceParent
+        }
+      };
+    }
+
+    return {
+      message,
+      spanContext: messageSpan.context()
+    };
+  } finally {
+    messageSpan.end();
+  }
+}
+
+/**
+ * Extracts the `SpanContext` from an `ServiceBusMessage` if the context exists.
+ * @param message - An individual `ServiceBusMessage` object.
+ * @internal
+ */
+export function extractSpanContextFromServiceBusMessage(
+  message: ServiceBusMessage
+): SpanContext | undefined {
+  if (!message.applicationProperties || !message.applicationProperties[TRACEPARENT_PROPERTY]) {
+    return;
+  }
+
+  const diagnosticId = message.applicationProperties[TRACEPARENT_PROPERTY] as string;
+  return extractSpanContextFromTraceParentHeader(diagnosticId);
 }

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -15,11 +15,7 @@ import {
   Message as RheaMessage
 } from "rhea-promise";
 import { SpanContext } from "@opentelemetry/api";
-import {
-  instrumentServiceBusMessage,
-  TRACEPARENT_PROPERTY
-} from "./diagnostics/instrumentServiceBusMessage";
-import { createMessageSpan } from "./diagnostics/tracing";
+import { instrumentMessage } from "./diagnostics/tracing";
 import { TryAddOptions } from "./modelsToBeSharedWithEventHubs";
 import { defaultDataTransformer } from "./dataTransformer";
 
@@ -230,32 +226,22 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next message.
    *
-   * @param message - An individual service bus message.
+   * @param originalMessage - An individual service bus message.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
-  public tryAddMessage(message: ServiceBusMessage, options: TryAddOptions = {}): boolean {
-    throwTypeErrorIfParameterMissing(this._context.connectionId, "message", message);
+  public tryAddMessage(originalMessage: ServiceBusMessage, options: TryAddOptions = {}): boolean {
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "message", originalMessage);
     throwIfNotValidServiceBusMessage(
-      message,
+      originalMessage,
       "Provided value for 'message' must be of type ServiceBusMessage."
     );
 
-    // check if the event has already been instrumented
-    const previouslyInstrumented = Boolean(
-      message.applicationProperties && message.applicationProperties[TRACEPARENT_PROPERTY]
+    const { message, spanContext } = instrumentMessage(
+      originalMessage,
+      options,
+      this._context.config.entityPath!,
+      this._context.config.host
     );
-    let spanContext: SpanContext | undefined;
-    if (!previouslyInstrumented) {
-      const { span: messageSpan } = createMessageSpan(
-        options,
-        this._context.config.entityPath!,
-        this._context.config.host
-      );
-
-      message = instrumentServiceBusMessage(message, messageSpan);
-      spanContext = messageSpan.context();
-      messageSpan.end();
-    }
 
     // Convert ServiceBusMessage to AmqpMessage.
     const amqpMessage = toRheaMessage(message);


### PR DESCRIPTION
When we were instrumenting spans we wouldn't pay attention to whether we were currently recording or not, which could lead to us creating a bunch of empty/null spans and trying to add them as links to the span for our batches.

Rather than do that I just check (when we instrument) if the span we created is recording and if not don't add it.

Fixes #13049