### PR TITLE
[Text Analytics] Rename assertion types to not use the healthcare prefix

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -160,6 +160,22 @@ export interface Entity {
     text: string;
 }
 
+// @public (undocumented)
+export interface EntityAssertion {
+    association?: EntityAssociation;
+    certainty?: EntityCertainty;
+    conditionality?: EntityConditionality;
+}
+
+// @public
+export type EntityAssociation = "subject" | "other";
+
+// @public
+export type EntityCertainty = "Positive" | "PositivePossible" | "NeutralPossible" | "NegativePossible" | "Negative";
+
+// @public
+export type EntityConditionality = "Hypothetical" | "Conditional";
+
 // @public
 export interface EntityDataSource {
     entityId: string;
@@ -210,26 +226,10 @@ export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResu
 
 // @public
 export interface HealthcareEntity extends Entity {
-    assertion?: HealthcareEntityAssertion;
+    assertion?: EntityAssertion;
     dataSources: EntityDataSource[];
     normalizedText?: string;
 }
-
-// @public (undocumented)
-export interface HealthcareEntityAssertion {
-    association?: HealthcareEntityAssociation;
-    certainty?: HealthcareEntityCertainty;
-    conditionality?: HealthcareEntityConditionality;
-}
-
-// @public
-export type HealthcareEntityAssociation = "subject" | "other";
-
-// @public
-export type HealthcareEntityCertainty = "Positive" | "PositivePossible" | "NeutralPossible" | "NegativePossible" | "Negative";
-
-// @public
-export type HealthcareEntityConditionality = "Hypothetical" | "Conditional";
 
 // @public
 export interface HealthcareEntityRelation {

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -138,10 +138,10 @@ export {
   TokenSentimentValue,
   TextAnalyticsWarning,
   State as TextAnalyticsOperationStatus,
-  HealthcareAssertion as HealthcareEntityAssertion,
+  HealthcareAssertion as EntityAssertion,
   PiiCategory as PiiEntityCategory,
-  Association as HealthcareEntityAssociation,
-  Certainty as HealthcareEntityCertainty,
-  Conditionality as HealthcareEntityConditionality,
+  Association as EntityAssociation,
+  Certainty as EntityCertainty,
+  Conditionality as EntityConditionality,
   RelationType as HealthcareEntityRelationType
 } from "./generated/models";


### PR DESCRIPTION
This rename is based on the discussion here: https://github.com/Azure/azure-sdk-for-js/pull/14070#discussion_r586739488.