### PR TITLE
[Text Analytics] Better names for assertions

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -91,9 +91,6 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
 export interface AssessmentSentiment extends SentenceAssessment {
 }
 
-// @public
-export type Association = "subject" | "other";
-
 export { AzureKeyCredential }
 
 // @public
@@ -113,12 +110,6 @@ export interface BeginAnalyzeHealthcareEntitiesOptions extends TextAnalyticsOper
 // @public
 export interface CategorizedEntity extends Entity {
 }
-
-// @public
-export type Certainty = "Positive" | "Positive Possible" | "Neutral Possible" | "Negative Possible" | "Negative";
-
-// @public
-export type Conditionality = "Hypothetical" | "Conditional";
 
 // @public
 export interface DetectedLanguage {
@@ -217,19 +208,28 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
     keyPhrases: string[];
 }
 
-// @public (undocumented)
-export interface HealthcareAssertion {
-    association?: Association;
-    certainty?: Certainty;
-    conditionality?: Conditionality;
-}
-
 // @public
 export interface HealthcareEntity extends Entity {
-    assertion?: HealthcareAssertion;
+    assertion?: HealthcareEntityAssertion;
     dataSources: EntityDataSource[];
     normalizedText?: string;
 }
+
+// @public (undocumented)
+export interface HealthcareEntityAssertion {
+    association?: HealthcareEntityAssociation;
+    certainty?: HealthcareEntityCertainty;
+    conditionality?: HealthcareEntityConditionality;
+}
+
+// @public
+export type HealthcareEntityAssociation = "subject" | "other";
+
+// @public
+export type HealthcareEntityCertainty = "Positive" | "PositivePossible" | "NeutralPossible" | "NegativePossible" | "Negative";
+
+// @public
+export type HealthcareEntityConditionality = "Hypothetical" | "Conditional";
 
 // @public
 export interface HealthcareEntityRelation {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -1102,9 +1102,9 @@ export type Conditionality = "Hypothetical" | "Conditional";
 /** Defines values for Certainty. */
 export type Certainty =
   | "Positive"
-  | "Positive Possible"
-  | "Neutral Possible"
-  | "Negative Possible"
+  | "PositivePossible"
+  | "NeutralPossible"
+  | "NegativePossible"
   | "Negative";
 /** Defines values for Association. */
 export type Association = "subject" | "other";

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -138,10 +138,10 @@ export {
   TokenSentimentValue,
   TextAnalyticsWarning,
   State as TextAnalyticsOperationStatus,
-  HealthcareAssertion,
+  HealthcareAssertion as HealthcareEntityAssertion,
   PiiCategory as PiiEntityCategory,
-  Association,
-  Certainty,
-  Conditionality,
+  Association as HealthcareEntityAssociation,
+  Certainty as HealthcareEntityCertainty,
+  Conditionality as HealthcareEntityConditionality,
   RelationType as HealthcareEntityRelationType
 } from "./generated/models";


### PR DESCRIPTION
Implements new naming for assertions based on @mssfang suggestions. I am using the prefix Healthcare to conform to the naming for healthcare types. I am also fixing a small issue in the definition for `Certainty` (fixed in the swagger https://github.com/Azure/azure-rest-api-specs/pull/13247). 