### PR TITLE
[cosmos] use TokenCredential from core-auth instead of identity

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 3.10.3 (Unreleased)
+
+- BUGFIX: Removes direct dependency on @azure/identity while retaining compatibility.
+
 ## 3.10.2 (2021-03-11)
 
 - BUGFIX: Fixes @azure/identity dependency in dev deps.

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -87,7 +87,6 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.2.0",
-    "@azure/identity": "^1.1.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "jsbi": "^3.1.3",
@@ -102,6 +101,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/identity": "^1.1.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { TokenCredential } from '@azure/identity';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public (undocumented)
 export interface Agent {

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { TokenCredential } from "@azure/identity";
+import { TokenCredential } from "@azure/core-auth";
 import { TokenProvider } from "./auth";
 import { PermissionDefinition } from "./client";
 import { ConnectionPolicy, ConsistencyLevel } from "./documents";


### PR DESCRIPTION
Related to #14236 

/cc @zfoster 

The `@azure/core-auth` package exposes the `TokenCredential` type that `@azure/identity` credentials implement. We try to avoid depending on `@azure/identity` in our packages directly because:

1. User's should depend on it in their own projects directly so they can instantiate the credentials they want to use. This way they can also use the version of identity they want versus what our package pulls in.
2. Many packages offer an alternative auth mechanism, or a customer may have a custom TokenCredential implementation that doesn't need identity, so this avoids pulling in identity unnecessarily.

This change moves identity back as a dev dependency (we still want it for testing!) and depends on core-auth for the TokenCredential instead.
