### PR TITLE
Cosmos: project depends on azure/identity

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.2.0",
-    "@types/debug": "^4.1.4",
+    "@azure/identity": "^1.1.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "jsbi": "^3.1.3",
@@ -102,10 +102,10 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "^1.1.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
+    "@types/debug": "^4.1.4",
     "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^8.0.0",


### PR DESCRIPTION
The package.json for the project needs to have the identity package
within its dependencies, not the dev dependencies, or else it will
cause problems when building in TypeScript projects.

This:

- moves the package from dev deps to deps
- moves a types package from deps to dev deps

Note, there is reference to a library called @azure/dev-tool that
is not published, so I am unable to run tests.

See also:
- https://github.com/Azure/azure-sdk-for-js/issues/13202
- https://github.com/Azure/azure-sdk-for-js/issues/14236