### PR TITLE
[KeyVault] - added top level properties for a deleted secret

### DIFF
--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Updated the Latest service version to 7.2.
 - Added a `certificateKeyId?: string` secret property to use instead of the deprecated `keyId?: URL` and removed `"lib": ["dom"]` from `tsconfig.json`
+- Added `recoveryId`, `scheduledPurgeDate`, and `deletedOn` to a deleted secret's top-level attributes and deprecated these attributes from the deleted secret's `properties` collection.
 
 ## 4.2.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -26,12 +26,15 @@ export interface BeginRecoverDeletedSecretOptions extends SecretPollerOptions {
 
 // @public
 export interface DeletedSecret {
+    deletedOn?: Date;
     name: string;
     properties: SecretProperties & {
         recoveryId?: string;
         scheduledPurgeDate?: Date;
         deletedOn?: Date;
     };
+    recoveryId?: string;
+    scheduledPurgeDate?: Date;
     value?: string;
 }
 

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -146,6 +146,7 @@ export interface DeletedSecret {
     /**
      * The url of the recovery object, used to
      * identify and recover the deleted secret.
+     * @deprecated Please use {@link DeletedSecret.recoveryId}.
      */
     recoveryId?: string;
     /**
@@ -153,12 +154,14 @@ export interface DeletedSecret {
      * to be purged, in UTC
      * **NOTE: This property will not be serialized. It can only be populated by
      * the server.**
+     * @deprecated Please use {@link DeletedSecret.scheduledPurgeDate}.
      */
     scheduledPurgeDate?: Date;
     /**
      * The time when the secret was deleted, in UTC
      * **NOTE: This property will not be serialized. It can only be populated by
      * the server.**
+     * @deprecated Please use {@link DeletedSecret.deletedOn}.
      */
     deletedOn?: Date;
   };
@@ -170,6 +173,24 @@ export interface DeletedSecret {
    * The name of the secret.
    */
   name: string;
+  /**
+   * The url of the recovery object, used to
+   * identify and recover the deleted secret.
+   */
+  recoveryId?: string;
+  /**
+   * The time when the secret is scheduled
+   * to be purged, in UTC
+   * **NOTE: This property will not be serialized. It can only be populated by
+   * the server.**
+   */
+  scheduledPurgeDate?: Date;
+  /**
+   * The time when the secret was deleted, in UTC
+   * **NOTE: This property will not be serialized. It can only be populated by
+   * the server.**
+   */
+  deletedOn?: Date;
 }
 
 /**

--- a/sdk/keyvault/keyvault-secrets/src/transformations.ts
+++ b/sdk/keyvault/keyvault-secrets/src/transformations.ts
@@ -47,6 +47,9 @@ export function getSecretFromSecretBundle(
     resultObject.properties.recoveryId = deletedSecretBundle.recoveryId;
     resultObject.properties.scheduledPurgeDate = deletedSecretBundle.scheduledPurgeDate;
     resultObject.properties.deletedOn = deletedSecretBundle.deletedDate;
+    resultObject.recoveryId = deletedSecretBundle.recoveryId;
+    resultObject.scheduledPurgeDate = deletedSecretBundle.scheduledPurgeDate;
+    resultObject.deletedOn = deletedSecretBundle.deletedDate;
   }
 
   if (attributes) {

--- a/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/transformations.spec.ts
@@ -72,5 +72,8 @@ describe("Transformations", () => {
     assert.equal(secret.properties.recoveryId, "recovery_id");
     assert.equal(secret.properties.deletedOn, date);
     assert.equal(secret.properties.scheduledPurgeDate, date);
+    assert.equal(secret.recoveryId, "recovery_id");
+    assert.equal(secret.deletedOn, date);
+    assert.equal(secret.scheduledPurgeDate, date);
   });
 });

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -276,10 +276,18 @@ describe("Secret client - create, read, update and delete operations", () => {
     assert.ok(deletedSecret!.properties.deletedOn instanceof Date);
     assert.ok(deletedSecret!.properties.scheduledPurgeDate instanceof Date);
 
+    assert.equal(typeof deletedSecret!.recoveryId, "string");
+    assert.ok(deletedSecret!.deletedOn instanceof Date);
+    assert.ok(deletedSecret!.scheduledPurgeDate instanceof Date);
+
     deletedSecret = await deletePoller.pollUntilDone();
     assert.equal(typeof deletedSecret.properties.recoveryId, "string");
     assert.ok(deletedSecret.properties.deletedOn instanceof Date);
     assert.ok(deletedSecret.properties.scheduledPurgeDate instanceof Date);
+
+    assert.equal(typeof deletedSecret!.recoveryId, "string");
+    assert.ok(deletedSecret!.deletedOn instanceof Date);
+    assert.ok(deletedSecret!.scheduledPurgeDate instanceof Date);
 
     try {
       await client.getSecret(secretName);


### PR DESCRIPTION
## What

- Deprecates `recoveryId`, `scheduledPurgeDate`, and `deletedOn` from a deleted secret's property bag
- Adds and populates the same three properties on the top level of a deleted secret

## Why

- These were supposed to be at the root level but we missed it the first time around
- This aligns us with keyvault certs and with dotnet's secrets 

Resolves #12768 