### PR TITLE
[EventGrid] Add Performance Test

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -44,6 +44,7 @@ dependencies:
   '@rush-temp/mock-hub': file:projects/mock-hub.tgz
   '@rush-temp/monitor-opentelemetry-exporter': file:projects/monitor-opentelemetry-exporter.tgz
   '@rush-temp/perf-ai-text-analytics': file:projects/perf-ai-text-analytics.tgz
+  '@rush-temp/perf-eventgrid': file:projects/perf-eventgrid.tgz
   '@rush-temp/perf-storage-blob': file:projects/perf-storage-blob.tgz
   '@rush-temp/quantum-jobs': file:projects/quantum-jobs.tgz
   '@rush-temp/schema-registry': file:projects/schema-registry.tgz
@@ -7906,7 +7907,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-uk1zeFW+GrNjcc1uTY680Dv6L6XmtEdHk5HgA6CJafF2pfqqt6opR2vpeXqbn0WkMPXs7hu+ac4QsLVc03PANQ==
+      integrity: sha512-DcXxwlUYhV8lVuADpzmap8wLPNcQ7QHGKa4QnAetW1a3nQIHMAgFri6LYD2P25BfRT8i0I7cRhf1cLFE/vEYTw==
       tarball: file:projects/ai-anomaly-detector.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
@@ -7951,7 +7952,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-tvuaYAjk4fqyhLGwatSyOhj1jDV9kK0qznDzCD0ItOfeh/NBL25oZ4T2ra4qtmXgM1qBQtlBld40iTH4iKpeHA==
+      integrity: sha512-HcXTUps7Eeqn6ww4pdTNiYIsdFzYXuEEsVzi/3kf4tlx20+dqwpqnCWJppnGRAsgr0ByMy3Kwr3cP6zPl+XiZA==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
@@ -7997,7 +7998,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-6pEN9VTBLcNfKXmSgNYFIuApZUFPwgwM3OrG2e4Gyp/gK/nCCiNs6EWZ9xK/oGktwIWJZEm/77KKR897lPqPfA==
+      integrity: sha512-d+i4tG8NEGYFkvgYV4sJ8TnvS2piKe3oqjU50I0EQBfQ5rN2h4VZihPzfXB+22wN8ranLYvMubvxYtTSntMixw==
       tarball: file:projects/ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/ai-text-analytics.tgz:
@@ -8045,7 +8046,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-oqid9VsuiTUIQbsNyVvZJdGo1n/7YTIgYI+CxCzMAsgbdrziP7p++iLARCjiTEb3rd6yD69sQ5w18B4MgOvpXQ==
+      integrity: sha512-yNdgwUEuYIHKPfigSdMYW5bUtE4BuNGIUb+0RGNPOyVBCkPJn+LE9838LC9Yn0oJfK/RDks9jn4j7zLlJ6IQNA==
       tarball: file:projects/ai-text-analytics.tgz
     version: 0.0.0
   file:projects/app-configuration.tgz:
@@ -8100,7 +8101,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-tUqu6rEV17FcAGlqB3uNyPBQHFJbnMO4KAoZ139BGvdLIEGznbQkPidj/rj33lFh61oK+UQI6L2JTnwNB9ekRQ==
+      integrity: sha512-6MiKET/VaZyRRKPSIzHKVypOAKr6Iwft9p5nWH7P7fPmW2LDZiep2f30Qolaup7iX61y/Avmn/J+zIgc/lMy+g==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/attestation.tgz:
@@ -8204,7 +8205,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-administration'
     resolution:
-      integrity: sha512-9cTlGP9D+b8SayoWO3c4OUTxGVGkBuOwKP07pszELIun/X+TiKQyq/ZLvdyV7IrVg1GEfnoNnYPEYf/RiGOr7A==
+      integrity: sha512-uC00uPqqD4T6bZi7hnf0jx+YrsQj1Wz9XCRlb7/6s43dRvuzlhwB0MdXVVdMLx3vbysCnOGqrg7r5iMGn4hrlA==
       tarball: file:projects/communication-administration.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:
@@ -8261,7 +8262,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-7m/JXKR5VuNm8Sfyp+B9ZNIcr7GT23zqHtp9zJHomKEZiAB3h3aMIZCxkyxDfVEqEFFGPLAHLaPTmBz5XNDapg==
+      integrity: sha512-yGIuGujH5+CNQZ1jxRj9MGfUPA3/ekZs2gT7LMKB/tpyU95bN1UA0TOmM115BtvQCatND2A/ToOFheMT12zxFw==
       tarball: file:projects/communication-chat.tgz
     version: 0.0.0
   file:projects/communication-common.tgz:
@@ -8371,7 +8372,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-YDkLv0Gej/TwMgc/Fuh/REneC0JzluZsc9fOwyFIAc4z8+L93nkCedqpJWACaphdI71WLm8qNhqqbX00kr6IhA==
+      integrity: sha512-pk67nJfu3+YMUFT0NbXjQIy8tuUw2PNF+GzsbMt/WMrtnICFa+q2YmKWQdcAm1kpiZm34z4y3UstAZaOZYQWbA==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
@@ -8425,7 +8426,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-o0jyveS5bLniv+xIHS3VievHWSdjOr2X2DLUrDdjRkN3fIV6PJZpMbsCROvEh+9knP0vDkwKwktUEdJfAtc8DA==
+      integrity: sha512-BiyZK98oswnf4MJM+jNsT9R4dsAPDRs4ndFII4FSzvO/q9inZDLaewVNApYVfAt3d2z61Ypa740LtZgPEJCZvg==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -8468,7 +8469,7 @@ packages:
     dev: false
     name: '@rush-temp/container-registry'
     resolution:
-      integrity: sha512-0GnGl8cMQpBWEycrapgVqYf7KrVc8hr7DhTEXTMPfnEbg81Cb4wC4Vz50zbvNzyVV+iCyTefmAInNoMsGER/Ag==
+      integrity: sha512-jkdlQvJGZnlLHR85Xy+b2vw0FPfjQZXVPYSMi3yjl+ai3cfLenEVPy85tW8ekht8eT2LKe9qrFPsCQvszxfoQg==
       tarball: file:projects/container-registry.tgz
     version: 0.0.0
   file:projects/core-amqp.tgz:
@@ -8626,7 +8627,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-P2+n71qvpEaxgHNZRrown63TIZ92zyWk0a5PrVN32KCohAC81XSWTkggqG9WyLRwC6Hihyc08u+xKnHn/11SEg==
+      integrity: sha512-Cqav18PzSRxHFNoRkUdip6ukKsDUe8s7kW1W1ROnNzhsKkYCQFKKPAUv+AAAEydbb5pgfvCfHQa0WopFQ6kS1A==
       tarball: file:projects/core-client.tgz
     version: 0.0.0
   file:projects/core-crypto.tgz:
@@ -8740,7 +8741,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-jSO9fmQ+eLocIs72+usNsfhPXcLVw3VbOiBeHQvh4jYTSNdbWYQwxYf3tgXIIahObqu3dz0sXEBklt8EJQpuYg==
+      integrity: sha512-J62Gogye1K0/jeZKn7CYhIRNWxpBkwkjn8/xHg6CjHHKiaLfVk9qx9FgmQ6A44+IS2ohr3B4yNM64ZIir7sJxA==
       tarball: file:projects/core-http.tgz
     version: 0.0.0
   file:projects/core-lro.tgz:
@@ -8856,7 +8857,7 @@ packages:
     dev: false
     name: '@rush-temp/core-rest-pipeline'
     resolution:
-      integrity: sha512-tFEnGODW82WMBy4kI+yUfHYxeDk4DqjspSkwTEZo0Twavss1BmEPKPEIlq3vIQ8oTZBuTWrWrfNn+QtJ4QEEFA==
+      integrity: sha512-4fNeF/zNYV0I7VvFdZ+7bjYMqzOLU3QUZGQVb5ye0k6OVCDQ0Bsf+T8h6NS4JbE99NuBaCzUa0HG0YqPeWVWdQ==
       tarball: file:projects/core-rest-pipeline.tgz
     version: 0.0.0
   file:projects/core-tracing.tgz:
@@ -9101,7 +9102,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-mKR2zCbpn5l+5k1egdzWMfVaPuwqd3mcQ2qrqraiJJuIx+3xw420yaZnaYuU6lC0fiv2JAJEaWzeLPq4L9QwXg==
+      integrity: sha512-VpD7TFudSZ3XFPBw2CaLflUtmN+IywJ9rWcCXKTrzHqUpdWq+ydhYMkmKw0WKCzYrRiFZARnQx65M/upQNl+UA==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -9191,7 +9192,7 @@ packages:
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-nrUn2maTQcdwyE/a7uiYQkEUss/jFCRr7BLpmBudQw4kQpBn7kFF1Rwk23kvAxcSTMbiCoRDJyIznLx/xDS1pw==
+      integrity: sha512-Z+WAd842ONK0RCpAlO7hweZAXjHkiptnFymWA0m9tsZhbg2//GkGmq2hVHNfIfFWndvoxA0d9h81W6LEU0yFfA==
       tarball: file:projects/digital-twins-core.tgz
     version: 0.0.0
   file:projects/eslint-plugin-azure-sdk.tgz:
@@ -9301,7 +9302,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-kOiin8kHQAbo6XqGjUBUdGFsfMKpttIIVPesgnKmHQGjBtR2guTroPhyFOBPHULSgOkkX/3aBwkeJ4AZuRSSCQ==
+      integrity: sha512-ODs68iM+NiOd7JQdb7NKf0H/bXg8crUpxLromJg1/LiRmCh74LY3iCR1GTb26zpc5oAsZpek9v8d1sfexPCYjQ==
       tarball: file:projects/event-hubs.tgz
     version: 0.0.0
   file:projects/event-processor-host.tgz:
@@ -9408,7 +9409,7 @@ packages:
     dev: false
     name: '@rush-temp/eventgrid'
     resolution:
-      integrity: sha512-i09mBJLemF+CFiW0pxx+PKDJVXfVGh5roih2ADpC4vy6bBh3OTpe9ipJaSBs028r2kuBMUkwZqPuA2vvfWj2Rg==
+      integrity: sha512-V8vuB/yGQU+Glw2viD29kkswLk11nPWXjB2bJAcdOjhSGq3wAO2k0H8V68m6uBH14tYzk3THb+eHQ5J1iCs9QA==
       tarball: file:projects/eventgrid.tgz
     version: 0.0.0
   file:projects/eventhubs-checkpointstore-blob.tgz:
@@ -9530,7 +9531,7 @@ packages:
     optionalDependencies:
       keytar: 7.4.0
     resolution:
-      integrity: sha512-nqrEwv9c6izO9T7x9kwzHNd5rQgVfAbuNPTJG4zH22SL8UJ7tLnH8nZyZ+aP9uONLBts75bOoLR6F30DM8X4fQ==
+      integrity: sha512-GCPDD1pFMSCVZZR3hoHULTCuP3SMI4Yqvu5Y2/i1nk3JKehGQTkmSV2jwLbtFw/zmDM35v4drXiOpEE5N68K6Q==
       tarball: file:projects/identity.tgz
     version: 0.0.0
   file:projects/keyvault-admin.tgz:
@@ -9576,7 +9577,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-SQFrX6dak/Iv7Rmu1NVSJQW6UBQDAQpHjWv/6SZv8teE6lZqnMpypqiOMk/gV7Xw30bWIHmYC4KMXaS3Rk3Ohw==
+      integrity: sha512-mA3wCFv1VtyP1K3EIn8VjcJD1H7Kq1DbJ4hRPOnXYXAPCk3BaxLBAGK6iaHhc7XxjhH4nn6S7ZPY47UmJCWEZQ==
       tarball: file:projects/keyvault-admin.tgz
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
@@ -9635,7 +9636,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-/JJBjnGx+P5s3ULorZsAOqCsqv7d/pL1LesYAMRUfRjrs7zgPbTVeuxdpleHD39o7UGSn+qZDXTGT0akDxDNlw==
+      integrity: sha512-ezvJ33PyKC0uOoBnzANsuTSx828i2OgPMZxBVJE+PzJWYPG8Kg6yVLHxLxU0fyOIg18Ysl3kZMOVtZIilaRLSQ==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -9650,7 +9651,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-common'
     resolution:
-      integrity: sha512-tQo9XE4ub86bXoL6Rwfdj8V1n6e4x6UpR18vERmfVtKqTlCMJ3RQnimjgXGIlpozFUfmhvKazMKbTZGhaEyHAw==
+      integrity: sha512-loYhVlC37ROlBrDZqFIOLbZpNDTHjxbSLEMKWacYeeIgDchriWkpHulgAJ+AcET/dxaS+rnxU1v1Zl44ql31Hg==
       tarball: file:projects/keyvault-common.tgz
     version: 0.0.0
   file:projects/keyvault-keys.tgz:
@@ -9711,7 +9712,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-ezvh4ZNGvU8djXNrVL+tsX1GFoZSIjRFyNX4hjdCEAUlCzWuXiRI0cHftRzYpL70b20uhguudOeXPBfxHMMzVw==
+      integrity: sha512-JomXvUcrHagzIp2wgEEy0rzAS+GHGGlQDM6s0plZzar13+RfYLnmk1H6L+Jb+8CG2WRqXiUM3o9bDr6jWr2a1Q==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -9770,7 +9771,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-4un+TwTLEt/oEYbhH7O/B1D6l+d8AkX2sACiAQfy+JV0CSOIrzuhAeUAm9Ifw1bp4bXRr1b8hpaavlukfMK0Yw==
+      integrity: sha512-GuI6c2CRRyNibaxoApB9EpIRvbmFUqzH/TZTVFJ/7cdfGw3k0YbDh/T+U7f20wNvhvi+mPb6JZY3r6/fR+PVqA==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -9862,7 +9863,7 @@ packages:
     dev: false
     name: '@rush-temp/mixedreality-authentication'
     resolution:
-      integrity: sha512-4Qtftoi6mKFYSHZUo+SSofvB5IfmTU3jm5iguwM5FH6WSdem1NXs6pesOe7gPmSky9tZX/VjqI7oRG0xkJlnNQ==
+      integrity: sha512-RfiO+rJ+PftHHMN6SGCctCpeJFkHZWCe6DjHwWF21zR4rAXDA9kAXLGD8+4wk4XpUJpeqCQ5Y3k+fG1YFO99Hw==
       tarball: file:projects/mixedreality-authentication.tgz
     version: 0.0.0
   file:projects/mock-hub.tgz:
@@ -9925,6 +9926,20 @@ packages:
     resolution:
       integrity: sha512-F+eeV+aopIGTZp8/7sq8QGdNFqVQw5qGaZFEHi6paj/NDAk/2xb0lUMupAgkxHrH243PdvM2+Xr6s0CC3p4XFw==
       tarball: file:projects/perf-ai-text-analytics.tgz
+    version: 0.0.0
+  file:projects/perf-eventgrid.tgz:
+    dependencies:
+      '@types/dotenv': 8.2.0
+      '@types/node': 8.10.66
+      dotenv: 8.2.0
+      ts-node: 8.10.2_typescript@4.1.2
+      tslib: 2.1.0
+      typescript: 4.1.2
+    dev: false
+    name: '@rush-temp/perf-eventgrid'
+    resolution:
+      integrity: sha512-UBO6EjYqHg2ehxTLMG87FVDE6pz9Ggbriolp0NgTlVm4pYMqnlhQzcoMdABSQtZt9ULf0ai/Y/jhFf8S0vo6Sw==
+      tarball: file:projects/perf-eventgrid.tgz
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:
     dependencies:
@@ -10159,7 +10174,7 @@ packages:
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-kbfpNriJUveyPAbhPES3v3BKPsD5uM6A21iZ5H0xP5snEuIncL0dasJ/CsoKF4k9y9+8o5Cj/JP2KB3ikDYMSw==
+      integrity: sha512-ZJWiMhm+VT3/YCl93xBMPeZKWH8CyKfoYDeAhbrcOf1rhssG/4WtQbqgY+17mWWgasbCoJ1/mD6nazYMyS0WCA==
       tarball: file:projects/search-documents.tgz
     version: 0.0.0
   file:projects/service-bus.tgz:
@@ -10236,7 +10251,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-+1CfDf1YVRdFSjNwzvGQv6qpzCxObWVITPhsEeaLLUVrTuQhrIguJ9vXxm8SLiGwd/0M27nzicZ+FtVtQdFywA==
+      integrity: sha512-caNefoZ8Fmd2L8SutHkeEAsu7zjkQBzC6YXHAdWP1u3ASkfJP4PcFLn+WoT/KZeDrIzvHximvDMqNO6lO04oEQ==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
@@ -10296,7 +10311,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-pYFxDzHEmn4j3Kf+GZy1g+lJ+EeceRpzcP054qVhabyCcywOGIjn+4VZPIXfuUzljW8OUZvajnB4fv3gk4TNqQ==
+      integrity: sha512-e6d8HIP3WJHJh2x/e3AKZ+K+QT17i4bRiCm2M2HD6QWSbOKf98KQEFXMnHs85e3H2AKrLL3Ljhk9VHj6wmeSgg==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
@@ -10356,7 +10371,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-M1u2sKGn5nkvLaybAg7faSmMX2gt7trQQT9sRA+xd3ABmKXZTraRQT9UHR9aJZpJWIUN69cW8FZuFxDico938w==
+      integrity: sha512-1xNZlXqppucdHJz6QNR8w+CF47SWmiOs0sEJ4+Jzt+SNBjVQzYpo6JrAUvngF3rHOU/mlRXkeksXzXvcRYnwUQ==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
@@ -10417,7 +10432,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-BHsAn0rD62pw2gK463Ne0b0PahYaSM53wl2EPs3Uli69C+rTan+uhvYmGkPxtBtAi3AR7E4N7Qc+YnwOrBKdIg==
+      integrity: sha512-sWoObRPTiSz/U/rkBgv8yqa7575OV1L/hy/JCZj+76U5Q9FBa8p6YqZ0cCH3GO7lx73HJBVLSv13GIXZNaHiDQ==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
@@ -10473,7 +10488,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-Z3DjmbDwSHGt77kvZkAMTeFqI8ck7OLNCE/UQ3GYYn3+9Mk/vRoy5v6AmmIlwtXs/GeBQqSil6O2xA4QYenGJg==
+      integrity: sha512-6+YllKbsz59wuzVRrst2amew8qAX6kAdWe8aFeVtKWKW8or/+ykDSK7y676HcItim7Q3E9Xyj+UO0Wis7BE3LQ==
       tarball: file:projects/storage-file-share.tgz
     version: 0.0.0
   file:projects/storage-internal-avro.tgz:
@@ -10580,7 +10595,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-5SHT1lq8g8aRZko5pUMHm5BzON76AcjGAFyIeqVoExp5jABEMbXiO3Ti6/2nDI97a1rviZ201jZTB9TyMEar3w==
+      integrity: sha512-nA/tHojlA0BTcGeususPW7QlKAxSoFngEYdmFDTccKXiqnEq4pIUD9pjzWgzZIk2rNxZnQz7vBRTj7zBWtnyAw==
       tarball: file:projects/storage-queue.tgz
     version: 0.0.0
   file:projects/synapse-access-control.tgz:
@@ -10600,7 +10615,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
-      integrity: sha512-ec/dQP1fKNYhOHK2as7UMQ6IJAaSwnU3GdHEVJfqJ060wCVD1a/6SKXOHLXQ8b9wU0F/8CmPMUhnnFMn6iO5sQ==
+      integrity: sha512-aNi116+l3Cw1RoIbvwKY0Jvve6Vswa8w9/foX93RIeBB2kD4k7n6cCmsH7ClB0tnmw9eVU4/vM996keLWXLDEg==
       tarball: file:projects/synapse-access-control.tgz
     version: 0.0.0
   file:projects/synapse-artifacts.tgz:
@@ -10620,7 +10635,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
-      integrity: sha512-rADRTYPdVn+F4Ag+Ay1QHjZxrDKWey/0OFOX1iTqg0zsGsNIqV/zPoVbnrJ3gz1JL79SeFJZCe+qs5Iilt3oEw==
+      integrity: sha512-7rwxEAlfZS+IUSN7mpx+zJzAIrf4yu5fd708Kw9FrXsxykDS+HN6ahu+RYcHr6DTBAQnxmj79jNQyHtfbQTE3Q==
       tarball: file:projects/synapse-artifacts.tgz
     version: 0.0.0
   file:projects/synapse-managed-private-endpoints.tgz:
@@ -10640,7 +10655,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
-      integrity: sha512-FZeS1YOsh6bmmfYvbxFAIFAA+d+OoGiYMBw1WU/JpspFexZxIKKTgB6FkJb1W4I3v4usF+femKX5lmXgaeJzfQ==
+      integrity: sha512-QzBV8coW2Aswl9QyO4x2mSXepEUgpeqJ+6EWYrbrnK1jrElrfXIpt184/CgqhKhxQViXRq7IiJJjg6dKUK307A==
       tarball: file:projects/synapse-managed-private-endpoints.tgz
     version: 0.0.0
   file:projects/synapse-monitoring.tgz:
@@ -10660,7 +10675,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-monitoring'
     resolution:
-      integrity: sha512-jKNbZ+I7wJjAkDX0gxr08V6zs9Q6gY6fUv8wlnuL/nFuFV7kloF9ykp9q95FC7DwxaERybG2iRCq6TympvRx2A==
+      integrity: sha512-Xz8UKgdN0rJbGt90x4TOVzeTfjlJ+rAG0HAXdq0Ibv2PNdNCsIQqgwJ5q90hkk34fIXstWSR4z6P4QCN0XgzSA==
       tarball: file:projects/synapse-monitoring.tgz
     version: 0.0.0
   file:projects/synapse-spark.tgz:
@@ -10680,7 +10695,7 @@ packages:
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
-      integrity: sha512-o17eAX2X0xLGMZdAVbojMeemn+7Nqe43uPBUEpc237Ns4nEkiIh3Dn1+CbCfRNkd97Pj4NpKA8TDgq8KEaieLg==
+      integrity: sha512-42FrwtLEKDgVuOq1HXAG36hjJmEf+CP5ZI0i4GswiLon1HhVLNBcUYdhg5fyyoOyapNB7NPnydAbXqVgyiJejg==
       tarball: file:projects/synapse-spark.tgz
     version: 0.0.0
   file:projects/template.tgz:
@@ -10725,7 +10740,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-vDIEM+G9J4AdjHkdyKddr9xE5QmzY0aDsqB6EIU51xKfUk4dsmSnpwKbmj2wiESNqHIQUCEfQaAp5sYKUyKneQ==
+      integrity: sha512-q1Gsd5/2xLE5CY6zMm7t/0vUGmvzTj/cO9jHykJst2Ea2LypkcFXfzRv18bbaXWR69WRnPyVJyNxNAkaUIamyQ==
       tarball: file:projects/template.tgz
     version: 0.0.0
   file:projects/test-utils-multi-version.tgz:
@@ -10902,6 +10917,7 @@ specifiers:
   '@rush-temp/mock-hub': file:./projects/mock-hub.tgz
   '@rush-temp/monitor-opentelemetry-exporter': file:./projects/monitor-opentelemetry-exporter.tgz
   '@rush-temp/perf-ai-text-analytics': file:./projects/perf-ai-text-analytics.tgz
+  '@rush-temp/perf-eventgrid': file:./projects/perf-eventgrid.tgz
   '@rush-temp/perf-storage-blob': file:./projects/perf-storage-blob.tgz
   '@rush-temp/quantum-jobs': file:./projects/quantum-jobs.tgz
   '@rush-temp/schema-registry': file:./projects/schema-registry.tgz

--- a/rush.json
+++ b/rush.json
@@ -643,6 +643,11 @@
       "versionPolicyName": "client"
     },
     {
+      "packageName": "@azure-tests/perf-eventgrid",
+      "projectFolder": "sdk/eventgrid/perf-tests/eventgrid",
+      "versionPolicyName": "test"
+    },
+    {
       "packageName": "@azure-tests/perf-ai-text-analytics",
       "projectFolder": "sdk/textanalytics/perf-tests/text-analytics",
       "versionPolicyName": "test"

--- a/sdk/eventgrid/perf-tests/eventgrid/README.md
+++ b/sdk/eventgrid/perf-tests/eventgrid/README.md
@@ -1,0 +1,11 @@
+# Performance Testing for EventGrid
+
+## Instructions
+
+1. Build the eventgrid perf tests package `rush build -t perf-eventgrid`.
+2. Copy the `sample.env` file and name it as `.env`.
+3. Create an EventGrid topic, configured to use the Cloud Event schema.
+4. Run the tests as follows
+
+   - send cloud events
+     - `npm run perf-test:node -- SendCloudEventsTest --warmup 1 --iterations 1 --parallel 50 --duration 15 -n 50`

--- a/sdk/eventgrid/perf-tests/eventgrid/package.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@azure-tests/perf-eventgrid",
+  "version": "1.0.0",
+  "description": "",
+  "main": "",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/eventgrid": "^3.0.0-beta.3",
+    "@azure/test-utils-perfstress": "^1.0.0",
+    "dotenv": "^8.2.0"
+  },
+  "devDependencies": {
+    "@types/dotenv": "8.2.0",
+    "@types/node": "^8.0.0",
+    "tslib": "^2.0.0",
+    "ts-node": "^8.3.0",
+    "typescript": "4.1.2"
+  },
+  "private": true,
+  "scripts": {
+    "perf-test:node": "ts-node test/index.spec.ts",
+    "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
+    "build": "tsc -p .",
+    "build:samples": "echo skipped",
+    "build:test": "echo skipped",
+    "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
+    "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json src test --ext .ts -f html -o storage-blob-perf-test-lintReport.html || exit 0",
+    "pack": "npm pack 2>&1",
+    "prebuild": "npm run clean",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "echo skipped",
+    "unit-test": "echo skipped",
+    "test:browser": "echo skipped",
+    "test:node": "echo skipped",
+    "test": "echo skipped"
+  }
+}

--- a/sdk/eventgrid/perf-tests/eventgrid/package.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/package.json
@@ -12,7 +12,6 @@
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
-    "@types/dotenv": "8.2.0",
     "@types/node": "^8.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",

--- a/sdk/eventgrid/perf-tests/eventgrid/sample.env
+++ b/sdk/eventgrid/perf-tests/eventgrid/sample.env
@@ -1,0 +1,3 @@
+EVENT_GRID_CLOUD_EVENT_SCHEMA_ENDPOINT="https://<resource name>.cognitiveservies.azure.com/"
+EVENT_GRID_CLOUD_EVENT_SCHEMA_API_KEY="<api key>"
+

--- a/sdk/eventgrid/perf-tests/eventgrid/test/index.spec.ts
+++ b/sdk/eventgrid/perf-tests/eventgrid/test/index.spec.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { PerfStressProgram, selectPerfStressTest } from "@azure/test-utils-perfstress";
+import { SendCloudEventsTest } from "./sendCloudEvents.spec";
+
+import dotenv from "dotenv";
+dotenv.config();
+
+console.log("=== Starting the perfStress test ===");
+
+const perfStressProgram = new PerfStressProgram(selectPerfStressTest([SendCloudEventsTest]));
+
+perfStressProgram.run();

--- a/sdk/eventgrid/perf-tests/eventgrid/test/sendCloudEvents.spec.ts
+++ b/sdk/eventgrid/perf-tests/eventgrid/test/sendCloudEvents.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  PerfStressTest,
+  PerfStressOptionDictionary,
+  getEnvVar
+} from "@azure/test-utils-perfstress";
+import {
+  EventGridPublisherClient,
+  AzureKeyCredential,
+  SendCloudEventInput
+} from "@azure/eventgrid";
+
+interface SendCloudEventsPerfTestOptions {
+  "event-count": number;
+}
+
+export class SendCloudEventsTest extends PerfStressTest<SendCloudEventsPerfTestOptions> {
+  options: PerfStressOptionDictionary<SendCloudEventsPerfTestOptions> = {
+    "event-count": {
+      required: true,
+      description: "Number of events to send in a single request",
+      shortName: "n",
+      longName: "events-count",
+      defaultValue: 10
+    }
+  };
+  client: EventGridPublisherClient<"CloudEvent">;
+  events: SendCloudEventInput<string>[] = [];
+
+  constructor() {
+    super();
+    this.options = this.parsedOptions;
+
+    for (let i = 0; i < this.parsedOptions["event-count"]?.value!; i++) {
+      this.events.push({
+        source: "sdk/eventgrid/perf-tests/eventgrid",
+        type: "cloud-event-test-event",
+        data: `${i}`
+      });
+    }
+
+    const endpoint = getEnvVar("EVENT_GRID_CLOUD_EVENT_SCHEMA_ENDPOINT");
+    const key = getEnvVar("EVENT_GRID_CLOUD_EVENT_SCHEMA_API_KEY");
+
+    this.client = new EventGridPublisherClient(endpoint, "CloudEvent", new AzureKeyCredential(key));
+  }
+
+  async runAsync(): Promise<void> {
+    await this.client.send(this.events);
+  }
+}

--- a/sdk/eventgrid/perf-tests/eventgrid/test/sendCloudEvents.spec.ts
+++ b/sdk/eventgrid/perf-tests/eventgrid/test/sendCloudEvents.spec.ts
@@ -31,7 +31,6 @@ export class SendCloudEventsTest extends PerfStressTest<SendCloudEventsPerfTestO
 
   constructor() {
     super();
-    this.options = this.parsedOptions;
 
     for (let i = 0; i < this.parsedOptions["event-count"]?.value!; i++) {
       this.events.push({

--- a/sdk/eventgrid/perf-tests/eventgrid/tsconfig.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.package",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "declarationDir": "./typings/latest",
+    "lib": ["ES6", "ESNext.AsyncIterable", "DOM"],
+    "noEmit": true
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules"],
+  "include": ["./test/**/*.ts"]
+}


### PR DESCRIPTION
The EventGrid library is a fairly lightweight wrapper over the
service, but we would like to have a least one performance test so we
have a baseline to compare things with going forward.

This test just sends events using the CloudEvents schema to an
endpoint. This operation was choosen because it has the most work
being done by the SDK (there's a small level of translation that needs
to be done to adapt the user facing model to what the service expects
on the wire).