### PR TITLE
Avoid null error when no samples are found

### DIFF
--- a/common/smoke-test/Initialize-SmokeTests.ps1
+++ b/common/smoke-test/Initialize-SmokeTests.ps1
@@ -268,6 +268,10 @@ function Export-Configs {
 function Initialize-SmokeTests {
   Set-EnvironmentVariables
   $deployManifest = New-DeployManifest
+  if (!$deployManifest) {
+      Write-Warning "No javascript samples found for $ServiceDirectory"
+      return
+  }
   $configs = Deploy-TestResources $deployManifest
   Export-Configs $configs.Dependencies $configs.RunManifest
 


### PR DESCRIPTION
If there are no javascript samples detected, the Initialize-SmokeTests.ps1 script does not handle this gracefully:

```
VERBOSE: Detecting samples...
Deploy-TestResources: /home/ben/sdk/azure-sdk-for-js/common/smoke-test/Initialize-SmokeTests.ps1:271
Line |
 271 |    $configs = Deploy-TestResources $deployManifest
     |                                    ~~~~~~~~~~~~~~~
     | Cannot bind argument to parameter 'deployManifest' because it is null.

```

This is failing the cosmosdb release pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=778657&view=logs&j=6264c357-0dbd-550f-f8cc-1728c68e778a&t=964ac695-12eb-5bfc-a6f5-7011b6c06592