### PR TITLE
[Text Analytics] Fix a compiler option in perf test

### DIFF
--- a/sdk/textanalytics/perf-tests/text-analytics/test/detectLanguage.spec.ts
+++ b/sdk/textanalytics/perf-tests/text-analytics/test/detectLanguage.spec.ts
@@ -24,7 +24,7 @@ export class DetectLanguageTest extends PerfStressTest<DetectLanguagePerfTestOpt
       description: "Number of documents",
       shortName: "n",
       longName: "docs-count",
-      defaultValue: 10
+      defaultValue: 1000
     }
   };
   client: TextAnalyticsClient;

--- a/sdk/textanalytics/perf-tests/text-analytics/tsconfig.json
+++ b/sdk/textanalytics/perf-tests/text-analytics/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.package",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ES2015",
     "declarationDir": "./typings/latest",
     "lib": ["ES6", "ESNext.AsyncIterable", "DOM"],


### PR DESCRIPTION
Otherwise, ts-node will fail. I also set the default number of documents to 1k.