### PR TITLE
[core-rest-pipeline] Fix serialization of body of false

### DIFF
--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -127,7 +127,8 @@ export function serializeRequestBody(
       xmlName,
       xmlElementName,
       xmlNamespace,
-      xmlNamespacePrefix
+      xmlNamespacePrefix,
+      nullable
     } = bodyMapper;
     const typeName = bodyMapper.type.name;
 

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -132,7 +132,11 @@ export function serializeRequestBody(
     const typeName = bodyMapper.type.name;
 
     try {
-      if ((request.body !== undefined && request.body !== null) || required) {
+      if (
+        (request.body !== undefined && request.body !== null) ||
+        (nullable && request.body === null) ||
+        required
+      ) {
         const requestBodyParameterPathString: string = getPathStringFromParameter(
           operationSpec.requestBody
         );

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -132,7 +132,7 @@ export function serializeRequestBody(
     const typeName = bodyMapper.type.name;
 
     try {
-      if (request.body || required) {
+      if (request.body !== undefined || required) {
         const requestBodyParameterPathString: string = getPathStringFromParameter(
           operationSpec.requestBody
         );

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -132,7 +132,7 @@ export function serializeRequestBody(
     const typeName = bodyMapper.type.name;
 
     try {
-      if (request.body !== undefined || required) {
+      if ((request.body !== undefined && request.body !== null) || required) {
         const requestBodyParameterPathString: string = getPathStringFromParameter(
           operationSpec.requestBody
         );


### PR DESCRIPTION
If the body contains just false, this check will confuse it with the body being non existent. This PR fixes this issue.