### PR TITLE
[Mixed Reality] Deploy test resources in eastus only

### DIFF
--- a/sdk/mixedreality/test-resources.json
+++ b/sdk/mixedreality/test-resources.json
@@ -18,7 +18,7 @@
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]",
+      "defaultValue": "eastus2",
       "metadata": {
         "description": "The location of the resource. By default, this is the same as the resource group."
       }


### PR DESCRIPTION
The required resources for the mixed reality auth package are not available in all regions.
The live tests are restricted to use eastus2
Doing the same via the arm template so that the smoke tests can benefit from the same

Resolves #14059