### PR TITLE
[KeyVault] - Add an option to force remote in KeyVault CryptographyClient

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -105,6 +105,7 @@ export class CryptographyClient {
 
 // @public
 export interface CryptographyClientOptions extends KeyClientOptions {
+    remoteOnly?: boolean;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -51,7 +51,10 @@ export class CryptographyClient {
    */
   private remoteProvider?: RemoteCryptographyProvider;
 
-  private forceRemote: boolean = false;
+  /**
+   * When true this will force all cryptography operations to call the Key Vault API.
+   */
+  private remoteOnly: boolean = false;
 
   /**
    * Constructs a new instance of the Cryptography client for the given key
@@ -132,7 +135,7 @@ export class CryptographyClient {
       if (this.key.kind === "JsonWebKey") {
         throw new Error("The remoteOnly flag cannot be used with a local JsonWebKey");
       }
-      this.forceRemote = pipelineOptions.remoteOnly;
+      this.remoteOnly = pipelineOptions.remoteOnly;
     }
   }
 
@@ -530,10 +533,10 @@ export class CryptographyClient {
     algorithm: string
   ): Promise<CryptographyProvider> {
     if (!this.providers) {
-      const keyMaterial = await this.getKeyMaterial();
       this.providers = [];
 
-      if (!this.forceRemote) {
+      if (!this.remoteOnly) {
+        const keyMaterial = await this.getKeyMaterial();
         this.providers.push(new RsaCryptographyProvider(keyMaterial));
       }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -31,7 +31,14 @@ export interface KeyClientOptions extends coreHttp.PipelineOptions {
 /**
  * The optional parameters accepted by the KeyVault's CryptographyClient
  */
-export interface CryptographyClientOptions extends KeyClientOptions {}
+export interface CryptographyClientOptions extends KeyClientOptions {
+  /**
+   * Allows the CryptographyClient to be created in remote-only mode.
+   * A client that is created in this mode will perform all operations remotely using the Key Vault service.
+   * By default, this will be false; however, it can be used as a way to force all operations to run against Azure Key Vault.
+   */
+  remoteOnly?: boolean;
+}
 
 /**
  * As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -216,7 +216,7 @@ describe("internal crypto tests", () => {
     });
   });
 
-  describe.only("using the remoteOnly option", () => {
+  describe("using the remoteOnly option", () => {
     let key: KeyVaultKey;
     beforeEach(() => {
       key = {

--- a/sdk/keyvault/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
     "declarationDir": "./types",
+    "esModuleInterop": true,
     "outDir": "./dist-esm",
     "lib": ["dom"],
     "resolveJsonModule": true


### PR DESCRIPTION
## What

- Add a "remoteOnly" option to CryptographyClient

## Why

I think it makes sense to provide an escape hatch to force all crypto operations to run remotely. I can imagine developers running on an environment where crypto isn't available, or the underlying openssl implementation is missing something, or anything that is environment specific and outside our control that can cause local cryptography to go awry. 

In that case, this would be a lightweight workaround that would allow developers to force all crypto operations to go to KeyVault service. 