### PR TITLE
Preparing storage packages GA release for STG 76 features

### DIFF
--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@azure/core-http": "^1.2.0",
     "@azure/core-rest-pipeline": "1.0.0",
-    "@azure/storage-blob": "^12.5.0-beta.1",
+    "@azure/storage-blob": "^12.5.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "@types/uuid": "^8.0.0",
     "@types/node": "^8.0.0",

--- a/sdk/storage/perf-tests/storage-file-datalake/package.json
+++ b/sdk/storage/perf-tests/storage-file-datalake/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@azure/storage-file-datalake": "^12.4.0-beta.2",
+    "@azure/storage-file-datalake": "^12.4.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "@types/uuid": "^8.0.0",
     "@types/node": "^8.0.0",

--- a/sdk/storage/perf-tests/storage-file-share/package.json
+++ b/sdk/storage/perf-tests/storage-file-share/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@azure/storage-file-share": "^12.4.2",
+    "@azure/storage-file-share": "^12.5.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "@types/uuid": "^8.0.0",
     "@types/node": "^8.0.0",

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 12.5.0 (2021-03-05)
+## 12.5.0 (2021-03-10)
 
-- Included all features released in 12.5.0-beta.1.
+- Includes all features released in 12.5.0-beta.1.
 
 ## 12.5.0-beta.1 (2021-02-09)
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 12.5.0-beta.2 (Unreleased)
+## 12.5.0 (2021-03-05)
 
+- Included all features released in 12.5.0-beta.1.
 
 ## 12.5.0-beta.1 (2021-02-09)
 

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.5.0-beta.2",
+  "version": "12.5.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.5.0-beta.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.5.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.5.0-beta.1";
+const packageVersion = "12.5.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.5.0-beta.2";
+export const SDK_VERSION: string = "12.5.0";
 export const SERVICE_VERSION: string = "2020-06-12";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 12.4.0 (2021-03-05)
+## 12.4.0 (2021-03-10)
 
-- Included all features released in 12.4.0-beta.1.
+- Includes all features released in 12.4.0-beta.1.
 
 ## 12.4.0-beta.1 (2021-02-09)
 

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 12.4.0-beta.2 (Unreleased)
+## 12.4.0 (2021-03-05)
 
+- Included all features released in 12.4.0-beta.1.
 
 ## 12.4.0-beta.1 (2021-02-09)
 

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.4.0-beta.2",
+  "version": "12.4.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript  --package-version=12.4.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -103,7 +103,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.10",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.5.0-beta.1",
+    "@azure/storage-blob": "^12.5.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/storage/storage-file-datalake/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/models/parameters.ts
@@ -744,7 +744,7 @@ export const version: coreHttp.OperationParameter = {
     required: true,
     isConstant: true,
     serializedName: "x-ms-version",
-    defaultValue: '2020-04-08',
+    defaultValue: '2020-06-12',
     type: {
       name: "String"
     }

--- a/sdk/storage/storage-file-datalake/src/generated/src/operations/pathOperations.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/operations/pathOperations.ts
@@ -59,8 +59,9 @@ export class PathOperations {
   /**
    * Uploads data to be appended to a file, flushes (writes) previously uploaded data to a file, sets
    * properties for a file or directory, or sets access control for a file or directory. Data can
-   * only be appended to a file. This operation supports conditional HTTP requests. For more
-   * information, see [Specifying Conditional Headers for Blob Service
+   * only be appended to a file. Concurrent writes to the same file using multiple clients are not
+   * supported. This operation supports conditional HTTP requests. For more information, see
+   * [Specifying Conditional Headers for Blob Service
    * Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).
    * @summary Append Data | Flush Data | Set Properties | Set Access Control
    * @param action The action must be "append" to upload data to be appended to a file, "flush" to

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-datalake";
-const packageVersion = "1.0.0";
+const packageVersion = "12.4.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;
@@ -41,7 +41,7 @@ export class StorageClientContext extends coreHttp.ServiceClient {
     super(undefined, options);
 
     this.resource = 'filesystem';
-    this.version = '2020-04-08';
+    this.version = '2020-06-12';
     this.baseUri = "{url}";
     this.requestContentType = "application/json; charset=utf-8";
     this.url = url;

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-datalake";
-const packageVersion = "12.4.0";
+const packageVersion = "1.0.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.4.0-beta.2";
+export const SDK_VERSION: string = "12.4.0";
 export const SERVICE_VERSION: string = "2020-06-12";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -132,12 +132,3 @@ directive:
     transform: >
       $.properties.Code = { "type": "string" };
 ```
-
-### Update service version from "2020-02-10" to "2020-04-08"
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2020-04-08" ];
-```

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 12.4.2 (Unreleased)
+## 12.5.0 (2021-03-05)
 
+- Upgraded REST API version to "2020-06-12".
 
 ## 12.4.1 (2021-02-03)
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 12.5.0 (2021-03-05)
+## 12.5.0 (2021-03-10)
 
-- Upgraded REST API version to "2020-06-12".
+- Updated Azure Storage Service API version to 2020-06-12.
 
 ## 12.4.1 (2021-02-03)
 

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.4.2",
+  "version": "12.5.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.4.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.5.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-file-share";
-const packageVersion = "12.4.2";
+const packageVersion = "12.5.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   version: string;

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.4.2";
-export const SERVICE_VERSION: string = "2020-04-08";
+export const SDK_VERSION: string = "12.5.0";
+export const SERVICE_VERSION: string = "2020-06-12";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB
 export const FILE_RANGE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024; // 4MB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -302,4 +302,13 @@ directive:
       $.properties.Code = { "type": "string" };
 ```
 
+### Update service version from "2020-04-08" to "2020-06-12"
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.ApiVersionParameter
+    transform: $.enum = [ "2020-06-12" ];
+```
+
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2Fstorage-file-share%2Fswagger%2FREADME.png)

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 12.4.0 (2021-03-05)
+## 12.4.0 (2021-03-10)
 
-- Upgraded REST API version to "2020-06-12".
+- Updated Azure Storage Service API version to 2020-06-12.
 
 ## 12.3.1 (2021-02-03)
 

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 12.3.2 (Unreleased)
+## 12.4.0 (2021-03-05)
 
+- Upgraded REST API version to "2020-06-12".
 
 ## 12.3.1 (2021-02-03)
 

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.3.2",
+  "version": "12.4.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.3.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.4.0",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",

--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -154,7 +154,7 @@ export interface GeoReplication {
 }
 
 // @public
-export type GeoReplicationStatusType = string;
+export type GeoReplicationStatusType = 'live' | 'bootstrap' | 'unavailable';
 
 export { HttpHeaders }
 
@@ -163,16 +163,6 @@ export { HttpOperationResponse }
 export { HttpRequestBody }
 
 export { IHttpClient }
-
-// @public
-export const enum KnownGeoReplicationStatusType {
-    // (undocumented)
-    Bootstrap = "bootstrap",
-    // (undocumented)
-    Live = "live",
-    // (undocumented)
-    Unavailable = "unavailable"
-}
 
 // @public
 export type ListQueuesIncludeType = "metadata";

--- a/sdk/storage/storage-queue/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/index.ts
@@ -514,13 +514,6 @@ export interface MessageIdDeleteExceptionHeaders {
   clientRequestId?: string;
 }
 
-/** Known values of {@link GeoReplicationStatusType} that the service accepts. */
-export const enum KnownGeoReplicationStatusType {
-  Live = "live",
-  Bootstrap = "bootstrap",
-  Unavailable = "unavailable"
-}
-
 /**
  * Defines values for GeoReplicationStatusType. \
  * {@link KnownGeoReplicationStatusType} can be used interchangeably with GeoReplicationStatusType,
@@ -530,7 +523,7 @@ export const enum KnownGeoReplicationStatusType {
  * **bootstrap** \
  * **unavailable**
  */
-export type GeoReplicationStatusType = string;
+export type GeoReplicationStatusType = 'live' | 'bootstrap' | 'unavailable';
 
 /** Known values of {@link StorageErrorCode} that the service accepts. */
 export const enum KnownStorageErrorCode {

--- a/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/parameters.ts
@@ -100,7 +100,7 @@ export const timeoutInSeconds: OperationQueryParameter = {
 export const version: OperationParameter = {
   parameterPath: "version",
   mapper: {
-    defaultValue: "2020-04-08",
+    defaultValue: "2020-06-12",
     isConstant: true,
     serializedName: "x-ms-version",
     type: {

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "12.3.2";
+const packageVersion = "12.4.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;
@@ -43,6 +43,6 @@ export class StorageClientContext extends coreHttp.ServiceClient {
     this.url = url;
 
     // Assigning values to Constant parameters
-    this.version = options.version || "2020-04-08";
+    this.version = options.version || "2020-06-12";
   }
 }

--- a/sdk/storage/storage-queue/src/generatedModels.ts
+++ b/sdk/storage/storage-queue/src/generatedModels.ts
@@ -8,7 +8,6 @@ export {
   EnqueuedMessage,
   GeoReplication,
   GeoReplicationStatusType,
-  KnownGeoReplicationStatusType,
   ListQueuesSegmentResponse,
   Logging,
   MessageIdDeleteResponse,

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.3.2";
-export const SERVICE_VERSION: string = "2020-04-08";
+export const SDK_VERSION: string = "12.4.0";
+export const SERVICE_VERSION: string = "2020-06-12";
 
 /**
  * The OAuth scope to use with Azure Storage.

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -205,13 +205,13 @@ directive:
       $["x-ms-client-name"] = "queueAnalyticsLogging"
 ```
 
-### Update service version from "2018-03-28" to "2020-04-08"
+### Update service version from "2018-03-28" to "2020-06-12"
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2020-04-08" ];
+    transform: $.enum = [ "2020-06-12" ];
 ```
 
 ### Rename AccessPolicy start -> startsOn


### PR DESCRIPTION
Upgraded REST API version to 2020-06-12 in storage-queue/storage-file-share.
Updated package versions and change logs to prepare for release.