### PR TITLE
[KeyVault] - enable managed HSM tests

### DIFF
--- a/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_once_authenticated_new_requests_should_not_authenticate_again.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/challenge_based_authentication_tests/recording_once_authenticated_new_requests_should_not_authenticate_again.json
@@ -1,8 +1,8 @@
 {
  "recordings": [
   {
-   "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/create",
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/keys",
    "query": {
     "api-version": "7.2"
    },
@@ -13,17 +13,18 @@
     "cache-control": "no-cache",
     "content-length": "87",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:57 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:29 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "401",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "aec46f45-8261-45e9-aa3f-1b0e1b08cb49",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "82d0a54e-9674-448d-9910-8573f68fc0f8",
+    "x-ms-keyvault-service-version": "1.2.205.0",
+    "x-ms-request-id": "76254a5e-d96e-4968-bd8d-624c82006245",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -38,478 +39,122 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:29 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.5 - SCUS ProdSlices",
-    "x-ms-request-id": "4f5c7d32-8c97-4a38-a6e1-22fea85dff00"
+    "x-ms-ests-server": "2.1.11562.6 - SCUS ProdSlices",
+    "x-ms-request-id": "983b770d-a7ab-45bc-8f57-861ae9955c00"
    }
   },
   {
-   "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/create",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": "{\"kty\":\"RSA\"}",
-   "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/71dae7eacb804c7d91dbf4e91063ab91\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"3-2TAJLrMrdO4By2T1EEIDrbDpcOqHkgqH7zOIIvyB5XrXa5cLq2fDxLNez3dn0OsoxHUzXhmA0vXk3ZBdrMlOwchRGhcGd5JgHwLehrCUVGneYHcYUNPSGX8WY9t2IRhm7gH9J4V9UoZ4NwMhqO5qxdLe7BDsJdI-IAo_0eJBZmMhJEbYu41uLXC13cJgKNFa1x_Odp2Qa9_F6EFh_a3iobNrmPpGhr-yN-5l7V0G1WKgkWElO_VEMNSNEzuBvLy58zSS-JMUqsjHLq3QLK_zlmbGqk2vG9CtNZDS8DJW6p7eP7rmTxF_10MQpA89kbwZJH-TxBUuOoeGcFLxnyyQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499718,\"updated\":1613499718,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "768",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "580ee72b-854d-4667-ae5c-d279193e912e",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "POST",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/create",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": "{\"kty\":\"RSA\"}",
-   "status": 200,
-   "response": "{\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/d6d5890096c842b7a3cb092dedf43f61\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rT30G5jnUvbjlisQ-5ik4dJhVOD4y19qOnzxMjHnc1gxEtauQDEgjm54iZ0H9uib4ZoUgx4x6KViUeqTb9-l6ym1xIaP9FGRbQwKeVa7YOt2xs6lG5QekY5KKBE6rmzZuucZl7S0HaeghEsF5iwvOqsSSnrltLbFLC1vyJcXr4AxYhoFLMHR5s04bYni0JraVCcYDx3IDs_FfIWwaHcblFA_ZmDhI9TTQfC1a8V2sTEBRR9V9vuniq8lEpNC8gFN78IcBI3zKXW9UXLEX_DAROSyWRz3qypHXdt7lF2G3Qi1MuvK9nKCP2rpz9yya8hm2i8JHnLj1CUaAnPahFcSlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499719,\"updated\":1613499719,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "768",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "200",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "be5238dd-35cc-41f5-a3d2-b549263e1bfa",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/keys",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\",\"deletedDate\":1613499719,\"scheduledPurgeDate\":1614104519,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/71dae7eacb804c7d91dbf4e91063ab91\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"3-2TAJLrMrdO4By2T1EEIDrbDpcOqHkgqH7zOIIvyB5XrXa5cLq2fDxLNez3dn0OsoxHUzXhmA0vXk3ZBdrMlOwchRGhcGd5JgHwLehrCUVGneYHcYUNPSGX8WY9t2IRhm7gH9J4V9UoZ4NwMhqO5qxdLe7BDsJdI-IAo_0eJBZmMhJEbYu41uLXC13cJgKNFa1x_Odp2Qa9_F6EFh_a3iobNrmPpGhr-yN-5l7V0G1WKgkWElO_VEMNSNEzuBvLy58zSS-JMUqsjHLq3QLK_zlmbGqk2vG9CtNZDS8DJW6p7eP7rmTxF_10MQpA89kbwZJH-TxBUuOoeGcFLxnyyQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499718,\"updated\":1613499718,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"value\":[],\"nextLink\":null}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "981",
+    "content-length": "28",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:29 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "aec46f45-8261-45e9-aa3f-1b0e1b08cb49",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "4b504c65-701a-44b9-9d41-7d2c17cc0acd",
+    "x-ms-keyvault-service-version": "1.2.205.0",
+    "x-ms-request-id": "375e0796-1cae-4534-9e7c-bda9ff2deb93",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "057a8ae5-cd73-4154-a132-ff15cc586236",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:21:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "61609ed7-adfa-4eae-a6e5-7c51c61c3fd9",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:01 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "191d588c-215f-41b7-a942-42f1a063e5f2",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:03 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "4c74518a-4e8a-4c37-9d8e-b92ac76e1b7c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:05 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "f7e2f102-db7d-4634-9551-da69465e0324",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:07 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "2100f245-1b81-4350-b590-a37e22d0b40d",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
+   "url": "https://keyvault_name.vault.azure.net/keys",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0\",\"deletedDate\":1613499719,\"scheduledPurgeDate\":1614104519,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/71dae7eacb804c7d91dbf4e91063ab91\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"3-2TAJLrMrdO4By2T1EEIDrbDpcOqHkgqH7zOIIvyB5XrXa5cLq2fDxLNez3dn0OsoxHUzXhmA0vXk3ZBdrMlOwchRGhcGd5JgHwLehrCUVGneYHcYUNPSGX8WY9t2IRhm7gH9J4V9UoZ4NwMhqO5qxdLe7BDsJdI-IAo_0eJBZmMhJEbYu41uLXC13cJgKNFa1x_Odp2Qa9_F6EFh_a3iobNrmPpGhr-yN-5l7V0G1WKgkWElO_VEMNSNEzuBvLy58zSS-JMUqsjHLq3QLK_zlmbGqk2vG9CtNZDS8DJW6p7eP7rmTxF_10MQpA89kbwZJH-TxBUuOoeGcFLxnyyQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499718,\"updated\":1613499718,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"value\":[],\"nextLink\":null}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "981",
+    "content-length": "28",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:09 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:29 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "6dcbc5ea-d6ef-4aea-b140-e6b0087b3d6f",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "fbf6e103-0a8d-4217-9994-f198739e165d",
+    "x-ms-keyvault-service-version": "1.2.205.0",
+    "x-ms-request-id": "93c939f9-7e73-43c9-a454-7d9a895f4dbe",
     "x-powered-by": "ASP.NET"
    }
   },
   {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 204,
-   "response": "",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "date": "Tue, 16 Feb 2021 18:22:09 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "204",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "ed135039-2bf5-4333-b5b9-511110f08393",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/keys",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\",\"deletedDate\":1613499729,\"scheduledPurgeDate\":1614104529,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/d6d5890096c842b7a3cb092dedf43f61\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rT30G5jnUvbjlisQ-5ik4dJhVOD4y19qOnzxMjHnc1gxEtauQDEgjm54iZ0H9uib4ZoUgx4x6KViUeqTb9-l6ym1xIaP9FGRbQwKeVa7YOt2xs6lG5QekY5KKBE6rmzZuucZl7S0HaeghEsF5iwvOqsSSnrltLbFLC1vyJcXr4AxYhoFLMHR5s04bYni0JraVCcYDx3IDs_FfIWwaHcblFA_ZmDhI9TTQfC1a8V2sTEBRR9V9vuniq8lEpNC8gFN78IcBI3zKXW9UXLEX_DAROSyWRz3qypHXdt7lF2G3Qi1MuvK9nKCP2rpz9yya8hm2i8JHnLj1CUaAnPahFcSlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499719,\"updated\":1613499719,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"value\":[],\"nextLink\":null}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "981",
+    "content-length": "28",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:09 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:29 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "88de3910-e337-46f5-a26d-d17ddb167203",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "03615fe1-75b6-4289-87a0-c9865900f380",
+    "x-ms-keyvault-service-version": "1.2.205.0",
+    "x-ms-request-id": "e14b8eeb-30fd-4774-bbb4-28412d2e1574",
     "x-powered-by": "ASP.NET"
    }
   },
   {
    "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:09 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "ba583bc7-c5b8-4535-9b87-320553217b99",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:09 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "0a2f7443-dd50-43cc-9652-4023200bd1fe",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:11 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "7652881d-1255-48ee-97f5-25f4cda86802",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"KeyNotFound\",\"message\":\"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "162",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:13 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "3124e54e-174a-4850-ba08-6c8df9e0c797",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
+   "url": "https://keyvault_name.vault.azure.net/keys",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1\",\"deletedDate\":1613499729,\"scheduledPurgeDate\":1614104529,\"key\":{\"kid\":\"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/d6d5890096c842b7a3cb092dedf43f61\",\"kty\":\"RSA\",\"key_ops\":[\"encrypt\",\"decrypt\",\"sign\",\"verify\",\"wrapKey\",\"unwrapKey\"],\"n\":\"rT30G5jnUvbjlisQ-5ik4dJhVOD4y19qOnzxMjHnc1gxEtauQDEgjm54iZ0H9uib4ZoUgx4x6KViUeqTb9-l6ym1xIaP9FGRbQwKeVa7YOt2xs6lG5QekY5KKBE6rmzZuucZl7S0HaeghEsF5iwvOqsSSnrltLbFLC1vyJcXr4AxYhoFLMHR5s04bYni0JraVCcYDx3IDs_FfIWwaHcblFA_ZmDhI9TTQfC1a8V2sTEBRR9V9vuniq8lEpNC8gFN78IcBI3zKXW9UXLEX_DAROSyWRz3qypHXdt7lF2G3Qi1MuvK9nKCP2rpz9yya8hm2i8JHnLj1CUaAnPahFcSlQ\",\"e\":\"AQAB\"},\"attributes\":{\"enabled\":true,\"created\":1613499719,\"updated\":1613499719,\"recoveryLevel\":\"CustomizedRecoverable+Purgeable\",\"recoverableDays\":7}}",
+   "response": "{\"value\":[],\"nextLink\":null}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "981",
+    "content-length": "28",
     "content-type": "application/json; charset=utf-8",
-    "date": "Tue, 16 Feb 2021 18:22:15 GMT",
+    "date": "Thu, 11 Mar 2021 23:28:30 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "7f978224-70e3-42e5-adf0-8ffe54d7cf8a",
     "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "6ad206c9-8645-47cd-ad98-3b541f09870c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1",
-   "query": {
-    "api-version": "7.2"
-   },
-   "requestBody": null,
-   "status": 204,
-   "response": "",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "date": "Tue, 16 Feb 2021 18:22:15 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "status": "204",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus2",
-    "x-ms-keyvault-service-version": "1.2.164.2",
-    "x-ms-request-id": "960ddaf2-625e-4c8d-882e-791979021b4f",
+    "x-ms-keyvault-service-version": "1.2.205.0",
+    "x-ms-request-id": "224e4a05-4476-4188-80f9-ec83c2fda521",
     "x-powered-by": "ASP.NET"
    }
   }
@@ -518,5 +163,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "fe0ec113d9766925d232a4e3a9c7ddb9"
+ "hash": "49782f11ed6c6b9d31702ea00ac39ac8"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/create",
    "query": {
     "api-version": "7.2"
    },
@@ -18,8 +18,8 @@
     "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
     "x-content-type-options": "nosniff",
     "x-frame-options": "SAMEORIGIN",
-    "x-ms-request-id": "17149da4-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "1"
+    "x-ms-request-id": "c99793d2-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "0"
    }
   },
   {
@@ -33,29 +33,29 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1322",
     "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 20 Feb 2021 00:39:28 GMT",
+    "date": "Sat, 06 Mar 2021 01:10:48 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.7 - SCUS ProdSlices",
-    "x-ms-request-id": "107458da-d83a-485c-b7a6-d39642c01000"
+    "x-ms-ests-server": "2.1.11530.15 - NCUS ProdSlices",
+    "x-ms-request-id": "8b7ef9c1-c048-4778-835b-891d32307300"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/create",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"}}",
+   "response": "{\"attributes\":{\"created\":1614993049,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614993049},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"kty\":\"oct-HSM\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "361",
+    "content-length": "362",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -63,13 +63,13 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "173f699e-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "175"
+    "x-ms-request-id": "c9e07516-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "169"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac",
    "query": {
     "api-version": "7.2"
    },
@@ -86,7 +86,7 @@
     "x-content-type-options": "nosniff",
     "x-frame-options": "SAMEORIGIN",
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
-    "x-ms-request-id": "177396b0-7314-11eb-89bd-0242ac120006",
+    "x-ms-request-id": "ca159098-7e18-11eb-9e17-0242ac120009",
     "x-ms-server-latency": "0"
    }
   },
@@ -101,29 +101,29 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1322",
     "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 20 Feb 2021 00:39:29 GMT",
+    "date": "Sat, 06 Mar 2021 01:10:49 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11513.13 - WUS2 ProdSlices",
-    "x-ms-request-id": "6b1260e4-4839-4b05-8fc6-3ff760210900"
+    "x-ms-ests-server": "2.1.11530.17 - WUS2 ProdSlices",
+    "x-ms-request-id": "4c5e57ef-b400-4ddc-b98c-cb33f1553500"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"}}",
+   "response": "{\"attributes\":{\"created\":1614993049,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614993049},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"kty\":\"oct-HSM\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "361",
+    "content-length": "362",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -132,22 +132,22 @@
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1796c4aa-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "113"
+    "x-ms-request-id": "ca458b18-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "70"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2/encrypt",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac/encrypt",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
    "status": 200,
-   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"value\":\"77mhtBNfzpSkpdDyF-ubxDWQBLg3-afmZtVwamFq0Re7ueGnX0ftqcpAPhXRvejJ\"}",
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"value\":\"362q0cscUvY5tx-8FLGxaZzk-9PJwVsicp2_7bj-adBo-jQwJSz3JdD-feGalNJs\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "225",
+    "content-length": "226",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -155,22 +155,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "17c01c7e-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "1"
+    "x-ms-request-id": "ca69be98-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "0"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2/decrypt",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac/decrypt",
    "query": {
     "api-version": "7.2"
    },
-   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"77mhtBNfzpSkpdDyF-ubxDWQBLg3-afmZtVwamFq0Re7ueGnX0ftqcpAPhXRvejJ\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "requestBody": "{\"alg\":\"A256CBCPAD\",\"value\":\"362q0cscUvY5tx-8FLGxaZzk-9PJwVsicp2_7bj-adBo-jQwJSz3JdD-feGalNJs\",\"iv\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
    "status": 200,
-   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
+   "response": "{\"alg\":\"A256CBCPAD\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1DQkM\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "208",
+    "content-length": "209",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -178,22 +178,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "17d87e40-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "1"
+    "x-ms-request-id": "ca8254e4-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "0"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"deletedDate\":1613781570,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557570}",
+   "response": "{\"attributes\":{\"created\":1614993049,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614993049},\"deletedDate\":1614993050,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1622769050}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "529",
+    "content-length": "531",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -201,22 +201,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "17f1ced6-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "76"
+    "x-ms-request-id": "ca9b52d2-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "78"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781569,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781569},\"deletedDate\":1613781570,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/8b8bfaaf77d20d3d855070e0ef4baca2\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557570}",
+   "response": "{\"attributes\":{\"created\":1614993049,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614993049},\"deletedDate\":1614993050,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/a4ba9daafd724f8c813a89e2f7a7dcac\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1622769050}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "529",
+    "content-length": "531",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -225,13 +225,13 @@
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1815fb6c-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "31"
+    "x-ms-request-id": "cabfb460-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "29"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
@@ -248,8 +248,8 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "18341714-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "112"
+    "x-ms-request-id": "cadc868a-7e18-11eb-9e17-0242ac120009",
+    "x-ms-server-latency": "639"
    }
   }
  ],
@@ -257,5 +257,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "96eafd8e16ef41103b66d5111d0bbd12"
+ "hash": "54c7437a47c8042f9b445958e5ea0591"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/create",
    "query": {
     "api-version": "7.2"
    },
@@ -18,7 +18,7 @@
     "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
     "x-content-type-options": "nosniff",
     "x-frame-options": "SAMEORIGIN",
-    "x-ms-request-id": "15c17634-7314-11eb-89bd-0242ac120006",
+    "x-ms-request-id": "3be9ab56-7e18-11eb-aa5b-0242ac120009",
     "x-ms-server-latency": "0"
    }
   },
@@ -33,29 +33,29 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1322",
     "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 20 Feb 2021 00:39:26 GMT",
+    "date": "Sat, 06 Mar 2021 01:06:50 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.7 - NCUS ProdSlices",
-    "x-ms-request-id": "048c32e5-2f7f-44ca-b0dd-c9d700af3900"
+    "x-ms-ests-server": "2.1.11530.15 - EUS ProdSlices",
+    "x-ms-request-id": "f17d22a3-6a56-44ef-b774-4760d3bf6a00"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/create",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"kty\":\"AES\",\"key_size\":256,\"attributes\":{}}",
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"}}",
+   "response": "{\"attributes\":{\"created\":1614992811,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992811},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"kty\":\"oct-HSM\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "360",
+    "content-length": "362",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -63,13 +63,13 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "15f1f390-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "163"
+    "x-ms-request-id": "3c18a6f4-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "181"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5",
    "query": {
     "api-version": "7.2"
    },
@@ -86,8 +86,8 @@
     "x-content-type-options": "nosniff",
     "x-frame-options": "SAMEORIGIN",
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
-    "x-ms-request-id": "1623bf92-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "0"
+    "x-ms-request-id": "3c4c8c12-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "1"
    }
   },
   {
@@ -101,29 +101,29 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1322",
     "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 20 Feb 2021 00:39:26 GMT",
+    "date": "Sat, 06 Mar 2021 01:06:51 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11513.13 - WUS2 ProdSlices",
-    "x-ms-request-id": "9db08715-d946-4df2-b2b7-130ac27c0900"
+    "x-ms-ests-server": "2.1.11530.17 - WUS2 ProdSlices",
+    "x-ms-request-id": "b2e27252-8194-4159-8782-4dd8a6df3700"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"}}",
+   "response": "{\"attributes\":{\"created\":1614992811,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992811},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"encrypt\",\"decrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"kty\":\"oct-HSM\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "360",
+    "content-length": "362",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -132,22 +132,22 @@
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1645b908-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "113"
+    "x-ms-request-id": "3c6f22cc-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "72"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220/encrypt",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5/encrypt",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
    "status": 200,
-   "response": "{\"alg\":\"A256GCM\",\"iv\":\"1iin7lGfm3rPJ6qkAAAAAA\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"tag\":\"AMDEeHbdAX8JqfrSGISGWw\",\"value\":\"tINXpDH2Z9yu_7AoOXr5TQBJsQYTAnlumGP5kX2mB2ciQFM\"}",
+   "response": "{\"alg\":\"A256GCM\",\"iv\":\"Hyx_nUvUnPW3tAMyAAAAAA\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"tag\":\"8ouUOj01rZU8t86ZMX67SA\",\"value\":\"6gk8qAAhBM5Fe8akdGV7n34MwEnwyJW298CLi511d316iFk\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "265",
+    "content-length": "267",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -155,22 +155,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1670d44e-7314-11eb-89bd-0242ac120006",
+    "x-ms-request-id": "3c92892e-7e18-11eb-aa5b-0242ac120009",
     "x-ms-server-latency": "1"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220/decrypt",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5/decrypt",
    "query": {
     "api-version": "7.2"
    },
-   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"tINXpDH2Z9yu_7AoOXr5TQBJsQYTAnlumGP5kX2mB2ciQFM\",\"iv\":\"1iin7lGfm3rPJ6qkAAAAAA\",\"tag\":\"AMDEeHbdAX8JqfrSGISGWw\"}",
+   "requestBody": "{\"alg\":\"A256GCM\",\"value\":\"6gk8qAAhBM5Fe8akdGV7n34MwEnwyJW298CLi511d316iFk\",\"iv\":\"Hyx_nUvUnPW3tAMyAAAAAA\",\"tag\":\"8ouUOj01rZU8t86ZMX67SA\"}",
    "status": 200,
-   "response": "{\"alg\":\"A256GCM\",\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
+   "response": "{\"alg\":\"A256GCM\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"value\":\"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "204",
+    "content-length": "206",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -178,22 +178,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "16897e54-7314-11eb-89bd-0242ac120006",
+    "x-ms-request-id": "3cac2550-7e18-11eb-aa5b-0242ac120009",
     "x-ms-server-latency": "0"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/keys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"deletedDate\":1613781568,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557568}",
+   "response": "{\"attributes\":{\"created\":1614992811,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992811},\"deletedDate\":1614992812,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1622768812}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "527",
+    "content-length": "531",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -201,22 +201,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "16a32714-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "79"
+    "x-ms-request-id": "3cc4b8d6-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "81"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613781566,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613781566},\"deletedDate\":1613781568,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/ab0d0a6c32364aefac030acd268e8220\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1621557568}",
+   "response": "{\"attributes\":{\"created\":1614992811,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992811},\"deletedDate\":1614992812,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/8b0c69ca43f207c8356bfeff9c767de5\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test\",\"scheduledPurgeDate\":1622768812}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "527",
+    "content-length": "531",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -225,13 +225,13 @@
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "16c87726-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "38"
+    "x-ms-request-id": "3cea6dd8-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "29"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test",
    "query": {
     "api-version": "7.2"
    },
@@ -248,8 +248,8 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "16e7403e-7314-11eb-89bd-0242ac120006",
-    "x-ms-server-latency": "112"
+    "x-ms-request-id": "3d07817a-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "115"
    }
   }
  ],
@@ -257,5 +257,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "cd354e57cc232aa1217b1b2b448d3409"
+ "hash": "58d15ade616e6084de434f2e0abb5e09"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.json
+++ b/sdk/keyvault/keyvault-keys/recordings/browsers/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
    "query": {
     "api-version": "7.2"
    },
@@ -18,7 +18,7 @@
     "www-authenticate": "Bearer authorization=\"https://login.microsoftonline.com/azure_tenant_id\", resource=\"https://managedhsm.azure.net\"",
     "x-content-type-options": "nosniff",
     "x-frame-options": "SAMEORIGIN",
-    "x-ms-request-id": "1dfe6b3c-731d-11eb-a34d-0242ac120009",
+    "x-ms-request-id": "3af8a8aa-7e18-11eb-aa5b-0242ac120009",
     "x-ms-server-latency": "1"
    }
   },
@@ -33,29 +33,29 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1322",
     "content-type": "application/json; charset=utf-8",
-    "date": "Sat, 20 Feb 2021 01:44:05 GMT",
+    "date": "Sat, 06 Mar 2021 01:06:49 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11496.7 - EUS ProdSlices",
-    "x-ms-request-id": "dfe35c80-8b71-4758-96c9-7d29db4a3500"
+    "x-ms-ests-server": "2.1.11530.15 - SCUS ProdSlices",
+    "x-ms-request-id": "6149285e-f13c-45d7-bc1d-c7d4773d7300"
    }
   },
   {
    "method": "POST",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": "{\"kty\":\"oct-HSM\",\"attributes\":{}}",
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"}}",
+   "response": "{\"attributes\":{\"created\":1614992810,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992810},\"key\":{\"key_ops\":[\"wrapKey\",\"unwrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/8d113bde68a80a219e18ec19552fcd01\",\"kty\":\"oct-HSM\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "377",
+    "content-length": "380",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -63,22 +63,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1e46dbd8-731d-11eb-a34d-0242ac120009",
-    "x-ms-server-latency": "182"
+    "x-ms-request-id": "3b296b48-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "276"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "url": "https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"deletedDate\":1613785446,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1621561446}",
+   "response": "{\"attributes\":{\"created\":1614992810,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992810},\"deletedDate\":1614992810,\"key\":{\"key_ops\":[\"unwrapKey\",\"wrapKey\",\"decrypt\",\"encrypt\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/8d113bde68a80a219e18ec19552fcd01\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1622768810}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "561",
+    "content-length": "567",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -86,22 +86,22 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1e7b4f30-731d-11eb-a34d-0242ac120009",
-    "x-ms-server-latency": "168"
+    "x-ms-request-id": "3b6f66ac-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "141"
    }
   },
   {
    "method": "GET",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
    "query": {
     "api-version": "7.2"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"attributes\":{\"created\":1613785446,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1613785446},\"deletedDate\":1613785446,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/b95226990b9600fb8472a9bf98215bed\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1621561446}",
+   "response": "{\"attributes\":{\"created\":1614992810,\"enabled\":true,\"exportable\":false,\"recoverableDays\":90,\"recoveryLevel\":\"Recoverable+Purgeable\",\"updated\":1614992810},\"deletedDate\":1614992810,\"key\":{\"key_ops\":[\"encrypt\",\"decrypt\",\"unwrapKey\",\"wrapKey\"],\"kid\":\"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/8d113bde68a80a219e18ec19552fcd01\",\"kty\":\"oct-HSM\"},\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-\",\"scheduledPurgeDate\":1622768810}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "561",
+    "content-length": "567",
     "content-security-policy": "default-src 'self'",
     "content-type": "application/json; charset=utf-8",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
@@ -110,13 +110,13 @@
     "x-ms-build-version": "1.0.20210204-1-c9f88df4-develop",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1ead6420-731d-11eb-a34d-0242ac120009",
-    "x-ms-server-latency": "37"
+    "x-ms-request-id": "3b9d4f54-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "39"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
+   "url": "https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-",
    "query": {
     "api-version": "7.2"
    },
@@ -133,8 +133,8 @@
     "x-frame-options": "SAMEORIGIN",
     "x-ms-keyvault-network-info": "addr=50.35.231.105",
     "x-ms-keyvault-region": "westeurope",
-    "x-ms-request-id": "1ecb8658-731d-11eb-a34d-0242ac120009",
-    "x-ms-server-latency": "132"
+    "x-ms-request-id": "3bbd0f9c-7e18-11eb-aa5b-0242ac120009",
+    "x-ms-server-latency": "110"
    }
   }
  ],
@@ -142,5 +142,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "96a57ba357ac2a222e1d4dc23843e857"
+ "hash": "d144dd223975763c7dd0514b08720651"
 }

--- a/sdk/keyvault/keyvault-keys/recordings/node/challenge_based_authentication_tests/recording_once_authenticated_new_requests_should_not_authenticate_again.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/challenge_based_authentication_tests/recording_once_authenticated_new_requests_should_not_authenticate_again.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "cc9dc9671c9872d6507286478f379f46";
+module.exports.hash = "04ade627d0e7596f1e0ee5720e5f973b";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/create')
+  .get('/keys')
   .query(true)
   .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
   'Cache-Control',
@@ -22,10 +22,12 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
   'x-ms-keyvault-region',
   'westus2',
+  'x-ms-client-request-id',
+  '0cbf6528-fb42-4b64-8857-9e0bdf91a169',
   'x-ms-request-id',
-  '7cfb77f5-4730-4b9b-8ae7-70989fc65ad1',
+  'c90a5e18-df84-47bd-9b2d-3230c40855e0',
   'x-ms-keyvault-service-version',
-  '1.2.164.2',
+  '1.2.205.0',
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
@@ -35,7 +37,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:09:44 GMT'
+  'Thu, 11 Mar 2021 23:28:23 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -45,6 +47,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1315',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -56,25 +60,23 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '2bcf632e-9df3-461c-b760-3f052faa3400',
+  '5ece5c9c-7808-4a51-848d-32c1d1e14f00',
   'x-ms-ests-server',
-  '2.1.11496.6 - WUS2 ProdSlices',
+  '2.1.11562.6 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AlYh5w5_onJDnZLEqg70g4sA4qsDAgAAAFQBvtcOAAAA; expires=Thu, 18-Mar-2021 18:09:45 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ArtL8ztzJfZAjUfEnDX6LlPJFDv4AQAAAJee3NcOAAAA; expires=Sat, 10-Apr-2021 23:28:24 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 16 Feb 2021 18:09:44 GMT',
-  'Content-Length',
-  '1315'
+  'Thu, 11 Mar 2021 23:28:24 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/create', {"kty":"RSA"})
+  .get('/keys')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/6f81b214434647579a47c82ab81a8050","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1tCNWtJCux-VcMTj-LDI3rKHgZOiwEVP3S_YpL0mc96H0np5zqS80KCFncz7ed9jJ9MORrg99di664HAEPSJ_hXJpR_kFWYnzzt21imykkhABimd1PyZBklpOnfMEtHJlvVFU5dxhjaES-ZjQ6rAgUDKp0YRI1McptXcS2LUNX2wOprSgUQlA_X2PlUbUa-z8pGN2DBbtv67li1sVUdnzmkySAmnL9Q3vLBaWlDNT84Ds_y1pJGLgGGjHwAJIj5JNglsWqHR6Jv7tYo7O4WogdroZtP52BI0hCcWNpOvK_cZxvNUwbsLYzV1ryNKi4le6KgQ4S1ZDjcmVRrj86vaIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"value":[],"nextLink":null}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -85,10 +87,12 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   '-1',
   'x-ms-keyvault-region',
   'westus2',
+  'x-ms-client-request-id',
+  '0cbf6528-fb42-4b64-8857-9e0bdf91a169',
   'x-ms-request-id',
-  '4ab3820c-4047-4d1b-8e6c-4347fd81e1f7',
+  'd2186da4-7aa1-4699-80d0-78acb7b7a862',
   'x-ms-keyvault-service-version',
-  '1.2.164.2',
+  '1.2.205.0',
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
@@ -98,15 +102,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:09:44 GMT',
+  'Thu, 11 Mar 2021 23:28:23 GMT',
   'Content-Length',
-  '770'
+  '28'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/create', {"kty":"RSA"})
+  .get('/keys')
   .query(true)
-  .reply(200, {"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/3a2acf59d1104df0a51fecd8a56a3dba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xRITp0fXR0k7SB_Qo1-_wefVrTViG_LZL0QhZHANFLWnRhFBa1oeZqDEj0PaaLTiYQT5X0njGPrkTltP7Tw51XHP7DE4t3VeLOq7V089N1lO9ZdU_eMhCYhMWS3xgEPiK93U6nfF9yUnolqr-zKA-seyzLhA79LxB2fZ9iwb2uptM-Zt1C5dcY-9whjUSkHhkh7Ngwo7rsgqkP7dKF66WSJ_h-ntL3yrMefqIChg7-Xjie5e6cJ-8Tau2GW_JbGzjcurj5x0ABdAEWkNTKUl_cSRUlONdVuo0huDjNd0Yn4lWyodHx85PYan3yWZZV5Jdk_OkhqyjYXLkl6IV6Vg-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"value":[],"nextLink":null}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -117,10 +121,12 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   '-1',
   'x-ms-keyvault-region',
   'westus2',
+  'x-ms-client-request-id',
+  'ab18af16-c6a6-4bbf-9f67-3d5aa82017d9',
   'x-ms-request-id',
-  '139ac83d-ce6c-4b85-8734-6cdd1299f336',
+  'dd964852-ad02-45dd-86e5-3fafb00c820c',
   'x-ms-keyvault-service-version',
-  '1.2.164.2',
+  '1.2.205.0',
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
@@ -130,15 +136,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:09:44 GMT',
+  'Thu, 11 Mar 2021 23:28:23 GMT',
   'Content-Length',
-  '770'
+  '28'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
+  .get('/keys')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0","deletedDate":1613498985,"scheduledPurgeDate":1614103785,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/6f81b214434647579a47c82ab81a8050","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1tCNWtJCux-VcMTj-LDI3rKHgZOiwEVP3S_YpL0mc96H0np5zqS80KCFncz7ed9jJ9MORrg99di664HAEPSJ_hXJpR_kFWYnzzt21imykkhABimd1PyZBklpOnfMEtHJlvVFU5dxhjaES-ZjQ6rAgUDKp0YRI1McptXcS2LUNX2wOprSgUQlA_X2PlUbUa-z8pGN2DBbtv67li1sVUdnzmkySAmnL9Q3vLBaWlDNT84Ds_y1pJGLgGGjHwAJIj5JNglsWqHR6Jv7tYo7O4WogdroZtP52BI0hCcWNpOvK_cZxvNUwbsLYzV1ryNKi4le6KgQ4S1ZDjcmVRrj86vaIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"value":[],"nextLink":null}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -149,10 +155,12 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   '-1',
   'x-ms-keyvault-region',
   'westus2',
+  'x-ms-client-request-id',
+  '53e769a2-3217-4800-8daa-0dc1e3912636',
   'x-ms-request-id',
-  'dcfd9613-5337-4589-b510-dcf61e7e434c',
+  '32e67b84-4c14-4726-b584-2672a7983ae0',
   'x-ms-keyvault-service-version',
-  '1.2.164.2',
+  '1.2.205.0',
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
@@ -162,175 +170,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:09:45 GMT',
+  'Thu, 11 Mar 2021 23:28:23 GMT',
   'Content-Length',
-  '985'
+  '28'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
+  .get('/keys')
   .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'ab705b2e-e2a6-4762-a9bb-f9522bdf960c',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:45 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '568d01a7-ef8f-4e55-987d-5f5fa975fbb8',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:45 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '132b74c9-1b64-44fe-af5e-bde207771304',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:47 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'e7528429-321e-44d4-9c47-94aa76f5c1e0',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:49 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '5c307dee-919a-4983-b050-6c18eaf7faee',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:51 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0","deletedDate":1613498985,"scheduledPurgeDate":1614103785,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0/6f81b214434647579a47c82ab81a8050","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"1tCNWtJCux-VcMTj-LDI3rKHgZOiwEVP3S_YpL0mc96H0np5zqS80KCFncz7ed9jJ9MORrg99di664HAEPSJ_hXJpR_kFWYnzzt21imykkhABimd1PyZBklpOnfMEtHJlvVFU5dxhjaES-ZjQ6rAgUDKp0YRI1McptXcS2LUNX2wOprSgUQlA_X2PlUbUa-z8pGN2DBbtv67li1sVUdnzmkySAmnL9Q3vLBaWlDNT84Ds_y1pJGLgGGjHwAJIj5JNglsWqHR6Jv7tYo7O4WogdroZtP52BI0hCcWNpOvK_cZxvNUwbsLYzV1ryNKi4le6KgQ4S1ZDjcmVRrj86vaIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
+  .reply(200, {"value":[],"nextLink":null}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -341,10 +189,12 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   '-1',
   'x-ms-keyvault-region',
   'westus2',
+  'x-ms-client-request-id',
+  'f957c332-ad31-478f-848d-97e086665402',
   'x-ms-request-id',
-  'd7098624-6892-448d-989b-c720568218bf',
+  'c203436d-b334-414a-ba79-9bcfeb2a7586',
   'x-ms-keyvault-service-version',
-  '1.2.164.2',
+  '1.2.205.0',
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
   'X-Powered-By',
@@ -354,319 +204,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 16 Feb 2021 18:09:53 GMT',
+  'Thu, 11 Mar 2021 23:28:23 GMT',
   'Content-Length',
-  '985'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--0')
-  .query(true)
-  .reply(204, "", [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'fa4d6f60-52c0-4d8c-b79a-d794dc996887',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:53 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1","deletedDate":1613498994,"scheduledPurgeDate":1614103794,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/3a2acf59d1104df0a51fecd8a56a3dba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xRITp0fXR0k7SB_Qo1-_wefVrTViG_LZL0QhZHANFLWnRhFBa1oeZqDEj0PaaLTiYQT5X0njGPrkTltP7Tw51XHP7DE4t3VeLOq7V089N1lO9ZdU_eMhCYhMWS3xgEPiK93U6nfF9yUnolqr-zKA-seyzLhA79LxB2fZ9iwb2uptM-Zt1C5dcY-9whjUSkHhkh7Ngwo7rsgqkP7dKF66WSJ_h-ntL3yrMefqIChg7-Xjie5e6cJ-8Tau2GW_JbGzjcurj5x0ABdAEWkNTKUl_cSRUlONdVuo0huDjNd0Yn4lWyodHx85PYan3yWZZV5Jdk_OkhqyjYXLkl6IV6Vg-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '2eb8a542-ace8-4aa4-b780-8eb2236c265a',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:53 GMT',
-  'Content-Length',
-  '985'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '4684cd9f-4453-4a76-92c3-5cb1411c0a99',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:53 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '134f2534-4b8c-4b55-96dd-3fb6361e452f',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:53 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '7e0b1d2f-f95e-4b55-ab64-62a41a0dfc56',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:55 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '638e9da1-8ca6-406b-8833-ce8d8a27511c',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:09:58 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  'd95ee1fe-37a9-471a-943b-cdc87753ef9c',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:10:00 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(404, {"error":{"code":"KeyNotFound","message":"Deleted Key not found: challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '164',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '58c8ddfe-aab6-4a52-84a1-b58a2085c932',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:10:02 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1","deletedDate":1613498994,"scheduledPurgeDate":1614103794,"key":{"kid":"https://keyvault_name.vault.azure.net/keys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1/3a2acf59d1104df0a51fecd8a56a3dba","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"xRITp0fXR0k7SB_Qo1-_wefVrTViG_LZL0QhZHANFLWnRhFBa1oeZqDEj0PaaLTiYQT5X0njGPrkTltP7Tw51XHP7DE4t3VeLOq7V089N1lO9ZdU_eMhCYhMWS3xgEPiK93U6nfF9yUnolqr-zKA-seyzLhA79LxB2fZ9iwb2uptM-Zt1C5dcY-9whjUSkHhkh7Ngwo7rsgqkP7dKF66WSJ_h-ntL3yrMefqIChg7-Xjie5e6cJ-8Tau2GW_JbGzjcurj5x0ABdAEWkNTKUl_cSRUlONdVuo0huDjNd0Yn4lWyodHx85PYan3yWZZV5Jdk_OkhqyjYXLkl6IV6Vg-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1613498985,"updated":1613498985,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '7f0fec11-41e7-479f-ba50-3573c75b4b6b',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:10:03 GMT',
-  'Content-Length',
-  '985'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .delete('/deletedkeys/challengeAuthKeyName-Onceauthenticatednewrequestsshouldnotauthenticateagain--1')
-  .query(true)
-  .reply(204, "", [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Expires',
-  '-1',
-  'x-ms-keyvault-region',
-  'westus2',
-  'x-ms-request-id',
-  '88569586-750f-4046-8b67-7cf99a5a1054',
-  'x-ms-keyvault-service-version',
-  '1.2.164.2',
-  'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=InterNetwork;',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 16 Feb 2021 18:10:04 GMT'
+  '28'
 ]);

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aescbc.js
@@ -4,14 +4,14 @@ module.exports.hash = "cc07d789124e6008369d8ee590d0ec33";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/cryptography-client-test/create')
   .query(true)
   .reply(401, "", [
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-server-latency',
-  '0',
+  '1',
   'x-content-type-options',
   'nosniff',
   'www-authenticate',
@@ -63,7 +63,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'Tue, 06 Apr 2021 19:39:18 GMT'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
   .query(true)
   .reply(200, {"attributes":{"created":1617737958,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617737958},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/e2a8da05da804c1f1fdc11efc4733a90","kty":"oct-HSM"}}, [
@@ -231,14 +231,14 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
   'x-ms-server-latency',
-  '0',
+  '1',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/cryptography-client-test')
   .query(true)
   .reply(200, {"attributes":{"created":1617737958,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617737958},"deletedDate":1617737960,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/e2a8da05da804c1f1fdc11efc4733a90","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1625513960}, [
@@ -266,7 +266,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/cryptography-client-test')
   .query(true)
   .reply(200, {"attributes":{"created":1617737958,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617737958},"deletedDate":1617737960,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/e2a8da05da804c1f1fdc11efc4733a90","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1625513960}, [
@@ -296,7 +296,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   '26'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/deletedkeys/cryptography-client-test')
   .query(true)
   .reply(204, "", [

--- a/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/cryptographyclient_for_managed_hsm_skipped_if_mhsm_is_not_deployed_with_aes_crypto_algorithms/recording_encrypts_and_decrypts_using_aesgcm.js
@@ -1,10 +1,10 @@
 let nock = require('nock');
 
-module.exports.hash = "4b644a3a4de1b95ee31429b07ed2eaf1";
+module.exports.hash = "036ca64a6040a0d91a222681caf2ba7c";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/cryptography-client-test/create')
   .query(true)
   .reply(401, "", [
@@ -21,7 +21,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '0',
   'x-ms-request-id',
-  '0f33277c-7314-11eb-bf79-0242ac120006',
+  '362e3a06-7e18-11eb-b53a-0242ac120005',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -50,31 +50,31 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '2b41fa0d-ce56-4a8a-b663-26906c043400',
+  'f43a6703-34b4-4d20-adcc-4e484f013500',
   'x-ms-ests-server',
-  '2.1.11496.7 - EUS ProdSlices',
+  '2.1.11530.17 - WUS2 ProdSlices',
   'Set-Cookie',
-  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAQAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:15 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ar4lQP0-fFFFlh735WVosg9YXQRlAgAAAKDM1NcOAAAA; expires=Mon, 05-Apr-2021 01:06:41 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Sat, 20 Feb 2021 00:39:15 GMT'
+  'Sat, 06 Mar 2021 01:06:41 GMT'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/cryptography-client-test/create', {"kty":"AES","key_size":256,"attributes":{}})
   .query(true)
-  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"}}, [
+  .reply(200, {"attributes":{"created":1614992802,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992802},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","kty":"oct-HSM"}}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '360',
+  '361',
   'x-ms-request-id',
-  '0f6569b2-7314-11eb-bf79-0242ac120006',
+  '3650d886-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -84,15 +84,15 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '170',
+  '191',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8')
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50')
   .query(true)
   .reply(401, "OK", [
   'content-type',
@@ -106,7 +106,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '2',
   'x-ms-request-id',
-  '0f9837ac-7314-11eb-bf79-0242ac120006',
+  '36877c6a-7e18-11eb-b53a-0242ac120005',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -139,33 +139,33 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'e6cb8b30-23f1-46b9-a8bc-99fc35af0f00',
+  '019f34a3-3b34-43ef-b79c-ca8bac316f00',
   'x-ms-ests-server',
-  '2.1.11496.7 - SCUS ProdSlices',
+  '2.1.11530.15 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AsSRibbnRRBPsF58_J886-z8QxJoAgAAADNRwtcOAAAA; expires=Mon, 22-Mar-2021 00:39:16 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ar4lQP0-fFFFlh735WVosg9YXQRlAwAAAKDM1NcOAAAA; expires=Mon, 05-Apr-2021 01:06:42 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Sat, 20 Feb 2021 00:39:15 GMT'
+  'Sat, 06 Mar 2021 01:06:41 GMT'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .get('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8')
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50')
   .query(true)
-  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"}}, [
+  .reply(200, {"attributes":{"created":1614992802,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992802},"key":{"key_ops":["wrapKey","unwrapKey","encrypt","decrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","kty":"oct-HSM"}}, [
   'x-frame-options',
   'SAMEORIGIN',
   'x-ms-request-id',
-  '0fc495f4-7314-11eb-bf79-0242ac120006',
+  '36c5e0ae-7e18-11eb-b53a-0242ac120005',
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-keyvault-region',
   'westeurope',
   'content-length',
-  '360',
+  '361',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -179,21 +179,21 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '113'
+  '60'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8/encrypt', {"alg":"A256GCM","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50/encrypt', {"alg":"A256GCM","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"})
   .query(true)
-  .reply(200, {"alg":"A256GCM","iv":"U5Oz8CUYBD3mK0ocAAAAAA","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","tag":"S5sBQE2Y1k63OkvAbJXo2Q","value":"EtnsQUDCwjeEOSWtRT4PJ5iACWox_DOZoEPhtOUaBLMl-t0"}, [
+  .reply(200, {"alg":"A256GCM","iv":"HpuXOm1mrvV25UBNAAAAAA","kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","tag":"QcYK5QCYkQpK90X4Ou6byQ","value":"zM6Bkvaadymzszk1EhfG9CNsqLwosqtHrWhHISk1HI5fs04"}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '265',
+  '266',
   'x-ms-request-id',
-  '0fee63ac-7314-11eb-bf79-0242ac120006',
+  '36e7ba1c-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -203,25 +203,25 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '1',
+  '0',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .post('/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8/decrypt', {"alg":"A256GCM","value":"EtnsQUDCwjeEOSWtRT4PJ5iACWox_DOZoEPhtOUaBLMl-t0","iv":"U5Oz8CUYBD3mK0ocAAAAAA","tag":"S5sBQE2Y1k63OkvAbJXo2Q"})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50/decrypt', {"alg":"A256GCM","value":"zM6Bkvaadymzszk1EhfG9CNsqLwosqtHrWhHISk1HI5fs04","iv":"HpuXOm1mrvV25UBNAAAAAA","tag":"QcYK5QCYkQpK90X4Ou6byQ"})
   .query(true)
-  .reply(200, {"alg":"A256GCM","kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"}, [
+  .reply(200, {"alg":"A256GCM","kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","value":"ZW5jcnlwdHMgYW5kIGRlY3J5cHRzIHVzaW5nIEFFUy1HQ00"}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '204',
+  '205',
   'x-ms-request-id',
-  '10072752-7314-11eb-bf79-0242ac120006',
+  '37006832-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -231,25 +231,25 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '1',
+  '0',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/cryptography-client-test')
   .query(true)
-  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"deletedDate":1613781557,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557557}, [
+  .reply(200, {"attributes":{"created":1614992802,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992802},"deletedDate":1614992803,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1622768803}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '527',
+  '529',
   'x-ms-request-id',
-  '101fe738-7314-11eb-bf79-0242ac120006',
+  '3718fd5c-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -259,27 +259,27 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '77',
+  '82',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/cryptography-client-test')
   .query(true)
-  .reply(200, {"attributes":{"created":1613781555,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613781555},"deletedDate":1613781557,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/cryptography-client-test/c1a3cd3849514cc08cb716a73da476d8","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1621557557}, [
+  .reply(200, {"attributes":{"created":1614992802,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992802},"deletedDate":1614992803,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://keyvault_name.vault.azure.net/keys/cryptography-client-test/340bf2c7a3ed04f627a711cc42a14b50","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/cryptography-client-test","scheduledPurgeDate":1622768803}, [
   'x-frame-options',
   'SAMEORIGIN',
   'x-ms-request-id',
-  '10440fb4-7314-11eb-bf79-0242ac120006',
+  '373ee1ac-7e18-11eb-b53a-0242ac120005',
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-keyvault-region',
   'westeurope',
   'content-length',
-  '527',
+  '529',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -293,10 +293,10 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '32'
+  '31'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/deletedkeys/cryptography-client-test')
   .query(true)
   .reply(204, "", [
@@ -307,7 +307,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '0',
   'x-ms-request-id',
-  '10627198-7314-11eb-bf79-0242ac120006',
+  '375d5772-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -317,7 +317,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '110',
+  '113',
   'cache-control',
   'no-cache',
   'x-frame-options',

--- a/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.js
+++ b/sdk/keyvault/keyvault-keys/recordings/node/keys_client__create_read_update_and_delete_operations_for_managed_hsm/recording_can_create_an_oct_key_with_options.js
@@ -1,17 +1,17 @@
 let nock = require('nock');
 
-module.exports.hash = "03df4f9906bd7a40099d7eea3c16c3d8";
+module.exports.hash = "6c008e7540cbd6bf710ea0e219a367e5";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create')
   .query(true)
   .reply(401, "", [
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-server-latency',
-  '0',
+  '1',
   'x-content-type-options',
   'nosniff',
   'www-authenticate',
@@ -21,7 +21,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '0',
   'x-ms-request-id',
-  '19784542-731d-11eb-9617-0242ac120006',
+  '352e079e-7e18-11eb-b53a-0242ac120005',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -50,31 +50,31 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '667cf5ca-4faf-4d16-8d48-0efb940a3c00',
+  '7891cbb8-88f0-4ff6-ac39-b43a9fe17200',
   'x-ms-ests-server',
-  '2.1.11496.7 - NCUS ProdSlices',
+  '2.1.11530.15 - SCUS ProdSlices',
   'Set-Cookie',
-  'fpc=Aku4h6oc5D1IieMG-eZr9NH8QxJoAQAAAF5gwtcOAAAA; expires=Mon, 22-Mar-2021 01:43:58 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ar4lQP0-fFFFlh735WVosg9YXQRlAQAAAKDM1NcOAAAA; expires=Mon, 05-Apr-2021 01:06:40 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Sat, 20 Feb 2021 01:43:58 GMT'
+  'Sat, 06 Mar 2021 01:06:39 GMT'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/create', {"kty":"oct-HSM","attributes":{}})
   .query(true)
-  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"}}, [
+  .reply(200, {"attributes":{"created":1614992800,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992800},"key":{"key_ops":["wrapKey","unwrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/104ae934344f46923b6ff6016d90917b","kty":"oct-HSM"}}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '377',
+  '378',
   'x-ms-request-id',
-  '19cb413e-731d-11eb-9617-0242ac120006',
+  '3561eaa0-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -84,25 +84,25 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '195',
+  '355',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/keys/CRUDKeyName-cancreateanOCTkeywithoptions-')
   .query(true)
-  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"deletedDate":1613785439,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1621561439}, [
+  .reply(200, {"attributes":{"created":1614992800,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992800},"deletedDate":1614992801,"key":{"key_ops":["unwrapKey","wrapKey","decrypt","encrypt"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/104ae934344f46923b6ff6016d90917b","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1622768801}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '561',
+  '563',
   'x-ms-request-id',
-  '1a01fbfc-731d-11eb-9617-0242ac120006',
+  '35b116ac-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -112,27 +112,27 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '183',
+  '144',
   'cache-control',
   'no-cache',
   'x-frame-options',
   'SAMEORIGIN'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
   .query(true)
-  .reply(200, {"attributes":{"created":1613785438,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1613785438},"deletedDate":1613785439,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://azure_managedhsm.managedhsm.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/70e288c11c3500290431c99887a27d16","kty":"oct-HSM"},"recoveryId":"https://azure_managedhsm.managedhsm.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1621561439}, [
+  .reply(200, {"attributes":{"created":1614992800,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1614992800},"deletedDate":1614992801,"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://keyvault_name.vault.azure.net/keys/CRUDKeyName-cancreateanOCTkeywithoptions-/104ae934344f46923b6ff6016d90917b","kty":"oct-HSM"},"recoveryId":"https://keyvault_name.vault.azure.net/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-","scheduledPurgeDate":1622768801}, [
   'x-frame-options',
   'SAMEORIGIN',
   'x-ms-request-id',
-  '1a36776a-731d-11eb-9617-0242ac120006',
+  '35e13102-7e18-11eb-b53a-0242ac120005',
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-keyvault-region',
   'westeurope',
   'content-length',
-  '561',
+  '563',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -146,10 +146,10 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '36'
+  '33'
 ]);
 
-nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/deletedkeys/CRUDKeyName-cancreateanOCTkeywithoptions-')
   .query(true)
   .reply(204, "", [
@@ -160,7 +160,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '0',
   'x-ms-request-id',
-  '1a54be6e-731d-11eb-9617-0242ac120006',
+  '35ff99b2-7e18-11eb-b53a-0242ac120005',
   'x-ms-keyvault-region',
   'westeurope',
   'strict-transport-security',
@@ -170,7 +170,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-ms-keyvault-network-info',
   'addr=50.35.231.105',
   'x-ms-server-latency',
-  '120',
+  '131',
   'cache-control',
   'no-cache',
   'x-frame-options',

--- a/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -84,16 +84,9 @@ describe("Challenge based authentication tests", () => {
     const sandbox = createSandbox();
     const spy = sandbox.spy(AuthenticationChallengeCache.prototype, "setCachedChallenge");
 
-    // Now we run what would be a normal use of the client.
-    // Here we will create two keys, then flush them.
-    // testClient.flushKey deletes, then purges the keys.
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    const keyNames = [`${keyName}-0`, `${keyName}-1`];
-    for (const name of keyNames) {
-      await client.createKey(name, "RSA");
-    }
-    for (const name of keyNames) {
-      await testClient.flushKey(name);
+    // Now we run a few operations against the client in order.
+    for (let i = 0; i < 4; i++) {
+      await client.listPropertiesOfKeys().next();
     }
 
     // The challenge should have been written to the cache exactly ONCE.

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -16,7 +16,7 @@ onVersions({ minVer: "7.2" }).describe(
   () => {
     const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
     let keySuffix: string;
-    let hsmClient: KeyClient;
+    let client: KeyClient;
     let testClient: TestClient;
     let recorder: Recorder;
 
@@ -24,13 +24,13 @@ onVersions({ minVer: "7.2" }).describe(
       const authentication = await authenticate(this, getServiceVersion());
       recorder = authentication.recorder;
 
-      if (!authentication.hsmClient) {
+      if (!authentication.hsmEnabled) {
         // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
         // This is only necessary while Managed HSM is in preview.
         this.skip();
       }
 
-      hsmClient = authentication.hsmClient;
+      client = authentication.client;
       keySuffix = authentication.keySuffix;
       testClient = new TestClient(authentication.hsmClient);
     });
@@ -44,7 +44,7 @@ onVersions({ minVer: "7.2" }).describe(
       const options: CreateOctKeyOptions = {
         hsm: true
       };
-      const result = await hsmClient.createOctKey(keyName, options);
+      const result = await client.createOctKey(keyName, options);
       assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
       assert.equal(result.keyType, "oct-HSM");
       await testClient.flushKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -16,7 +16,7 @@ import { isNode } from "@azure/core-http";
 onVersions({ minVer: "7.2" }).describe(
   "CryptographyClient for managed HSM (skipped if MHSM is not deployed)",
   () => {
-    let hsmClient: KeyClient;
+    let client: KeyClient;
     let testClient: TestClient;
     let cryptoClient: CryptographyClient;
     let recorder: Recorder;
@@ -29,13 +29,13 @@ onVersions({ minVer: "7.2" }).describe(
       const authentication = await authenticate(this, getServiceVersion());
       recorder = authentication.recorder;
 
-      if (!authentication.hsmClient) {
+      if (!authentication.hsmEnabled) {
         // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
         // This is only necessary while Managed HSM is in preview.
         this.skip();
       }
 
-      hsmClient = authentication.hsmClient;
+      client = authentication.hsmClient;
       testClient = new TestClient(authentication.hsmClient);
       credential = authentication.credential;
       keySuffix = authentication.keySuffix;
@@ -44,7 +44,7 @@ onVersions({ minVer: "7.2" }).describe(
 
     describe("with AES crypto algorithms", async function() {
       it("encrypts and decrypts using AES-GCM", async function(this: Context) {
-        keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+        keyVaultKey = await client.createKey(keyName, "AES", { keySize: 256 });
         cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
         const text = this.test!.title;
         const encryptResult = await cryptoClient.encrypt({
@@ -69,7 +69,7 @@ onVersions({ minVer: "7.2" }).describe(
         if (!isNode) {
           this.skip();
         }
-        keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+        keyVaultKey = await client.createKey(keyName, "AES", { keySize: 256 });
         cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
         const text = this.test!.title;
         // We are using a predictable IV to support our recorded tests; however, you should use a cryptographically secure IV or omit it and

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import { Context } from "mocha";
 import { createHash } from "crypto";
-import { Recorder, env, isPlaybackMode } from "@azure/test-utils-recorder";
+import { Recorder, isPlaybackMode } from "@azure/test-utils-recorder";
 import { ClientSecretCredential } from "@azure/identity";
 import { isNode } from "@azure/core-http";
 
@@ -16,7 +16,6 @@ import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyP
 import { getServiceVersion } from "../utils/utils.common";
 
 describe("CryptographyClient (all decrypts happen remotely)", () => {
-  const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;
   let client: KeyClient;
   let testClient: TestClient;
   let cryptoClient: CryptographyClient;
@@ -115,9 +114,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
     });
 
     it("the CryptographyClient can be created from a full KeyVaultKey object", async function(this: Context) {
-      const customKeyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const customKeyVaultKey = await client.createKey(customKeyName, "RSA");
-      const cryptoClientFromKey = new CryptographyClient(customKeyVaultKey, credential);
+      const cryptoClientFromKey = new CryptographyClient(keyVaultKey, credential);
 
       const text = this.test!.title;
       const encryptResult = await cryptoClientFromKey.encrypt({

--- a/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
@@ -18,6 +18,7 @@ describe("Keys client - Long Running Operations - delete", () => {
   let client: KeyClient;
   let testClient: TestClient;
   let recorder: Recorder;
+  let hsmEnabled: boolean;
 
   beforeEach(async function(this: Context) {
     const authentication = await authenticate(this, getServiceVersion());
@@ -25,6 +26,7 @@ describe("Keys client - Long Running Operations - delete", () => {
     client = authentication.client;
     testClient = authentication.testClient;
     recorder = authentication.recorder;
+    hsmEnabled = authentication.hsmEnabled;
   });
 
   afterEach(async function() {
@@ -54,7 +56,7 @@ describe("Keys client - Long Running Operations - delete", () => {
 
   it("can resume from a stopped poller", async function(this: Context) {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
+    await client.createRsaKey(keyName, { hsm: hsmEnabled });
     const poller = await client.beginDeleteKey(keyName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -3,7 +3,7 @@
 
 import { ClientSecretCredential } from "@azure/identity";
 import { KeyClient } from "../../src";
-import { env, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
+import { env, isLiveMode, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
@@ -32,20 +32,29 @@ export async function authenticate(that: Context, version: string): Promise<any>
     env.AZURE_CLIENT_SECRET
   );
 
-  const keyVaultUrl = env.KEYVAULT_URI;
-  if (!keyVaultUrl) {
-    throw new Error("Missing KEYVAULT_URI environment variable.");
+  // We mostly test against Azure KeyVault; however, we want to test
+  // Azure Managed HSM as well, and we want to run all the KV Keys against it.
+  // So by checking if the right environment variable exists (it will only exist in one configuration in live mode)
+  // we can run live tests against a single Managed HSM and the rest against KeyVault.
+  let keyVaultUrl;
+  if (isLiveMode()) {
+    keyVaultUrl = env.AZURE_MANAGEDHSM_URI || env.KEYVAULT_URI;
+  } else {
+    keyVaultUrl = env.KEYVAULT_URI;
   }
+
+  if (!keyVaultUrl) {
+    throw new Error(
+      "Missing either the KEYVAULT_URI or AZURE_MANAGEDHSM_URI environment variable."
+    );
+  }
+
+  const hsmEnabled = !!env.AZURE_MANAGEDHSM_URI;
 
   const client = new KeyClient(keyVaultUrl, credential, {
     serviceVersion: version
   });
   const testClient = new TestClient(client);
 
-  let hsmClient: KeyClient | undefined = undefined;
-  if (env.AZURE_MANAGEDHSM_URI) {
-    hsmClient = new KeyClient(env.AZURE_MANAGEDHSM_URI, credential);
-  }
-
-  return { recorder, client, credential, testClient, hsmClient, keySuffix };
+  return { recorder, client, credential, testClient, keySuffix, hsmEnabled };
 }


### PR DESCRIPTION
## What

- Standardize the test client to always point to a single instance. Either KV or MHSM
- Remove `hsmClient` and replace with a boolean `hsmEnabled`
- In playback mode they both get replaced with the same url so it won't matter which is used, but in live mode we want to run one test run against a MHSM instance. 

## Why

We want to test our client library against Managed HSM, which should in theory be a superset of KeyVault as far as functionality. It's still in preview, but should be good to start running our tests against it.

I won't merge it until I see tests pass consistently because I am not sure if I want to block CI runs because of MHSM bugs, but this would be a good test to see if there are service issues to be had.

Resolves #11181