### PR TITLE
Exclude min/max testing for communication-administration live tests

### DIFF
--- a/sdk/communication/communication-administration/tests.yml
+++ b/sdk/communication/communication-administration/tests.yml
@@ -5,6 +5,8 @@ stages:
     parameters:
       PackageName: "@azure/communication-administration"
       ServiceDirectory: communication
+      MatrixFilters:
+        - DependencyVersion=^$
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
Another live test that needs to exclude min/max testing, now that it's opt-out.