### PR TITLE
Set dev tag as depenency and update version for published

### DIFF
--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -82,7 +82,6 @@ const updateDependencySection = (rushPackages, dependencySection, buildId) => {
         parsedDepMinVersion.major == parsedPackageVersion.major &&
         parsedDepMinVersion.minor == parsedPackageVersion.minor &&
         parsedDepMinVersion.patch == parsedPackageVersion.patch &&
-        rushPackages[depName].json["sdk-type"] === "client" &&
         !rushPackages[depName].json["private"]
       ) {
         rushPackages = updatePackageVersion(rushPackages, depName, buildId);
@@ -99,13 +98,6 @@ const updateInternalDependencyVersions = (rushPackages, package, buildId) => {
   rushPackages = updateDependencySection(
     rushPackages,
     rushPackages[package].json.dependencies,
-    buildId
-  );
-
-  console.log("checking devDependencies ..");
-  rushPackages = updateDependencySection(
-    rushPackages,
-    rushPackages[package].json.devDependencies,
     buildId
   );
 
@@ -144,7 +136,6 @@ const makeDependencySectionConsistentForPackage = (rushPackages, dependencySecti
       parsedDepMinVersion.minor == parsedPackageVersion.minor &&
       parsedDepMinVersion.patch == parsedPackageVersion.patch &&
       rushPackages[depName].newVer !== undefined &&
-      rushPackages[depName].json["sdk-type"] === "client" &&
       !rushPackages[depName].json["private"]
     ) {
 

--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -81,7 +81,9 @@ const updateDependencySection = (rushPackages, dependencySection, buildId) => {
       if (
         parsedDepMinVersion.major == parsedPackageVersion.major &&
         parsedDepMinVersion.minor == parsedPackageVersion.minor &&
-        parsedDepMinVersion.patch == parsedPackageVersion.patch
+        parsedDepMinVersion.patch == parsedPackageVersion.patch &&
+        rushPackages[depName].json["sdk-type"] === "client" &&
+        !rushPackages[depName].json["private"]
       ) {
         rushPackages = updatePackageVersion(rushPackages, depName, buildId);
       }
@@ -141,12 +143,14 @@ const makeDependencySectionConsistentForPackage = (rushPackages, dependencySecti
       parsedDepMinVersion.major == parsedPackageVersion.major &&
       parsedDepMinVersion.minor == parsedPackageVersion.minor &&
       parsedDepMinVersion.patch == parsedPackageVersion.patch &&
-      rushPackages[depName].newVer !== undefined
+      rushPackages[depName].newVer !== undefined &&
+      rushPackages[depName].json["sdk-type"] === "client" &&
+      !rushPackages[depName].json["private"]
     ) {
 
       // Setting version to ^[major.minor.patch]-alpha so that this automatically matches 
       // with the latest dev version published on npm
-      dependencySection[depName] = `^${parsedPackageVersion.major}.${parsedPackageVersion.minor}.${parsedPackageVersion.patch}-alpha`;
+      dependencySection[depName] = `dev`;
     }
   }
   return rushPackages;


### PR DESCRIPTION
Alpha version dependency resolves true for beta and preview versions as well. Update dependency to "dev" tag to use latest alpha version.  

Also added changes to avoid updating dependency for private packages and devDependency packages.