### PR TITLE
Update JS samples: issueToken() is now getToken()

### DIFF
--- a/sdk/communication/communication-identity/samples/javascript/issueToken.js
+++ b/sdk/communication/communication-identity/samples/javascript/issueToken.js
@@ -31,7 +31,7 @@ async function main() {
   console.log("Issuing Token");
 
   // Issue token and get token from response
-  const { token } = await client.issueToken(user, scopes);
+  const { token } = await client.getToken(user, scopes);
 
   console.log(`Issued token: ${token}`);
 }

--- a/sdk/communication/communication-identity/samples/javascript/revokeTokens.js
+++ b/sdk/communication/communication-identity/samples/javascript/revokeTokens.js
@@ -32,9 +32,9 @@ async function main() {
   console.log("Issuing Tokens");
 
   // Issue tokens
-  const { token: token1 } = await client.issueToken(user, scopes);
-  const { token: token2 } = await client.issueToken(user, scopes);
-  const { token: token3 } = await client.issueToken(user, scopes);
+  const { token: token1 } = await client.getToken(user, scopes);
+  const { token: token2 } = await client.getToken(user, scopes);
+  const { token: token3 } = await client.getToken(user, scopes);
 
   console.log("Issued tokens:");
   console.log(token1);


### PR DESCRIPTION
In #13819, `issueToken` got renamed to `getToken`
While the TS samples were updated, the JS ones were missed

Fixes #14057