### PR TITLE
[Text Analytics] Add displayName back for analyzeBatchActions

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_operation_metadata.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_lros_analyze/recording_operation_metadata.json
@@ -11,506 +11,275 @@
     "cache-control": "no-store, no-cache",
     "content-length": "1331",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:09 GMT",
+    "date": "Mon, 08 Mar 2021 14:57:47 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11513.14 - EUS ProdSlices",
-    "x-ms-request-id": "786b848b-efcb-45b0-b6ff-cf18f5782300"
+    "x-ms-ests-server": "2.1.11530.15 - SCUS ProdSlices",
+    "x-ms-request-id": "20d6ae99-691d-49bd-ac8b-fa02b8e1d500"
    }
   },
   {
    "method": "POST",
    "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze",
    "query": {},
-   "requestBody": "{\"tasks\":{\"entityRecognitionPiiTasks\":[{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}}]},\"analysisInput\":{\"documents\":[{\"id\":\"1\",\"text\":\"I will go to the park.\"},{\"id\":\"2\",\"text\":\"Este es un document escrito en Español.\"},{\"id\":\"3\",\"text\":\"猫は幸せ\"}]}}",
+   "requestBody": "{\"displayName\":\"testJob\",\"tasks\":{\"entityRecognitionPiiTasks\":[{\"parameters\":{\"model-version\":\"latest\",\"stringIndexType\":\"Utf16CodeUnit\"}}]},\"analysisInput\":{\"documents\":[{\"id\":\"1\",\"text\":\"I will go to the park.\"},{\"id\":\"2\",\"text\":\"Este es un document escrito en Español.\"},{\"id\":\"3\",\"text\":\"猫は幸せ\"}]}}",
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "apim-request-id": "7ff6353d-99c8-4482-b8bb-3116ca9e882b",
-    "date": "Wed, 24 Feb 2021 02:35:10 GMT",
-    "operation-location": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+    "apim-request-id": "888654a2-987e-43be-b2f3-190c3e22a3fa",
+    "date": "Mon, 08 Mar 2021 14:57:49 GMT",
+    "operation-location": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "356"
+    "x-envoy-upstream-service-time": "975"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "78123c04-16c5-4039-baab-84430a1202a0",
+    "apim-request-id": "6b6c50b3-e677-4d66-84b6-2d0e9e7ef995",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:10 GMT",
+    "date": "Mon, 08 Mar 2021 14:57:53 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "13"
+    "x-envoy-upstream-service-time": "4582"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "4eb532fa-d944-4be9-bf77-1283d2854d72",
+    "apim-request-id": "d66a24ec-3012-4867-b496-b033ebb17f39",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:10 GMT",
+    "date": "Mon, 08 Mar 2021 14:57:56 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "9"
+    "x-envoy-upstream-service-time": "3076"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"notStarted\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:09Z\"},\"completed\":0,\"failed\":0,\"inProgress\":0,\"total\":0}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "3a50bd67-db95-4ae6-9c19-bd5a8c06b0a4",
+    "apim-request-id": "a108f063-4c1f-40cf-a1d1-8e2396f07778",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:12 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:00 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "10"
+    "x-envoy-upstream-service-time": "1613"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "8f72d72b-73f4-4332-8ebf-477b1bd24091",
+    "apim-request-id": "779bb163-983e-470b-9e14-300b9ba5abdc",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:14 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:05 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "41"
+    "x-envoy-upstream-service-time": "2836"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "148f5e0e-dc08-4135-bec7-cadb0ec5bf25",
+    "apim-request-id": "0730b413-ec36-4470-afa7-6d8841c0dbb9",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:16 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:11 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "101"
+    "x-envoy-upstream-service-time": "2953"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "c0009124-d2b3-4805-a7c0-0011718069c5",
+    "apim-request-id": "7f6a251c-0b09-4627-b77f-d5cd731ee36e",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:18 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:14 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "62"
+    "x-envoy-upstream-service-time": "1311"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "e3723785-bcd6-487a-ac69-a0955229794a",
+    "apim-request-id": "9e77dd00-c0e5-443a-bfc3-765c49c88f23",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:20 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:16 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "31"
+    "x-envoy-upstream-service-time": "586"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "e27d62ae-0039-4f71-bd57-c3d6b46e5d61",
+    "apim-request-id": "e599aeac-434d-4ff1-a3f6-d78629aa4bc1",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:22 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:18 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "65"
+    "x-envoy-upstream-service-time": "44"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "87db1830-5284-4910-96d7-5503ab229490",
+    "apim-request-id": "0374ba38-2784-4b36-906f-c9d5dba713e7",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:24 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:20 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "41"
+    "x-envoy-upstream-service-time": "42"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "550917b2-a6ab-4d88-9a80-1792409fef0b",
+    "apim-request-id": "28e7c5a9-671a-4be4-83cb-a16377234b12",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:26 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:22 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "49"
+    "x-envoy-upstream-service-time": "105"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "12ee5e8f-148e-4250-b09c-debc8320c4f9",
+    "apim-request-id": "b24782cc-83bd-4c9b-91e3-02757dc27088",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:28 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:25 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "38"
+    "x-envoy-upstream-service-time": "108"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "c1d9ffc7-4c6d-42f6-b0f4-e54626d90ddc",
+    "apim-request-id": "0ece407d-9164-4d28-b5c2-d5cff2a2ff32",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:30 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:27 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "70"
+    "x-envoy-upstream-service-time": "52"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "72af7bbf-fcda-430d-ae53-62c521cb4a3d",
+    "apim-request-id": "1f1a7ac2-a0c9-42a6-ad69-15c8f4768493",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:32 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "37"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "14d374a3-c181-4878-a06a-602c0f73acdf",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:34 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "41"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "122268d5-5166-4813-b343-9cd8280fcd09",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:37 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "73"
-   }
-  },
-  {
-   "method": "POST",
-   "url": "https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token",
-   "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
-   "status": 200,
-   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
-   "responseHeaders": {
-    "cache-control": "no-store, no-cache",
-    "content-length": "1331",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:39 GMT",
-    "expires": "-1",
-    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
-    "pragma": "no-cache",
-    "referrer-policy": "strict-origin-when-cross-origin",
-    "strict-transport-security": "max-age=31536000; includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11513.14 - NCUS ProdSlices",
-    "x-ms-request-id": "9723ea02-7033-456f-8b48-6abc20ba2300"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "9712bc89-3a3b-4f0b-8f82-522b3f6008af",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:40 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "795"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "2c27022b-982c-419a-86e2-48f1ca4c85c5",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:42 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "247"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "d34fe34a-af9f-49a8-997c-5ede2491a1bb",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:44 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "46"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "0e02c27e-02aa-4a1a-8ee2-2530448c8ffe",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:46 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "39"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "6ffbdc93-a1ae-47a6-bb98-98305a0fb90b",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:48 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "33"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "fe7a8ae8-ab02-4c8d-b1c8-1955edaf8d0a",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:50 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "111"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "44cc3bef-c70d-474c-95ab-f91cabfb9f8e",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:52 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "77"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "7874146b-0dfe-4503-baa9-038527b3b2e0",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:54 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "39"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "f34dc781-f19a-43a1-a12d-adbf87c47ab5",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:56 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:29 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
@@ -519,17 +288,55 @@
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "24bdaa1e-58ca-465f-8525-29f6b4ab29d5",
+    "apim-request-id": "6702ab9c-d4c3-4a76-b235-efeb6af4c672",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:35:58 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:31 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "72"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "46f1ed97-4e78-4c19-8a68-a977a25c7c95",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:33 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "153"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "1d285481-239b-46fe-8bd4-60bba5e64b5a",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:35 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
@@ -538,36 +345,150 @@
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "8b374255-8862-4695-ab0e-912c46daa90f",
+    "apim-request-id": "80c29f74-205d-42cc-baab-682f20d93938",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:00 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:38 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "64"
+    "x-envoy-upstream-service-time": "281"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "a209ac3c-3b0d-4033-8a70-5f2cbdc24c64",
+    "apim-request-id": "7e8a331c-f4b2-4b82-add6-a54a8e5ce47f",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:02 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:40 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "70"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a443dd81-9a94-4391-8699-c2ae59640239",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:42 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "91"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "608d31b4-8a3f-458d-8d00-b0f27e2bb77b",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:44 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "374"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a57dc692-e9fc-4b98-bba1-69a3da8dcb43",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:46 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "48"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a306b39a-bc68-48fd-88d0-3db79fac6e67",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:48 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "69"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "a52f9021-bf51-4150-a765-c84ad3245956",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:50 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "84"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
+   "query": {
+    "$top": "20"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "responseHeaders": {
+    "apim-request-id": "0628f05f-db5b-4d23-870c-a553139f9a51",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Mon, 08 Mar 2021 14:58:52 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
@@ -576,157 +497,40 @@
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
    "responseHeaders": {
-    "apim-request-id": "e8c4e824-684d-4c2e-a3a4-10075ac493e2",
+    "apim-request-id": "eadc1732-f386-4200-b5b0-a0ab701f51de",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:05 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:54 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "36"
+    "x-envoy-upstream-service-time": "66"
    }
   },
   {
    "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
+   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/1737ff58-254d-464a-abfe-da78326803f4",
    "query": {
     "$top": "20"
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
+   "response": "{\"displayName\":\"testJob\",\"jobId\":\"1737ff58-254d-464a-abfe-da78326803f4\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\",\"createdDateTime\":\"2021-03-08T14:57:49Z\",\"expirationDateTime\":\"2021-03-09T14:57:49Z\",\"status\":\"succeeded\",\"errors\":[],\"tasks\":{\"details\":{\"name\":\"testJob\",\"lastUpdateDateTime\":\"2021-03-08T14:57:49Z\"},\"completed\":1,\"failed\":0,\"inProgress\":0,\"total\":1,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-03-08T14:57:49.8417865Z\",\"name\":\"testJob\",\"state\":\"succeeded\",\"results\":{\"documents\":[{\"redactedText\":\"I will go to the park.\",\"id\":\"1\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"Este es un document escrito en Español.\",\"id\":\"2\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"猫は幸せ\",\"id\":\"3\",\"entities\":[],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2021-01-15\"}}]}}",
    "responseHeaders": {
-    "apim-request-id": "a17afa61-1aff-4207-8825-1c78e6e237bb",
+    "apim-request-id": "9120bba3-ffa8-4515-86d3-c4a0ff498abe",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:07 GMT",
+    "date": "Mon, 08 Mar 2021 14:58:57 GMT",
     "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
     "transfer-encoding": "chunked",
     "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "96"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "3212d62f-ec7f-406c-b3be-b3befb7756f2",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:09 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "62"
-   }
-  },
-  {
-   "method": "POST",
-   "url": "https://login.microsoftonline.com/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token",
-   "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
-   "status": 200,
-   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
-   "responseHeaders": {
-    "cache-control": "no-store, no-cache",
-    "content-length": "1331",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:09 GMT",
-    "expires": "-1",
-    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
-    "pragma": "no-cache",
-    "referrer-policy": "strict-origin-when-cross-origin",
-    "strict-transport-security": "max-age=31536000; includeSubDomains",
-    "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.11530.11 - WUS2 ProdSlices",
-    "x-ms-request-id": "2c3dcd5c-fc9c-44c0-85fc-bda4af130400"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "9a8af494-acb8-419c-a787-1d94960ef29e",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:13 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "858"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "e0598a4a-b87f-4946-9633-3a4e65ceeecd",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:15 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "702"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"running\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":0,\"failed\":0,\"inProgress\":1,\"total\":1}}",
-   "responseHeaders": {
-    "apim-request-id": "fe8ee903-38b1-4592-90a4-5a2b975cf2e6",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:17 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "31"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/7c85297c-3933-4080-a010-12c3f31c2ae4",
-   "query": {
-    "$top": "20"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"jobId\":\"7c85297c-3933-4080-a010-12c3f31c2ae4\",\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\",\"createdDateTime\":\"2021-02-24T02:35:09Z\",\"expirationDateTime\":\"2021-02-25T02:35:09Z\",\"status\":\"succeeded\",\"errors\":[],\"tasks\":{\"details\":{\"lastUpdateDateTime\":\"2021-02-24T02:35:12Z\"},\"completed\":1,\"failed\":0,\"inProgress\":0,\"total\":1,\"entityRecognitionPiiTasks\":[{\"lastUpdateDateTime\":\"2021-02-24T02:35:12.3784661Z\",\"state\":\"succeeded\",\"results\":{\"documents\":[{\"redactedText\":\"I will go to the park.\",\"id\":\"1\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"Este es un document escrito en Español.\",\"id\":\"2\",\"entities\":[],\"warnings\":[]},{\"redactedText\":\"猫は幸せ\",\"id\":\"3\",\"entities\":[],\"warnings\":[]}],\"errors\":[],\"modelVersion\":\"2021-01-15\"}}]}}",
-   "responseHeaders": {
-    "apim-request-id": "a89a209a-ee3a-4284-8868-63204d861687",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 24 Feb 2021 02:36:20 GMT",
-    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-    "transfer-encoding": "chunked",
-    "x-content-type-options": "nosniff",
-    "x-envoy-upstream-service-time": "469"
+    "x-envoy-upstream-service-time": "149"
    }
   }
  ],
@@ -734,5 +538,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "8cf9de49737032aae010255a35b13816"
+ "hash": "44134fc8773c39c9b41bd05b4ce2c84f"
 }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_operation_metadata.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_lros_analyze/recording_operation_metadata.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "7b6d6a579a71ca7a5c79151e7ea04a90";
+module.exports.hash = "d8f968b336ad56ff1552042da3290b5e";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -11,6 +11,8 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'no-store, no-cache',
   'Pragma',
   'no-cache',
+  'Content-Length',
+  '1331',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
@@ -22,264 +24,362 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'cfa7c857-928f-4a0d-a44b-e4f9c2861700',
+  '3ef48b4e-3965-4379-99ed-da4299e3d200',
   'x-ms-ests-server',
-  '2.1.11513.14 - WUS2 ProdSlices',
+  '2.1.11530.15 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AjD5-380YexHjqzsgRoIFGNz_bg1EAAAAJtTx9cOAAAA; expires=Thu, 25-Mar-2021 19:55:27 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ApWo-E1NkG1GvNXj5NFxXfJz_bg1AQAAAAwy2NcOAAAA; expires=Wed, 07-Apr-2021 14:56:13 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Tue, 23 Feb 2021 19:55:26 GMT',
-  'Content-Length',
-  '1331'
+  'Mon, 08 Mar 2021 14:56:12 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/text/analytics/v3.1-preview.4/analyze', {"tasks":{"entityRecognitionPiiTasks":[{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}}]},"analysisInput":{"documents":[{"id":"1","text":"I will go to the park."},{"id":"2","text":"Este es un document escrito en Español."},{"id":"3","text":"猫は幸せ"}]}})
+  .post('/text/analytics/v3.1-preview.4/analyze', {"displayName":"testJob","tasks":{"entityRecognitionPiiTasks":[{"parameters":{"model-version":"latest","stringIndexType":"Utf16CodeUnit"}}]},"analysisInput":{"documents":[{"id":"1","text":"I will go to the park."},{"id":"2","text":"Este es un document escrito en Español."},{"id":"3","text":"猫は幸せ"}]}})
   .reply(202, "", [
   'Transfer-Encoding',
   'chunked',
   'operation-location',
-  'https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e',
+  'https://endpoint/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf',
   'x-envoy-upstream-service-time',
-  '27',
+  '5305',
   'apim-request-id',
-  '05dec94e-e03a-4de6-adf6-c613b2aa830b',
+  'c2f57d98-d66c-40a8-ac0d-574a10d4c6a3',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:26 GMT'
+  'Mon, 08 Mar 2021 14:56:23 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:27Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:27Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:23Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"notStarted","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:23Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '11',
+  '1224',
   'apim-request-id',
-  'cc433eff-4b14-4f03-b305-7e3c9435c803',
+  'd72ad7d0-e028-48b5-9346-5d32f5caa4ba',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:27 GMT'
+  'Mon, 08 Mar 2021 14:56:25 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:27Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"notStarted","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:27Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:23Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"notStarted","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:23Z"},"completed":0,"failed":0,"inProgress":0,"total":0}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '9',
+  '1561',
   'apim-request-id',
-  '549925f7-a834-4a08-88a4-9ebaa71ac336',
+  '9efa739c-5886-45f8-8478-413ec4cddac5',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:27 GMT'
+  'Mon, 08 Mar 2021 14:56:26 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '41',
+  '1739',
   'apim-request-id',
-  '8e5e0b56-0577-436b-87e5-732bb8687d42',
+  '58977ed4-f818-4d3c-916e-3d89e3cbfb6b',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:29 GMT'
+  'Mon, 08 Mar 2021 14:56:31 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '49',
+  '848',
   'apim-request-id',
-  '7d0491ad-ba36-40d0-b12c-bcdc7c27c893',
+  'c59ade49-351a-4bf8-b4a4-2db0407925f6',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:31 GMT'
+  'Mon, 08 Mar 2021 14:56:34 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '40',
+  '676',
   'apim-request-id',
-  'd295480e-7924-4bbc-a441-a6b2d8abdf5c',
+  'b9117a0d-ed9c-4bc4-b9b5-64628f2455cb',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:33 GMT'
+  'Mon, 08 Mar 2021 14:56:36 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '349',
+  '1138',
   'apim-request-id',
-  'faf50869-9c27-4361-8eae-b931317af394',
+  'c8c4f300-a90b-4453-8746-2be0680d35c6',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:35 GMT'
+  'Mon, 08 Mar 2021 14:56:39 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '43',
+  '687',
   'apim-request-id',
-  '30766e53-f388-4323-822b-adabe4e53f2a',
+  '5d400891-8ccf-478c-afed-b010b1381c83',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:37 GMT'
+  'Mon, 08 Mar 2021 14:56:42 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '45',
+  '830',
   'apim-request-id',
-  'd3a1c027-c956-4c1b-bfcc-cf7c8a41d610',
+  '1fc0660e-7006-4186-a88e-74396aec6125',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:39 GMT'
+  'Mon, 08 Mar 2021 14:56:45 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '83',
+  '137',
   'apim-request-id',
-  '901fcd5d-e16f-455a-a837-d2e383eb78a3',
+  '15c32e0b-e9e6-40c9-9ecc-35177be2dfb1',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:41 GMT'
+  'Mon, 08 Mar 2021 14:56:48 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '56',
+  '1090',
   'apim-request-id',
-  '1c30a81c-fbb8-4b79-b0fe-0dc6ad3cf39a',
+  '5dcc1c0f-b29f-4b3d-858a-0f09cd921178',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:43 GMT'
+  'Mon, 08 Mar 2021 14:56:51 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '101',
+  '39',
   'apim-request-id',
-  'fd00074b-03f6-4f76-b2a6-9d9bb7ba4668',
+  '351ccca7-e6c6-45cc-a19e-1adb0acc5095',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:46 GMT'
+  'Mon, 08 Mar 2021 14:56:53 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '824',
+  'apim-request-id',
+  '5828c88c-3e48-4940-80cf-73534cb2c1da',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 08 Mar 2021 14:56:55 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '961',
+  'apim-request-id',
+  '37496328-0e83-44dd-9a8a-2f33387a836a',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 08 Mar 2021 14:56:58 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '76',
+  'apim-request-id',
+  '9928a392-b486-4bdd-9e66-06f38876c48e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 08 Mar 2021 14:57:00 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '827',
+  'apim-request-id',
+  'ee20822a-acbc-4a65-a18d-9d91cddc9449',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 08 Mar 2021 14:57:03 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '74',
+  'apim-request-id',
+  'ae4256d4-3426-4507-8f71-c20b15acb607',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Mon, 08 Mar 2021 14:57:05 GMT'
+]);
+
+nock('https://endpoint', {"encodedQueryParams":true})
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
+  .query(true)
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -287,132 +387,79 @@ nock('https://endpoint', {"encodedQueryParams":true})
   'x-envoy-upstream-service-time',
   '63',
   'apim-request-id',
-  'ff79fedd-0b54-4408-ad66-d01352faed32',
+  'a61e923a-577d-4254-99b7-f1d62bf18b44',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:48 GMT'
+  'Mon, 08 Mar 2021 14:57:07 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '39',
+  '764',
   'apim-request-id',
-  '07589ca9-6e2f-4886-9eaf-36445126dd4e',
+  '165a0272-231a-4ebb-9862-16a91bc7445f',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:50 GMT'
+  'Mon, 08 Mar 2021 14:57:10 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '42',
+  '86',
   'apim-request-id',
-  '57b3290f-b6e0-4f64-b8bd-b8898d630328',
+  'c531150c-86ef-44ad-ac73-33600f99613e',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:52 GMT'
+  'Mon, 08 Mar 2021 14:57:13 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '446',
+  '38',
   'apim-request-id',
-  '85e9d060-5ecb-4000-8b40-4a1af75c6129',
+  'a2941edd-0df0-4cca-a589-8f7ca4a338a3',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:54 GMT'
+  'Mon, 08 Mar 2021 14:57:15 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '45',
-  'apim-request-id',
-  'f96aefa0-c3ca-43e1-be30-165ecdb5897c',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:55:57 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '6c43895e-f811-408c-bcba-56ff64831400',
-  'x-ms-ests-server',
-  '2.1.11513.14 - EUS ProdSlices',
-  'Set-Cookie',
-  'fpc=AjD5-380YexHjqzsgRoIFGNz_bg1DAAAAMdUx9cOAAAA; expires=Thu, 25-Mar-2021 19:55:57 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 23 Feb 2021 19:55:57 GMT',
-  'Content-Length',
-  '1331'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -420,364 +467,171 @@ nock('https://endpoint', {"encodedQueryParams":true})
   'x-envoy-upstream-service-time',
   '79',
   'apim-request-id',
-  '30957732-ed6a-4b10-a23c-c7c29bdd8ba2',
+  '22f7bb55-7a5b-450b-aba3-8b980aede70c',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:55:59 GMT'
+  'Mon, 08 Mar 2021 14:57:17 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '41',
+  '76',
   'apim-request-id',
-  'ea477086-4a85-4e8d-8db9-fb76e8c0c427',
+  '2f0f15c8-552d-4d82-a000-d6b9a8058b58',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:01 GMT'
+  'Mon, 08 Mar 2021 14:57:19 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '36',
+  '320',
   'apim-request-id',
-  '13267606-a6a5-4df6-9747-1d86e666a950',
+  '1107c1ff-ac4d-4fef-928a-17e017e4bbcc',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:03 GMT'
+  'Mon, 08 Mar 2021 14:57:21 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '79',
+  '866',
   'apim-request-id',
-  'b8615fef-6c3a-4e39-b2e1-112e6d4a0898',
+  '56aded2b-3de1-44c4-8f2c-f3ac19ce061b',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:05 GMT'
+  'Mon, 08 Mar 2021 14:57:24 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '36',
+  '107',
   'apim-request-id',
-  '8979eca6-8699-4c33-a8c0-c2374749da8b',
+  '905bf6b4-d481-4f94-99bd-8862d1daae39',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:08 GMT'
+  'Mon, 08 Mar 2021 14:57:26 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '48',
+  '335',
   'apim-request-id',
-  '60c55599-a8bc-4e85-b19d-8df9203d815d',
+  'e170f2cb-eb32-4331-a929-da748009a34c',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:10 GMT'
+  'Mon, 08 Mar 2021 14:57:28 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '39',
+  '51',
   'apim-request-id',
-  '70856daf-bd03-4d29-8cb7-5f7563751e13',
+  'dcd36b2c-14fc-4854-bec4-df6c8fb353e7',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:12 GMT'
+  'Mon, 08 Mar 2021 14:57:31 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"running","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '939',
+  '118',
   'apim-request-id',
-  '8b958a36-0e89-430c-96d2-a61adea69473',
+  '129d3f57-2d8b-478a-a258-c6481b7a9ac4',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:15 GMT'
+  'Mon, 08 Mar 2021 14:57:33 GMT'
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
+  .get('/text/analytics/v3.1-preview.4/analyze/jobs/76f29aa6-8859-4bed-a97a-a7321a443dcf')
   .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
+  .reply(200, {"displayName":"testJob","jobId":"76f29aa6-8859-4bed-a97a-a7321a443dcf","lastUpdateDateTime":"2021-03-08T14:56:27Z","createdDateTime":"2021-03-08T14:56:23Z","expirationDateTime":"2021-03-09T14:56:23Z","status":"succeeded","errors":[],"tasks":{"details":{"name":"testJob","lastUpdateDateTime":"2021-03-08T14:56:27Z"},"completed":1,"failed":0,"inProgress":0,"total":1,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-03-08T14:56:27.8409173Z","name":"testJob","state":"succeeded","results":{"documents":[{"redactedText":"I will go to the park.","id":"1","entities":[],"warnings":[]},{"redactedText":"Este es un document escrito en Español.","id":"2","entities":[],"warnings":[]},{"redactedText":"猫は幸せ","id":"3","entities":[],"warnings":[]}],"errors":[],"modelVersion":"2021-01-15"}}]}}, [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-envoy-upstream-service-time',
-  '36',
+  '736',
   'apim-request-id',
-  '91acd622-852e-4121-8a41-fb9beeae76ac',
+  '70f7008a-d51f-484f-adcb-7080c35d8dc7',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Tue, 23 Feb 2021 19:56:17 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '88',
-  'apim-request-id',
-  'd3b2307b-1af2-4df3-a351-9be5eefcc45d',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:19 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '605',
-  'apim-request-id',
-  'ba05c078-97f7-4977-8b9f-14a9f74d8339',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:23 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '56',
-  'apim-request-id',
-  '37e0a639-07b7-48dc-9c65-4eadeb570105',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:25 GMT'
-]);
-
-nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/88888888-8888-8888-8888-888888888888/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
-  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
-  'Cache-Control',
-  'no-store, no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'P3P',
-  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
-  'x-ms-request-id',
-  '60b46c3f-9a86-442a-9947-a09b9f901800',
-  'x-ms-ests-server',
-  '2.1.11513.14 - WUS2 ProdSlices',
-  'Set-Cookie',
-  'fpc=AjD5-380YexHjqzsgRoIFGNz_bg1DAAAAMdUx9cOAAAA; expires=Thu, 25-Mar-2021 19:56:27 GMT; path=/; secure; HttpOnly; SameSite=None',
-  'Set-Cookie',
-  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
-  'Set-Cookie',
-  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:27 GMT',
-  'Content-Length',
-  '1331'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '61',
-  'apim-request-id',
-  'c454c491-2f5f-4a1f-bf22-56c035bf4dca',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:27 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '42',
-  'apim-request-id',
-  '198bdf5d-55aa-4214-9e07-11990dbca1b4',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:29 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '45',
-  'apim-request-id',
-  '3c6a9339-873c-4622-b1bc-23b67b84025f',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:31 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"running","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":0,"failed":0,"inProgress":1,"total":1}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '61',
-  'apim-request-id',
-  '28d7334f-fe36-4ce6-aaea-ea2f1c60c847',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:33 GMT'
-]);
-
-nock('https://endpoint', {"encodedQueryParams":true})
-  .get('/text/analytics/v3.1-preview.4/analyze/jobs/9366b7a9-560b-408f-972b-8c1b88d39c7e')
-  .query(true)
-  .reply(200, {"jobId":"9366b7a9-560b-408f-972b-8c1b88d39c7e","lastUpdateDateTime":"2021-02-23T19:55:28Z","createdDateTime":"2021-02-23T19:55:27Z","expirationDateTime":"2021-02-24T19:55:27Z","status":"succeeded","errors":[],"tasks":{"details":{"lastUpdateDateTime":"2021-02-23T19:55:28Z"},"completed":1,"failed":0,"inProgress":0,"total":1,"entityRecognitionPiiTasks":[{"lastUpdateDateTime":"2021-02-23T19:55:28.415581Z","state":"succeeded","results":{"documents":[{"redactedText":"I will go to the park.","id":"1","entities":[],"warnings":[]},{"redactedText":"Este es un document escrito en Español.","id":"2","entities":[],"warnings":[]},{"redactedText":"猫は幸せ","id":"3","entities":[],"warnings":[]}],"errors":[],"modelVersion":"2021-01-15"}}]}}, [
-  'Transfer-Encoding',
-  'chunked',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'x-envoy-upstream-service-time',
-  '95',
-  'apim-request-id',
-  '3eae9bc0-a164-4771-8257-3a558954763f',
-  'Strict-Transport-Security',
-  'max-age=31536000; includeSubDomains; preload',
-  'x-content-type-options',
-  'nosniff',
-  'Date',
-  'Tue, 23 Feb 2021 19:56:35 GMT'
+  'Mon, 08 Mar 2021 14:57:35 GMT'
 ]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -22,6 +22,7 @@ export interface AnalyzeBatchActionsOperationMetadata extends OperationMetadata 
     actionsFailedCount?: number;
     actionsInProgressCount?: number;
     actionsSucceededCount?: number;
+    displayName?: string;
 }
 
 // @public
@@ -95,6 +96,7 @@ export { AzureKeyCredential }
 
 // @public
 export interface BeginAnalyzeBatchActionsOptions extends OperationOptions {
+    displayName?: string;
     includeStatistics?: boolean;
     resumeFrom?: string;
     updateIntervalInMs?: number;

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -54,6 +54,10 @@ export interface AnalyzeBatchActionsOperationMetadata extends OperationMetadata 
    * Number of actions still in progress.
    */
   actionsInProgressCount?: number;
+  /**
+   * The operation's display name.
+   */
+  displayName?: string;
 }
 
 /**
@@ -93,6 +97,10 @@ export interface BeginAnalyzeBatchActionsOptions extends OperationOptions {
    * If set to true, response will contain input and document level statistics.
    */
   includeStatistics?: boolean;
+  /**
+   * The operation's display name.
+   */
+  displayName?: string;
 }
 
 /**
@@ -113,7 +121,8 @@ function getMetaInfoFromResponse(response: AnalyzeJobState): AnalyzeBatchActions
     status: response.status,
     actionsSucceededCount: response.tasks.completed,
     actionsFailedCount: response.tasks.failed,
-    actionsInProgressCount: response.tasks.inProgress
+    actionsInProgressCount: response.tasks.inProgress,
+    displayName: response.displayName
   };
 }
 
@@ -292,6 +301,7 @@ export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperati
     if (!state.isStarted) {
       state.isStarted = true;
       const response = await this.beginAnalyzeBatchActions(this.documents, this.actions, {
+        displayName: this.options.displayName,
         tracingOptions: this.options.tracingOptions,
         requestOptions: this.options.requestOptions,
         abortSignal: updatedAbortSignal ? updatedAbortSignal : this.options.abortSignal
@@ -317,6 +327,7 @@ export class BeginAnalyzeBatchActionsPollerOperation extends AnalysisPollOperati
     state.actionsSucceededCount = operationStatus.operationMetdata?.actionsSucceededCount;
     state.actionsFailedCount = operationStatus.operationMetdata?.actionsFailedCount;
     state.actionsInProgressCount = operationStatus.operationMetdata?.actionsInProgressCount;
+    state.displayName = operationStatus.operationMetdata?.displayName;
 
     if (!state.isCompleted && operationStatus.done) {
       const pagedIterator = this.listAnalyzeBatchActionsResults(state.operationId!, {

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
@@ -44,6 +44,7 @@ export class BeginAnalyzeBatchActionsPoller extends AnalysisPoller<
       documents,
       analysisOptions,
       actions,
+      displayName,
       includeStatistics,
       updateIntervalInMs = 5000,
       resumeFrom
@@ -61,6 +62,7 @@ export class BeginAnalyzeBatchActionsPoller extends AnalysisPoller<
       documents,
       actions,
       {
+        displayName,
         requestOptions,
         tracingOptions,
         updateIntervalInMs,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -977,6 +977,7 @@ export class TextAnalyticsClient {
         onResponse: realOptions.onResponse,
         serializerOptions: realOptions.serializerOptions
       },
+      displayName: realOptions.displayName,
       includeStatistics: realOptions.includeStatistics,
       updateIntervalInMs: realOptions.updateIntervalInMs,
       resumeFrom: realOptions.resumeFrom

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1798,7 +1798,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         }
       });
 
-      it.only("operation metadata", async function() {
+      it("operation metadata", async function() {
         const docs = [
           { id: "1", text: "I will go to the park." },
           { id: "2", text: "Este es un document escrito en Español." },

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -1798,7 +1798,7 @@ describe("[AAD] TextAnalyticsClient", function() {
         }
       });
 
-      it("operation metadata", async function() {
+      it.only("operation metadata", async function() {
         const docs = [
           { id: "1", text: "I will go to the park." },
           { id: "2", text: "Este es un document escrito en Español." },
@@ -1811,7 +1811,8 @@ describe("[AAD] TextAnalyticsClient", function() {
             recognizePiiEntitiesActions: [{ modelVersion: "latest" }]
           },
           {
-            updateIntervalInMs: pollingInterval
+            updateIntervalInMs: pollingInterval,
+            displayName: "testJob"
           }
         );
         poller.onProgress((state) => {
@@ -1822,6 +1823,7 @@ describe("[AAD] TextAnalyticsClient", function() {
           assert.isDefined(state.actionsSucceededCount, "actionsSucceededCount is undefined!");
           assert.equal(state.actionsFailedCount, 0);
           assert.isDefined(state.actionsInProgressCount, "actionsInProgressCount is undefined!");
+          assert.equal(state.displayName, "testJob");
         });
         const result = await poller.pollUntilDone();
         assert.ok(result);


### PR DESCRIPTION
I can not remember why I took it out here: https://github.com/Azure/azure-sdk-for-js/pull/13933. This PR adds the option `displayName` back to `beginAnalyzeBatchActions`.