### PR TITLE
Perf projects should depend on the versions present in master branch

### DIFF
--- a/sdk/eventgrid/perf-tests/eventgrid/package.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/eventgrid": "^3.0.0-beta.3",
+    "@azure/eventgrid": "^3.0.0-beta.4",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0"
   },

--- a/sdk/textanalytics/perf-tests/text-analytics/package.json
+++ b/sdk/textanalytics/perf-tests/text-analytics/package.json
@@ -7,13 +7,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/ai-text-analytics": "^5.1.0-beta.4",
+    "@azure/ai-text-analytics": "^5.1.0-beta.5",
     "@azure/identity": "^1.1.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
-    "@types/dotenv": "8.2.0",
     "@types/node": "^8.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",


### PR DESCRIPTION
Perf test projects for eventgrid and text-analytics are depending on a released version of the packages.
This PR updates it to depend on the versions on master instead.