### PR TITLE
Fix broken live test configurations

### DIFF
--- a/sdk/attestation/attestation/tests.yml
+++ b/sdk/attestation/attestation/tests.yml
@@ -8,6 +8,8 @@ stages:
       TimeoutInMinutes: 90
       Clouds: Preview
       Location: westus
+      MatrixFilters:
+        - DependencyVersion=^$
       MatrixConfigs:
         - Name: Attestation_live_test_base
           Path: sdk/attestation/platform-matrix.json

--- a/sdk/containerregistry/container-registry/tests.yml
+++ b/sdk/containerregistry/container-registry/tests.yml
@@ -1,12 +1,13 @@
 trigger: none
 
-extends:
-  template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
-  parameters:
-    PackageName: "@azure/container-registry"
-    ResourceServiceDirectory: containerregistry
-    TestMinMax: true
-    EnvVars:
-      AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-      AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-      AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+stages:
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    parameters:
+      PackageName: "@azure/container-registry"
+      ServiceDirectory: containerregistry
+      MatrixFilters:
+        - DependencyVersion=^$
+      EnvVars:
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/eventgrid/eventgrid/tests.yml
+++ b/sdk/eventgrid/eventgrid/tests.yml
@@ -6,4 +6,4 @@ stages:
       PackageName: "@azure/eventgrid"
       ServiceDirectory: eventgrid
       MatrixFilters:
-        - DependencyVersion: ^$
+        - DependencyVersion=^$

--- a/sdk/eventhub/event-processor-host/tests.yml
+++ b/sdk/eventhub/event-processor-host/tests.yml
@@ -7,4 +7,5 @@ stages:
       ServiceDirectory: eventhub
       TimeoutInMinutes: 90
       MatrixFilters:
+        - TestType=^(?!browser).*
         - DependencyVersion=^$

--- a/sdk/mixedreality/mixedreality-authentication/tests.yml
+++ b/sdk/mixedreality/mixedreality-authentication/tests.yml
@@ -7,4 +7,5 @@ stages:
       ServiceDirectory: mixedreality
       Location: eastus2
       MatrixFilters:
+        - TestType=^(?!sample).*
         - DependencyVersion=^$

--- a/sdk/schemaregistry/schema-registry-avro/tests.yml
+++ b/sdk/schemaregistry/schema-registry-avro/tests.yml
@@ -5,6 +5,8 @@ stages:
     parameters:
       PackageName: "@azure/schema-registry-avro"
       ServiceDirectory: schemaregistry
+      MatrixFilters:
+        - DependencyVersion=^$
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/schemaregistry/schema-registry/tests.yml
+++ b/sdk/schemaregistry/schema-registry/tests.yml
@@ -5,6 +5,8 @@ stages:
     parameters:
       PackageName: "@azure/schema-registry"
       ServiceDirectory: schemaregistry
+      MatrixFilters:
+        - DependencyVersion=^$
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -8,6 +8,8 @@ stages:
       TimeoutInMinutes: 90
       Clouds: Preview
       Location: westus
+      MatrixFilters:
+        - DependencyVersion=^$
       MatrixConfigs:
         - Name: Storage_live_test_base
           Path: sdk/storage/storage-blob/platform-matrix.json

--- a/sdk/storage/storage-file-datalake/tests.yml
+++ b/sdk/storage/storage-file-datalake/tests.yml
@@ -4,10 +4,12 @@ stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       PackageName: "@azure/storage-file-datalake"
-      Directory: storage
+      ServiceDirectory: storage
       TimeoutInMinutes: 90
       Location: canadacentral
       Clouds: 'Preview'
+      MatrixFilters:
+        - DependencyVersion=^$
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-file-share/tests.yml
+++ b/sdk/storage/storage-file-share/tests.yml
@@ -8,6 +8,8 @@ stages:
       TimeoutInMinutes: 90
       Location: canadacentral
       Clouds: 'Preview'
+      MatrixFilters:
+        - DependencyVersion=^$
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -7,3 +7,5 @@ stages:
       ServiceDirectory: storage
       Location: canadacentral
       Clouds: 'Preview'
+      MatrixFilters:
+        - DependencyVersion=^$


### PR DESCRIPTION
This PR fixes a few gaps I missed in my cross section testing of https://github.com/Azure/azure-sdk-for-js/pull/13886, now that all nightly pipelines have had a chance to run.