### PR TITLE
[core-http] Allow no url credential scopes

### DIFF
--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -209,8 +209,7 @@ function createDefaultPipeline(options: ServiceClientOptions): Pipeline {
 
 function getCredentialScopes(options: ServiceClientOptions): string | string[] | undefined {
   if (options.credentialScopes) {
-    const scopes = options.credentialScopes;
-    return Array.isArray(scopes) ? scopes.map((scope) => scope) : scopes;
+    return options.credentialScopes;
   }
 
   if (options.baseUri) {

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -18,7 +18,6 @@ import {
 import { getStreamingResponseStatusCodes } from "./interfaceHelpers";
 import { getRequestUrl } from "./urlHelpers";
 import { flattenResponse } from "./utils";
-import { URL } from "./url";
 import { getCachedDefaultHttpsClient } from "./httpClientCache";
 import { getOperationRequestInfo } from "./operationHelpers";
 import { createClientPipeline } from "./pipeline";
@@ -211,9 +210,7 @@ function createDefaultPipeline(options: ServiceClientOptions): Pipeline {
 function getCredentialScopes(options: ServiceClientOptions): string | string[] | undefined {
   if (options.credentialScopes) {
     const scopes = options.credentialScopes;
-    return Array.isArray(scopes)
-      ? scopes.map((scope) => new URL(scope).toString())
-      : new URL(scopes).toString();
+    return Array.isArray(scopes) ? scopes.map((scope) => scope) : scopes;
   }
 
   if (options.baseUri) {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -60,7 +60,6 @@ import { tracingPolicy } from "./policies/tracingPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 import { ndJsonPolicy } from "./policies/ndJsonPolicy";
 import { XML_ATTRKEY, SerializerOptions, XML_CHARKEY } from "./util/serializer.common";
-import { URL } from "./url";
 import { getCachedDefaultHttpClient } from "./httpClientCache";
 
 /**
@@ -1052,9 +1051,7 @@ function getCredentialScopes(
 ): string | string[] | undefined {
   if (options?.credentialScopes) {
     const scopes = options.credentialScopes;
-    return Array.isArray(scopes)
-      ? scopes.map((scope) => new URL(scope).toString())
-      : new URL(scopes).toString();
+    return Array.isArray(scopes) ? scopes.map((scope) => scope) : scopes;
   }
 
   if (baseUri) {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -1050,8 +1050,7 @@ function getCredentialScopes(
   baseUri?: string
 ): string | string[] | undefined {
   if (options?.credentialScopes) {
-    const scopes = options.credentialScopes;
-    return Array.isArray(scopes) ? scopes.map((scope) => scope) : scopes;
+    return options.credentialScopes;
   }
 
   if (baseUri) {

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -77,30 +77,6 @@ describe("ServiceClient", function() {
       }
     };
 
-    it("should throw when there is a non fqdm as credentialScopes", async () => {
-      const cred: TokenCredential = {
-        getToken: async (_scopes) => {
-          return { token: "testToken", expiresOnTimestamp: 11111 };
-        }
-      };
-      let request: WebResource;
-      try {
-        const client = new ServiceClient(cred, {
-          httpClient: {
-            sendRequest: (req) => {
-              request = req;
-              return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
-            }
-          },
-          credentialScopes: ["/lalala//", "https://microsoft.com"]
-        });
-        await client.sendOperationRequest(testArgs, testOperationSpec);
-        assert.fail("Expected to throw");
-      } catch (error) {
-        assert.include(error.message, `Invalid URL`);
-      }
-    });
-
     it("should throw when there is no credentialScopes or baseUri", async () => {
       const cred: TokenCredential = {
         getToken: async (_scopes) => {
@@ -128,7 +104,7 @@ describe("ServiceClient", function() {
     });
 
     it("should use the provided scope", async () => {
-      const scope = "https://microsoft.com/.default";
+      const scope = "nourl/.default";
       const cred: TokenCredential = {
         getToken: async (scopes) => {
           assert.equal(scopes, scope);

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -77,6 +77,29 @@ describe("ServiceClient", function() {
       }
     };
 
+    it("should work when credentialScopes is not url ", async () => {
+      const credentialScopes = ["/lalala//", "https://microsoft.com"];
+      const cred: TokenCredential = {
+        getToken: async (scopes) => {
+          assert.deepEqual(scopes, credentialScopes);
+          return { token: "testToken", expiresOnTimestamp: 11111 };
+        }
+      };
+      let request: WebResource;
+
+      const client = new ServiceClient(cred, {
+        httpClient: {
+          sendRequest: (req) => {
+            request = req;
+            return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
+          }
+        },
+        credentialScopes
+      });
+      await client.sendOperationRequest(testArgs, testOperationSpec);
+      assert.ok("Didn't throw");
+    });
+
     it("should throw when there is no credentialScopes or baseUri", async () => {
       const cred: TokenCredential = {
         getToken: async (_scopes) => {
@@ -104,7 +127,7 @@ describe("ServiceClient", function() {
     });
 
     it("should use the provided scope", async () => {
-      const scope = "nourl/.default";
+      const scope = "https://microsoft.com/.default";
       const cred: TokenCredential = {
         getToken: async (scopes) => {
           assert.equal(scopes, scope);


### PR DESCRIPTION
We had the assumption that Credential Scopes had to be valid URLs. However there are services that have credential scopes that are no full URLs.

This PR removes the functionality we had in place to make sure credential scopes are URLs and will use exactly what was passed to Autorest at generation time. This code path is not generally exposed to end users so I believe it is fair to trust what has been passed to Autorest