### PR TITLE
[Text Analytics] Remove relatedEntities property from healthcare entities

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `beginAnalyzeBatchActions` can now process recognize linked entities actions.
 - `beginAnalyzeHealthcareEntities` returns `entityRelations` per document, a list of relations between healthcare entities.
 - `beginAnalyzeHealthcareEntities` entities now include `assertions` instead of `isNegated` which gives more context about the respective entity.
+- [Breaking] `beginAnalyzeHealthcareEntities` no longer returns `relatedEntities`.
 
 ## 5.1.0-beta.4 (2021-02-10)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -229,7 +229,6 @@ export interface HealthcareEntity extends Entity {
     assertion?: HealthcareAssertion;
     dataSources: EntityDataSource[];
     normalizedText?: string;
-    relatedEntities: Map<HealthcareEntity, string>;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
@@ -41,18 +41,22 @@ async function main() {
     if (!result.error) {
       console.log("\tRecognized Entities:");
       for (const entity of result.entities) {
-        console.log(
-          `\t- Entity ${entity.text} of type ${entity.category} ${
-            entity.relatedEntities.size > 0 ? "and it is related to the following entities" : ""
-          }`
-        );
-        for (const edge of entity.relatedEntities) {
-          console.log(`\t\t- ${edge[0].text} with the relationship being ${edge[1]}`);
-        }
+        console.log(`\t- Entity "${entity.text}" of type ${entity.category}`);
         if (entity.dataSources.length > 0) {
           console.log("\t and it can be referenced in the following data sources:");
           for (const ds of entity.dataSources) {
             console.log(`\t\t- ${ds.name} with Entity ID: ${ds.entityId}`);
+          }
+        }
+      }
+      if (result.entityRelations.length > 0) {
+        console.log(`\tRecognized relations between entities:`);
+        for (const relation of result.entityRelations) {
+          console.log(
+            `\t\t- Relation of type ${relation.relationType} found between the following entities:`
+          );
+          for (const role of relation.roles) {
+            console.log(`\t\t\t- "${role.entity.text}" with the role ${role.name}`);
           }
         }
       }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcareEntities.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeHealthcareEntities.ts
@@ -42,18 +42,22 @@ export async function main() {
     if (!result.error) {
       console.log("\tRecognized Entities:");
       for (const entity of result.entities) {
-        console.log(
-          `\t- Entity ${entity.text} of type ${entity.category} ${
-            entity.relatedEntities.size > 0 ? "and it is related to the following entities" : ""
-          }`
-        );
-        for (const edge of entity.relatedEntities) {
-          console.log(`\t\t- ${edge[0].text} with the relationship being ${edge[1]}`);
-        }
+        console.log(`\t- Entity "${entity.text}" of type ${entity.category}`);
         if (entity.dataSources.length > 0) {
           console.log("\t and it can be referenced in the following data sources:");
           for (const ds of entity.dataSources) {
             console.log(`\t\t- ${ds.name} with Entity ID: ${ds.entityId}`);
+          }
+        }
+      }
+      if (result.entityRelations.length > 0) {
+        console.log(`\tRecognized relations between entities:`);
+        for (const relation of result.entityRelations) {
+          console.log(
+            `\t\t- Relation of type ${relation.relationType} found between the following entities:`
+          );
+          for (const role of relation.roles) {
+            console.log(`\t\t\t- "${role.entity.text}" with the role ${role.name}`);
           }
         }
       }

--- a/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/apiKey.spec.ts
@@ -120,10 +120,6 @@ describe("[API Key] TextAnalyticsClient", function() {
           assert.ok(doc2.entities);
           const doc2Entity1 = doc2.entities[0];
           assert.equal(doc2Entity1.text, "100mg");
-          const doc2Entity1Target1 = doc2Entity1.relatedEntities.keys().next().value;
-          const doc2Entity1Edge1Label = doc2Entity1.relatedEntities.values().next().value;
-          assert.equal(doc2Entity1Target1.text, "ibuprofen");
-          assert.equal(doc2Entity1Edge1Label, "DosageOfMedication");
           assert.deepEqual(doc2.entityRelations[0], {
             relationType: "DosageOfMedication",
             roles: [
@@ -156,10 +152,6 @@ describe("[API Key] TextAnalyticsClient", function() {
 
           const doc2Entity3 = doc2.entities[2];
           assert.equal(doc2Entity3.text, "twice daily");
-          const doc2Entity3Target1 = doc2Entity3.relatedEntities.keys().next().value;
-          const doc2Entity3Edge1Label = doc2Entity3.relatedEntities.values().next().value;
-          assert.equal(doc2Entity3Target1.text, "ibuprofen");
-          assert.equal(doc2Entity3Edge1Label, "FrequencyOfMedication");
         }
       });
 


### PR DESCRIPTION
It has been agreed on between the text analytics crew to remove this property. The user can use the new `entityRelations` to get the same information.