### PR TITLE
[ai-form-recognizer] Bugfix for error codes not being shown correctly.

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/src/internalModels.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/internalModels.ts
@@ -88,23 +88,3 @@ export interface RecognizedForms {
    */
   lastModified: Date;
 }
-
-/**
- * Contains the response data for recognize form operation using a custom model from training.
- */
-export type RecognizeFormResultResponse = RecognizedForms & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: AnalyzeOperationResultModel;
-  };
-};

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/recognitionPoller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/recognitionPoller.ts
@@ -3,9 +3,11 @@
 
 import { delay } from "@azure/core-http";
 import { Poller, PollOperation, PollOperationState } from "@azure/core-lro";
-import { OperationStatus } from "../../generated/models";
 
-import { RecognizeFormResultResponse } from "../../internalModels";
+import {
+  GeneratedClientGetAnalyzeFormResultResponse,
+  OperationStatus
+} from "../../generated/models";
 import { RecognizedFormArray } from "../../models";
 import { toRecognizedFormArray } from "../../transforms";
 
@@ -42,7 +44,10 @@ export interface FormRecognitionOperationClient {
   /**
    * Returns the results of the operation
    */
-  getResult(operationId: string, modelId?: string): Promise<RecognizeFormResultResponse>;
+  getResult(
+    operationId: string,
+    modelId?: string
+  ): Promise<GeneratedClientGetAnalyzeFormResultResponse>;
 }
 
 /**
@@ -109,9 +114,9 @@ function makeFormRecognitionOperation(
             [
               `Failed to recognize forms using the model "${description.modelId}"`,
               "Error(s):",
-              ...(response.errors?.map((e) => `  Code ${e.code}, message: '${e.message}'`) ?? [
-                "  <empty>"
-              ])
+              ...(response.analyzeResult?.errors?.map(
+                (e) => `  Code ${e.code}, message: '${e.message}'`
+              ) ?? ["  <empty>"])
             ].join("\n")
           );
         }

--- a/sdk/formrecognizer/ai-form-recognizer/test/public/node/formrecognizerclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/public/node/formrecognizerclient.spec.ts
@@ -186,8 +186,9 @@ matrix([[true, false]] as const, async (useAad) => {
 
           await poller.pollUntilDone();
           assert.fail("Expected an exception due to invalid language.");
-        } catch {
-          // Intentionally left empty
+        } catch (ex) {
+          // Just make sure we didn't get a bad error message
+          assert.isFalse((ex as Error).message.includes("<empty>"));
         }
       });
 
@@ -215,8 +216,9 @@ matrix([[true, false]] as const, async (useAad) => {
 
           await poller.pollUntilDone();
           assert.fail("Expected an exception due to invalid pages.");
-        } catch {
-          // Intentionally left empty
+        } catch (ex) {
+          // Just make sure we didn't get a bad error message
+          assert.isFalse((ex as Error).message.includes("<empty>"));
         }
       });
     });
@@ -376,8 +378,9 @@ matrix([[true, false]] as const, async (useAad) => {
 
           await poller.pollUntilDone();
           assert.fail("Expected an exception due to invalid locale.");
-        } catch {
-          // Intentionally left empty
+        } catch (ex) {
+          // Just make sure we didn't get a bad error message
+          assert.isFalse((ex as Error).message.includes("<empty>"));
         }
       });
     });
@@ -475,8 +478,9 @@ matrix([[true, false]] as const, async (useAad) => {
 
           await poller.pollUntilDone();
           assert.fail("Expected an exception due to invalid locale.");
-        } catch {
-          // Intentionally left empty
+        } catch (ex) {
+          // Just make sure we didn't get a bad error message
+          assert.isFalse((ex as Error).message.includes("<empty>"));
         }
       });
     });
@@ -572,8 +576,9 @@ matrix([[true, false]] as const, async (useAad) => {
 
           await poller.pollUntilDone();
           assert.fail("Expected an exception due to invalid locale.");
-        } catch {
-          // Intentionally left empty
+        } catch (ex) {
+          // Just make sure we didn't get a bad error message
+          assert.isFalse((ex as Error).message.includes("<empty>"));
         }
       });
     });


### PR DESCRIPTION
Closes #13880

This fixes a bug where Form Recognizer wasn't showing error codes for errors that are received during analysis polling and adds assertions to existing tests to make sure it stays that way.

A total fluke of structural typing and optional fields let me apply the wrong return type to the polling function, so I removed that type as well because it's not used.

GA releases of this package are **not** affected, as this was introduced as part of the LRO refactor for the first 3.1.0 beta, so a hotfix is not needed.