### PR TITLE
Skip mixed reality samples temporarily until region overrides are supported

### DIFF
--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -112,7 +112,7 @@
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },
-  "//smokeTestConfiguration": {
+  "//sampleConfiguration": {
     "skipFolder": true
   }
 }


### PR DESCRIPTION
This PR temporarily removes mixed reality from the global smoke test samples tests, as the underlying azure resources for these samples require a region different from the default one used, and currently there is no mechanism to support region overrides. Once region override support is added, we can re-include these samples.

See https://github.com/Azure/azure-sdk-for-js/issues/14059