### PR TITLE
[Text Analytics] Adding the model version issue to known issues section

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -501,6 +501,7 @@ main();
 ## Known Issues
 
 - `beginAnalyzeHealthcare` is still in gated preview and can not be used with AAD credentials. For more information, see (the Text Analytics for Health documentation)[https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview].
+- At time of this SDK release, the `modelVersion` option to `beginAnalyzeHealthcareEntities` is ignored by the service. The service always processes the operation using the "latest" model.
 
 ## Troubleshooting
 


### PR DESCRIPTION
The healthcare endpoint doesn't respect the value passed in under the `model-version` query param, it only uses value "latest". Service-side issue: https://msazure.visualstudio.com/Cognitive%20Services/_workitems/edit/9479280.