### PR TITLE
[Text Analytics] Disable pii categories for analyze

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -428,7 +428,6 @@ export type RecognizePiiEntitiesAction = {
     domain?: PiiEntityDomainType;
     modelVersion?: string;
     stringIndexType?: StringIndexType;
-    categoriesFilter?: PiiEntityCategory[];
 };
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -171,7 +171,7 @@ export interface EntityAssertion {
 export type EntityAssociation = "subject" | "other";
 
 // @public
-export type EntityCertainty = "Positive" | "PositivePossible" | "NeutralPossible" | "NegativePossible" | "Negative";
+export type EntityCertainty = "positive" | "positivePossible" | "neutralPossible" | "negativePossible" | "negative";
 
 // @public
 export type EntityConditionality = "Hypothetical" | "Conditional";

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -1101,11 +1101,11 @@ export type State =
 export type Conditionality = "Hypothetical" | "Conditional";
 /** Defines values for Certainty. */
 export type Certainty =
-  | "Positive"
-  | "PositivePossible"
-  | "NeutralPossible"
-  | "NegativePossible"
-  | "Negative";
+  | "positive"
+  | "positivePossible"
+  | "neutralPossible"
+  | "negativePossible"
+  | "negative";
 /** Defines values for Association. */
 export type Association = "subject" | "other";
 /** Defines values for DocumentSentimentLabel. */

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -228,10 +228,6 @@ export type RecognizePiiEntitiesAction = {
    * The default is the JavaScript's default which is "Utf16CodeUnit".
    */
   stringIndexType?: StringIndexType;
-  /**
-   * Specifies the list of Pii categories to return.
-   */
-  categoriesFilter?: PiiCategory[];
 };
 
 /**


### PR DESCRIPTION
Because this parameter is not currently supported by the service in analyze and we as the crew decided to disable it. It also fixes the casing for the certainty enum to match what we get from the service.