### PR TITLE
[communication] remove unsupported lro options

### DIFF
--- a/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
+++ b/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
@@ -24,20 +24,20 @@ export interface AcquiredPhoneNumber {
     purchaseDate: Date;
 }
 
-// @public (undocumented)
-export interface BeginPurchasePhoneNumbersOptions extends PhoneNumberPollerOptionsBase, OperationOptions {
+// @public
+export interface BeginPurchasePhoneNumbersOptions extends OperationOptions {
 }
 
-// @public (undocumented)
-export interface BeginReleasePhoneNumberOptions extends PhoneNumberPollerOptionsBase, OperationOptions {
+// @public
+export interface BeginReleasePhoneNumberOptions extends OperationOptions {
 }
 
-// @public (undocumented)
-export interface BeginSearchAvailablePhoneNumbersOptions extends PhoneNumberPollerOptionsBase, OperationOptions {
+// @public
+export interface BeginSearchAvailablePhoneNumbersOptions extends OperationOptions {
 }
 
-// @public (undocumented)
-export interface BeginUpdatePhoneNumberOptions extends PhoneNumberPollerOptionsBase, OperationOptions {
+// @public
+export interface BeginUpdatePhoneNumberCapabilitiesOptions extends OperationOptions {
 }
 
 // @public
@@ -74,14 +74,6 @@ export interface PhoneNumberCost {
     currencyCode: string;
 }
 
-// @public (undocumented)
-export interface PhoneNumberPollerOptionsBase {
-    // (undocumented)
-    pollInterval?: number;
-    // (undocumented)
-    resumeFrom?: string;
-}
-
 // @public
 export class PhoneNumbersClient {
     constructor(connectionString: string, options?: PhoneNumbersClientOptions);
@@ -90,7 +82,7 @@ export class PhoneNumbersClient {
     beginPurchasePhoneNumbers(searchId: string, options?: BeginPurchasePhoneNumbersOptions): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>>;
     beginReleasePhoneNumber(phoneNumber: string, options?: BeginReleasePhoneNumberOptions): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>>;
     beginSearchAvailablePhoneNumbers(search: SearchAvailablePhoneNumbersRequest, options?: BeginSearchAvailablePhoneNumbersOptions): Promise<PollerLike<PollOperationState<PhoneNumberSearchResult>, PhoneNumberSearchResult>>;
-    beginUpdatePhoneNumberCapabilities(phoneNumber: string, request: PhoneNumberCapabilitiesRequest, options?: BeginUpdatePhoneNumberOptions): Promise<PollerLike<PollOperationState<AcquiredPhoneNumber>, AcquiredPhoneNumber>>;
+    beginUpdatePhoneNumberCapabilities(phoneNumber: string, request: PhoneNumberCapabilitiesRequest, options?: BeginUpdatePhoneNumberCapabilitiesOptions): Promise<PollerLike<PollOperationState<AcquiredPhoneNumber>, AcquiredPhoneNumber>>;
     getPurchasedPhoneNumber(phoneNumber: string, options?: GetPurchasedPhoneNumberOptions): Promise<AcquiredPhoneNumber>;
     listPurchasedPhoneNumbers(options?: ListPurchasedPhoneNumbersOptions): PagedAsyncIterableIterator<AcquiredPhoneNumber>;
 }

--- a/sdk/communication/communication-phone-numbers/src/lroModels.ts
+++ b/sdk/communication/communication-phone-numbers/src/lroModels.ts
@@ -3,23 +3,22 @@
 
 import { OperationOptions } from "@azure/core-http";
 
-export interface PhoneNumberPollerOptionsBase {
-  pollInterval?: number;
-  resumeFrom?: string;
-}
+/**
+ * Additional options for the search available phone numbers operation.
+ */
+export interface BeginSearchAvailablePhoneNumbersOptions extends OperationOptions {}
 
-export interface BeginSearchAvailablePhoneNumbersOptions
-  extends PhoneNumberPollerOptionsBase,
-    OperationOptions {}
+/**
+ * Additional options for the release phone number operation.
+ */
+export interface BeginReleasePhoneNumberOptions extends OperationOptions {}
 
-export interface BeginReleasePhoneNumberOptions
-  extends PhoneNumberPollerOptionsBase,
-    OperationOptions {}
+/**
+ * Additional options for the purchase phone number operation.
+ */
+export interface BeginPurchasePhoneNumbersOptions extends OperationOptions {}
 
-export interface BeginPurchasePhoneNumbersOptions
-  extends PhoneNumberPollerOptionsBase,
-    OperationOptions {}
-
-export interface BeginUpdatePhoneNumberOptions
-  extends PhoneNumberPollerOptionsBase,
-    OperationOptions {}
+/**
+ * Additional options for the update phone number capabilities operation.
+ */
+export interface BeginUpdatePhoneNumberCapabilitiesOptions extends OperationOptions {}

--- a/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
@@ -34,7 +34,7 @@ import {
   BeginPurchasePhoneNumbersOptions,
   BeginReleasePhoneNumberOptions,
   BeginSearchAvailablePhoneNumbersOptions,
-  BeginUpdatePhoneNumberOptions
+  BeginUpdatePhoneNumberCapabilitiesOptions
 } from "./lroModels";
 
 /**
@@ -326,12 +326,12 @@ export class PhoneNumbersClient {
    *
    * @param {string} phoneNumber The E.164 formatted phone number being updated. The leading plus can be either + or encoded as %2B.
    * @param {PhoneNumberCapabilitiesRequest} request The updated properties which will be applied to the phone number.
-   * @param {BeginUpdatePhoneNumberOptions} options Additional request options.
+   * @param {BeginUpdatePhoneNumberCapabilitiesOptions} options Additional request options.
    */
   public async beginUpdatePhoneNumberCapabilities(
     phoneNumber: string,
     request: PhoneNumberCapabilitiesRequest,
-    options: BeginUpdatePhoneNumberOptions = {}
+    options: BeginUpdatePhoneNumberCapabilitiesOptions = {}
   ): Promise<PollerLike<PollOperationState<AcquiredPhoneNumber>, AcquiredPhoneNumber>> {
     const { span, updatedOptions } = createSpan(
       "PhoneNumbersClient-beginUpdatePhoneNumberCapabilities",

--- a/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
@@ -5,7 +5,7 @@ import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import { PhoneNumberSearchResult, SearchAvailablePhoneNumbersRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
-import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
+import { createRecordedClient } from "./utils/recordedClient";
 
 describe("PhoneNumbersClient - lro - purchase", function() {
   let recorder: Recorder;
@@ -40,10 +40,7 @@ describe("PhoneNumbersClient - lro - purchase", function() {
           calling: "none"
         }
       };
-      const searchPoller = await client.beginSearchAvailablePhoneNumbers(
-        searchRequest,
-        testPollerOptions
-      );
+      const searchPoller = await client.beginSearchAvailablePhoneNumbers(searchRequest);
 
       searchResults = await searchPoller.pollUntilDone();
 
@@ -54,10 +51,7 @@ describe("PhoneNumbersClient - lro - purchase", function() {
     }).timeout(20000);
 
     it("purchases the phone number from the search", async function() {
-      const purchasePoller = await client.beginPurchasePhoneNumbers(
-        searchResults.searchId,
-        testPollerOptions
-      );
+      const purchasePoller = await client.beginPurchasePhoneNumbers(searchResults.searchId);
 
       await purchasePoller.pollUntilDone();
       assert.ok(purchasePoller.getOperationState().isCompleted);

--- a/sdk/communication/communication-phone-numbers/test/lro.release.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.release.spec.ts
@@ -4,7 +4,7 @@
 import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
-import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
+import { createRecordedClient } from "./utils/recordedClient";
 
 describe("PhoneNumbersClient - lro - release", function() {
   let recorder: Recorder;
@@ -38,10 +38,7 @@ describe("PhoneNumbersClient - lro - release", function() {
     }).timeout(10000);
 
     it("releases the phone number", async function() {
-      const releasePoller = await client.beginReleasePhoneNumber(
-        phoneNumberToRelease,
-        testPollerOptions
-      );
+      const releasePoller = await client.beginReleasePhoneNumber(phoneNumberToRelease);
 
       await releasePoller.pollUntilDone();
       assert.ok(releasePoller.getOperationState().isCompleted);

--- a/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
@@ -5,7 +5,7 @@ import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import { SearchAvailablePhoneNumbersRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
-import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
+import { createRecordedClient } from "./utils/recordedClient";
 
 describe("PhoneNumbersClient - lro - search", function() {
   let recorder: Recorder;
@@ -45,10 +45,7 @@ describe("PhoneNumbersClient - lro - search", function() {
   }).timeout(20000);
 
   it("can cancel search", async function() {
-    const searchPoller = await client.beginSearchAvailablePhoneNumbers(
-      searchRequest,
-      testPollerOptions
-    );
+    const searchPoller = await client.beginSearchAvailablePhoneNumbers(searchRequest);
 
     await searchPoller.cancelOperation();
     assert.ok(searchPoller.isStopped);

--- a/sdk/communication/communication-phone-numbers/test/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.update.spec.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { PhoneNumberCapabilitiesRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { buildCapabilityUpdate } from "./utils";
-import { createRecordedClient, testPollerOptions } from "./utils/recordedClient";
+import { createRecordedClient } from "./utils/recordedClient";
 
 describe("PhoneNumbersClient - lro - update", function() {
   const acquiredPhoneNumber = isPlaybackMode() ? "+14155550100" : env.AZURE_PHONE_NUMBER;
@@ -37,8 +37,7 @@ describe("PhoneNumbersClient - lro - update", function() {
 
     const updatePoller = await client.beginUpdatePhoneNumberCapabilities(
       acquiredPhoneNumber,
-      update,
-      testPollerOptions
+      update
     );
 
     const phoneNumber = await updatePoller.pollUntilDone();
@@ -56,8 +55,7 @@ describe("PhoneNumbersClient - lro - update", function() {
 
     const updatePoller = await client.beginUpdatePhoneNumberCapabilities(
       acquiredPhoneNumber,
-      update,
-      testPollerOptions
+      update
     );
 
     await updatePoller.cancelOperation();


### PR DESCRIPTION
This PR removes the `pollInterval` and `resumeFrom` lro options as they are not currently supported by the generated poller.