### PR TITLE
[Core HTTPS] Export delay

### DIFF
--- a/sdk/core/core-https/CHANGELOG.md
+++ b/sdk/core/core-https/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed from exposing `DefaultHttpsClient` as a class directly, to providing `createDefaultHttpsClient()` to instantiate the appropriate runtime class.
 - Fix an issue when passing in proxy hosts. [PR 13911](https://github.com/Azure/azure-sdk-for-js/pull/13911)
+- Export the `delay` function.
 
 ## 1.0.0-beta.1 (2021-02-04)
 

--- a/sdk/core/core-https/review/core-https.api.md
+++ b/sdk/core/core-https/review/core-https.api.md
@@ -51,6 +51,9 @@ export function decompressResponsePolicy(): PipelinePolicy;
 export const decompressResponsePolicyName = "decompressResponsePolicy";
 
 // @public
+export function delay(timeInMs: number): Promise<void>;
+
+// @public
 export function exponentialRetryPolicy(options?: ExponentialRetryPolicyOptions): PipelinePolicy;
 
 // @public

--- a/sdk/core/core-https/src/index.ts
+++ b/sdk/core/core-https/src/index.ts
@@ -68,3 +68,4 @@ export {
   bearerTokenAuthenticationPolicyName
 } from "./policies/bearerTokenAuthenticationPolicy";
 export { ndJsonPolicy, ndJsonPolicyName } from "./policies/ndJsonPolicy";
+export { delay } from "./util/helpers";

--- a/sdk/core/core-https/src/util/helpers.ts
+++ b/sdk/core/core-https/src/util/helpers.ts
@@ -13,8 +13,8 @@ export const isNode =
  * @param value - The value to be resolved with after a timeout of t milliseconds.
  * @returns Resolved promise
  */
-export function delay<T>(t: number, value?: T): Promise<T | void> {
-  return new Promise((resolve) => setTimeout(() => resolve(value), t));
+export function delay(timeInMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(() => resolve(), timeInMs));
 }
 
 /**


### PR DESCRIPTION
I need this function in text analytics to implement the LRO's delay and it could be useful for other packages as well. This PR is factored out of https://github.com/Azure/azure-sdk-for-js/pull/13715.