### PR TITLE
[logger] Split up logging in the browser

### DIFF
--- a/sdk/core/logger/CHANGELOG.md
+++ b/sdk/core/logger/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.2 (Unreleased)
 
+- When logging in the browser, the default log function will now log messages to the corresponding console log function (e.g. `info` level is sent to `console.info()`.) PR [#14103](https://github.com/Azure/azure-sdk-for-js/pull/14103)
 
 ## 1.0.1 (2021-01-07)
 

--- a/sdk/core/logger/rollup.base.config.js
+++ b/sdk/core/logger/rollup.base.config.js
@@ -36,8 +36,8 @@ export function nodeConfig(test = false) {
   };
 
   if (test) {
-    // entry point is every test file
-    baseConfig.input = "dist-esm/test/**/*.spec.js";
+    // Entry points - test files under the `test` folder(common for both browser and node), node specific test files
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
@@ -100,7 +100,8 @@ export function browserConfig(test = false) {
     ]
   };
   if (test) {
-    baseConfig.input = "dist-esm/test/**/*.spec.js";
+    // Entry points - test files under the `test` folder(common for both browser and node), browser specific test files
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/browser/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "test-browser/index.js";
     baseConfig.context = "null";

--- a/sdk/core/logger/src/log.browser.ts
+++ b/sdk/core/logger/src/log.browser.ts
@@ -1,7 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-const logFunction = console.debug || console.log;
 export function log(...args: any[]): void {
-  logFunction(...args);
+  if (args.length > 0) {
+    const firstArg = String(args[0]);
+    if (firstArg.includes(":error")) {
+      console.error(...args);
+    } else if (firstArg.includes(":warning")) {
+      console.warn(...args);
+    } else if (firstArg.includes(":info")) {
+      console.info(...args);
+    } else if (firstArg.includes(":verbose")) {
+      console.debug(...args);
+    } else {
+      console.debug(...args);
+    }
+  }
 }

--- a/sdk/core/logger/test/browser/logger.spec.ts
+++ b/sdk/core/logger/test/browser/logger.spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as Logger from "../../src";
+import * as sinon from "sinon";
+import { assert } from "chai";
+
+const testLogger = Logger.createClientLogger("test");
+
+describe("AzureLogger (browser)", function() {
+  function expectedTestMessage(namespace: string, message: string): string {
+    return `${namespace} ${message}`;
+  }
+
+  afterEach(() => {
+    Logger.setLogLevel(undefined);
+    sinon.restore();
+  });
+
+  it("logs to the correct console function", () => {
+    Logger.setLogLevel("verbose");
+
+    const debugStub = sinon.stub(console, "debug");
+    testLogger.verbose("verbose");
+    assert.isTrue(debugStub.calledOnce, "console.debug called");
+    assert.strictEqual(
+      debugStub.firstCall.args[0],
+      expectedTestMessage("azure:test:verbose", "verbose")
+    );
+    debugStub.restore();
+
+    const infoStub = sinon.stub(console, "info");
+    testLogger.info("info");
+    assert.isTrue(infoStub.calledOnceWith(expectedTestMessage("azure:test:info", "info")));
+    infoStub.restore();
+
+    const warningStub = sinon.stub(console, "warn");
+    testLogger.warning("warning");
+    assert.isTrue(warningStub.calledOnceWith(expectedTestMessage("azure:test:warning", "warning")));
+    warningStub.restore();
+
+    const errorStub = sinon.stub(console, "error");
+    testLogger.error("error");
+    assert.isTrue(errorStub.calledOnceWith(expectedTestMessage("azure:test:error", "error")));
+    errorStub.restore();
+  });
+});


### PR DESCRIPTION
Use the corresponding console log functions for each log level when using the default log function.

Fixes #14099