### PR TITLE
[Perf Framework] Run all tests with a single command

### DIFF
--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -27,7 +27,7 @@
     "prebuild": "npm run clean",
     "perf-test:node": "npm run build && node dist-esm/test/index.spec.js",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "echo skipped",
+    "unit-test:node": "ts-node runAllTests.ts",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test:browser": "npm run clean && npm run build npm run unit-test:browser",
     "test:node": "npm run clean && npm run build && npm run unit-test:node",

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -82,6 +82,7 @@
     "karma-env-preprocessor": "^0.1.1",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
+    "ts-node": "^8.3.0",
     "typescript": "4.1.2"
   }
 }

--- a/sdk/test-utils/perfstress/runAllTests.ts
+++ b/sdk/test-utils/perfstress/runAllTests.ts
@@ -12,7 +12,7 @@ function spawn(command: string) {
 function runTest(testClassName: string, options: string = "") {
   console.log("\n");
   if (options === "") {
-    options = `--warmup 1 --iterations 1 --duration 1`;
+    options = `--warmup 0 --iterations 1 --duration 1`;
   }
   spawn(`ts-node ./test/index.spec.ts ${testClassName} ${options}`);
 }

--- a/sdk/test-utils/perfstress/runAllTests.ts
+++ b/sdk/test-utils/perfstress/runAllTests.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { testClasses } from "./test/declareTests";
+import { testsRequiringAdditionalParams, testsWithDefaultParams } from "./test/declareTests";
 
 function spawn(command: string) {
   const ret = spawnSync(command, { shell: true, stdio: "inherit" });
@@ -9,7 +9,26 @@ function spawn(command: string) {
   }
 }
 
+function runTest(testClassName: string, options: string = "") {
+  console.log("\n");
+  if (options === "") {
+    options = `--warmup 1 --iterations 1 --duration 1`;
+  }
+  spawn(`ts-node ./test/index.spec.ts ${testClassName} ${options}`);
+}
+
 // This runs all the perf tests one after the other with the default parameters
-testClasses.forEach((testClass) => {
-  spawn(`ts-node ./test/index.spec.ts ${testClass.name}`);
+testsWithDefaultParams.forEach((testClass) => {
+  runTest(testClass.name);
+});
+
+// This runs all the perf tests one after the other with the default parameters
+testsRequiringAdditionalParams.forEach((testClass) => {
+  let options = "";
+  if (testClass.name === "OptionsTest") {
+    options = "--req some-string";
+  } else if (testClass.name === "PerfStressPolicyTest") {
+    options = `--url http://bing.com/`;
+  }
+  runTest(testClass.name, options);
 });

--- a/sdk/test-utils/perfstress/runAllTests.ts
+++ b/sdk/test-utils/perfstress/runAllTests.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "child_process";
+import { testClasses } from "./test/declareTests";
+
+function spawn(command: string) {
+  const ret = spawnSync(command, { shell: true, stdio: "inherit" });
+
+  if (ret.status !== 0) {
+    throw new Error(`${command} failed with exit code ${ret.status}`);
+  }
+}
+
+// This runs all the perf tests one after the other with the default parameters
+testClasses.forEach((testClass) => {
+  spawn(`ts-node ./test/index.spec.ts ${testClass.name}`);
+});

--- a/sdk/test-utils/perfstress/test/declareTests.ts
+++ b/sdk/test-utils/perfstress/test/declareTests.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Tests:
+import { NoOp } from "./noop.spec";
+import { OptionsTest } from "./options.spec";
+import { SetupCleanupTest } from "./setupCleanup.spec";
+import { Delay500ms } from "./delay.spec";
+import { Exception } from "./exception.spec";
+import { PerfStressPolicyTest } from "./perfStressPolicy.spec";
+import { SleepTest } from "./sleep.spec";
+import { NodeFetchTest } from "./nodeFetch.spec";
+
+// Populate the array below whenever a new test is added
+export const testClasses = [
+  NoOp,
+  OptionsTest,
+  SetupCleanupTest,
+  Delay500ms,
+  Exception,
+  PerfStressPolicyTest,
+  SleepTest,
+  NodeFetchTest
+];

--- a/sdk/test-utils/perfstress/test/declareTests.ts
+++ b/sdk/test-utils/perfstress/test/declareTests.ts
@@ -11,14 +11,21 @@ import { PerfStressPolicyTest } from "./perfStressPolicy.spec";
 import { SleepTest } from "./sleep.spec";
 import { NodeFetchTest } from "./nodeFetch.spec";
 
-// Populate the array below whenever a new test is added
-export const testClasses = [
+// Populate one of the arrays below whenever a new test is added
+//  testsWithDefaultParams         - tests that can run with default params
+//  testsRequiringAdditionalParams - tests that require more setup such as passing more commandline options
+// The above differentiation allows us to run all the tests one after the other using the `unit-test:node` command
+
+export const testsWithDefaultParams = [
   NoOp,
-  OptionsTest,
   SetupCleanupTest,
   Delay500ms,
   Exception,
-  PerfStressPolicyTest,
   SleepTest,
   NodeFetchTest
 ];
+
+export const testsRequiringAdditionalParams = [OptionsTest, PerfStressPolicyTest];
+
+// Exports all the test classes so that the index.spec.ts can pick them up
+export const allTestClasses = testsWithDefaultParams.concat(testsRequiringAdditionalParams);

--- a/sdk/test-utils/perfstress/test/index.spec.ts
+++ b/sdk/test-utils/perfstress/test/index.spec.ts
@@ -2,30 +2,10 @@
 // Licensed under the MIT license.
 
 import { PerfStressProgram, selectPerfStressTest } from "../src";
-
-// Tests:
-import { NoOp } from "./noop.spec";
-import { OptionsTest } from "./options.spec";
-import { SetupCleanupTest } from "./setupCleanup.spec";
-import { Delay500ms } from "./delay.spec";
-import { Exception } from "./exception.spec";
-import { PerfStressPolicyTest } from "./perfStressPolicy.spec";
-import { SleepTest } from "./sleep.spec";
-import { NodeFetchTest } from "./nodeFetch.spec";
+import { testClasses } from "./declareTests";
 
 console.log("=== Starting the perfStress test ===");
 
-const perfStressProgram = new PerfStressProgram(
-  selectPerfStressTest([
-    NoOp,
-    OptionsTest,
-    SetupCleanupTest,
-    Delay500ms,
-    Exception,
-    PerfStressPolicyTest,
-    SleepTest,
-    NodeFetchTest
-  ])
-);
+const perfStressProgram = new PerfStressProgram(selectPerfStressTest(testClasses));
 
 perfStressProgram.run();

--- a/sdk/test-utils/perfstress/test/index.spec.ts
+++ b/sdk/test-utils/perfstress/test/index.spec.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import { PerfStressProgram, selectPerfStressTest } from "../src";
-import { testClasses } from "./declareTests";
+import { allTestClasses } from "./declareTests";
 
 console.log("=== Starting the perfStress test ===");
 
-const perfStressProgram = new PerfStressProgram(selectPerfStressTest(testClasses));
+const perfStressProgram = new PerfStressProgram(selectPerfStressTest(allTestClasses));
 
 perfStressProgram.run();

--- a/sdk/test-utils/perfstress/test/options.spec.ts
+++ b/sdk/test-utils/perfstress/test/options.spec.ts
@@ -76,4 +76,6 @@ export class OptionsTest extends PerfStressTest<OptionsTestOptions> {
       this.compare(key as keyof OptionsTestOptions);
     }
   }
+
+  async runAsync(): Promise<void> {}
 }

--- a/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
+++ b/sdk/test-utils/perfstress/test/setupCleanup.spec.ts
@@ -48,4 +48,5 @@ export class SetupCleanupTest extends PerfStressTest {
   }
 
   run(): void {}
+  async runAsync(): Promise<void> {}
 }


### PR DESCRIPTION
Tests of the framework were becoming stale.

In order to run all the tests with a single command without needing an explicit setup, this PR attempts to add a `unit-test:node` command for the framework to allow testing the perf framework features.
This also adds a `runAllTests.ts` script which takes care of importing and running all the tests with default params if it can or runs the commands with special params if provided.

This doesn't impact the existing ways of running the tests such as `node dist-esm/test/index.spec.js ...params`