### PR TITLE
[Text Analytics] Use camel case in assertion response strings

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -176,7 +176,7 @@ export type EntityAssociation = "subject" | "other";
 export type EntityCertainty = "positive" | "positivePossible" | "neutralPossible" | "negativePossible" | "negative";
 
 // @public
-export type EntityConditionality = "Hypothetical" | "Conditional";
+export type EntityConditionality = "hypothetical" | "conditional";
 
 // @public
 export interface EntityDataSource {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -1098,7 +1098,7 @@ export type State =
   | "cancelling"
   | "partiallyCompleted";
 /** Defines values for Conditionality. */
-export type Conditionality = "Hypothetical" | "Conditional";
+export type Conditionality = "hypothetical" | "conditional";
 /** Defines values for Certainty. */
 export type Certainty =
   | "positive"


### PR DESCRIPTION
This change is needed to match the current service's response. The swagger is being updated in https://github.com/Azure/azure-rest-api-specs/pull/13361.