### PR TITLE
[core v2] prepare for GA release

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2021-03-08)
 
 - [Breaking] Removed `createSpanFunction` and `SpanConfig`. These have been moved into
   `@azure/core-tracing`.

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -79,7 +79,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.2.0",
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-tracing": "1.0.0-preview.10",
     "@opentelemetry/api": "^0.10.2",
     "tslib": "^2.0.0"

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -85,7 +85,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@azure/core-xml": "1.0.0-beta.1",
+    "@azure/core-xml": "1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2021-03-08)
 
 - Renamed interfaces with `HTTPS` in the name to have `HTTP` instead.
 - Changed from exposing `DefaultHttpsClient` as a class directly, to providing `createDefaultHttpsClient()` to instantiate the appropriate runtime class.

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0-beta.2";
+export const SDK_VERSION: string = "1.0.0";

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2021-03-08)
+
+- GA release of package.
 
 ## 1.0.0-beta.1 (2021-02-04)
 

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.2.0",
     "@azure/core-client": "1.0.0-beta.2",
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-tracing": "1.0.0-preview.10",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -78,7 +78,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.2.0",
-    "@azure/core-client": "1.0.0-beta.2",
+    "@azure/core-client": "1.0.0",
     "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-tracing": "1.0.0-preview.10",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "devDependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "@azure/core-rest-pipeline": "1.0.0",
     "@azure/storage-blob": "^12.5.0-beta.1",
     "@azure/test-utils-perfstress": "^1.0.0",
     "@types/uuid": "^8.0.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -129,7 +129,6 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -70,7 +70,7 @@
     "@azure/core-client": "1.0.0-beta.2",
     "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-xml": "1.0.0-beta.1",
+    "@azure/core-xml": "1.0.0",
     "@azure/logger": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.10",
     "@opentelemetry/api": "^0.10.2",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -68,7 +68,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-client": "1.0.0-beta.2",
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-xml": "1.0.0-beta.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -67,7 +67,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-client": "1.0.0-beta.2",
+    "@azure/core-client": "1.0.0",
     "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-xml": "1.0.0",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -85,7 +85,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.2.0",
     "@azure/core-client": "1.0.0-beta.2",
-    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.10",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -84,7 +84,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.2.0",
-    "@azure/core-client": "1.0.0-beta.2",
+    "@azure/core-client": "1.0.0",
     "@azure/core-rest-pipeline": "1.0.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",


### PR DESCRIPTION
This PR updates core v2 libraries' version number to 1.0.0 and update the release date in CHANGELOG files.