### PR TITLE
change keyId from unknown to never

### DIFF
--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -144,7 +144,7 @@ export interface SecretProperties {
     readonly expiresOn?: Date;
     id?: string;
     // @deprecated
-    readonly keyId?: unknown;
+    readonly keyId?: never;
     readonly managed?: boolean;
     name: string;
     readonly notBefore?: Date;

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -83,7 +83,7 @@ export interface SecretProperties {
    * this field specifies the corresponding key backing the KV certificate.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
-   * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. `keyId` has and will be left as undefined.
+   * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. `keyId` will always be undefined.
    */
   readonly keyId?: never;
 

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -83,9 +83,9 @@ export interface SecretProperties {
    * this field specifies the corresponding key backing the KV certificate.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
-   * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. This field will always be undefined.
+   * @deprecated Please use {@link SecretProperties.certificateKeyId} instead. `keyId` has and will be left as undefined.
    */
-  readonly keyId?: unknown;
+  readonly keyId?: never;
 
   /**
    * If this is a secret backing a KV certificate, then


### PR DESCRIPTION
## What

- Changes the type of `SecretProperties.keyId` from `unknown` to `never`

## Why

Had a conversation with @witemple-msft about this, and this would be the better type since we can narrow but not expand this server-populated type. Given that it's already never set at runtime this seemed appropriate. In passing, updated the doc comment to reflect Ramya's review from the last change.