### PR TITLE
[Text Analytics] Fix a bug for returning stats for analyze

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `beginAnalyzeHealthcareEntities` entities now include `assertions` instead of `isNegated` which gives more context about the respective entity.
 - [Breaking] `beginAnalyzeHealthcareEntities` no longer returns `relatedEntities`.
 - `recognizePiiEntities` takes a new option, `categoriesFilter`, that specifies a list of Pii categories to return.
+- [Breaking] `statistics` is no longer part of `PagedAnalyzeBatchActionsResult`.
 
 ## 5.1.0-beta.4 (2021-02-10)
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -500,7 +500,6 @@ main();
 
 ## Known Issues
 
-- Currently, the `beginAnalyze` API accepts `includeStatistics` in its options bag, a feature that was not yet supported by the service at the time of the current release. This feature is expected to be supported soon after the release.
 - `beginAnalyzeHealthcare` is still in gated preview and can not be used with AAD credentials. For more information, see (the Text Analytics for Health documentation)[https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview].
 
 ## Troubleshooting

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_statistics.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_statistics.json
@@ -1,0 +1,708 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1331",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:32 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11530.15 - NCUS ProdSlices",
+    "x-ms-request-id": "7bc9d388-fcfd-4206-a822-3ef6f52d6300"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze",
+   "query": {},
+   "requestBody": "{\"tasks\":{\"entityRecognitionTasks\":[{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}}],\"entityRecognitionPiiTasks\":[{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}}],\"keyPhraseExtractionTasks\":[{\"parameters\":{\"model-version\":\"latest\"}}]},\"analysisInput\":{\"documents\":[{\"id\":\"56\",\"text\":\":)\"},{\"id\":\"0\",\"text\":\":(\"},{\"id\":\"22\",\"text\":\"\"},{\"id\":\"19\",\"text\":\":P\"},{\"id\":\"1\",\"text\":\":D\"}]}}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "apim-request-id": "1388d517-6eb7-49df-9366-56aa86febb2f",
+    "date": "Fri, 05 Mar 2021 21:11:37 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "333"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:37Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:37Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "responseHeaders": {
+    "apim-request-id": "e88e8546-8651-45c5-9041-e8126282a5d2",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:37 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "111"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":0,\"failed\":0,\"inProgress\":3,\"total\":3}}",
+   "responseHeaders": {
+    "apim-request-id": "38f9efc7-3126-4877-a7c7-720807c0e848",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:39 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "936"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "b13a9f0a-2474-4d3a-b01a-091b63d7fa9f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "1031"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "10f33860-207f-4fa3-8543-ab09a6d97e17",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "357"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "cf07c895-d3d0-4b8b-a0a4-040ffe181a3e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:47 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "734"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "9f00d9c1-7b0c-491a-9677-d5f4e697e33f",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:49 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "191"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "9b04aef2-d473-4294-8308-97132bc8544c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:52 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "1063"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "f25a8e83-b436-4e7b-a4ad-f0c01024d396",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:54 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "166"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "8bb88f23-2410-40c4-8871-f646e75c292e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:56 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "182"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "115ff9b1-d421-468e-95bd-f9967b467328",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:11:58 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "182"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "9a39e5aa-1b5f-40ed-b96b-5e8371500831",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:00 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "186"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "8eb9d4c2-ab24-472e-9dd4-4d63121b1ec2",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:03 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "230"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "9b75879f-fde1-47d9-95ff-f19674cdc3e7",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:05 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "154"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "26627696-dea8-4437-b4ef-d96773c75fd9",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:07 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "186"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "7b2b4712-d47b-474a-b62a-dd39ecea1428",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:09 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "131"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "d8157bb9-5cad-4499-bc1b-9160f2754f90",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:11 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "243"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "06cf211f-ff86-4e25-b9ec-ccaf59b28d5c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:15 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "175"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "6f8d91cb-f1bc-47e0-ac17-3dbd57262b36",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:17 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "154"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "721a9dfa-ffff-406b-a082-c2bd0bbedaca",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:19 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "211"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "ef32eecc-43d2-437b-b6b7-5199751388db",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:21 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "215"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "84dbac0b-cf84-4a76-9ad0-0a1d38f5785e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "179"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "27d3eb27-ee9d-43a1-98f4-3166a345e954",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:25 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "159"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "cf5120cf-1781-4ded-98ae-cac5ada44292",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:28 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "177"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "31f7afd9-ee8a-438c-8990-610aa14a6063",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:30 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "216"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "5d840dc4-17fd-4d09-b987-1a62ea4d7d18",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:32 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "184"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "52c37d8e-87a1-4926-9096-9c8d715b903e",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:34 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "147"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "a804b497-5e6b-44a9-a7da-ba352ecc7f11",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:37 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "186"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "8db42f22-5336-4750-b3fa-d1c8af620781",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:39 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "154"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "8fff14ad-c9b2-4b69-84a8-c4f53b3d15cf",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:41 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "202"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "c64c76ce-9210-411a-a8bd-2d1cea559c9c",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:43 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "186"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":1,\"failed\":0,\"inProgress\":2,\"total\":3,\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "e4e0dae3-2fcc-4c2a-8bb8-c93995135a02",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:45 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "218"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"succeeded\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":3,\"failed\":0,\"inProgress\":0,\"total\":3,\"entityRecognitionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"0\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"19\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"1\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2021-01-15\"}}],\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"redactedText\":\":)\",\"id\":\"56\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":(\",\"id\":\"0\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":P\",\"id\":\"19\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":D\",\"id\":\"1\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2021-01-15\"}}],\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "010eb36c-8e55-430f-9598-08bb8718c6d8",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:48 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "358"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/b3e0dd23-98cf-4395-ac07-9386e0e8282c",
+   "query": {
+    "showStats": "true",
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"jobId\":\"b3e0dd23-98cf-4395-ac07-9386e0e8282c\",\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\",\"createdDateTime\":\"2021-03-05T21:11:37Z\",\"expirationDateTime\":\"2021-03-06T21:11:37Z\",\"status\":\"succeeded\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-03-05T21:11:38Z\"},\"completed\":3,\"failed\":0,\"inProgress\":0,\"total\":3,\"entityRecognitionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"0\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"19\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"id\":\"1\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2021-01-15\"}}],\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"redactedText\":\":)\",\"id\":\"56\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":(\",\"id\":\"0\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":P\",\"id\":\"19\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]},{\"redactedText\":\":D\",\"id\":\"1\",\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"entities\":[],\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2021-01-15\"}}],\"keyPhraseExtractionTasks\":[{\"lastUpdateDateTime\":\"2021-03-05T21:11:38.4978003Z\",\"state\":\"succeeded\",\"results\":{\"statistics\":{\"documentsCount\":5,\"validDocumentsCount\":4,\"erroneousDocumentsCount\":1,\"transactionsCount\":4},\"documents\":[{\"id\":\"56\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"0\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"19\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]},{\"id\":\"1\",\"keyPhrases\":[],\"statistics\":{\"charactersCount\":2,\"transactionsCount\":1},\"warnings\":[]}],\"errors\":[{\"id\":\"22\",\"error\":{\"code\":\"InvalidRequest\",\"message\":\"Invalid document in request.\",\"innererror\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2020-07-01\"}}]}}",
+   "responseHeaders": {
+    "apim-request-id": "ac40683f-6137-4245-bc5c-8561cd5f3a7d",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 05 Mar 2021 21:12:48 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "273"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "3d676b43599b8b4e47e17f0b3cff8949"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_statistics.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_statistics.js
@@ -1,0 +1,597 @@
+let nock = require('nock');
+
+module.exports.hash = "9d5b39c71a9313c579a003b2a0557e47";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '5bb2e781-00e6-465d-a5e2-022f38cb6700',
+  'x-ms-ests-server',
+  '2.1.11530.15 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AtLUJj6gS5dGl0RnKRkwUEpz_bg1AQAAAC2V1NcOAAAA; expires=Sun, 04-Apr-2021 21:10:05 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:05 GMT',
+  'Content-Length',
+  '1331'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.1-preview.4/analyze', {"tasks":{"entityRecognitionTasks":[{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}}],"entityRecognitionPiiTasks":[{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}}],"keyPhraseExtractionTasks":[{"parameters":{"model-version":"latest"}}]},"analysisInput":{"documents":[{"id":"56","text":":)"},{"id":"0","text":":("},{"id":"22","text":""},{"id":"19","text":":P"},{"id":"1","text":":D"}]}})
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'operation-location',
+  'https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c',
+  'x-envoy-upstream-service-time',
+  '1357',
+  'apim-request-id',
+  'a883ba1d-c0b2-4780-909d-ad0bbb7aedbd',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:12 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:12Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:12Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '1405',
+  'apim-request-id',
+  '5a996d92-5ec1-4730-b9aa-1b1445cba6fa',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:14 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '3413',
+  'apim-request-id',
+  '9c38dc22-a1d2-45fc-9ac0-15223a1a722f',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:18 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '723',
+  'apim-request-id',
+  'c680d3ad-3f18-47f5-a2ef-53ab0a0ef71c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:21 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '1643',
+  'apim-request-id',
+  'f0dec742-c958-4e51-bf9d-ccc3aaf50442',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:24 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '1106',
+  'apim-request-id',
+  '8b88941c-cba7-406a-8163-bf78ea179275',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:27 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '2002',
+  'apim-request-id',
+  '2866b412-6a2b-4311-9232-7cc787ff7695',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:31 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '1787',
+  'apim-request-id',
+  'bf0762f4-6272-43ec-a602-e00d20f59bf8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:35 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '2402',
+  'apim-request-id',
+  'b0e36c42-e122-4761-bf16-a0a9b73ddd81',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:40 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '244',
+  'apim-request-id',
+  'd7bb3d19-268e-44eb-a269-9f1c4de1af60',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:42 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '337',
+  'apim-request-id',
+  '883c7823-63a1-4129-9675-bec85c73cd62',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:44 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '184',
+  'apim-request-id',
+  '003ac93f-5b6f-4d6d-8081-cffbc1f66f99',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:46 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '621',
+  'apim-request-id',
+  '9770a7c1-a8e8-43bc-bd1e-8d28aba9fe68',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:49 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '202',
+  'apim-request-id',
+  '1340e3fa-5b58-4f12-84cb-6cfb6a450092',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:51 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '196',
+  'apim-request-id',
+  '17aa0b1e-3f71-4ba4-b860-69cb79c62d36',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:53 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '251',
+  'apim-request-id',
+  '41943cc1-842d-4fa7-a6bf-1ccbf0d8c255',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '155',
+  'apim-request-id',
+  'a4185b91-f07f-4db0-aed0-74d91c0a3225',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:10:58 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '139',
+  'apim-request-id',
+  '1b53e6e0-82bd-4cb1-9581-4374838438cc',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:00 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '157',
+  'apim-request-id',
+  '095cbe15-ee5a-4184-ae9d-205ce42f6b9c',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:02 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '222',
+  'apim-request-id',
+  'dcfd12ac-886f-4607-8dfd-291c889ddc87',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:05 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '239',
+  'apim-request-id',
+  '5acea655-b7d6-4be8-94d4-b06cea5e642b',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:07 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '907',
+  'apim-request-id',
+  '6de404fc-cfed-4d07-a522-3784263f5603',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:10 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '184',
+  'apim-request-id',
+  '8377e627-8e46-47b0-ad52-a615bc480273',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:12 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '155',
+  'apim-request-id',
+  'b9a2a22c-fb5e-4d4c-b2ba-a0b0e9c377cc',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:14 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '218',
+  'apim-request-id',
+  '82b8c99f-3aa7-435f-b4d9-2cf46b35ef64',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:17 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":1,"failed":0,"inProgress":2,"total":3,"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '190',
+  'apim-request-id',
+  'f770fb0d-0e36-4fc6-837a-623b970aa7b7',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:19 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"succeeded","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":3,"failed":0,"inProgress":0,"total":3,"entityRecognitionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"0","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"19","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"1","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2021-01-15"}}],"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"redactedText":":)","id":"56","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":(","id":"0","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":P","id":"19","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":D","id":"1","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2021-01-15"}}],"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '1195',
+  'apim-request-id',
+  '32c2b979-280c-4cc3-8743-581edc844a98',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:22 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/695a8331-d4ce-4499-bbbf-32e398c7536c')
+  .query(true)
+  .reply(200, {"jobId":"695a8331-d4ce-4499-bbbf-32e398c7536c","lastUpdateDateTime":"2021-03-05T21:10:15Z","createdDateTime":"2021-03-05T21:10:12Z","expirationDateTime":"2021-03-06T21:10:12Z","status":"succeeded","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-03-05T21:10:15Z"},"completed":3,"failed":0,"inProgress":0,"total":3,"entityRecognitionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"0","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"19","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"1","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2021-01-15"}}],"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"redactedText":":)","id":"56","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":(","id":"0","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":P","id":"19","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]},{"redactedText":":D","id":"1","statistics":{"charactersCount":2,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2021-01-15"}}],"keyPhraseExtractionTasks":[{"lastUpdateDateTime":"2021-03-05T21:10:15.2080175Z","state":"succeeded","results":{"statistics":{"documentsCount":5,"validDocumentsCount":4,"erroneousDocumentsCount":1,"transactionsCount":4},"documents":[{"id":"56","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"0","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"19","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]},{"id":"1","keyPhrases":[],"statistics":{"charactersCount":2,"transactionsCount":1},"warnings":[]}],"errors":[{"id":"22","error":{"code":"InvalidRequest","message":"Invalid document in request.","innererror":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2020-07-01"}}]}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '279',
+  'apim-request-id',
+  '1109cb75-0771-461d-89c4-00c2e9717536',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 05 Mar 2021 21:11:22 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -318,7 +318,6 @@ export interface Opinion {
 
 // @public
 export interface PagedAnalyzeBatchActionsResult extends PagedAsyncIterableAnalyzeBatchActionsResult {
-    statistics?: TextDocumentBatchStatistics;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -33,7 +33,22 @@ async function main() {
     recognizePiiEntitiesActions: [{ modelVersion: "latest" }],
     extractKeyPhrasesActions: [{ modelVersion: "latest" }]
   };
-  const poller = await client.beginAnalyzeBatchActions(documents, actions);
+  const poller = await client.beginAnalyzeBatchActions(documents, actions, "en", {
+    includeStatistics: true
+  });
+  poller.onProgress(() => {
+    console.log(
+      `Number of actions still in progress: ${poller.getOperationState().actionsInProgressCount}`
+    );
+  });
+  console.log(
+    `The analyze batch actions operation created on ${poller.getOperationState().createdOn}`
+  );
+  console.log(
+    `The analyze batch actions operation results will expire on ${
+      poller.getOperationState().expiresOn
+    }`
+  );
   const resultPages = await poller.pollUntilDone();
   for await (const page of resultPages) {
     const keyPhrasesAction = page.extractKeyPhrasesResults[0];
@@ -49,6 +64,8 @@ async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(keyPhrasesAction.results.statistics));
     }
 
     const entitiesAction = page.recognizeEntitiesResults[0];
@@ -64,6 +81,8 @@ async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(entitiesAction.results.statistics));
     }
 
     const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
@@ -79,6 +98,8 @@ async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(piiEntitiesAction.results.statistics));
     }
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeBatchActions.js
@@ -42,7 +42,7 @@ async function main() {
     );
   });
   console.log(
-    `The analyze batch actions operation created on ${poller.getOperationState().createdOn}`
+    `The analyze batch actions operation was created on ${poller.getOperationState().createdOn}`
   );
   console.log(
     `The analyze batch actions operation results will expire on ${

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/beginAnalyzeBatchActions.ts
@@ -33,12 +33,17 @@ export async function main() {
     recognizePiiEntitiesActions: [{ modelVersion: "latest" }],
     extractKeyPhrasesActions: [{ modelVersion: "latest" }]
   };
-  const poller = await client.beginAnalyzeBatchActions(documents, actions);
+  const poller = await client.beginAnalyzeBatchActions(documents, actions, "en", {
+    includeStatistics: true
+  });
   const resultPages = await poller.pollUntilDone();
+  poller.onProgress(() => {
+    console.log(
+      `Number of actions still in progress: ${poller.getOperationState().actionsInProgressCount}`
+    );
+  });
   console.log(
-    `The analyze batch actions operation created on ${
-      poller.getOperationState().createdOn
-    } finished process`
+    `The analyze batch actions operation created on ${poller.getOperationState().createdOn}`
   );
   console.log(
     `The analyze batch actions operation results will expire on ${
@@ -60,6 +65,8 @@ export async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(keyPhrasesAction.results.statistics));
     }
 
     const entitiesAction = page.recognizeEntitiesResults[0];
@@ -75,6 +82,8 @@ export async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(entitiesAction.results.statistics));
     }
 
     const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
@@ -90,6 +99,8 @@ export async function main() {
           console.error("\tError:", doc.error);
         }
       }
+      console.log("Action statistics: ");
+      console.log(JSON.stringify(piiEntitiesAction.results.statistics));
     }
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeBatchActionsResult.ts
@@ -12,7 +12,6 @@ import {
   TasksStateTasksEntityRecognitionPiiTasksItem,
   TasksStateTasksEntityRecognitionTasksItem,
   TasksStateTasksKeyPhraseExtractionTasksItem,
-  TextDocumentBatchStatistics,
   TextDocumentInput
 } from "./generated/models";
 import {
@@ -184,12 +183,12 @@ export type PagedAsyncIterableAnalyzeBatchActionsResult = PagedAsyncIterableIter
  */
 export interface PagedAnalyzeBatchActionsResult
   extends PagedAsyncIterableAnalyzeBatchActionsResult {
-  /**
-   * Statistics about the input document batch and how it was processed
-   * by the service. This property will have a value when includeStatistics is set to true
-   * in the client call.
-   */
-  statistics?: TextDocumentBatchStatistics;
+  // /**
+  //  * Statistics about the input document batch and how it was processed
+  //  * by the service. This property will have a value when includeStatistics is set to true
+  //  * in the client call.
+  //  */
+  // statistics?: TextDocumentBatchStatistics;
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -102,6 +102,9 @@ export interface AnalyzeBatchActionsOperationState
   extends AnalysisPollOperationState<PagedAnalyzeBatchActionsResult>,
     AnalyzeBatchActionsOperationMetadata {}
 
+/**
+ * @internal
+ */
 function getMetInfoFromResponse(response: AnalyzeJobState): AnalyzeBatchActionsOperationMetadata {
   return {
     createdOn: response.createdDateTime,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -6,6 +6,7 @@ import { OperationOptions } from "@azure/core-client";
 import { AbortSignalLike } from "@azure/abort-controller";
 
 import {
+  AnalyzeJobState,
   GeneratedClientAnalyzeResponse as BeginAnalyzeResponse,
   GeneratedClientAnalyzeStatusOptionalParams as AnalyzeBatchActionsOperationStatusOptions,
   JobManifestTasks as GeneratedActions,
@@ -100,6 +101,18 @@ export interface BeginAnalyzeBatchActionsOptions extends OperationOptions {
 export interface AnalyzeBatchActionsOperationState
   extends AnalysisPollOperationState<PagedAnalyzeBatchActionsResult>,
     AnalyzeBatchActionsOperationMetadata {}
+
+function getMetInfoFromResponse(response: AnalyzeJobState): AnalyzeBatchActionsOperationMetadata {
+  return {
+    createdOn: response.createdDateTime,
+    lastModifiedOn: response.lastUpdateDateTime,
+    expiresOn: response.expirationDateTime,
+    status: response.status,
+    actionsSucceededCount: response.tasks.completed,
+    actionsFailedCount: response.tasks.failed,
+    actionsInProgressCount: response.tasks.inProgress
+  };
+}
 
 /**
  * Class that represents a poller that waits for results of the analyze
@@ -218,19 +231,11 @@ export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperati
           return {
             done: true,
             statistics: response.statistics,
-            operationMetdata: {
-              createdOn: response.createdDateTime,
-              lastModifiedOn: response.lastUpdateDateTime,
-              expiresOn: response.expirationDateTime,
-              status: response.status,
-              actionsSucceededCount: response.tasks.completed,
-              actionsFailedCount: response.tasks.failed,
-              actionsInProgressCount: response.tasks.inProgress
-            }
+            operationMetdata: getMetInfoFromResponse(response)
           };
         }
       }
-      return { done: false };
+      return { done: false, operationMetdata: getMetInfoFromResponse(response) };
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -311,17 +316,24 @@ export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperati
     state.actionsInProgressCount = operationStatus.operationMetdata?.actionsInProgressCount;
 
     if (!state.isCompleted && operationStatus.done) {
-      if (typeof options.fireProgress === "function") {
-        options.fireProgress(state);
-      }
       const pagedIterator = this.listAnalyzeBatchActionsResults(state.operationId!, {
         abortSignal: this.options.abortSignal,
-        tracingOptions: this.options.tracingOptions
+        tracingOptions: this.options.tracingOptions,
+        includeStatistics: this.options.includeStatistics,
+        onResponse: this.options.onResponse,
+        serializerOptions: this.options.serializerOptions
       });
-      state.result = Object.assign(pagedIterator, {
-        statistics: operationStatus.statistics
-      });
+      // Attach stats if the service starts to return them
+      // https://github.com/Azure/azure-sdk-for-js/issues/14139
+      // state.result = Object.assign(pagedIterator, {
+      //   statistics: operationStatus.statistics
+      // });
+      state.result = pagedIterator;
       state.isCompleted = true;
+    }
+
+    if (typeof options.fireProgress === "function") {
+      options.fireProgress(state);
     }
     return this;
   }

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -105,7 +105,7 @@ export interface AnalyzeBatchActionsOperationState
 /**
  * @internal
  */
-function getMetInfoFromResponse(response: AnalyzeJobState): AnalyzeBatchActionsOperationMetadata {
+function getMetaInfoFromResponse(response: AnalyzeJobState): AnalyzeBatchActionsOperationMetadata {
   return {
     createdOn: response.createdDateTime,
     lastModifiedOn: response.lastUpdateDateTime,
@@ -234,11 +234,11 @@ export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperati
           return {
             done: true,
             statistics: response.statistics,
-            operationMetdata: getMetInfoFromResponse(response)
+            operationMetdata: getMetaInfoFromResponse(response)
           };
         }
       }
-      return { done: false, operationMetdata: getMetInfoFromResponse(response) };
+      return { done: false, operationMetdata: getMetaInfoFromResponse(response) };
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -48,6 +48,7 @@ import { textAnalyticsAzureKeyCredentialPolicy } from "./azureKeyCredentialPolic
 import {
   AddParamsToTask,
   addStrEncodingParam,
+  compose,
   handleInvalidDocumentBatch,
   setModelVersionParam,
   setStrEncodingParam,
@@ -908,7 +909,9 @@ export class TextAnalyticsClient {
       analysisOptions: {
         requestOptions: realOptions.requestOptions,
         tracingOptions: realOptions.tracingOptions,
-        abortSignal: realOptions.abortSignal
+        abortSignal: realOptions.abortSignal,
+        onResponse: realOptions.onResponse,
+        serializerOptions: realOptions.serializerOptions
       },
       updateIntervalInMs: realOptions.updateIntervalInMs,
       resumeFrom: realOptions.resumeFrom,
@@ -978,7 +981,9 @@ export class TextAnalyticsClient {
       analysisOptions: {
         requestOptions: realOptions.requestOptions,
         tracingOptions: realOptions.tracingOptions,
-        abortSignal: realOptions.abortSignal
+        abortSignal: realOptions.abortSignal,
+        onResponse: realOptions.onResponse,
+        serializerOptions: realOptions.serializerOptions
       },
       includeStatistics: realOptions.includeStatistics,
       updateIntervalInMs: realOptions.updateIntervalInMs,
@@ -988,13 +993,6 @@ export class TextAnalyticsClient {
     await poller.poll();
     return poller;
   }
-}
-
-/**
- * @internal
- */
-function compose<T1, T2, T3>(fn1: (x: T1) => T2, fn2: (y: T2) => T3): (x: T1) => T3 {
-  return (value: T1) => fn2(fn1(value));
 }
 
 /**
@@ -1072,7 +1070,9 @@ function makeAnalyzeSentimentOptionsModel(
     modelVersion: params.modelVersion,
     requestOptions: params.requestOptions,
     stringIndexType: params.stringIndexType,
-    tracingOptions: params.tracingOptions
+    tracingOptions: params.tracingOptions,
+    onResponse: params.onResponse,
+    serializerOptions: params.serializerOptions
   };
 }
 
@@ -1092,6 +1092,8 @@ function makePiiEntitiesOptionsModel(
     requestOptions: params.requestOptions,
     stringIndexType: params.stringIndexType,
     tracingOptions: params.tracingOptions,
-    piiCategories: params.categoriesFilter
+    piiCategories: params.categoriesFilter,
+    onResponse: params.onResponse,
+    serializerOptions: params.serializerOptions
   };
 }

--- a/sdk/textanalytics/ai-text-analytics/src/util.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/util.ts
@@ -223,3 +223,10 @@ export function handleInvalidDocumentBatch(error: unknown): any {
 export function delay(timeInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(() => resolve(), timeInMs));
 }
+
+/**
+ * @internal
+ */
+export function compose<T1, T2, T3>(fn1: (x: T1) => T2, fn2: (y: T2) => T3): (x: T1) => T3 {
+  return (value: T1) => fn2(fn1(value));
+}

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1465,10 +1465,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         }
       });
 
-      /**
-       * The service does not returns statistics
-       */
-      it.skip("statistics", async function() {
+      it("statistics", async function() {
         const docs = [
           { id: "56", text: ":)" },
           { id: "0", text: ":(" },
@@ -1489,11 +1486,29 @@ describe("[AAD] TextAnalyticsClient", function() {
             updateIntervalInMs: pollingInterval
           }
         );
-        const result = await poller.pollUntilDone();
-        assert.equal(result.statistics?.documentCount, 5);
-        assert.equal(result.statistics?.transactionCount, 4);
-        assert.equal(result.statistics?.validDocumentCount, 4);
-        assert.equal(result.statistics?.erroneousDocumentCount, 1);
+        const response = await poller.pollUntilDone();
+        const results = (await response.next()).value;
+        const recognizeEntitiesResults = results.recognizeEntitiesResults[0];
+        if (!recognizeEntitiesResults.error) {
+          assert.equal(recognizeEntitiesResults.results.statistics?.documentCount, 5);
+          assert.equal(recognizeEntitiesResults.results.statistics?.transactionCount, 4);
+          assert.equal(recognizeEntitiesResults.results.statistics?.validDocumentCount, 4);
+          assert.equal(recognizeEntitiesResults.results.statistics?.erroneousDocumentCount, 1);
+        }
+        const recognizePiiEntitiesResults = results.recognizePiiEntitiesResults[0];
+        if (!recognizePiiEntitiesResults.error) {
+          assert.equal(recognizePiiEntitiesResults.results.statistics?.documentCount, 5);
+          assert.equal(recognizePiiEntitiesResults.results.statistics?.transactionCount, 4);
+          assert.equal(recognizePiiEntitiesResults.results.statistics?.validDocumentCount, 4);
+          assert.equal(recognizePiiEntitiesResults.results.statistics?.erroneousDocumentCount, 1);
+        }
+        const extractKeyPhrasesResults = results.extractKeyPhrasesResults[0];
+        if (!extractKeyPhrasesResults.error) {
+          assert.equal(extractKeyPhrasesResults.results.statistics?.documentCount, 5);
+          assert.equal(extractKeyPhrasesResults.results.statistics?.transactionCount, 4);
+          assert.equal(extractKeyPhrasesResults.results.statistics?.validDocumentCount, 4);
+          assert.equal(extractKeyPhrasesResults.results.statistics?.erroneousDocumentCount, 1);
+        }
       });
 
       it("whole batch language hint", async function() {
@@ -1799,20 +1814,14 @@ describe("[AAD] TextAnalyticsClient", function() {
             updateIntervalInMs: pollingInterval
           }
         );
-        poller.onProgress(() => {
-          assert.ok(poller.getOperationState().createdOn, "createdOn is undefined!");
-          assert.ok(poller.getOperationState().expiresOn, "expiresOn is undefined!");
-          assert.ok(poller.getOperationState().lastModifiedOn, "lastModifiedOn is undefined!");
-          assert.ok(poller.getOperationState().status, "status is undefined!");
-          assert.ok(
-            poller.getOperationState().actionsSucceededCount,
-            "actionsSucceededCount is undefined!"
-          );
-          assert.equal(poller.getOperationState().actionsFailedCount, 0);
-          assert.isDefined(
-            poller.getOperationState().actionsInProgressCount,
-            "actionsInProgressCount is undefined!"
-          );
+        poller.onProgress((state) => {
+          assert.ok(state.createdOn, "createdOn is undefined!");
+          assert.ok(state.expiresOn, "expiresOn is undefined!");
+          assert.ok(state.lastModifiedOn, "lastModifiedOn is undefined!");
+          assert.ok(state.status, "status is undefined!");
+          assert.isDefined(state.actionsSucceededCount, "actionsSucceededCount is undefined!");
+          assert.equal(state.actionsFailedCount, 0);
+          assert.isDefined(state.actionsInProgressCount, "actionsInProgressCount is undefined!");
         });
         const result = await poller.pollUntilDone();
         assert.ok(result);


### PR DESCRIPTION
This PR fixes several issues:

- when the user asks for statistics, they did not get it because the request parameter did not make it to the status endpoint. This PR fixes this issue by sending the `includeStatistics` parameter to the status endpoint
- removes statistics from the top-level response because the service does not return it. See issue:https://github.com/Azure/azure-sdk-for-js/issues/14139
- the LRO's onProgress function was broken because the input callback was only applied when the LRO finished which defeats the purpose
- the new core lib parameters (e.g. `onResponse`) were not being handled correctly
- updates the samples with the includeStatistics parameter