### PR TITLE
Revert "[core-http] Token refresher fix"

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.2.4 (Unreleased)
 
-- Updated the `bearerTokenAuthenticationPolicy` to refresh tokens only when they're about to expire and not multiple times before. This fixes the issue: [13369](https://github.com/Azure/azure-sdk-for-js/issues/13369).
 
 ## 1.2.3 (2021-02-04)
 

--- a/sdk/core/core-http/karma.conf.ts
+++ b/sdk/core/core-http/karma.conf.ts
@@ -4,7 +4,7 @@ const defaults = {
 
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 
-module.exports = function (config: any) {
+module.exports = function(config: any) {
   config.set({
     plugins: [
       "karma-mocha",

--- a/sdk/core/core-http/src/credentials/accessTokenRefresher.ts
+++ b/sdk/core/core-http/src/credentials/accessTokenRefresher.ts
@@ -23,7 +23,7 @@ export class AccessTokenRefresher {
   public isReady(): boolean {
     // We're only ready for a new refresh if the required milliseconds have passed.
     return (
-      !this.lastCalled || Date.now() - this.lastCalled >= this.requiredMillisecondsBeforeNewRefresh
+      !this.lastCalled || Date.now() - this.lastCalled > this.requiredMillisecondsBeforeNewRefresh
     );
   }
 

--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -87,14 +87,30 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
     return this._nextPolicy.sendRequest(webResource);
   }
 
-  private async getToken(options: GetTokenOptions): Promise<string | undefined> {
-    // We reset the cached token some before it expires,
-    // after that point, we retry the refresh of the token only if the token refresher is ready.
-    let token = this.tokenCache.getCachedToken();
-    if (!token && this.tokenRefresher.isReady()) {
-      token = await this.tokenRefresher.refresh(options);
-      this.tokenCache.setCachedToken(token);
+  /**
+   * Attempts a token update if any other time related conditionals have been reached based on the tokenRefresher class.
+   */
+  private async updateTokenIfNeeded(options: GetTokenOptions): Promise<void> {
+    if (this.tokenRefresher.isReady()) {
+      const accessToken = await this.tokenRefresher.refresh(options);
+      this.tokenCache.setCachedToken(accessToken);
     }
-    return token ? token.token : undefined;
+  }
+
+  private async getToken(options: GetTokenOptions): Promise<string | undefined> {
+    let accessToken = this.tokenCache.getCachedToken();
+    if (accessToken === undefined) {
+      // Waiting for the next refresh only if the cache is unable to retrieve the access token,
+      // which means that it has expired, or it has never been set.
+      accessToken = await this.tokenRefresher.refresh(options);
+      this.tokenCache.setCachedToken(accessToken);
+    } else {
+      // If we still have a cached access token,
+      // And any other time related conditionals have been reached based on the tokenRefresher class,
+      // then attempt to refresh without waiting.
+      this.updateTokenIfNeeded(options);
+    }
+
+    return accessToken ? accessToken.token : undefined;
   }
 }


### PR DESCRIPTION
PR Azure/azure-sdk-for-js#13736 introduced a bug that ai-form-recognizer tests catch. Multiple parallel requests when there is no token or when the token has expired will result in request failures. I made a PR to fix this: https://github.com/Azure/azure-sdk-for-js/pull/14140 but while we discuss approaches, ai-form-recognizer should be unblocked.