### PR TITLE
[MetrisAdvisor][Test] use simple values in key rotation unit tests

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/keyRotation.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/keyRotation.spec.ts
@@ -4,16 +4,12 @@
 import { assert } from "chai";
 
 import { MetricsAdvisorKeyCredential } from "../../src";
-import { testEnv } from "./util/recordedClients";
 
 describe("MetricsAdvisorKeyCredential", () => {
   let credential: MetricsAdvisorKeyCredential;
 
   beforeEach(function() {
-    credential = new MetricsAdvisorKeyCredential(
-      testEnv.METRICS_ADVISOR_SUBSCRIPTION_KEY,
-      testEnv.METRICS_ADVISOR_API_KEY
-    );
+    credential = new MetricsAdvisorKeyCredential("key1", "key2");
   });
 
   it("update subscriptionKey", async function() {


### PR DESCRIPTION
We don't need real key values for testing this functionality.