### PR TITLE
upgrade karma from ^5.1.0 to ^6.2.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -73,14 +73,14 @@ dependencies:
   '@rush-temp/testhub': file:projects/testhub.tgz
 lockfileVersion: 5.2
 packages:
-  /@azure/abort-controller/1.0.3:
+  /@azure/abort-controller/1.0.4:
     dependencies:
       tslib: 2.1.0
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-kCibMwqffnwlw3c+e879rCE1Am1I2BfhjOeO54XNA8i/cEuzktnBQbTrzh67XwibHO05YuNgZzSWy9ocVfFAGw==
+      integrity: sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==
   /@azure/amqp-common/1.0.0-preview.9:
     dependencies:
       '@azure/ms-rest-nodeauth': 0.9.3_debug@3.2.7
@@ -89,7 +89,7 @@ packages:
       async-lock: 1.2.8
       buffer: 5.7.1
       debug: 3.2.7
-      events: 3.2.0
+      events: 3.3.0
       is-buffer: 2.0.5
       jssha: 2.4.2
       process: 0.11.10
@@ -104,11 +104,11 @@ packages:
       integrity: sha512-RVG1Ad3Afv9gwFFmpeCXQAm+Sa0L8KEZRJJAAZEGoYDb6EoO1iQDVmoBz720h8mdrGpi0D60xNU/KhriIwuZfQ==
   /@azure/communication-common/1.0.0-beta.6:
     dependencies:
-      '@azure/abort-controller': 1.0.3
+      '@azure/abort-controller': 1.0.4
       '@azure/core-auth': 1.2.0
       '@azure/core-http': 1.2.3
       '@opentelemetry/api': 0.10.2
-      events: 3.2.0
+      events: 3.3.0
       jwt-decode: 2.2.0
       tslib: 2.1.0
     dev: false
@@ -118,16 +118,16 @@ packages:
       integrity: sha512-Xkm+g6bjZj75kafYBGejuY+TaIFwIyXHt9AcgHXnt+gzpU4c/6GIKpIyOnDJSgjt/BZLX49Zs66fGH7mBb82AQ==
   /@azure/communication-identity/1.0.0-beta.5:
     dependencies:
-      '@azure/abort-controller': 1.0.3
+      '@azure/abort-controller': 1.0.4
       '@azure/communication-common': 1.0.0-beta.6
       '@azure/core-auth': 1.2.0
       '@azure/core-http': 1.2.3
       '@azure/core-lro': 1.0.3
       '@azure/core-paging': 1.1.3
       '@azure/core-tracing': 1.0.0-preview.10
-      '@azure/logger': 1.0.1
+      '@azure/logger': 1.0.2
       '@opentelemetry/api': 0.10.2
-      events: 3.2.0
+      events: 3.3.0
       tslib: 2.1.0
     dev: false
     engines:
@@ -138,9 +138,9 @@ packages:
     dependencies:
       '@azure/core-http': 1.2.3
       '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/logger': 1.0.1
+      '@azure/logger': 1.0.2
       '@opentelemetry/api': 0.10.2
-      events: 3.2.0
+      events: 3.3.0
       tslib: 1.14.1
     dev: false
     engines:
@@ -153,7 +153,7 @@ packages:
       integrity: sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
   /@azure/core-auth/1.2.0:
     dependencies:
-      '@azure/abort-controller': 1.0.3
+      '@azure/abort-controller': 1.0.4
       tslib: 2.1.0
     dev: false
     engines:
@@ -162,10 +162,10 @@ packages:
       integrity: sha512-KUl+Nwn/Sm6Lw5d3U90m1jZfNSL087SPcqHLxwn2T6PupNKmcgsEbDjHB25gDvHO4h7pBsTlrdJAY7dz+Qk8GA==
   /@azure/core-http/1.2.3:
     dependencies:
-      '@azure/abort-controller': 1.0.3
+      '@azure/abort-controller': 1.0.4
       '@azure/core-auth': 1.2.0
       '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/logger': 1.0.1
+      '@azure/logger': 1.0.2
       '@opentelemetry/api': 0.10.2
       '@types/node-fetch': 2.5.8
       '@types/tunnel': 0.0.1
@@ -184,9 +184,9 @@ packages:
       integrity: sha512-g5C1zUJO5dehP2Riv+vy9iCYoS1UwKnZsBVCzanScz9A83LbnXKpZDa9wie26G9dfXUhQoFZoFT8LYWhPKmwcg==
   /@azure/core-lro/1.0.3:
     dependencies:
-      '@azure/abort-controller': 1.0.3
+      '@azure/abort-controller': 1.0.4
       '@azure/core-http': 1.2.3
-      events: 3.2.0
+      events: 3.3.0
       tslib: 2.1.0
     dev: false
     engines:
@@ -244,15 +244,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==
-  /@azure/identity/1.2.3:
+  /@azure/identity/1.2.4:
     dependencies:
       '@azure/core-http': 1.2.3
       '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/logger': 1.0.1
+      '@azure/logger': 1.0.2
       '@azure/msal-node': 1.0.0-beta.6
       '@opentelemetry/api': 0.10.2
       axios: 0.21.1
-      events: 3.2.0
+      events: 3.3.0
       jws: 4.0.0
       msal: 1.4.6
       open: 7.4.2
@@ -265,16 +265,16 @@ packages:
     optionalDependencies:
       keytar: 7.4.0
     resolution:
-      integrity: sha512-ujuQ7UzzbMNkyDa4UXoBOqubYkiLfu+bftPakr3d8CO1Zg3YadXBuZruU3ADYeYD7v229YnPL3i1WBR1S5m78w==
-  /@azure/identity/1.2.3_debug@4.3.1:
+      integrity: sha512-C9mZL700fMvw9xxCGT5V0QHI8KsykZjSjhiFO9ySIiaMYvRCqKyWAXUvxI2ON9FL/n7v0x677n8UhmgrB9BYTA==
+  /@azure/identity/1.2.4_debug@4.3.1:
     dependencies:
       '@azure/core-http': 1.2.3
       '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/logger': 1.0.1
+      '@azure/logger': 1.0.2
       '@azure/msal-node': 1.0.0-beta.6_debug@4.3.1
       '@opentelemetry/api': 0.10.2
       axios: 0.21.1_debug@4.3.1
-      events: 3.2.0
+      events: 3.3.0
       jws: 4.0.0
       msal: 1.4.6
       open: 7.4.2
@@ -289,21 +289,21 @@ packages:
     peerDependencies:
       debug: '*'
     resolution:
-      integrity: sha512-ujuQ7UzzbMNkyDa4UXoBOqubYkiLfu+bftPakr3d8CO1Zg3YadXBuZruU3ADYeYD7v229YnPL3i1WBR1S5m78w==
+      integrity: sha512-C9mZL700fMvw9xxCGT5V0QHI8KsykZjSjhiFO9ySIiaMYvRCqKyWAXUvxI2ON9FL/n7v0x677n8UhmgrB9BYTA==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.14.1
     dev: false
     resolution:
       integrity: sha512-h58oEROO2tniBTSmFmuHBGvuiFuYsHQBWTVdpT2AiOED4F2Kgf7rs0MPYPXiBcDvihC70M7QPRhIQ3JK1H/ygw==
-  /@azure/logger/1.0.1:
+  /@azure/logger/1.0.2:
     dependencies:
       tslib: 2.1.0
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-QYQeaJ+A5x6aMNu8BG5qdsVBnYBop9UMwgUvGihSjf1PdZZXB+c/oMdM2ajKwzobLBh9e9QuMQkN9iL+IxLBLA==
+      integrity: sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==
   /@azure/ms-rest-azure-env/1.1.2:
     dev: false
     resolution:
@@ -374,17 +374,17 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha512-Y1Id+jG59S3eY2ZQQtUA/lxwbRcgjcWaiib9YX+SwV3zeRauKfEiZT7l3z+lwV+T+Sst20F6l1mJsfQcfE7CEQ==
-  /@azure/msal-common/4.0.1:
+  /@azure/msal-common/4.0.2:
     dependencies:
       debug: 4.3.1
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha512-dHdTmLnRpqGasqAUCOzDt9Os8rke1cRk6Mo6yeI0ucis+G/CwLFQ2G08SEdPfZZnvemhTRP0l70UBPax1Gwxmw==
+      integrity: sha512-Z6FiDV+uWUZ4jcchRciKYYYKRWOc0sh/UaF5evfx7lXEp/8+KxO7cY1efgD7VOK75FkpRI5YyUzZAdX7I7sTAg==
   /@azure/msal-node/1.0.0-beta.6:
     dependencies:
-      '@azure/msal-common': 4.0.1
+      '@azure/msal-common': 4.0.2
       axios: 0.21.1
       jsonwebtoken: 8.5.1
       uuid: 8.3.2
@@ -393,7 +393,7 @@ packages:
       integrity: sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==
   /@azure/msal-node/1.0.0-beta.6_debug@4.3.1:
     dependencies:
-      '@azure/msal-common': 4.0.1
+      '@azure/msal-common': 4.0.2
       axios: 0.21.1_debug@4.3.1
       jsonwebtoken: 8.5.1
       uuid: 8.3.2
@@ -402,46 +402,30 @@ packages:
       debug: '*'
     resolution:
       integrity: sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==
-  /@azure/storage-blob/12.4.1:
-    dependencies:
-      '@azure/abort-controller': 1.0.3
-      '@azure/core-http': 1.2.3
-      '@azure/core-lro': 1.0.3
-      '@azure/core-paging': 1.1.3
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/logger': 1.0.1
-      '@opentelemetry/api': 0.10.2
-      events: 3.2.0
-      tslib: 2.1.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-RH6ru8LbnCC+m1rlVLon6mYUXdHsTcyUXFCJAWRQQM7p0XOwVKPS+UiVk2tZXfvMWd3q/qT/meOrEbHEcp/c4g==
   /@babel/code-frame/7.12.11:
     dependencies:
-      '@babel/highlight': 7.12.13
+      '@babel/highlight': 7.13.10
     dev: false
     resolution:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   /@babel/code-frame/7.12.13:
     dependencies:
-      '@babel/highlight': 7.12.13
+      '@babel/highlight': 7.13.10
     dev: false
     resolution:
       integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
-  /@babel/compat-data/7.13.6:
+  /@babel/compat-data/7.13.8:
     dev: false
     resolution:
-      integrity: sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==
-  /@babel/core/7.13.1:
+      integrity: sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==
+  /@babel/core/7.13.10:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.0
-      '@babel/helper-compilation-targets': 7.13.0_@babel+core@7.13.1
+      '@babel/generator': 7.13.9
+      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
       '@babel/helper-module-transforms': 7.13.0
-      '@babel/helpers': 7.13.0
-      '@babel/parser': 7.13.4
+      '@babel/helpers': 7.13.10
+      '@babel/parser': 7.13.10
       '@babel/template': 7.12.13
       '@babel/traverse': 7.13.0
       '@babel/types': 7.13.0
@@ -450,33 +434,33 @@ packages:
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       lodash: 4.17.21
-      semver: 7.0.0
+      semver: 6.3.0
       source-map: 0.5.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==
-  /@babel/generator/7.13.0:
+      integrity: sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
+  /@babel/generator/7.13.9:
     dependencies:
       '@babel/types': 7.13.0
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
     resolution:
-      integrity: sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==
-  /@babel/helper-compilation-targets/7.13.0_@babel+core@7.13.1:
+      integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
+  /@babel/helper-compilation-targets/7.13.10_@babel+core@7.13.10:
     dependencies:
-      '@babel/compat-data': 7.13.6
-      '@babel/core': 7.13.1
+      '@babel/compat-data': 7.13.8
+      '@babel/core': 7.13.10
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.3
-      semver: 7.0.0
+      semver: 6.3.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==
+      integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
   /@babel/helper-function-name/7.12.13:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
@@ -552,39 +536,39 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
-  /@babel/helpers/7.13.0:
+  /@babel/helpers/7.13.10:
     dependencies:
       '@babel/template': 7.12.13
       '@babel/traverse': 7.13.0
       '@babel/types': 7.13.0
     dev: false
     resolution:
-      integrity: sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==
-  /@babel/highlight/7.12.13:
+      integrity: sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
+  /@babel/highlight/7.13.10:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
     resolution:
-      integrity: sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
-  /@babel/parser/7.13.4:
+      integrity: sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
+  /@babel/parser/7.13.10:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
-  /@babel/runtime/7.13.7:
+      integrity: sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==
+  /@babel/runtime/7.13.10:
     dependencies:
       regenerator-runtime: 0.13.7
     dev: false
     resolution:
-      integrity: sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==
+      integrity: sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.13.4
+      '@babel/parser': 7.13.10
       '@babel/types': 7.13.0
     dev: false
     resolution:
@@ -592,10 +576,10 @@ packages:
   /@babel/traverse/7.13.0:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.0
+      '@babel/generator': 7.13.9
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.4
+      '@babel/parser': 7.13.10
       '@babel/types': 7.13.0
       debug: 4.3.1
       globals: 11.12.0
@@ -620,7 +604,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==
-  /@eslint/eslintrc/0.3.0:
+  /@eslint/eslintrc/0.4.0:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.1
@@ -629,14 +613,13 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      lodash: 4.17.21
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
-      integrity: sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+      integrity: sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
   /@istanbuljs/schema/0.1.3:
     dev: false
     engines:
@@ -964,7 +947,7 @@ packages:
   /@types/body-parser/1.19.0:
     dependencies:
       '@types/connect': 3.4.34
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
@@ -986,28 +969,33 @@ packages:
       integrity: sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==
   /@types/chalk/2.2.0:
     dependencies:
-      chalk: 4.1.0
+      chalk: 3.0.0
     deprecated: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
     dev: false
     resolution:
       integrity: sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
+  /@types/component-emitter/1.2.10:
+    dev: false
+    resolution:
+      integrity: sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
   /@types/connect/3.4.34:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
+  /@types/cookie/0.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
+  /@types/cors/2.8.10:
+    dev: false
+    resolution:
+      integrity: sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
   /@types/debug/4.1.5:
     dev: false
     resolution:
       integrity: sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
-  /@types/dotenv/8.2.0:
-    dependencies:
-      dotenv: 8.2.0
-    deprecated: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.
-    dev: false
-    resolution:
-      integrity: sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==
   /@types/eslint/7.2.6:
     dependencies:
       '@types/estree': 0.0.46
@@ -1025,8 +1013,8 @@ packages:
       integrity: sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
   /@types/express-serve-static-core/4.17.18:
     dependencies:
-      '@types/node': 10.17.54
-      '@types/qs': 6.9.5
+      '@types/node': 8.10.66
+      '@types/qs': 6.9.6
       '@types/range-parser': 1.2.3
     dev: false
     resolution:
@@ -1035,7 +1023,7 @@ packages:
     dependencies:
       '@types/body-parser': 1.19.0
       '@types/express-serve-static-core': 4.17.18
-      '@types/qs': 6.9.5
+      '@types/qs': 6.9.6
       '@types/serve-static': 1.13.9
     dev: false
     resolution:
@@ -1046,20 +1034,20 @@ packages:
       integrity: sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
   /@types/fs-extra/8.1.1:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
   /@types/glob/7.1.3:
     dependencies:
       '@types/minimatch': 3.0.3
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   /@types/is-buffer/2.0.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==
@@ -1071,13 +1059,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-  /@types/jsrsasign/8.0.9:
+  /@types/jsrsasign/8.0.10:
     dev: false
     resolution:
-      integrity: sha512-Od34HkZR4DAaNpl6/fGEFVMQ5gWlwfwsbEeBjVDMMh9zlQD7hDwVEs0oUQDiVSfHImb0tlJVgfVGkp1jL9zOkg==
+      integrity: sha512-TtLis3HRTt7wLfdpkDBem6vs+MbEGMsC7ob5gNYsJV40tHNAFxw00HMMsEHsg9FWduD38NtACWuSqQpXbFulUg==
   /@types/jws/3.2.3:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-g54CHxwvaHvyJyeuZqe7VQujV9SfCXwEkboJp355INPL+kjlS3Aq153EHptaeO/Cch/NPJ1i2sHz0sDDizn7LQ==
@@ -1091,7 +1079,7 @@ packages:
       integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
   /@types/md5/2.3.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-556YJ7ejzxIqSSxzyGGpctuZOarNZJt/zlEkhmmDc1f/slOEANHuwu2ZX7YaZ40rMiWoxt8GvAhoDpW1cmSy6A==
@@ -1113,13 +1101,13 @@ packages:
       integrity: sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
   /@types/mock-fs/4.10.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-FQ5alSzmHMmliqcL36JqIA4Yyn9jyJKvRSGV3mvPh108VFatX7naJDzSG4fnFQNZFq9dIx0Dzoe6ddflMB2Xkg==
   /@types/mock-require/2.0.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==
@@ -1129,7 +1117,7 @@ packages:
       integrity: sha512-DPxmjiDwubsNmguG5X4fEJ+XCyzWM3GXWsqQlvUcjJKa91IOoJUy51meDr0GkzK64qqNcq85ymLlyjoct9tInw==
   /@types/node-fetch/2.5.8:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
       form-data: 3.0.1
     dev: false
     resolution:
@@ -1138,10 +1126,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
-  /@types/node/10.17.54:
+  /@types/node/10.17.55:
     dev: false
     resolution:
-      integrity: sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==
+      integrity: sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==
   /@types/node/8.10.66:
     dev: false
     resolution:
@@ -1154,10 +1142,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-bqrDJHpMXO/JRILl2Hw3MLNfUFM=
-  /@types/qs/6.9.5:
+  /@types/qs/6.9.6:
     dev: false
     resolution:
-      integrity: sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
+      integrity: sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
   /@types/query-string/6.2.0:
     dev: false
     resolution:
@@ -1168,7 +1156,7 @@ packages:
       integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
   /@types/resolve/1.17.1:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
@@ -1179,23 +1167,23 @@ packages:
   /@types/serve-static/1.13.9:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==
-  /@types/sinon/9.0.10:
+  /@types/sinon/9.0.11:
     dependencies:
       '@types/sinonjs__fake-timers': 6.0.2
     dev: false
     resolution:
-      integrity: sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==
+      integrity: sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==
   /@types/sinonjs__fake-timers/6.0.2:
     dev: false
     resolution:
       integrity: sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
   /@types/stoppable/1.1.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-BRR23Q9CJduH7AM6mk4JRttd8XyFkb4qIPZu4mdLF+VoP+wcjIxIWIKiBbN78NBbEuynrAyMPtzOHnIp2B/JPQ==
@@ -1205,27 +1193,27 @@ packages:
       integrity: sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
-  /@types/underscore/1.10.24:
+  /@types/underscore/1.11.0:
     dev: false
     resolution:
-      integrity: sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w==
+      integrity: sha512-ipNAQLgRnG0EWN1cTtfdVHp5AyTW/PAMJ1PxLN4bAKSHbusSZbj48mIHiydQpN7GgQrYqwfnvZ573OVfJm5Nzg==
   /@types/uuid/8.3.0:
     dev: false
     resolution:
       integrity: sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
   /@types/ws/7.4.0:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==
   /@types/xml2js/0.4.8:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     resolution:
       integrity: sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==
@@ -1241,39 +1229,23 @@ packages:
       integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   /@types/yauzl/2.9.1:
     dependencies:
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
     dev: false
     optional: true
     resolution:
       integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
-  /@typescript-eslint/eslint-plugin-tslint/4.15.2_d757d41b47cb08695379f82123722461:
+  /@typescript-eslint/eslint-plugin/4.13.0_01b3bfb19f42ed087655aa69bb24f4f9:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.15.2_eslint@7.20.0+typescript@4.1.2
-      eslint: 7.20.0
-      lodash: 4.17.21
-      tslint: 5.20.1_typescript@4.1.2
-      typescript: 4.1.2
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      tslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-8ZqDhB/WpzZfURd4mgiWqGvEnhKOPlvJnK0uQIlEg1hzKoUIX8I1hPNr/7ghjkky++C6q8Qsm85Megk0JKT8MQ==
-  /@typescript-eslint/eslint-plugin/4.13.0_3aa6ac8cbad4a9e6247c45fb70b39e2c:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.20.0+typescript@4.1.2
-      '@typescript-eslint/parser': 4.13.0_eslint@7.20.0+typescript@4.1.2
+      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.21.0+typescript@4.1.2
+      '@typescript-eslint/parser': 4.13.0_eslint@7.21.0+typescript@4.1.2
       '@typescript-eslint/scope-manager': 4.13.0
       debug: 4.3.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       functional-red-black-tree: 1.0.1
       lodash: 4.17.21
       regexpp: 3.1.0
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.1.2
+      tsutils: 3.21.0_typescript@4.1.2
       typescript: 4.1.2
     dev: false
     engines:
@@ -1287,13 +1259,13 @@ packages:
         optional: true
     resolution:
       integrity: sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
-  /@typescript-eslint/experimental-utils/4.13.0_eslint@7.20.0+typescript@4.1.2:
+  /@typescript-eslint/experimental-utils/4.13.0_eslint@7.21.0+typescript@4.1.2:
     dependencies:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/scope-manager': 4.13.0
       '@typescript-eslint/types': 4.13.0
       '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.1.2
-      eslint: 7.20.0
+      eslint: 7.21.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
@@ -1304,30 +1276,13 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
-  /@typescript-eslint/experimental-utils/4.15.2_eslint@7.20.0+typescript@4.1.2:
-    dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.15.2
-      '@typescript-eslint/types': 4.15.2
-      '@typescript-eslint/typescript-estree': 4.15.2_typescript@4.1.2
-      eslint: 7.20.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-Fxoshw8+R5X3/Vmqwsjc8nRO/7iTysRtDqx6rlfLZ7HbT8TZhPeQqbPjTyk2RheH3L8afumecTQnUc9EeXxohQ==
-  /@typescript-eslint/parser/4.13.0_eslint@7.20.0+typescript@4.1.2:
+  /@typescript-eslint/parser/4.13.0_eslint@7.21.0+typescript@4.1.2:
     dependencies:
       '@typescript-eslint/scope-manager': 4.13.0
       '@typescript-eslint/types': 4.13.0
       '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.1.2
       debug: 4.3.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       typescript: 4.1.2
     dev: false
     engines:
@@ -1349,27 +1304,12 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
-  /@typescript-eslint/scope-manager/4.15.2:
-    dependencies:
-      '@typescript-eslint/types': 4.15.2
-      '@typescript-eslint/visitor-keys': 4.15.2
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-Zm0tf/MSKuX6aeJmuXexgdVyxT9/oJJhaCkijv0DvJVT3ui4zY6XYd6iwIo/8GEZGy43cd7w1rFMiCLHbRzAPQ==
   /@typescript-eslint/types/4.13.0:
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
-  /@typescript-eslint/types/4.15.2:
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-r7lW7HFkAarfUylJ2tKndyO9njwSyoy6cpfDKWPX6/ctZA+QyaYscAHXVAfJqtnY6aaTwDYrOhp+ginlbc7HfQ==
   /@typescript-eslint/typescript-estree/4.13.0_typescript@4.1.2:
     dependencies:
       '@typescript-eslint/types': 4.13.0
@@ -1379,7 +1319,7 @@ packages:
       is-glob: 4.0.1
       lodash: 4.17.21
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.1.2
+      tsutils: 3.21.0_typescript@4.1.2
       typescript: 4.1.2
     dev: false
     engines:
@@ -1391,26 +1331,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
-  /@typescript-eslint/typescript-estree/4.15.2_typescript@4.1.2:
-    dependencies:
-      '@typescript-eslint/types': 4.15.2
-      '@typescript-eslint/visitor-keys': 4.15.2
-      debug: 4.3.1
-      globby: 11.0.2
-      is-glob: 4.0.1
-      semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.1.2
-      typescript: 4.1.2
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-cGR8C2g5SPtHTQvAymEODeqx90pJHadWsgTtx6GbnTWKqsg7yp6Eaya9nFzUd4KrKhxdYTTFBiYeTPQaz/l8bw==
   /@typescript-eslint/visitor-keys/4.13.0:
     dependencies:
       '@typescript-eslint/types': 4.13.0
@@ -1420,19 +1340,6 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
-  /@typescript-eslint/visitor-keys/4.15.2:
-    dependencies:
-      '@typescript-eslint/types': 4.15.2
-      eslint-visitor-keys: 2.0.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-TME1VgSb7wTwgENN5KVj4Nqg25hP8DisXxNBojM4Nn31rYaNDIocNm5cmjOFfh42n7NVERxWrDFoETO/76ePyg==
-  /abbrev/1.0.9:
-    dev: false
-    resolution:
-      integrity: sha1-kbR5JYinc4wl813W9jdSovh3YTU=
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.29
@@ -1466,17 +1373,13 @@ packages:
       request: 2.88.2
       underscore: 1.12.0
       uuid: 3.4.0
-      xmldom: 0.4.0
+      xmldom: 0.5.0
       xpath.js: 1.1.0
     dev: false
     engines:
       node: '>= 0.6.15'
     resolution:
       integrity: sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=
-  /after/0.8.2:
-    dev: false
-    resolution:
-      integrity: sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
   /agent-base/4.2.1:
     dependencies:
       es6-promisify: 5.0.0
@@ -1516,7 +1419,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  /ajv/7.1.1:
+  /ajv/7.2.1:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1524,13 +1427,7 @@ packages:
       uri-js: 4.4.1
     dev: false
     resolution:
-      integrity: sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==
-  /amdefine/1.0.1:
-    dev: false
-    engines:
-      node: '>=0.4.2'
-    resolution:
-      integrity: sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+      integrity: sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
   /ansi-colors/3.2.3:
     dev: false
     engines:
@@ -1543,14 +1440,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-  /ansi-gray/0.1.1:
-    dependencies:
-      ansi-wrap: 0.1.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-KWLPVOyXksSFEKPetSRDaGHvclE=
   /ansi-regex/2.1.1:
     dev: false
     engines:
@@ -1597,12 +1486,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  /ansi-wrap/0.1.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-qCJQ3bABXponyoLoLqYDu/pF768=
   /anymatch/3.1.1:
     dependencies:
       normalize-path: 3.0.0
@@ -1653,22 +1536,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
-  /array-differ/1.0.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
   /array-filter/1.0.0:
     dev: false
     resolution:
       integrity: sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
-  /array-find-index/1.0.2:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
   /array-flatten/1.1.1:
     dev: false
     resolution:
@@ -1677,7 +1548,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
       get-intrinsic: 1.1.1
       is-string: 1.0.5
     dev: false
@@ -1691,26 +1562,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-  /array-uniq/1.0.3:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
   /array.prototype.flat/1.2.4:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
-  /arraybuffer.slice/0.0.7:
-    dev: false
-    resolution:
-      integrity: sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
   /asap/2.0.6:
     dev: false
     resolution:
@@ -1762,10 +1623,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-G+26B2jc0Gw0EG/WN2M6IczuGepBsfR1+DtqLnyFSH4p2C668qkOCtEkGNVEaaNAVlYwEMazy1+/jnLxltBkIQ==
-  /async/1.5.2:
-    dev: false
-    resolution:
-      integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
   /async/3.2.0:
     dev: false
     resolution:
@@ -1805,13 +1662,13 @@ packages:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
   /axios/0.21.1:
     dependencies:
-      follow-redirects: 1.13.2
+      follow-redirects: 1.13.3
     dev: false
     resolution:
       integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /axios/0.21.1_debug@3.2.7:
     dependencies:
-      follow-redirects: 1.13.2_debug@3.2.7
+      follow-redirects: 1.13.3_debug@3.2.7
     dev: false
     peerDependencies:
       debug: '*'
@@ -1819,7 +1676,7 @@ packages:
       integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.13.2_debug@4.3.1
+      follow-redirects: 1.13.3_debug@4.3.1
     dev: false
     peerDependencies:
       debug: '*'
@@ -1856,10 +1713,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
-  /backo2/1.0.2:
-    dev: false
-    resolution:
-      integrity: sha1-MasayLEpNjRj41s+u2n038+6eUc=
   /balanced-match/1.0.0:
     dev: false
     resolution:
@@ -1886,12 +1739,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  /beeper/1.1.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=
   /binary-extensions/2.2.0:
     dev: false
     engines:
@@ -1906,10 +1753,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
-  /blob/0.0.5:
-    dev: false
-    resolution:
-      integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
   /body-parser/1.19.0:
     dependencies:
       bytes: 3.1.0
@@ -1952,9 +1795,9 @@ packages:
       integrity: sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=
   /browserslist/4.16.3:
     dependencies:
-      caniuse-lite: 1.0.30001192
+      caniuse-lite: 1.0.30001198
       colorette: 1.2.2
-      electron-to-chromium: 1.3.674
+      electron-to-chromium: 1.3.685
       escalade: 3.1.1
       node-releases: 1.1.71
     dev: false
@@ -1982,12 +1825,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  /builtin-modules/1.1.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
   /builtin-modules/2.0.0:
     dev: false
     engines:
@@ -2036,62 +1873,47 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-  /camelcase-keys/2.1.0:
-    dependencies:
-      camelcase: 2.1.1
-      map-obj: 1.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
-  /camelcase/2.1.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
   /camelcase/5.3.1:
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30001192:
+  /caniuse-lite/1.0.30001198:
     dev: false
     resolution:
-      integrity: sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
+      integrity: sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==
   /caseless/0.12.0:
     dev: false
     resolution:
       integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-  /chai-as-promised/7.1.1_chai@4.3.0:
+  /chai-as-promised/7.1.1_chai@4.3.3:
     dependencies:
-      chai: 4.3.0
+      chai: 4.3.3
       check-error: 1.0.2
     dev: false
     peerDependencies:
       chai: '>= 2.1.2 < 5'
     resolution:
       integrity: sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
-  /chai-exclude/2.0.2_chai@4.3.0:
+  /chai-exclude/2.0.2_chai@4.3.3:
     dependencies:
-      chai: 4.3.0
+      chai: 4.3.3
       fclone: 1.0.11
     dev: false
     peerDependencies:
       chai: '>= 4.0.0 < 5'
     resolution:
       integrity: sha512-QmNVnvdSw8Huccdjm49mKu3HtoHxvjdavgYkY0KPQ5MI5UWfbc9sX1YqRgaMPf2GGtDXPoF2ram3AeNS4945Xw==
-  /chai-string/1.5.0_chai@4.3.0:
+  /chai-string/1.5.0_chai@4.3.3:
     dependencies:
-      chai: 4.3.0
+      chai: 4.3.3
     dev: false
     peerDependencies:
       chai: ^4.1.2
     resolution:
       integrity: sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==
-  /chai/4.3.0:
+  /chai/4.3.3:
     dependencies:
       assertion-error: 1.1.0
       check-error: 1.0.2
@@ -2101,9 +1923,9 @@ packages:
       type-detect: 4.0.8
     dev: false
     engines:
-      node: '>=8'
+      node: '>=4'
     resolution:
-      integrity: sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==
+      integrity: sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==
   /chalk/1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -2162,7 +1984,7 @@ packages:
     dependencies:
       anymatch: 3.1.1
       braces: 3.0.2
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.1
       normalize-path: 3.0.0
@@ -2178,7 +2000,7 @@ packages:
     dependencies:
       anymatch: 3.1.1
       braces: 3.0.2
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.1
       normalize-path: 3.0.0
@@ -2208,7 +2030,7 @@ packages:
       integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
   /cliui/6.0.0:
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
       wrap-ansi: 6.2.0
     dev: false
@@ -2216,22 +2038,12 @@ packages:
       integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   /cliui/7.0.4:
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
       wrap-ansi: 7.0.0
     dev: false
     resolution:
       integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  /clone-stats/0.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=
-  /clone/1.0.4:
-    dev: false
-    engines:
-      node: '>=0.8'
-    resolution:
-      integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
   /co/4.6.0:
     dev: false
     engines:
@@ -2268,11 +2080,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-  /color-support/1.1.3:
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
   /colorette/1.2.2:
     dev: false
     resolution:
@@ -2311,22 +2118,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-  /component-bind/1.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
-  /component-emitter/1.2.1:
-    dev: false
-    resolution:
-      integrity: sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
   /component-emitter/1.3.0:
     dev: false
     resolution:
       integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-  /component-inherit/0.0.3:
-    dev: false
-    resolution:
-      integrity: sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
   /concat-map/0.0.1:
     dev: false
     resolution:
@@ -2395,15 +2190,24 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-  /core-js/3.9.0:
+  /core-js/3.9.1:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==
+      integrity: sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
   /core-util-is/1.0.2:
     dev: false
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+  /cors/2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
+    engines:
+      node: '>= 0.10'
+    resolution:
+      integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
   /cp-file/6.2.0:
     dependencies:
       graceful-fs: 4.2.6
@@ -2464,14 +2268,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w==
-  /currently-unhandled/0.4.1:
-    dependencies:
-      array-find-index: 1.0.2
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-mI3zP+qxke95mmE2nddsF635V+o=
   /custom-event/1.0.1:
     dev: false
     resolution:
@@ -2506,22 +2302,14 @@ packages:
       node: '>0.4.0'
     resolution:
       integrity: sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=
-  /dateformat/1.0.12:
-    dependencies:
-      get-stdin: 4.0.1
-      meow: 3.7.0
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=
   /death/1.1.0:
     dev: false
     resolution:
       integrity: sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=
-  /debounce/1.2.0:
+  /debounce/1.2.1:
     dev: false
     resolution:
-      integrity: sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+      integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
   /debug/2.6.9:
     dependencies:
       ms: 2.0.0
@@ -2536,7 +2324,7 @@ packages:
       integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   /debug/3.2.6:
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.1
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dev: false
     resolution:
@@ -2754,12 +2542,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-nh5vM3n2pRhPwZqh0iWo5gpItPAYEGEWw9yd0YpI+lO60B7A3A6iJlxDbt7kKVNbqBXKsptL+jwE/Yg5Go66WQ==
-  /duplexer2/0.0.2:
-    dependencies:
-      readable-stream: 1.1.14
-    dev: false
-    resolution:
-      integrity: sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=
   /ecc-jsbn/0.1.2:
     dependencies:
       jsbn: 0.1.1
@@ -2781,10 +2563,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.674:
+  /electron-to-chromium/1.3.685:
     dev: false
     resolution:
-      integrity: sha512-DBmEKRVYLZAoQSW+AmLcTF5Bpwhk4RUkobtzXVDlfPPYIlbsH3Jfg3QbBjAfFcRARzMIo4YiMhp3N+RnMuo1Eg==
+      integrity: sha512-C3oFZNkJ8lz85ADqr3hzpjBc2ciejMRN2SCd/D0hwcqpr6MGxfdN/j89VN6l+ERTuCUvhg0VYsf40Q4qTz4bhQ==
   /emoji-regex/7.0.3:
     dev: false
     resolution:
@@ -2805,45 +2587,28 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  /engine.io-client/3.5.0:
+  /engine.io-parser/4.0.2:
     dependencies:
-      component-emitter: 1.3.0
-      component-inherit: 0.0.3
-      debug: 3.1.0
-      engine.io-parser: 2.2.1
-      has-cors: 1.1.0
-      indexof: 0.0.1
-      parseqs: 0.0.6
-      parseuri: 0.0.6
-      ws: 7.4.3
-      xmlhttprequest-ssl: 1.5.5
-      yeast: 0.1.2
-    dev: false
-    resolution:
-      integrity: sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==
-  /engine.io-parser/2.2.1:
-    dependencies:
-      after: 0.8.2
-      arraybuffer.slice: 0.0.7
       base64-arraybuffer: 0.1.4
-      blob: 0.0.5
-      has-binary2: 1.0.3
-    dev: false
-    resolution:
-      integrity: sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==
-  /engine.io/3.5.0:
-    dependencies:
-      accepts: 1.3.7
-      base64id: 2.0.0
-      cookie: 0.4.1
-      debug: 4.1.1
-      engine.io-parser: 2.2.1
-      ws: 7.4.3
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
+      integrity: sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==
+  /engine.io/4.1.1:
+    dependencies:
+      accepts: 1.3.7
+      base64id: 2.0.0
+      cookie: 0.4.1
+      cors: 2.8.5
+      debug: 4.3.1
+      engine.io-parser: 4.0.2
+      ws: 7.4.4
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==
   /enquirer/2.3.6:
     dependencies:
       ansi-colors: 4.1.1
@@ -2862,27 +2627,29 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.18.0-next.2:
+  /es-abstract/1.18.0:
     dependencies:
       call-bind: 1.0.2
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       get-intrinsic: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
       is-callable: 1.2.3
       is-negative-zero: 2.0.1
       is-regex: 1.1.2
+      is-string: 1.0.5
       object-inspect: 1.9.0
       object-keys: 1.1.1
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.4
       string.prototype.trimstart: 1.0.4
+      unbox-primitive: 1.0.0
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
+      integrity: sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
   /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.2.3
@@ -2943,23 +2710,9 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  /escodegen/1.8.1:
+  /eslint-config-prettier/7.2.0_eslint@7.21.0:
     dependencies:
-      esprima: 2.7.3
-      estraverse: 1.9.3
-      esutils: 2.0.3
-      optionator: 0.8.3
-    dev: false
-    engines:
-      node: '>=0.12.0'
-    hasBin: true
-    optionalDependencies:
-      source-map: 0.2.0
-    resolution:
-      integrity: sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=
-  /eslint-config-prettier/7.2.0_eslint@7.20.0:
-    dependencies:
-      eslint: 7.20.0
+      eslint: 7.21.0
     dev: false
     hasBin: true
     peerDependencies:
@@ -2982,9 +2735,9 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
-  /eslint-plugin-es/3.0.1_eslint@7.20.0:
+  /eslint-plugin-es/3.0.1_eslint@7.21.0:
     dependencies:
-      eslint: 7.20.0
+      eslint: 7.21.0
       eslint-utils: 2.1.0
       regexpp: 3.1.0
     dev: false
@@ -2994,14 +2747,14 @@ packages:
       eslint: '>=4.19.1'
     resolution:
       integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
-  /eslint-plugin-import/2.22.1_eslint@7.20.0:
+  /eslint-plugin-import/2.22.1_eslint@7.21.0:
     dependencies:
       array-includes: 3.1.3
       array.prototype.flat: 1.2.4
       contains-path: 0.1.0
       debug: 2.6.9
       doctrine: 1.5.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       eslint-import-resolver-node: 0.3.4
       eslint-module-utils: 2.6.0
       has: 1.0.3
@@ -3023,10 +2776,10 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
-  /eslint-plugin-node/11.1.0_eslint@7.20.0:
+  /eslint-plugin-node/11.1.0_eslint@7.21.0:
     dependencies:
-      eslint: 7.20.0
-      eslint-plugin-es: 3.0.1_eslint@7.20.0
+      eslint: 7.21.0
+      eslint-plugin-es: 3.0.1_eslint@7.21.0
       eslint-utils: 2.1.0
       ignore: 5.1.8
       minimatch: 3.0.4
@@ -3081,10 +2834,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
-  /eslint/7.20.0:
+  /eslint/7.21.0:
     dependencies:
       '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.3.0
+      '@eslint/eslintrc': 0.4.0
       ajv: 6.12.6
       chalk: 4.1.0
       cross-spawn: 7.0.3
@@ -3099,7 +2852,7 @@ packages:
       esutils: 2.0.3
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       globals: 12.4.0
       ignore: 4.0.6
       import-fresh: 3.3.0
@@ -3119,13 +2872,13 @@ packages:
       strip-json-comments: 3.1.1
       table: 6.0.7
       text-table: 0.2.0
-      v8-compile-cache: 2.2.0
+      v8-compile-cache: 2.3.0
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     resolution:
-      integrity: sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
+      integrity: sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==
   /esm/3.2.25:
     dev: false
     engines:
@@ -3142,13 +2895,6 @@ packages:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
-  /esprima/2.7.3:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    hasBin: true
-    resolution:
-      integrity: sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
   /esprima/3.1.3:
     dev: false
     engines:
@@ -3179,12 +2925,6 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  /estraverse/1.9.3:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
   /estraverse/4.3.0:
     dev: false
     engines:
@@ -3221,12 +2961,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-  /events/3.2.0:
+  /events/3.3.0:
     dev: false
     engines:
       node: '>=0.8.x'
     resolution:
-      integrity: sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+      integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
   /execa/3.4.0:
     dependencies:
       cross-spawn: 7.0.3
@@ -3319,17 +3059,6 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-  /fancy-log/1.3.3:
-    dependencies:
-      ansi-gray: 0.1.1
-      color-support: 1.1.3
-      parse-node-version: 1.0.1
-      time-stamp: 1.1.0
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
   /fast-deep-equal/3.1.3:
     dev: false
     resolution:
@@ -3338,7 +3067,7 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       '@nodelib/fs.walk': 1.2.6
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
@@ -3373,9 +3102,9 @@ packages:
       integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   /fetch-mock/9.11.0_node-fetch@2.6.1:
     dependencies:
-      '@babel/core': 7.13.1
-      '@babel/runtime': 7.13.7
-      core-js: 3.9.0
+      '@babel/core': 7.13.10
+      '@babel/runtime': 7.13.10
+      core-js: 3.9.1
       debug: 4.3.1
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
@@ -3438,15 +3167,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
-  /find-up/1.1.2:
-    dependencies:
-      path-exists: 2.1.0
-      pinkie-promise: 2.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
   /find-up/2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -3500,7 +3220,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==
-  /follow-redirects/1.13.2:
+  /follow-redirects/1.13.3:
     dev: false
     engines:
       node: '>=4.0'
@@ -3510,8 +3230,8 @@ packages:
       debug:
         optional: true
     resolution:
-      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
-  /follow-redirects/1.13.2_debug@3.2.7:
+      integrity: sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+  /follow-redirects/1.13.3_debug@3.2.7:
     dependencies:
       debug: 3.2.7
     dev: false
@@ -3523,8 +3243,8 @@ packages:
       debug:
         optional: true
     resolution:
-      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
-  /follow-redirects/1.13.2_debug@4.3.1:
+      integrity: sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+  /follow-redirects/1.13.3_debug@4.3.1:
     dependencies:
       debug: 4.3.1
     dev: false
@@ -3536,7 +3256,7 @@ packages:
       debug:
         optional: true
     resolution:
-      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+      integrity: sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
   /foreach/2.0.5:
     dev: false
     resolution:
@@ -3696,16 +3416,10 @@ packages:
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     dev: false
     resolution:
       integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
-  /get-stdin/4.0.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
   /get-stream/5.2.0:
     dependencies:
       pump: 3.0.0
@@ -3736,28 +3450,18 @@ packages:
     optional: true
     resolution:
       integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
-  /glob-parent/5.1.1:
+  /glob-parent/5.1.2:
     dependencies:
       is-glob: 4.0.1
     dev: false
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+      integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   /glob-to-regexp/0.4.1:
     dev: false
     resolution:
       integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-  /glob/5.0.15:
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
   /glob/7.1.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -3836,14 +3540,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
-  /glogg/1.0.2:
-    dependencies:
-      sparkles: 1.0.1
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
   /graceful-fs/4.2.6:
     dev: false
     resolution:
@@ -3858,40 +3554,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==
-  /gulp-util/3.0.7:
-    dependencies:
-      array-differ: 1.0.0
-      array-uniq: 1.0.3
-      beeper: 1.1.1
-      chalk: 1.1.3
-      dateformat: 1.0.12
-      fancy-log: 1.3.3
-      gulplog: 1.0.0
-      has-gulplog: 0.1.0
-      lodash._reescape: 3.0.0
-      lodash._reevaluate: 3.0.0
-      lodash._reinterpolate: 3.0.0
-      lodash.template: 3.6.2
-      minimist: 1.2.5
-      multipipe: 0.1.2
-      object-assign: 3.0.0
-      replace-ext: 0.0.1
-      through2: 2.0.1
-      vinyl: 0.5.3
-    deprecated: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
-    dev: false
-    engines:
-      node: '>=0.10'
-    resolution:
-      integrity: sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=
-  /gulplog/1.0.0:
-    dependencies:
-      glogg: 1.0.2
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
   /handlebars/4.7.7:
     dependencies:
       minimist: 1.2.5
@@ -3903,7 +3565,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     resolution:
       integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   /har-schema/2.0.0:
@@ -3930,22 +3592,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  /has-binary2/1.0.3:
-    dependencies:
-      isarray: 2.0.1
+  /has-bigints/1.0.1:
     dev: false
     resolution:
-      integrity: sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
-  /has-cors/1.1.0:
-    dev: false
-    resolution:
-      integrity: sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
-  /has-flag/1.0.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
+      integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
   /has-flag/3.0.0:
     dev: false
     engines:
@@ -3966,26 +3616,18 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=
-  /has-gulplog/0.1.0:
-    dependencies:
-      sparkles: 1.0.1
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=
   /has-only/1.1.1:
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==
-  /has-symbols/1.0.1:
+  /has-symbols/1.0.2:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+      integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
   /has-unicode/2.0.1:
     dev: false
     optional: true
@@ -4080,7 +3722,7 @@ packages:
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.2
+      follow-redirects: 1.13.3
       requires-port: 1.0.0
     dev: false
     engines:
@@ -4090,7 +3732,7 @@ packages:
   /http-proxy/1.18.1_debug@4.3.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.2_debug@4.3.1
+      follow-redirects: 1.13.3_debug@4.3.1
       requires-port: 1.0.0
     dev: false
     engines:
@@ -4188,18 +3830,6 @@ packages:
       node: '>=0.8.19'
     resolution:
       integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=
-  /indent-string/2.1.0:
-    dependencies:
-      repeating: 2.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
-  /indexof/0.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
   /inflight/1.0.6:
     dependencies:
       once: 1.4.0
@@ -4251,6 +3881,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+  /is-bigint/1.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
   /is-binary-path/2.1.0:
     dependencies:
       binary-extensions: 2.2.0
@@ -4259,6 +3893,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  /is-boolean-object/1.1.0:
+    dependencies:
+      call-bind: 1.0.2
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
   /is-buffer/1.1.6:
     dev: false
     resolution:
@@ -4307,12 +3949,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
-  /is-finite/1.1.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
   /is-fullwidth-code-point/1.0.0:
     dependencies:
       number-is-nan: 1.0.1
@@ -4366,6 +4002,12 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+  /is-number-object/1.0.4:
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
   /is-number/7.0.0:
     dev: false
     engines:
@@ -4381,7 +4023,7 @@ packages:
   /is-regex/1.1.2:
     dependencies:
       call-bind: 1.0.2
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     dev: false
     engines:
       node: '>= 0.4'
@@ -4411,7 +4053,7 @@ packages:
       integrity: sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
   /is-symbol/1.0.3:
     dependencies:
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     dev: false
     engines:
       node: '>= 0.4'
@@ -4421,9 +4063,9 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.2
       call-bind: 1.0.2
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
       foreach: 2.0.5
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     dev: false
     engines:
       node: '>= 0.4'
@@ -4433,10 +4075,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-  /is-utf8/0.2.1:
-    dev: false
-    resolution:
-      integrity: sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
   /is-valid-glob/1.0.0:
     dev: false
     engines:
@@ -4465,10 +4103,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-  /isarray/2.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
   /isbinaryfile/4.0.6:
     dev: false
     engines:
@@ -4505,8 +4139,8 @@ packages:
       integrity: sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.13.0
-      '@babel/parser': 7.13.4
+      '@babel/generator': 7.13.9
+      '@babel/parser': 7.13.10
       '@babel/template': 7.12.13
       '@babel/traverse': 7.13.0
       '@babel/types': 7.13.0
@@ -4519,7 +4153,7 @@ packages:
       integrity: sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.13.1
+      '@babel/core': 7.13.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -4587,30 +4221,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
-  /istanbul/0.4.5:
-    dependencies:
-      abbrev: 1.0.9
-      async: 1.5.2
-      escodegen: 1.8.1
-      esprima: 2.7.3
-      glob: 5.0.15
-      handlebars: 4.7.7
-      js-yaml: 3.14.1
-      mkdirp: 0.5.5
-      nopt: 3.0.6
-      once: 1.4.0
-      resolve: 1.1.7
-      supports-color: 3.2.3
-      which: 1.3.1
-      wordwrap: 1.0.0
-    deprecated: |-
-      This module is no longer maintained, try this instead:
-        npm i nyc
-      Visit https://istanbul.js.org/integrations for other alternatives.
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
   /its-name/1.0.0:
     dev: false
     engines:
@@ -4630,10 +4240,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=
-  /jquery/3.5.1:
+  /jquery/3.6.0:
     dev: false
     resolution:
-      integrity: sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+      integrity: sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
   /js-tokens/4.0.0:
     dev: false
     resolution:
@@ -4760,10 +4370,10 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  /jsrsasign/10.1.12:
+  /jsrsasign/10.1.13:
     dev: false
     resolution:
-      integrity: sha512-1IWDl3DQOxXJpShE+Sb7vYOw3RhclqkqLuLagScuQrxgzwpCcp2DJcRzW92O4eSCPqMWoGdNJVfY3TKMb/JBZQ==
+      integrity: sha512-EKifn2DocDxU2fWVqTJgFYjZUcL4fTUtfgN5OQP4t4i/WOioios8wq350E1aJFxCLmtdxGNqhLX3O0tdVqJoFg==
   /jssha/2.4.2:
     deprecated: jsSHA versions < 3.0.0 will no longer receive feature updates
     dev: false
@@ -4811,10 +4421,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
-  /karma-chai/0.1.0_chai@4.3.0+karma@5.2.3:
+  /karma-chai/0.1.0_chai@4.3.3+karma@6.2.0:
     dependencies:
-      chai: 4.3.0
-      karma: 5.2.3
+      chai: 4.3.3
+      karma: 6.2.0
     dev: false
     peerDependencies:
       chai: '*'
@@ -4840,10 +4450,10 @@ packages:
       node: '>=10.0.0'
     resolution:
       integrity: sha512-atDvLQqvPcLxhED0cmXYdsPMCQuh6Asa9FMZW1bhNqlVEhJoB9qyZ2BY1gu7D/rr5GLGb5QzYO4siQskxaWP/g==
-  /karma-edge-launcher/0.4.2_karma@5.2.3:
+  /karma-edge-launcher/0.4.2_karma@6.2.0:
     dependencies:
       edge-launcher: 1.2.2
-      karma: 5.2.3
+      karma: 6.2.0
     dev: false
     engines:
       node: '>=4'
@@ -4861,18 +4471,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Fi7xPhwrRgr+94BnHX0F5dCl1miIW4RHnzjIGxF8GaIEp7rNqX7LSi7ok63VXs3PS/5MQaQMhGxw+bvD+pibBQ==
-  /karma-ie-launcher/1.0.0_karma@5.2.3:
+  /karma-ie-launcher/1.0.0_karma@6.2.0:
     dependencies:
-      karma: 5.2.3
+      karma: 6.2.0
       lodash: 4.17.21
     dev: false
     peerDependencies:
       karma: '>=0.9'
     resolution:
       integrity: sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
-  /karma-json-preprocessor/0.3.3_karma@5.2.3:
+  /karma-json-preprocessor/0.3.3_karma@6.2.0:
     dependencies:
-      karma: 5.2.3
+      karma: 6.2.0
     dev: false
     peerDependencies:
       karma: '>=0.9'
@@ -4884,9 +4494,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kNCi+0UrXAeTJMpMsHkHNbfmlErsYT+/haNakJIhsE/gtj3Jx7zWRg7BTc1HHSbH5KeVXVRJr3/KLB/NHWY7Hg==
-  /karma-junit-reporter/2.0.1_karma@5.2.3:
+  /karma-junit-reporter/2.0.1_karma@6.2.0:
     dependencies:
-      karma: 5.2.3
+      karma: 6.2.0
       path-is-absolute: 1.0.1
       xmlbuilder: 12.0.0
     dev: false
@@ -4896,10 +4506,10 @@ packages:
       karma: '>=0.9'
     resolution:
       integrity: sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==
-  /karma-mocha-reporter/2.2.5_karma@5.2.3:
+  /karma-mocha-reporter/2.2.5_karma@6.2.0:
     dependencies:
       chalk: 2.4.2
-      karma: 5.2.3
+      karma: 6.2.0
       log-symbols: 2.2.0
       strip-ansi: 4.0.0
     dev: false
@@ -4913,20 +4523,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==
-  /karma-remap-istanbul/0.6.0_karma@5.2.3:
-    dependencies:
-      istanbul: 0.4.5
-      karma: 5.2.3
-      remap-istanbul: 0.9.6
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-l/O3cAZSVPm0ck8tm+SjouG69vw=
   /karma-rollup-preprocessor/7.0.6_rollup@1.32.1:
     dependencies:
       chokidar: 3.5.1
-      debounce: 1.2.0
+      debounce: 1.2.1
       rollup: 1.32.1
     dev: false
     engines:
@@ -4947,7 +4547,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-zorxyAakYZuBcHRJE+vbrK2o2JXLFWK8VVjiT/6P+ltLBUGUvqTEkUiQ119MGdOrK7mrmxXHZF1/pfT6GgIZ6g==
-  /karma/5.2.3:
+  /karma/6.2.0:
     dependencies:
       body-parser: 1.19.0
       braces: 3.0.2
@@ -4967,18 +4567,18 @@ packages:
       qjobs: 1.2.0
       range-parser: 1.2.1
       rimraf: 3.0.2
-      socket.io: 2.4.1
+      socket.io: 3.1.2
       source-map: 0.6.1
       tmp: 0.2.1
-      ua-parser-js: 0.7.22
-      yargs: 15.4.1
+      ua-parser-js: 0.7.24
+      yargs: 16.2.0
     dev: false
     engines:
       node: '>= 10'
     hasBin: true
     resolution:
-      integrity: sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==
-  /karma/5.2.3_debug@4.3.1:
+      integrity: sha512-pCB8eNxGgdIdZeC885rbhZ/VyuOPNHUIDNL9EaaMf1NVzpvTjMO8a7zRTn51ZJhOOOxCSpalUdT1A8x76LyVqg==
+  /karma/6.2.0_debug@4.3.1:
     dependencies:
       body-parser: 1.19.0
       braces: 3.0.2
@@ -4998,11 +4598,11 @@ packages:
       qjobs: 1.2.0
       range-parser: 1.2.1
       rimraf: 3.0.2
-      socket.io: 2.4.1
+      socket.io: 3.1.2
       source-map: 0.6.1
       tmp: 0.2.1
-      ua-parser-js: 0.7.22
-      yargs: 15.4.1
+      ua-parser-js: 0.7.24
+      yargs: 16.2.0
     dev: false
     engines:
       node: '>= 10'
@@ -5010,7 +4610,7 @@ packages:
     peerDependencies:
       debug: '*'
     resolution:
-      integrity: sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==
+      integrity: sha512-pCB8eNxGgdIdZeC885rbhZ/VyuOPNHUIDNL9EaaMf1NVzpvTjMO8a7zRTn51ZJhOOOxCSpalUdT1A8x76LyVqg==
   /keytar/7.4.0:
     dependencies:
       node-addon-api: 3.1.0
@@ -5044,18 +4644,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  /load-json-file/1.1.0:
-    dependencies:
-      graceful-fs: 4.2.6
-      parse-json: 2.2.0
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-      strip-bom: 2.0.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   /load-json-file/2.0.0:
     dependencies:
       graceful-fs: 4.2.6
@@ -5104,48 +4692,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  /lodash._basecopy/3.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
-  /lodash._basetostring/3.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=
-  /lodash._basevalues/3.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=
-  /lodash._getnative/3.9.1:
-    dev: false
-    resolution:
-      integrity: sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
-  /lodash._isiterateecall/3.0.9:
-    dev: false
-    resolution:
-      integrity: sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
-  /lodash._reescape/3.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=
-  /lodash._reevaluate/3.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=
-  /lodash._reinterpolate/3.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-  /lodash._root/3.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
-  /lodash.escape/3.2.0:
-    dependencies:
-      lodash._root: 3.0.1
-    dev: false
-    resolution:
-      integrity: sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=
   /lodash.flattendeep/4.4.0:
     dev: false
     resolution:
@@ -5158,14 +4704,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
-  /lodash.isarguments/3.1.0:
-    dev: false
-    resolution:
-      integrity: sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
-  /lodash.isarray/3.0.4:
-    dev: false
-    resolution:
-      integrity: sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
   /lodash.isboolean/3.0.3:
     dev: false
     resolution:
@@ -5190,14 +4728,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-  /lodash.keys/3.1.2:
-    dependencies:
-      lodash._getnative: 3.9.1
-      lodash.isarguments: 3.1.0
-      lodash.isarray: 3.0.4
-    dev: false
-    resolution:
-      integrity: sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
   /lodash.merge/4.6.2:
     dev: false
     resolution:
@@ -5206,35 +4736,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-  /lodash.restparam/3.6.1:
-    dev: false
-    resolution:
-      integrity: sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
   /lodash.sortby/4.7.0:
     dev: false
     resolution:
       integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-  /lodash.template/3.6.2:
-    dependencies:
-      lodash._basecopy: 3.0.1
-      lodash._basetostring: 3.0.1
-      lodash._basevalues: 3.0.0
-      lodash._isiterateecall: 3.0.9
-      lodash._reinterpolate: 3.0.0
-      lodash.escape: 3.2.0
-      lodash.keys: 3.1.2
-      lodash.restparam: 3.6.1
-      lodash.templatesettings: 3.1.1
-    dev: false
-    resolution:
-      integrity: sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=
-  /lodash.templatesettings/3.1.1:
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-      lodash.escape: 3.2.0
-    dev: false
-    resolution:
-      integrity: sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=
   /lodash/4.17.21:
     dev: false
     resolution:
@@ -5271,15 +4776,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-  /loud-rejection/1.6.0:
-    dependencies:
-      currently-unhandled: 0.4.1
-      signal-exit: 3.0.3
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
   /lru-cache/4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -5332,12 +4828,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-  /map-obj/1.0.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
   /marked/0.7.0:
     dev: false
     engines:
@@ -5385,23 +4875,6 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=
-  /meow/3.7.0:
-    dependencies:
-      camelcase-keys: 2.1.0
-      decamelize: 1.2.0
-      loud-rejection: 1.6.0
-      map-obj: 1.0.1
-      minimist: 1.2.5
-      normalize-package-data: 2.5.0
-      object-assign: 4.1.1
-      read-pkg-up: 1.0.1
-      redent: 1.0.0
-      trim-newlines: 1.0.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
@@ -5598,12 +5071,6 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha512-tPwgKoWBRf+d2YG4CgCm2C9MiRUwzdn2aOwlLtaBCj3ekM1afkWMKbAsbKuuWSdoMPhhxrvALIOV0FfX3WKJlg==
-  /multipipe/0.1.2:
-    dependencies:
-      duplexer2: 0.0.2
-    dev: false
-    resolution:
-      integrity: sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=
   /nanoid/3.1.20:
     dev: false
     engines:
@@ -5665,13 +5132,13 @@ packages:
       node: '>= 10.13'
     resolution:
       integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==
-  /node-abi/2.19.3:
+  /node-abi/2.21.0:
     dependencies:
       semver: 5.7.1
     dev: false
     optional: true
     resolution:
-      integrity: sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
+      integrity: sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==
   /node-abort-controller/1.1.0:
     dev: false
     resolution:
@@ -5703,13 +5170,6 @@ packages:
     optional: true
     resolution:
       integrity: sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
-  /nopt/3.0.6:
-    dependencies:
-      abbrev: 1.0.9
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.8
@@ -5812,12 +5272,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-  /object-assign/3.0.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
   /object-assign/4.1.1:
     dev: false
     engines:
@@ -5838,7 +5292,7 @@ packages:
     dependencies:
       define-properties: 1.1.3
       function-bind: 1.1.1
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
       object-keys: 1.1.1
     dev: false
     engines:
@@ -5849,7 +5303,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
       object-keys: 1.1.1
     dev: false
     engines:
@@ -5860,7 +5314,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
     dev: false
     engines:
       node: '>= 0.8'
@@ -5870,7 +5324,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
       has: 1.0.3
     dev: false
     engines:
@@ -6057,26 +5511,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-node-version/1.0.1:
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
   /parse-passwd/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
-  /parseqs/0.0.6:
-    dev: false
-    resolution:
-      integrity: sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
-  /parseuri/0.0.6:
-    dev: false
-    resolution:
-      integrity: sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==
   /parseurl/1.3.3:
     dev: false
     engines:
@@ -6087,14 +5527,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
-  /path-exists/2.1.0:
-    dependencies:
-      pinkie-promise: 2.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
   /path-exists/3.0.0:
     dev: false
     engines:
@@ -6143,16 +5575,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-  /path-type/1.1.0:
-    dependencies:
-      graceful-fs: 4.2.6
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
   /path-type/2.0.0:
     dependencies:
       pify: 2.3.0
@@ -6218,20 +5640,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
-  /pinkie-promise/2.0.1:
-    dependencies:
-      pinkie: 2.0.4
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ITXW36ejWMBprJsXh3YogihFD/o=
-  /pinkie/2.0.4:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
   /pkg-dir/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -6262,7 +5670,7 @@ packages:
       minimist: 1.2.5
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
-      node-abi: 2.19.3
+      node-abi: 2.21.0
       noop-logger: 0.1.1
       npmlog: 4.1.2
       pump: 3.0.0
@@ -6397,7 +5805,7 @@ packages:
       rimraf: 3.0.2
       tar-fs: 2.1.1
       unbzip2-stream: 1.4.3
-      ws: 7.4.3
+      ws: 7.4.4
     dev: false
     engines:
       node: '>=10.18.1'
@@ -6507,15 +5915,6 @@ packages:
     optional: true
     resolution:
       integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  /read-pkg-up/1.0.1:
-    dependencies:
-      find-up: 1.1.2
-      read-pkg: 1.1.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -6534,16 +5933,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
-  /read-pkg/1.1.0:
-    dependencies:
-      load-json-file: 1.1.0
-      normalize-package-data: 2.5.0
-      path-type: 1.1.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
   /read-pkg/2.0.0:
     dependencies:
       load-json-file: 2.0.0
@@ -6630,15 +6019,6 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  /redent/1.0.0:
-    dependencies:
-      indent-string: 2.1.0
-      strip-indent: 1.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
   /regenerator-runtime/0.11.1:
     dev: false
     resolution:
@@ -6661,36 +6041,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
-  /remap-istanbul/0.9.6:
-    dependencies:
-      amdefine: 1.0.1
-      gulp-util: 3.0.7
-      istanbul: 0.4.5
-      minimatch: 3.0.4
-      source-map: 0.6.1
-      through2: 2.0.1
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-l0WDBsVjaTzP8m3glERJO6bjlAFUahcgfcgvcX+owZw7dKeDLT3CVRpS7UO4L9LfGcMiNsqk223HopwVxlh8Hg==
   /remove-trailing-separator/1.1.0:
     dev: false
     resolution:
       integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
-  /repeating/2.0.1:
-    dependencies:
-      is-finite: 1.1.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
-  /replace-ext/0.0.1:
-    dev: false
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
   /request/2.88.2:
     dependencies:
       aws-sign2: 0.7.0
@@ -6766,10 +6120,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-  /resolve/1.1.7:
-    dev: false
-    resolution:
-      integrity: sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
   /resolve/1.17.0:
     dependencies:
       path-parse: 1.0.6
@@ -6910,7 +6260,7 @@ packages:
   /rollup/1.32.1:
     dependencies:
       '@types/estree': 0.0.46
-      '@types/node': 10.17.54
+      '@types/node': 8.10.66
       acorn: 7.4.1
     dev: false
     hasBin: true
@@ -6963,11 +6313,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-  /semver/7.0.0:
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
   /semver/7.3.4:
     dependencies:
       lru-cache: 6.0.0
@@ -7180,53 +6525,36 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==
-  /socket.io-adapter/1.1.2:
+  /socket.io-adapter/2.1.0:
     dev: false
     resolution:
-      integrity: sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
-  /socket.io-client/2.4.0:
+      integrity: sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==
+  /socket.io-parser/4.0.4:
     dependencies:
-      backo2: 1.0.2
-      component-bind: 1.0.0
+      '@types/component-emitter': 1.2.10
       component-emitter: 1.3.0
-      debug: 3.1.0
-      engine.io-client: 3.5.0
-      has-binary2: 1.0.3
-      indexof: 0.0.1
-      parseqs: 0.0.6
-      parseuri: 0.0.6
-      socket.io-parser: 3.3.2
-      to-array: 0.1.4
+      debug: 4.3.1
     dev: false
+    engines:
+      node: '>=10.0.0'
     resolution:
-      integrity: sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
-  /socket.io-parser/3.3.2:
+      integrity: sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+  /socket.io/3.1.2:
     dependencies:
-      component-emitter: 1.3.0
-      debug: 3.1.0
-      isarray: 2.0.1
+      '@types/cookie': 0.4.0
+      '@types/cors': 2.8.10
+      '@types/node': 10.17.13
+      accepts: 1.3.7
+      base64id: 2.0.0
+      debug: 4.3.1
+      engine.io: 4.1.1
+      socket.io-adapter: 2.1.0
+      socket.io-parser: 4.0.4
     dev: false
+    engines:
+      node: '>=10.0.0'
     resolution:
-      integrity: sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
-  /socket.io-parser/3.4.1:
-    dependencies:
-      component-emitter: 1.2.1
-      debug: 4.1.1
-      isarray: 2.0.1
-    dev: false
-    resolution:
-      integrity: sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==
-  /socket.io/2.4.1:
-    dependencies:
-      debug: 4.1.1
-      engine.io: 3.5.0
-      has-binary2: 1.0.3
-      socket.io-adapter: 1.1.2
-      socket.io-client: 2.4.0
-      socket.io-parser: 3.4.1
-    dev: false
-    resolution:
-      integrity: sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
+      integrity: sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==
   /socks-proxy-agent/4.0.2:
     dependencies:
       agent-base: 4.2.1
@@ -7267,15 +6595,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
-  /source-map/0.2.0:
-    dependencies:
-      amdefine: 1.0.1
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    optional: true
-    resolution:
-      integrity: sha1-2rc/vPwrqBm03gO9b26qSBZLP50=
   /source-map/0.5.7:
     dev: false
     engines:
@@ -7298,12 +6617,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
-  /sparkles/1.0.1:
-    dev: false
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
   /spawn-wrap/1.4.3:
     dependencies:
       foreground-child: 1.5.6
@@ -7430,7 +6743,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  /string-width/4.2.0:
+  /string-width/4.2.2:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
@@ -7439,12 +6752,12 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+      integrity: sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   /string.prototype.padend/3.1.2:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
     dev: false
     engines:
       node: '>= 0.4'
@@ -7512,14 +6825,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  /strip-bom/2.0.0:
-    dependencies:
-      is-utf8: 0.2.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   /strip-bom/3.0.0:
     dev: false
     engines:
@@ -7532,15 +6837,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-  /strip-indent/1.0.1:
-    dependencies:
-      get-stdin: 4.0.1
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    hasBin: true
-    resolution:
-      integrity: sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   /strip-json-comments/2.0.1:
     dev: false
     engines:
@@ -7559,14 +6855,6 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-  /supports-color/3.2.3:
-    dependencies:
-      has-flag: 1.0.0
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    resolution:
-      integrity: sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   /supports-color/5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -7601,10 +6889,10 @@ packages:
       integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   /table/6.0.7:
     dependencies:
-      ajv: 7.1.1
+      ajv: 7.2.1
       lodash: 4.17.21
       slice-ansi: 4.0.0
-      string-width: 4.2.0
+      string-width: 4.2.2
     dev: false
     engines:
       node: '>=10.0.0'
@@ -7661,23 +6949,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-  /through2/2.0.1:
-    dependencies:
-      readable-stream: 2.0.6
-      xtend: 4.0.2
-    dev: false
-    resolution:
-      integrity: sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=
   /thunkify/2.1.2:
     dev: false
     resolution:
       integrity: sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
-  /time-stamp/1.1.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
   /timsort/0.3.0:
     dev: false
     resolution:
@@ -7690,10 +6965,6 @@ packages:
       node: '>=8.17.0'
     resolution:
       integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  /to-array/0.1.4:
-    dev: false
-    resolution:
-      integrity: sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
   /to-fast-properties/2.0.0:
     dev: false
     engines:
@@ -7739,12 +7010,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
-  /trim-newlines/1.0.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-WIeWa7WCpFA6QetST301ARgVphM=
   /ts-node/8.10.2_typescript@4.1.2:
     dependencies:
       arg: 4.1.3
@@ -7778,47 +7043,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-  /tslint-config-prettier/1.18.0:
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-  /tslint/5.20.1_typescript@4.1.2:
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      builtin-modules: 1.1.1
-      chalk: 2.4.2
-      commander: 2.20.3
-      diff: 4.0.2
-      glob: 7.1.6
-      js-yaml: 3.14.1
-      minimatch: 3.0.4
-      mkdirp: 0.5.5
-      resolve: 1.20.0
-      semver: 5.7.1
-      tslib: 1.14.1
-      tsutils: 2.29.0_typescript@4.1.2
-      typescript: 4.1.2
-    dev: false
-    engines:
-      node: '>=4.8.0'
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
-    resolution:
-      integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  /tsutils/2.29.0_typescript@4.1.2:
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.1.2
-    dev: false
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    resolution:
-      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/3.20.0_typescript@4.1.2:
+  /tsutils/3.21.0_typescript@4.1.2:
     dependencies:
       tslib: 1.14.1
       typescript: 4.1.2
@@ -7828,7 +7053,7 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
-      integrity: sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
+      integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   /tunnel-agent/0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -7885,7 +7110,7 @@ packages:
   /typedoc-default-themes/0.6.3:
     dependencies:
       backbone: 1.4.0
-      jquery: 3.5.1
+      jquery: 3.6.0
       lunr: 2.3.9
       underscore: 1.12.0
     dev: false
@@ -7933,17 +7158,26 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
-  /ua-parser-js/0.7.22:
+  /ua-parser-js/0.7.24:
     dev: false
     resolution:
-      integrity: sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
-  /uglify-js/3.12.8:
+      integrity: sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+  /uglify-js/3.13.0:
     dev: false
     engines:
       node: '>=0.8.0'
     hasBin: true
     resolution:
-      integrity: sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==
+      integrity: sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==
+  /unbox-primitive/1.0.0:
+    dependencies:
+      function-bind: 1.1.1
+      has-bigints: 1.0.1
+      has-symbols: 1.0.2
+      which-boxed-primitive: 1.0.2
+    dev: false
+    resolution:
+      integrity: sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
   /unbzip2-stream/1.4.3:
     dependencies:
       buffer: 5.7.1
@@ -8036,10 +7270,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-  /v8-compile-cache/2.2.0:
+  /v8-compile-cache/2.3.0:
     dev: false
     resolution:
-      integrity: sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+      integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
   /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -8082,16 +7316,6 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
-  /vinyl/0.5.3:
-    dependencies:
-      clone: 1.0.4
-      clone-stats: 0.0.1
-      replace-ext: 0.0.1
-    dev: false
-    engines:
-      node: '>= 0.9'
-    resolution:
-      integrity: sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=
   /void-elements/2.0.1:
     dev: false
     engines:
@@ -8110,6 +7334,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+  /which-boxed-primitive/1.0.2:
+    dependencies:
+      is-bigint: 1.0.1
+      is-boolean-object: 1.1.0
+      is-number-object: 1.0.4
+      is-string: 1.0.5
+      is-symbol: 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
   /which-module/2.0.0:
     dev: false
     resolution:
@@ -8123,10 +7357,10 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.2
       call-bind: 1.0.2
-      es-abstract: 1.18.0-next.2
+      es-abstract: 1.18.0
       foreach: 2.0.5
       function-bind: 1.1.1
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
       is-typed-array: 1.1.5
     dev: false
     engines:
@@ -8178,7 +7412,7 @@ packages:
   /wrap-ansi/6.2.0:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
     dev: false
     engines:
@@ -8188,7 +7422,7 @@ packages:
   /wrap-ansi/7.0.0:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
     dev: false
     engines:
@@ -8207,7 +7441,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
-  /ws/7.4.3:
+  /ws/7.4.4:
     dev: false
     engines:
       node: '>=8.3.0'
@@ -8220,7 +7454,7 @@ packages:
       utf-8-validate:
         optional: true
     resolution:
-      integrity: sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+      integrity: sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
   /xhr-mock/2.5.1:
     dependencies:
       global: 4.4.0
@@ -8265,19 +7499,12 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
-  /xmldom/0.4.0:
-    deprecated: Deprecated due to CVE-2021-21366 resolved in 0.5.0
+  /xmldom/0.5.0:
     dev: false
     engines:
       node: '>=10.0.0'
     resolution:
-      integrity: sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==
-  /xmlhttprequest-ssl/1.5.5:
-    dev: false
-    engines:
-      node: '>=0.4.0'
-    resolution:
-      integrity: sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+      integrity: sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
   /xpath.js/1.1.0:
     dev: false
     engines:
@@ -8288,12 +7515,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
-  /xtend/4.0.2:
-    dev: false
-    engines:
-      node: '>=0.4'
-    resolution:
-      integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
   /y18n/4.0.1:
     dev: false
     resolution:
@@ -8332,12 +7553,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  /yargs-parser/20.2.6:
+  /yargs-parser/20.2.7:
     dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
+      integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
   /yargs-unparser/1.6.0:
     dependencies:
       flat: 4.1.1
@@ -8372,7 +7593,7 @@ packages:
       require-directory: 2.1.1
       require-main-filename: 2.0.0
       set-blocking: 2.0.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       which-module: 2.0.0
       y18n: 4.0.1
       yargs-parser: 18.1.3
@@ -8387,9 +7608,9 @@ packages:
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.0
+      string-width: 4.2.2
       y18n: 5.0.5
-      yargs-parser: 20.2.6
+      yargs-parser: 20.2.7
     dev: false
     engines:
       node: '>=10'
@@ -8402,10 +7623,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
-  /yeast/0.1.2:
-    dev: false
-    resolution:
-      integrity: sha1-AI4G2AlDIMNy28L47XagymyKxBk=
   /yn/3.1.1:
     dev: false
     engines:
@@ -8436,17 +7653,17 @@ packages:
       cross-env: 7.0.3
       delay: 4.4.1
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8463,13 +7680,12 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-+o3sVHmEvCh0ezHz3KWwdUo1d444Wqgnzs88P49XJaejLjBGNMgsPPJcxrtgncDADyuKsnHS4643rnjzWJuYrg==
+      integrity: sha512-UtGLbMEfOi4QTeREvLKyrpXi+YEiD42JIAhddouJwmXSFWA7lszkPe3YcDcqT1OYaPOoF1m8gdbEZ7ctjGAYMQ==
       tarball: file:projects/abort-controller.tgz
     version: 0.0.0
   file:projects/ai-anomaly-detector.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8480,22 +7696,22 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       csv-parse: 4.15.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8514,36 +7730,35 @@ packages:
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-DcXxwlUYhV8lVuADpzmap8wLPNcQ7QHGKa4QnAetW1a3nQIHMAgFri6LYD2P25BfRT8i0I7cRhf1cLFE/vEYTw==
+      integrity: sha512-Xz4JQgeSL/FFp77LimXOQDz4RJH//6SA8tVSXXSbzjw+joLI+XnU1n6fB277vxlJPuECHFJjSoiS+HsuuArtRg==
       tarball: file:projects/ai-anomaly-detector.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8559,36 +7774,35 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-HcXTUps7Eeqn6ww4pdTNiYIsdFzYXuEEsVzi/3kf4tlx20+dqwpqnCWJppnGRAsgr0ByMy3Kwr3cP6zPl+XiZA==
+      integrity: sha512-LgHD00KHy2oRc18MF4ww1DAJQCVj3sUYB6kAu+Elxt4QQS9Up1MmwKEOTp4JMOygernFQBCrh7Ol0hgkurzRSg==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8605,37 +7819,36 @@ packages:
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-d+i4tG8NEGYFkvgYV4sJ8TnvS2piKe3oqjU50I0EQBfQ5rN2h4VZihPzfXB+22wN8ranLYvMubvxYtTSntMixw==
+      integrity: sha512-XhjdtfoGioYHt1bZOJ9lRi5XN+hwCizXfSp8wQuYmuigADeXcKhdH2ECtV3Jp4f8DdSWblQNbE0ioVJUgh6paw==
       tarball: file:projects/ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/ai-text-analytics.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
@@ -8653,13 +7866,12 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-YiqbNdv3MFBYzV7kUH9+Bup43kWU0BczX60daHnlvKiucMBgLSNDUKVVtikhK0COST4ZL/NluvKyUf68VTWDfg==
+      integrity: sha512-3S5kH12KUSDJ7bzsBjQ2QBz4pm782PN6zSZhLuI/AUkfDNHvcaTFNO/PGPVNXx5LnbaB9MSEPfqwYEZDqEQ+NA==
       tarball: file:projects/ai-text-analytics.tgz
     version: 0.0.0
   file:projects/app-configuration.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8671,23 +7883,23 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8704,41 +7916,41 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-6MiKET/VaZyRRKPSIzHKVypOAKr6Iwft9p5nWH7P7fPmW2LDZiep2f30Qolaup7iX61y/Avmn/J+zIgc/lMy+g==
+      integrity: sha512-Bkz0oPteA/jvhCiCgtl+XhaGpKbZMR59Oz82NIrLWbxRtHX7VnG2AU31PDIKKrnAIqmGnETw92pPcPt4lB6N9w==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/attestation.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/chai-as-promised': 7.1.3
-      '@types/jsrsasign': 8.0.9
+      '@types/jsrsasign': 8.0.10
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       buffer: 5.7.1
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      jsrsasign: 10.1.12
-      karma: 5.2.3
+      eslint: 7.21.0
+      jsrsasign: 10.1.13
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
@@ -8756,14 +7968,13 @@ packages:
     dev: false
     name: '@rush-temp/attestation'
     resolution:
-      integrity: sha512-gw5DkWNXWrIKsxZa7RrkO7IfS4kmuoh9l4K9c4ZdlALtI7s03Ife/1LeZ7VsvYRDk9DvCUEplTB0vr/HSWlTMA==
+      integrity: sha512-iT1mvD/jl5GrWw66kK84k8mhOXj6JwKgr2OLHJ7ECvoA1fL7ry3uKw0YqVQgD0ys0B4259BShc99tOOUC+RdSg==
       tarball: file:projects/attestation.tgz
     version: 0.0.0
   file:projects/communication-administration.tgz:
     dependencies:
       '@azure/communication-common': 1.0.0-beta.6
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-documenter': 7.8.56
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -8775,26 +7986,26 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8813,7 +8024,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-administration'
     resolution:
-      integrity: sha512-N4urQh6w69vwJ4ZODdHwx1yYj5jTL5cdxFmar53ivqauWu8AJcNpI1dvuJnChUDjZCKFPklzEjTY+GQkWaD+kg==
+      integrity: sha512-whG+7mmbnOf6EaKIV++fJN9KVUD3ILO3cUHOLqAQKDlFtmj69QDy6qsbHyTyIOGsKSHHB8KyPPZItGgULngPpw==
       tarball: file:projects/communication-administration.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:
@@ -8821,7 +8032,6 @@ packages:
       '@azure/communication-common': 1.0.0-beta.6
       '@azure/communication-identity': 1.0.0-beta.5
       '@azure/communication-signaling': 1.0.0-beta.2
-      '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -8832,26 +8042,26 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8871,7 +8081,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-ABJiLTFbFWwv95oeOpHwhDgU+SmsJXRO/YBv3xge/vetwZOZZHdDuZPo23L5UJixAW8nq3jUoJ5mIUBSkyQZ7A==
+      integrity: sha512-GeSjm0QX1D7rgFhTlH7X8STkmD5h5fP3S6OEOyPY/pRbVHSbf10Qe1yRYrhroA1Ziyh2MCERCkG/0uuah4wg8w==
       tarball: file:projects/communication-chat.tgz
     version: 0.0.0
   file:projects/communication-common.tgz:
@@ -8888,25 +8098,25 @@ packages:
       '@types/jwt-decode': 2.2.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
       jwt-decode: 2.2.0
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8925,14 +8135,13 @@ packages:
     dev: false
     name: '@rush-temp/communication-common'
     resolution:
-      integrity: sha512-Vs8kd6GWppCNcbkO/+cJvaxsx3V1RhDySVLmGVziz7I8sm9ykatUaIp0XaGxd9qRWdXgs5R9RPLLry2JNwIbkA==
+      integrity: sha512-OTbbE3U8rZzWhw6U5OQ3RITJrqSZawv2VA0W0Nwq+e9Qm8ZRD+OPcWPrNFI5Wws9dGot0HbNTlJ/Q4G/M1Udjg==
       tarball: file:projects/communication-common.tgz
     version: 0.0.0
   file:projects/communication-identity.tgz:
     dependencies:
       '@azure/communication-common': 1.0.0-beta.6
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-documenter': 7.8.56
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -8944,26 +8153,26 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8982,13 +8191,13 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-L0yXfzrT4e96K2HOb45TWcvvUZWre0BZeYEXTmZiCcu5nswTL/bxM7qc+ecWokEGn7ukagXPzi/Z50YswbWwng==
+      integrity: sha512-Nvy14vvoy4ekaOHptUflWXpEeGuYVNZr6NWBe2Xue1qc4gf9ovl/t41QqlJcpSvIUE8UzC3eH1arEytc8oWaMA==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-phone-numbers.tgz:
     dependencies:
       '@azure/communication-common': 1.0.0-beta.6
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-documenter': 7.8.56
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -9000,27 +8209,26 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
-      karma-remap-istanbul: 0.6.0_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9039,14 +8247,13 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-jRgtDeSMbaFbmYjRtN/LOHVaJR3k5P9z0LSKBX1FWV6nFnZZehcU9tN5MiAmjeaGbX7bEntO0ut5P0Zr0aTcPw==
+      integrity: sha512-4hBuz3yoYH2R0qzZGW+TdpIAvEkGL6pWaHdaNI3PA2ikBCKYuHsCZarHgy8Vx//tsLEGb9aJcRgeX68U98BKxQ==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
     dependencies:
       '@azure/communication-common': 1.0.0-beta.6
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -9057,24 +8264,24 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9094,36 +8301,36 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-oU3HQq9+JrZMXCj7w9d9ufheqeHClL45/eSmrFvhEiUzCJrlZRFw7ba6H6N+xf3U1zTcIuDXuRNkX74Wg2r51w==
+      integrity: sha512-OG8/pwUCKSVDjLzSgPNGBtZdRvdDdMiq2BJ1WSwjCZSAwkhsIAwo2vgh6ZwwAntxJ6QnCTtO6nZ4Vw1fdjDtRA==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
@@ -9137,12 +8344,12 @@ packages:
     dev: false
     name: '@rush-temp/container-registry'
     resolution:
-      integrity: sha512-jkdlQvJGZnlLHR85Xy+b2vw0FPfjQZXVPYSMi3yjl+ai3cfLenEVPy85tW8ekht8eT2LKe9qrFPsCQvszxfoQg==
+      integrity: sha512-ww11EO3BP5w1iUvYgmVoq3Z7/XPerV2nqVgDr0O9W/SninGBWOdIBjNwyjF4w48YCB7fTi0V82h7mOtsWIoGtA==
       tarball: file:projects/container-registry.tgz
     version: 0.0.0
   file:projects/core-amqp.tgz:
     dependencies:
-      '@azure/identity': 1.2.3_debug@4.3.1
+      '@azure/identity': 1.2.4_debug@4.3.1
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -9157,22 +8364,22 @@ packages:
       '@types/is-buffer': 2.0.0
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/ws': 7.4.0
       assert: 1.5.0
       async-lock: 1.2.8
       buffer: 5.7.1
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       is-buffer: 2.0.5
       jssha: 3.2.0
-      karma: 5.2.3_debug@4.3.1
+      karma: 6.2.0_debug@4.3.1
       karma-chrome-launcher: 3.1.0
       karma-mocha: 2.0.1
       mocha: 7.2.0
@@ -9195,17 +8402,17 @@ packages:
       typescript: 4.1.2
       url: 0.11.0
       util: 0.12.3
-      ws: 7.4.3
+      ws: 7.4.4
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-43+7+eHuUasAbQGsZ1Fl3f6+OcoTnS2VgBAUXf9VJj656yE+qhBvnSIeeP2bS+f4grV11O8/9uEp6bVFrWarUw==
+      integrity: sha512-FBnRMkNG48RZIOjjhvfrPBc2OI7APLrhR3vuuUvm6CMAdmV/Z+/HaJ5pK4nn/+CB1Srr5Lz03xOekWUi6tkp5Q==
       tarball: file:projects/core-amqp.tgz
     version: 0.0.0
   file:projects/core-asynciterator-polyfill.tgz:
     dependencies:
       '@types/node': 8.10.66
-      eslint: 7.20.0
+      eslint: 7.21.0
       prettier: 1.19.1
       typedoc: 0.15.2
       typescript: 4.1.2
@@ -9228,7 +8435,7 @@ packages:
       assert: 1.5.0
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9250,7 +8457,6 @@ packages:
     version: 0.0.0
   file:projects/core-client.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@azure/core-xml': 1.0.0-beta.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -9262,22 +8468,22 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9295,7 +8501,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-BRd6lassQH2zn4QiGC7cGr3b+TqRx0amW11t6pW8yc7NGEkl075UPHsv+hl5ZuReJkq5158vG4VzQHmD+unueg==
+      integrity: sha512-OXmyS+WjKRGoF35em+EMx9HgwHu2eeQyppAtlP8supHL2e0noFQn7XER73EjPXS6ym9Xw/7S5wy0spmfswxYLA==
       tarball: file:projects/core-client.tgz
     version: 0.0.0
   file:projects/core-crypto.tgz:
@@ -9309,22 +8515,22 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9340,12 +8546,11 @@ packages:
     dev: false
     name: '@rush-temp/core-crypto'
     resolution:
-      integrity: sha512-buR2x0kE682JR/oMS4D5DViLaQ8BNCb8lrkk7Bsoylqqq2Lig0n8CtAxmQbJOlOXCMscTWw8sRizPSQUDZd63A==
+      integrity: sha512-QcIa1HGkhEi8WoY67H0GrOR4oU8fyXSjweKweBiMx93WfyPi7pRcDjOX302kmJIrCTF5E2yfneBBYcoUntyNww==
       tarball: file:projects/core-crypto.tgz
     version: 0.0.0
   file:projects/core-http.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger-js': 1.3.2
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -9359,24 +8564,24 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       '@types/node-fetch': 2.5.8
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/tough-cookie': 4.0.0
       '@types/tunnel': 0.0.1
       '@types/uuid': 8.3.0
       '@types/xml2js': 0.4.8
       babel-runtime: 6.26.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       express: 4.17.1
       fetch-mock: 9.11.0_node-fetch@2.6.1
       form-data: 3.0.1
       glob: 7.1.6
-      karma: 5.2.3
-      karma-chai: 0.1.0_chai@4.3.0+karma@5.2.3
+      karma: 6.2.0
+      karma-chai: 0.1.0_chai@4.3.3+karma@6.2.0
       karma-chrome-launcher: 3.1.0
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-firefox-launcher: 1.3.0
       karma-mocha: 2.0.1
       karma-rollup-preprocessor: 7.0.6_rollup@1.32.1
@@ -9402,14 +8607,14 @@ packages:
       tunnel: 0.0.6
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
       uuid: 8.3.2
       xhr-mock: 2.5.1
       xml2js: 0.4.23
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-J62Gogye1K0/jeZKn7CYhIRNWxpBkwkjn8/xHg6CjHHKiaLfVk9qx9FgmQ6A44+IS2ohr3B4yNM64ZIir7sJxA==
+      integrity: sha512-RiQ8vJIGESFGF5TI3mmWyLH6e/6wfO4rWjKiG0jLrP2XiutfRS8r7eIZDfnNouDF1Kw7SFPzLQtmuM4mCDEN1g==
       tarball: file:projects/core-http.tgz
     version: 0.0.0
   file:projects/core-lro.tgz:
@@ -9424,20 +8629,20 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
-      eslint: 7.20.0
-      events: 3.2.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      events: 3.3.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9454,17 +8659,17 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
-      integrity: sha512-PKEMNt6k7V6j5faOpNM+jFMnz9GKF5sCsJmwXkJ7ERdHIJFcKtgd0RuQKA+JTY+i01u3UnQhzxITfELU3wRZfA==
+      integrity: sha512-Cp7ol5ADjre9IalL4DRe7UuUILmoyo/AegcUByUrB2atCgdzOKPyu6WD0bMu5M6pwhIZbD7gpdwnNKypxtFg4Q==
       tarball: file:projects/core-lro.tgz
     version: 0.0.0
   file:projects/core-paging.tgz:
     dependencies:
       '@types/node': 8.10.66
-      eslint: 7.20.0
+      eslint: 7.21.0
       prettier: 1.19.1
       rimraf: 3.0.2
       typedoc: 0.15.2
@@ -9487,25 +8692,25 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/uuid': 8.3.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       form-data: 3.0.1
       https-proxy-agent: 5.0.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9525,7 +8730,7 @@ packages:
     dev: false
     name: '@rush-temp/core-rest-pipeline'
     resolution:
-      integrity: sha512-4fNeF/zNYV0I7VvFdZ+7bjYMqzOLU3QUZGQVb5ye0k6OVCDQ0Bsf+T8h6NS4JbE99NuBaCzUa0HG0YqPeWVWdQ==
+      integrity: sha512-1vwJ5AIVkR2uVtqj2Dw9E1sDzMHmbjLVA5Ain7mEtujf2tyPtyWoErJVz6hhpm2W1kLeTulUDsXRLQCPZKUjsg==
       tarball: file:projects/core-rest-pipeline.tgz
     version: 0.0.0
   file:projects/core-tracing.tgz:
@@ -9540,10 +8745,10 @@ packages:
       '@rollup/plugin-replace': 2.4.1_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
       cross-env: 7.0.3
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9575,22 +8780,22 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9608,7 +8813,7 @@ packages:
     dev: false
     name: '@rush-temp/core-util'
     resolution:
-      integrity: sha512-OImydy+qxO0N84cf43gplu2RmV/TAlWN/BXt/sDRdAfNPVnKz91LODK4lZdwQW7ounVRp4FN8MdsfgCyiEnajQ==
+      integrity: sha512-cHDJPgK/5HFTgVE8rthahY/Xf+K2wU9CUJSAsyPQEq1n1qmwcxrZTnExxA4Nsl+yQEuUktZ4Z1spxS+OAik3NQ==
       tarball: file:projects/core-util.tgz
     version: 0.0.0
   file:projects/core-xml.tgz:
@@ -9622,23 +8827,23 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/xml2js': 0.4.8
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9657,12 +8862,12 @@ packages:
     dev: false
     name: '@rush-temp/core-xml'
     resolution:
-      integrity: sha512-59ASfw4Rwrhn3Fj4E1W+blv2ZdkYUHSfnF3eEPED9Yp3ULjLkHeY5N1R7ExMTPkYsVrdmULLzup50MwEm9niTQ==
+      integrity: sha512-wxoqz2KTpBudiZ3ET1mzsATxhTpgokh7Qe2VJkqa0LNF2Ptq5BNG7jKxWmypDvgsY8EJsh8WdkMbe9UwFh5tbg==
       tarball: file:projects/core-xml.tgz
     version: 0.0.0
   file:projects/cosmos.tgz:
     dependencies:
-      '@azure/identity': 1.2.3_debug@4.3.1
+      '@azure/identity': 1.2.4_debug@4.3.1
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -9673,16 +8878,15 @@ packages:
       '@types/node-fetch': 2.5.8
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/tunnel': 0.0.1
-      '@types/underscore': 1.10.24
+      '@types/underscore': 1.11.0
       '@types/uuid': 8.3.0
-      '@typescript-eslint/eslint-plugin-tslint': 4.15.2_d757d41b47cb08695379f82123722461
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       execa: 3.4.0
       fast-json-stable-stringify: 2.1.0
@@ -9704,8 +8908,6 @@ packages:
       source-map-support: 0.5.19
       ts-node: 8.10.2_typescript@4.1.2
       tslib: 2.1.0
-      tslint: 5.20.1_typescript@4.1.2
-      tslint-config-prettier: 1.18.0
       typedoc: 0.15.2
       typescript: 4.1.2
       universal-user-agent: 6.0.0
@@ -9718,7 +8920,6 @@ packages:
     version: 0.0.0
   file:projects/data-tables.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@azure/core-xml': 1.0.0-beta.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
@@ -9731,24 +8932,24 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/uuid': 8.3.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9770,7 +8971,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-2duhcNW74QdBXIixKnK549rnwU56Zovxu8z9IgcYk0AHCpj9JFlJA+3WMHd0I2iuVeo0X8bBo+6ffVdOd5qUdA==
+      integrity: sha512-DKxV5TmuufmjqR1dR52PFXoCEYKVzwFNy5IU7owcHSxIX9xWrcTdiODeVWFHDgkTiIt20OVe3o4hC+WnkT3tTA==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -9788,10 +8989,10 @@ packages:
       '@types/node': 8.10.66
       '@types/prettier': 2.0.2
       builtin-modules: 3.1.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       chalk: 3.0.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       fs-extra: 8.1.0
       minimist: 1.2.5
       mocha: 7.2.0
@@ -9811,8 +9012,7 @@ packages:
     version: 0.0.0
   file:projects/digital-twins-core.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -9823,24 +9023,24 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9860,7 +9060,7 @@ packages:
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-Z+WAd842ONK0RCpAlO7hweZAXjHkiptnFymWA0m9tsZhbg2//GkGmq2hVHNfIfFWndvoxA0d9h81W6LEU0yFfA==
+      integrity: sha512-3V67JqdxYOjCxXLSTGuBAhNWBBma7INUBLxqO5Z/oGz1QQlgHmEXvgrmAJm9aE4O1FiVM8zsSTuOq6M5kG1o3A==
       tarball: file:projects/digital-twins-core.tgz
     version: 0.0.0
   file:projects/eslint-plugin-azure-sdk.tgz:
@@ -9872,14 +9072,14 @@ packages:
       '@types/json-schema': 7.0.7
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@typescript-eslint/eslint-plugin': 4.13.0_3aa6ac8cbad4a9e6247c45fb70b39e2c
-      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.20.0+typescript@4.1.2
-      '@typescript-eslint/parser': 4.13.0_eslint@7.20.0+typescript@4.1.2
+      '@typescript-eslint/eslint-plugin': 4.13.0_01b3bfb19f42ed087655aa69bb24f4f9
+      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.21.0+typescript@4.1.2
+      '@typescript-eslint/parser': 4.13.0_eslint@7.21.0+typescript@4.1.2
       '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.1.2
-      chai: 4.3.0
-      eslint: 7.20.0
-      eslint-config-prettier: 7.2.0_eslint@7.20.0
-      eslint-plugin-import: 2.22.1_eslint@7.20.0
+      chai: 4.3.3
+      eslint: 7.21.0
+      eslint-config-prettier: 7.2.0_eslint@7.21.0
+      eslint-plugin-import: 2.22.1_eslint@7.21.0
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.3.1
       eslint-plugin-tsdoc: 0.2.11
@@ -9901,8 +9101,7 @@ packages:
     version: 0.0.0
   file:projects/event-hubs.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3_debug@4.3.1
+      '@azure/identity': 1.2.4_debug@4.3.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -9919,33 +9118,33 @@ packages:
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/uuid': 8.3.0
       '@types/ws': 7.4.0
       assert: 1.5.0
       buffer: 5.7.1
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
-      chai-string: 1.5.0_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
+      chai-string: 1.5.0_chai@4.3.3
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       https-proxy-agent: 5.0.0
       is-buffer: 2.0.5
       jssha: 3.2.0
-      karma: 5.2.3_debug@4.3.1
+      karma: 6.2.0_debug@4.3.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9966,11 +9165,11 @@ packages:
       typedoc: 0.15.2
       typescript: 4.1.2
       uuid: 8.3.2
-      ws: 7.4.3
+      ws: 7.4.4
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-ODs68iM+NiOd7JQdb7NKf0H/bXg8crUpxLromJg1/LiRmCh74LY3iCR1GTb26zpc5oAsZpek9v8d1sfexPCYjQ==
+      integrity: sha512-qM1b7Q43G2q1Bp8lsk+pxt66SGPTMbUcXBxD9SBFE7WBEXYjuKocvjAAO5uKymnKjBoeeoqp/PaOJsgyLBQnXw==
       tarball: file:projects/event-hubs.tgz
     version: 0.0.0
   file:projects/event-processor-host.tgz:
@@ -9994,13 +9193,13 @@ packages:
       '@types/ws': 7.4.0
       async-lock: 1.2.8
       azure-storage: 2.10.3
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
-      chai-string: 1.5.0_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
+      chai-string: 1.5.0_chai@4.3.3
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       https-proxy-agent: 5.0.0
       mocha: 7.2.0
@@ -10016,7 +9215,7 @@ packages:
       typedoc: 0.15.2
       typescript: 4.1.2
       uuid: 8.3.2
-      ws: 7.4.3
+      ws: 7.4.4
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
@@ -10025,7 +9224,6 @@ packages:
     version: 0.0.0
   file:projects/eventgrid.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10037,25 +9235,25 @@ packages:
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/uuid': 8.3.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10077,12 +9275,11 @@ packages:
     dev: false
     name: '@rush-temp/eventgrid'
     resolution:
-      integrity: sha512-DAFspaDeGaJnFcrGGngNcl8ACeRpngOfmDfd5Mj5KoiLasaxcnUinPg55+cO60eOr0G7xzjHJh5yBaoRwFWRgw==
+      integrity: sha512-HbhUoMP0+jpL1WMrHpuA+DVO7TNd82MofyjrDihgsqvXwqBV21wXAhN6Zjsnz4UezkZscguaizwDnExw4lswWw==
       tarball: file:projects/eventgrid.tgz
     version: 0.0.0
   file:projects/eventhubs-checkpointstore-blob.tgz:
     dependencies:
-      '@azure/storage-blob': 12.4.1
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -10097,27 +9294,27 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       assert: 1.5.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
-      chai-string: 1.5.0_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
+      chai-string: 1.5.0_chai@4.3.3
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       guid-typescript: 1.0.9
       inherits: 2.0.4
-      karma: 5.2.3_debug@4.3.1
+      karma: 6.2.0_debug@4.3.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10137,12 +9334,11 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-Ya4u/CI/pPPQPr+srW2aedPxDvQxto5HQbAUqd9VCn1d83uQoasYW0TDtvGkWb172EI6YpnyYm22ozxqOF0hUQ==
+      integrity: sha512-ZIJ4C130Y07dGvDxX4qCY4crdsYC71r/3UkIN/GkCsBVGZM9FSMTeTAMBv9xiacoz6WSagav2LLT/T+O/hd2kA==
       tarball: file:projects/eventhubs-checkpointstore-blob.tgz
     version: 0.0.0
   file:projects/identity.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@azure/msal-browser': 2.9.0
       '@azure/msal-node': 1.0.0-beta.6
       '@microsoft/api-extractor': 7.7.11
@@ -10155,24 +9351,24 @@ packages:
       '@types/jws': 3.2.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/qs': 6.9.5
-      '@types/sinon': 9.0.10
+      '@types/qs': 6.9.6
+      '@types/sinon': 9.0.11
       '@types/stoppable': 1.1.0
       '@types/uuid': 8.3.0
       assert: 1.5.0
       axios: 0.21.1
       cross-env: 7.0.3
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
       jws: 4.0.0
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
       karma-env-preprocessor: 0.1.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10199,19 +9395,19 @@ packages:
     optionalDependencies:
       keytar: 7.4.0
     resolution:
-      integrity: sha512-GCPDD1pFMSCVZZR3hoHULTCuP3SMI4Yqvu5Y2/i1nk3JKehGQTkmSV2jwLbtFw/zmDM35v4drXiOpEE5N68K6Q==
+      integrity: sha512-F95wTEAG36GwwaMseI9locyPZ0vngMXmrjNMo4hFv4MIyL/PLzidKuEJxdCW10hJp34x8WSBUFIsh2YOFPsI8A==
       tarball: file:projects/identity.tgz
     version: 0.0.0
   file:projects/iot-device-update.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/node': 8.10.66
       '@types/uuid': 8.3.0
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       mkdirp: 1.0.4
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -10222,7 +9418,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/iot-device-update'
@@ -10232,8 +9428,7 @@ packages:
     version: 0.0.0
   file:projects/keyvault-admin.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10245,14 +9440,14 @@ packages:
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/uuid': 8.3.0
       assert: 1.5.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10278,8 +9473,7 @@ packages:
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10291,25 +9485,25 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       '@types/query-string': 6.2.0
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10332,14 +9526,13 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-ezvJ33PyKC0uOoBnzANsuTSx828i2OgPMZxBVJE+PzJWYPG8Kg6yVLHxLxU0fyOIg18Ysl3kZMOVtZIilaRLSQ==
+      integrity: sha512-Wk8fvEMr4yw0QP5FKu7nG31hK2rpm+hjuZbPLVHLbfIItSyJR+GxnYjchKiKe9A02CMz4QlzwNLTPwrPeEF/QQ==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@opentelemetry/api': 0.10.2
-      eslint: 7.20.0
+      eslint: 7.21.0
       prettier: 1.19.1
       rimraf: 3.0.2
       tslib: 2.1.0
@@ -10352,8 +9545,7 @@ packages:
     version: 0.0.0
   file:projects/keyvault-keys.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10366,26 +9558,26 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       '@types/query-string': 6.2.0
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10408,13 +9600,12 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-JomXvUcrHagzIp2wgEEy0rzAS+GHGGlQDM6s0plZzar13+RfYLnmk1H6L+Jb+8CG2WRqXiUM3o9bDr6jWr2a1Q==
+      integrity: sha512-IDUxL0I2FAka7TMKcdAvzwiZlLVGL9TLgPiQkdQ2iNFaX8x10kB0xTiwwRhTQ/xnBsJMLT7qvFjrIdYCzBvCnw==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10426,25 +9617,25 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       '@types/query-string': 6.2.0
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10467,7 +9658,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-GuI6c2CRRyNibaxoApB9EpIRvbmFUqzH/TZTVFJ/7cdfGw3k0YbDh/T+U7f20wNvhvi+mPb6JZY3r6/fR+PVqA==
+      integrity: sha512-EXKJJ8+0nShsG21V8hO6wp+OhnOQHvXgQdZH2wwdNBBeMlfVUdinqmSsjacfB1fhQ+Oud/YTWseHSNBUwphGtg==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -10480,23 +9671,23 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
-      chai: 4.3.0
+      chai: 4.3.3
       cross-env: 7.0.3
       delay: 4.4.1
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10515,36 +9706,35 @@ packages:
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-9C/8ICw825JPlQ6DGhRDKFWo2jO3CYzJYZeqqgg1qkdPIthab+aId/EnoW3oLeEUUwnEF3Gy8unrlFCIMCs5mA==
+      integrity: sha512-cxTL6N8MnSWx8kgBiml3v4ZLkyflDmvwz2Pdlyv1WhqFafNVp+HG7Zt1Ikq8CXxYhFih4Gcza5uKulZv0hy5fw==
       tarball: file:projects/logger.tgz
     version: 0.0.0
   file:projects/mixedreality-authentication.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10559,14 +9749,14 @@ packages:
     dev: false
     name: '@rush-temp/mixedreality-authentication'
     resolution:
-      integrity: sha512-RfiO+rJ+PftHHMN6SGCctCpeJFkHZWCe6DjHwWF21zR4rAXDA9kAXLGD8+4wk4XpUJpeqCQ5Y3k+fG1YFO99Hw==
+      integrity: sha512-VkO6sUoal9jE5/7/1ftyGiUL7TlwKIc5hQirSdD0FzY2LBZr2mXemopjOKAq+d0JjBYPtvj+Gp+ieDhiXiMCVw==
       tarball: file:projects/mixedreality-authentication.tgz
     version: 0.0.0
   file:projects/mock-hub.tgz:
     dependencies:
       '@types/node': 8.10.66
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       prettier: 1.19.1
       rhea: 1.0.24
       rimraf: 3.0.2
@@ -10587,9 +9777,9 @@ packages:
       '@opentelemetry/semantic-conventions': 0.17.0
       '@opentelemetry/tracing': 0.17.0
       '@types/mocha': 7.0.2
-      '@types/node': 10.17.54
-      eslint: 7.20.0
-      eslint-plugin-node: 11.1.0_eslint@7.20.0
+      '@types/node': 10.17.55
+      eslint: 7.21.0
+      eslint-plugin-node: 11.1.0_eslint@7.21.0
       execa: 3.4.0
       mocha: 7.2.0
       nock: 12.0.3
@@ -10610,8 +9800,7 @@ packages:
     version: 0.0.0
   file:projects/perf-ai-text-analytics.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
-      '@types/dotenv': 8.2.0
+      '@azure/identity': 1.2.4
       '@types/node': 8.10.66
       dotenv: 8.2.0
       rimraf: 3.0.2
@@ -10640,7 +9829,6 @@ packages:
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:
     dependencies:
-      '@types/dotenv': 8.2.0
       '@types/node': 8.10.66
       '@types/node-fetch': 2.5.8
       '@types/uuid': 8.3.0
@@ -10654,7 +9842,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-storage-blob'
     resolution:
-      integrity: sha512-/q8ryE6iSJu9tWWtEAhLFfPS3rAhJUK4f+CqZopFkdmqan+ViPBZX3XNvoN2UN9U/7uCoNqEVHUTCbr+PRD8Pw==
+      integrity: sha512-q6DRn6r/QgRB7Tdl9/i0LI+17T65ZvFQ6xZfg0OM1WENeH0TAYwfBGp1+PNbKNUeoqdqucL7cLQKXBlA9vEwvg==
       tarball: file:projects/perf-storage-blob.tgz
     version: 0.0.0
   file:projects/perf-storage-file-datalake.tgz:
@@ -10691,8 +9879,7 @@ packages:
     version: 0.0.0
   file:projects/quantum-jobs.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
-      '@azure/storage-blob': 12.4.1
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10703,25 +9890,25 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10741,12 +9928,12 @@ packages:
     dev: false
     name: '@rush-temp/quantum-jobs'
     resolution:
-      integrity: sha512-eH3JcAUF8X4IoFJnDFQEu01GtqEnzKvHqYhcM87mDGHNSoMKSNWfO16mGAwymIMWDsqKZuoEBPvCglBHiC73cw==
+      integrity: sha512-J7GqpoWknKU40iGwFkoNaZwUGfHSSIAGHovfEzm3LuP8tnom+5lgt2n/6Y2ueLCEnLQvfYY2XFz2ABxL/JketA==
       tarball: file:projects/quantum-jobs.tgz
     version: 0.0.0
   file:projects/schema-registry-avro.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10761,23 +9948,23 @@ packages:
       '@types/node': 8.10.66
       avsc: 5.5.3
       buffer: 5.7.1
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10797,12 +9984,12 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-jOZLueDs5biRkOPBfkPKfvIUmJz7Pu0bXxORAedq2Z4DAtumq/cCK3ALDPlKBU3HIYyf30yyxzt1ErT9U0Y4Rg==
+      integrity: sha512-sNaU6ARlcCfOMy6eZ0e9XE+ZmtKlKJyJMHzvBSwpwREGKE+0BDIirtY954Ajf+mXYXilvdHacBLSp7aAbR9kwA==
       tarball: file:projects/schema-registry-avro.tgz
     version: 0.0.0
   file:projects/schema-registry.tgz:
     dependencies:
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10814,23 +10001,23 @@ packages:
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10849,12 +10036,11 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-Why63wHyaPOVy7wJ+yKEluJdbDCBhFpBlu4PcnYkTQ3yf1b6JvzbzCvuzqBWkjfZOmwgDuExHgOOK4TBUWW8iQ==
+      integrity: sha512-pOPIkhaSe6d47D0cLf26r8K0etdTNEYP184BYdtHg6dh0BBHauLyPf2npj0bJR/ruJ/7pYhZFq+oBes7PlVdRw==
       tarball: file:projects/schema-registry.tgz
     version: 0.0.0
   file:projects/search-documents.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10865,25 +10051,25 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
-      chai: 4.3.0
+      '@types/sinon': 9.0.11
+      chai: 4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
-      eslint: 7.20.0
-      events: 3.2.0
+      eslint: 7.21.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10904,13 +10090,12 @@ packages:
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-ZJWiMhm+VT3/YCl93xBMPeZKWH8CyKfoYDeAhbrcOf1rhssG/4WtQbqgY+17mWWgasbCoJ1/mD6nazYMyS0WCA==
+      integrity: sha512-/fqcof0wFwqrpuDGqpeZ9xsJkb9CHmzlZIDWF6zeqoePAis8yFqqMVpndkNQCN5+dvptNHiN1E2oOfTZk4vbFw==
       tarball: file:projects/search-documents.tgz
     version: 0.0.0
   file:projects/service-bus.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3_debug@4.3.1
+      '@azure/identity': 1.2.4_debug@4.3.1
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10927,35 +10112,35 @@ packages:
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       '@types/ws': 7.4.0
       assert: 1.5.0
       buffer: 5.7.1
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
-      chai-exclude: 2.0.2_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
+      chai-exclude: 2.0.2_chai@4.3.3
       cross-env: 7.0.3
       debug: 4.3.1
       delay: 4.4.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       glob: 7.1.6
       https-proxy-agent: 5.0.0
       is-buffer: 2.0.5
       jssha: 3.2.0
-      karma: 5.2.3_debug@4.3.1
+      karma: 6.2.0_debug@4.3.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       long: 4.0.0
       mocha: 7.2.0
@@ -10977,18 +10162,16 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      ws: 7.4.3
+      ws: 7.4.4
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-caNefoZ8Fmd2L8SutHkeEAsu7zjkQBzC6YXHAdWP1u3ASkfJP4PcFLn+WoT/KZeDrIzvHximvDMqNO6lO04oEQ==
+      integrity: sha512-8lcSVcX4icuk36ASJJZwnYQSmGWspITZKXzow4fadS4rRgLzbCNa6vSdmPyrRluMMZXXohIVaMmY9GSQDsaPqQ==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
-      '@azure/storage-blob': 12.4.1
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -10997,28 +10180,28 @@ packages:
       '@rollup/plugin-replace': 2.4.1_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      '@types/sinon': 9.0.10
+      '@types/sinon': 9.0.11
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11041,13 +10224,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-rCDdiWh1LE1QmPvG19GkhPUqA7DJ0+XY1lDNXxK4hmvxli6lzKJRxVI5TMGCkYZRNC90SdLO/ukCnYZ4v3Wa7A==
+      integrity: sha512-MXjuKV5rcZRRtxtNg2aEZhLef4uuvgrlVvmob7J2zm/cocKAK+alSYbwBtl9uHS9XSxLR2QL84ZKI/qoFIOenw==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -11063,22 +10245,22 @@ packages:
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11101,13 +10283,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-T/VMMtL0Vz5hEEuMWhex07MBbnLAp1XoPQ6/6NaDzlfDVPehF+Xxhyx7Wlu7yWGuaRgrO5nRPht7kv1sPfYmLQ==
+      integrity: sha512-xSgpePgXc7AbL9kuOjiMfcns+H0xx7Xi6bDaUvQOQawOh5G3OxAjnvGj6lAXUizFlc024adkGm9KBeq7AB6Fig==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -11123,23 +10304,23 @@ packages:
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       execa: 3.4.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11162,12 +10343,11 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-geH0E4AWvKxd8pMdWz7q8bM2cHI+OdgRReitfDdpZ4JTPafY/3GJIStAKFMi76CjTyCQqtTG7oq7LMM4zQ3+NA==
+      integrity: sha512-0pF1FQYTMa10JTxu+bqGvds8tsy/v9Fo4D3+9rsxha/jP3+3u9RnavyXJjuNmSOC+TPOPP1ETrtybo0TICk9oA==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -11181,22 +10361,22 @@ packages:
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
-      events: 3.2.0
+      events: 3.3.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11218,7 +10398,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-6+YllKbsz59wuzVRrst2amew8qAX6kAdWe8aFeVtKWKW8or/+ykDSK7y676HcItim7Q3E9Xyj+UO0Wis7BE3LQ==
+      integrity: sha512-f0U/Ff7GEsZQ/xlTyTlkBhOxckFZHzGCmYqcvudTxBFO+pehEPSwK3rz1gEZL5wGYKY3AKf0LP0VyxHJccXohQ==
       tarball: file:projects/storage-file-share.tgz
     version: 0.0.0
   file:projects/storage-internal-avro.tgz:
@@ -11234,21 +10414,21 @@ packages:
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11269,13 +10449,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-internal-avro'
     resolution:
-      integrity: sha512-2FmKCVHxTxcbDVDze9oTlqfAazzRaEEt+k9wz4JkNQfEp4sW1plxMmlPREGhl7kNGhbmFDkv2OHsXZrOCSxPmg==
+      integrity: sha512-xfu5W0K5vt7IpQecmpp3rwn0nhoIulN2eA5bvvx/vUc9BK6i9KefR1pWH8gKBbfeEceSkldzQSPcRsyXkCQrtA==
       tarball: file:projects/storage-internal-avro.tgz
     version: 0.0.0
   file:projects/storage-queue.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -11289,21 +10468,21 @@ packages:
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.20.0
+      eslint: 7.21.0
       esm: 3.2.25
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -11325,7 +10504,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-nA/tHojlA0BTcGeususPW7QlKAxSoFngEYdmFDTccKXiqnEq4pIUD9pjzWgzZIk2rNxZnQz7vBRTj7zBWtnyAw==
+      integrity: sha512-dTQZ4s5yATu31PyflTcLew5w3x+Ox6ZRdgBroBJyG6/qenzzrztilRRLYhv7MkLqftoQJWjmaMIGQ615OGMpQQ==
       tarball: file:projects/storage-queue.tgz
     version: 0.0.0
   file:projects/synapse-access-control.tgz:
@@ -11333,7 +10512,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11341,7 +10520,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
@@ -11353,7 +10532,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11361,7 +10540,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
@@ -11373,7 +10552,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11381,7 +10560,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
@@ -11393,7 +10572,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11401,7 +10580,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/synapse-monitoring'
     resolution:
@@ -11413,7 +10592,7 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11421,7 +10600,7 @@ packages:
       tslib: 2.1.0
       typedoc: 0.15.2
       typescript: 4.1.2
-      uglify-js: 3.12.8
+      uglify-js: 3.13.0
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
@@ -11430,33 +10609,32 @@ packages:
     version: 0.0.0
   file:projects/template.tgz:
     dependencies:
-      '@azure/core-tracing': 1.0.0-preview.9
-      '@azure/identity': 1.2.3
+      '@azure/identity': 1.2.4
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.10.2
       '@types/chai': 4.2.15
       '@types/chai-as-promised': 7.1.3
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
       cross-env: 7.0.3
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       inherits: 2.0.4
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
@@ -11470,7 +10648,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-q1Gsd5/2xLE5CY6zMm7t/0vUGmvzTj/cO9jHykJst2Ea2LypkcFXfzRv18bbaXWR69WRnPyVJyNxNAkaUIamyQ==
+      integrity: sha512-kSBcTIYEr4Z/DsNw99Mp0/dZoUQzPCbSgb4JaQxmed60ftHwuEj8yP8Rn6+D6dh+GdvaTLvqWAoTMQrEND+Zxw==
       tarball: file:projects/template.tgz
     version: 0.0.0
   file:projects/test-utils-multi-version.tgz:
@@ -11479,10 +10657,10 @@ packages:
       '@types/chai': 4.2.15
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
-      chai: 4.3.0
-      chai-as-promised: 7.1.1_chai@4.3.0
-      eslint: 7.20.0
-      karma: 5.2.3
+      chai: 4.3.3
+      chai-as-promised: 7.1.1_chai@4.3.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
       karma-env-preprocessor: 0.1.1
@@ -11495,7 +10673,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utils-multi-version'
     resolution:
-      integrity: sha512-U0DDGv+oz4TBx12RGZuOsCVtW5RjjA34eFywEa71wxiRJrjWwcKWJutCLh6OlTAjVFWftdrlCwmtpnk4/7tAXg==
+      integrity: sha512-p1ehA1Uj+7dPG7tCat6dP31NmBHMJd23Ye3E4sPx8G55wSZbBuu116P4RRag7/DW9klyaJF2xavWTQILXfgvHA==
       tarball: file:projects/test-utils-multi-version.tgz
     version: 0.0.0
   file:projects/test-utils-perfstress.tgz:
@@ -11504,8 +10682,8 @@ packages:
       '@types/minimist': 1.2.1
       '@types/node': 8.10.66
       '@types/node-fetch': 2.5.8
-      eslint: 7.20.0
-      karma: 5.2.3
+      eslint: 7.21.0
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
       karma-env-preprocessor: 0.1.1
@@ -11518,7 +10696,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utils-perfstress'
     resolution:
-      integrity: sha512-xO4V+yYsQ0PZejVwvZGFThwd2nQoGhovX4Vo7TlCyKJ/uHxSAjC0v972vzz7qpA9FTseiYshYUrKtSdoBqewPg==
+      integrity: sha512-xY3noZfwE+5JjTv/Ts+Co363s9B3RaxR45yGRMJPamBq+bGq4p/64of956KEUtgklAf5Gjo51KukHPhQ8B/LaQ==
       tarball: file:projects/test-utils-perfstress.tgz
     version: 0.0.0
   file:projects/test-utils-recorder.tgz:
@@ -11536,22 +10714,22 @@ packages:
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
       '@types/node': 8.10.66
-      chai: 4.3.0
+      chai: 4.3.3
       dotenv: 8.2.0
-      eslint: 7.20.0
+      eslint: 7.21.0
       fs-extra: 8.1.0
-      karma: 5.2.3
+      karma: 6.2.0
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
-      karma-edge-launcher: 0.4.2_karma@5.2.3
+      karma-edge-launcher: 0.4.2_karma@6.2.0
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-ie-launcher: 1.0.0_karma@5.2.3
-      karma-json-preprocessor: 0.3.3_karma@5.2.3
+      karma-ie-launcher: 1.0.0_karma@6.2.0
+      karma-json-preprocessor: 0.3.3_karma@6.2.0
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 2.0.1_karma@5.2.3
+      karma-junit-reporter: 2.0.1_karma@6.2.0
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@5.2.3
+      karma-mocha-reporter: 2.2.5_karma@6.2.0
       karma-sourcemap-loader: 0.3.8
       md5: 2.3.0
       mocha: 7.2.0
@@ -11575,7 +10753,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utils-recorder'
     resolution:
-      integrity: sha512-HbbQjbq3UyuhaUzKIEPr0UVOijScGpUPbQ1shjONeT79MKd+AVFCKcZ60RBebj0XIO4Y/lNJ9hrVRyEuF3Nucg==
+      integrity: sha512-xx7GZ2XToZkOp2NMiAvuhItWOPgmikKEZ9FANVuoAvuKWOlA3UHX/uy9vFCdYgERyP+Ln5Cq7zy545VS0mlXaA==
       tarball: file:projects/test-utils-recorder.tgz
     version: 0.0.0
   file:projects/testhub.tgz:
@@ -11587,7 +10765,7 @@ packages:
       async-lock: 1.2.8
       death: 1.1.0
       debug: 4.3.1
-      eslint: 7.20.0
+      eslint: 7.21.0
       rhea: 1.0.24
       rimraf: 3.0.2
       tslib: 2.1.0
@@ -11600,7 +10778,6 @@ packages:
       integrity: sha512-HdIdDAAHx0bZpTjzl4xH0KPQUYPdfcJgNiZpAQzbVrhePPH/giaWNW0OMrD4PkKdo9iCrbsA4EN3tTb4z4gavQ==
       tarball: file:projects/testhub.tgz
     version: 0.0.0
-registry: ''
 specifiers:
   '@rush-temp/abort-controller': file:./projects/abort-controller.tgz
   '@rush-temp/ai-anomaly-detector': file:./projects/ai-anomaly-detector.tgz

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -88,7 +88,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -114,7 +114,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -41,7 +41,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "jsrsasign": "^10.1.4",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -112,7 +112,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -108,7 +108,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -101,7 +101,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -110,7 +110,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -110,7 +110,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -108,7 +108,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -95,7 +95,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -96,7 +96,7 @@
     "delay": "^4.2.0",
     "downlevel-dts": "~0.4.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -110,7 +110,7 @@
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-mocha": "^2.0.1",
     "mocha": "^7.1.1",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -102,7 +102,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-crypto/package.json
+++ b/sdk/core/core-crypto/package.json
@@ -96,7 +96,7 @@
     "downlevel-dts": "~0.4.0",
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -172,7 +172,7 @@
     "express": "^4.16.3",
     "fetch-mock": "^9.10.1",
     "glob": "^7.1.2",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -115,7 +115,7 @@
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -119,7 +119,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -88,7 +88,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -96,7 +96,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -90,7 +90,7 @@
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -93,7 +93,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -108,7 +108,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -138,7 +138,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "https-proxy-agent": "^5.0.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -94,7 +94,7 @@
     "esm": "^3.2.18",
     "guid-typescript": "^1.0.9",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -102,7 +102,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -119,7 +119,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -124,7 +124,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -119,7 +119,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -122,7 +122,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -101,7 +101,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -89,7 +89,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -91,7 +91,7 @@
     "eslint": "^7.15.0",
     "events": "^3.0.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -91,7 +91,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -102,7 +102,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -101,7 +101,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -146,7 +146,7 @@
     "esm": "^3.2.18",
     "glob": "^7.1.2",
     "https-proxy-agent": "^5.0.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -124,7 +124,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -150,7 +150,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -132,7 +132,7 @@
     "esm": "^3.2.18",
     "execa": "^3.3.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -139,7 +139,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -83,7 +83,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -133,7 +133,7 @@
     "eslint": "^7.15.0",
     "esm": "^3.2.18",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -96,7 +96,7 @@
     "downlevel-dts": "~0.4.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -105,7 +105,7 @@
     "downlevel-dts": "~0.4.0",
     "eslint": "^7.15.0",
     "inherits": "^2.0.3",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/test-utils/multi-version/package.json
+++ b/sdk/test-utils/multi-version/package.json
@@ -73,7 +73,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -76,7 +76,7 @@
     "@types/node": "^8.0.0",
     "@types/node-fetch": "^2.5.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -89,7 +89,7 @@
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -109,7 +109,7 @@
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "karma": "^5.1.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-edge-launcher": "^0.4.2",


### PR DESCRIPTION
This change is necessary to satisfy our component governance guidelines.

A vulnerability was detected in xmlhttprequest-ssl which is a deep transitive dependency of karma 5.x. It's pulled in by `engine.io-client@3.5.1`, and [this issue](https://github.com/socketio/engine.io-client/issues/656) suggests xmlhttprequest-ssl isn't being used in a way that can trigger the vulnerability.

![image](https://user-images.githubusercontent.com/51000525/110741623-d96b8f00-81e9-11eb-9c74-d656b379e34f.png)

`xmlhttprequest-ssl` hasn't been updated in over 2 years, and there isn't a version that is free of this vulnerability. However, upgrading karma from 5.x to 6.x removes this transitive dependency.

## Potential breaking changes

Looking at the Karma changelog's breaking changes section, nothing sticks out as something our packages would be impacted by:
https://github.com/karma-runner/karma/blob/master/CHANGELOG.md#breaking-changes

### Node 8 support dropped

Running karma 6.x requires at least node.js version 10.x. I don't think this is a problem because:
1. Most (all?) of our CI uses node 12.x to launch browser tests.
2. The node runtime used to launch the test really shouldn't matter. What matters is if the tests execute in the browser environment being launched, so only testing in newer versions of node.js seems reasonable.

## Testing changes

I ran all the browser unit tests using the new version of karma by doing the following:
```
rush build && rush build:test && rush unit-test:browser
```
Some packages don't have unit-tests, such as service bus and event hubs, so I'll run the live tests for those as well.

I also ran storage-blob tests using IE11 launched through Karma. Karma 6.x is able to launch the IE11 browser and execute tests. I did notice that some tests are failing in IE11, but then I ran again using the master branch and Karma 5.x and see the same test failures, so this change doesn't seem to introduce any new IE11 breakages.