### PR TITLE
[KeyVault] - Use status field for LRO error conditions

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0-beta.3 (Unreleased)
 
 - Updated the Latest service version to 7.2.
+- Long Running Operations will now use the `status` field to determine whether the operation failed.
 
 ## 4.0.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-admin/recordings/node/keyvaultaccesscontrolclient_role_definitions_upsertroledefinition/recording_errors_when_name_is_not_a_valid_guid.js
+++ b/sdk/keyvault/keyvault-admin/recordings/node/keyvaultaccesscontrolclient_role_definitions_upsertroledefinition/recording_errors_when_name_is_not_a_valid_guid.js
@@ -1,0 +1,88 @@
+let nock = require('nock');
+
+module.exports.hash = "aa49bc26dd2b5eaa4bd55c512d8cdb8f";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .put('///providers/Microsoft.Authorization/roleDefinitions/foo')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/azure_tenant_id", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '14b3bc12-8038-11eb-9948-000d3abf52b7',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '1813e1cd-340a-4404-8b03-ae835734e000',
+  'x-ms-ests-server',
+  '2.1.11530.15 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=Aj1PYPqGGBZCvaKaRYAFcclYXQRlAQAAABdd2NcOAAAA; expires=Wed, 07-Apr-2021 17:59:52 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Mon, 08 Mar 2021 17:59:51 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .put('///providers/Microsoft.Authorization/roleDefinitions/foo', {"properties":{"roleName":"foo","type":"CustomRole","permissions":[],"assignableScopes":["/"]}})
+  .query(true)
+  .reply(400, {"error":{"code":"BadParameter","message":"Role definition name must be a GUID (Activity ID: 14e58ff8-8038-11eb-9948-000d3abf52b7)"}}, [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'content-length',
+  '133',
+  'x-ms-request-id',
+  '14e58ff8-8038-11eb-9948-000d3abf52b7',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'x-frame-options',
+  'SAMEORIGIN'
+]);

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -142,13 +142,13 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
     state.status = status;
     state.statusDetails = statusDetails;
 
-    if (error?.message) {
-      throw new Error(error?.message);
+    if (status?.toLowerCase() === "failed") {
+      throw new Error(error?.message || statusDetails);
     }
 
     state.isCompleted = !!endTime;
 
-    if (state.isCompleted && azureStorageBlobContainerUri) {
+    if (state.isCompleted) {
       state.result = {
         backupFolderUri: azureStorageBlobContainerUri,
         startTime,

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -147,8 +147,8 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
 
     state.isCompleted = !!endTime;
 
-    if (error?.message) {
-      throw new Error(error?.message);
+    if (status?.toLowerCase() === "failed") {
+      throw new Error(error?.message || statusDetails);
     }
 
     if (state.isCompleted) {

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
@@ -146,8 +146,8 @@ export class SelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
     state.status = status;
     state.statusDetails = statusDetails;
 
-    if (error?.message) {
-      throw new Error(error?.message);
+    if (status?.toLowerCase() === "failed") {
+      throw new Error(error?.message || statusDetails);
     }
 
     state.isCompleted = !!endTime;

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
@@ -124,9 +124,7 @@ describe("KeyVaultAccessControlClient", () => {
     });
 
     describe("upsertRoleDefinition", function() {
-      it.skip("errors when name is not a valid guid", async function() {
-        // There's a service issue preventing this test from running.
-        // Skipping until ADO 9226405 is resolved
+      it("errors when name is not a valid guid", async function() {
         await assert.isRejected(client.upsertRoleDefinition(globalScope, "foo", []));
       });
 

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -65,6 +65,11 @@ describe("KeyVaultBackupClient", () => {
 
   describe("beginRestore", function() {
     it("full restore completes successfully", async function() {
+      if (!isPlaybackMode()) {
+        // There is a service issue preventing backups from completing successfully.
+        // Skipped until that is resolved.
+        this.skip();
+      }
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         blobSasToken,


### PR DESCRIPTION
## What

- Use the status field instead of presence of errors for determining whether the LRO failed
- Unpend the "failed if custom role not guid" test
- Pend the full restore test in live mode

## Why

- Using the status field is more reliable and should be the field to decide whether there's an error. The actual error _might_ come in under statusDetails but the status field should be accurate
- There's a service-issue affecting restores and it's impacting our live test pipeline.

Resolves #13632