### PR TITLE
[Text Analytics] Fix samples

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -61,6 +61,7 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",
+    "execute:sample": "npm run build:samples && dev-tool samples run",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -44,7 +44,7 @@
     "node": ">=8.0.0"
   },
   "//sampleConfiguration": {
-    "skipFolder": true
+    "skipFolder": false
   },
   "browser": {
     "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js",

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
@@ -60,7 +60,7 @@ async function main() {
           }
         }
       }
-      if (result.entityRelations.length !== undefined && result.entityRelations.length > 0) {
+      if (result.entityRelations !== undefined && result.entityRelations.length > 0) {
         console.log(`\tRecognized relations between entities:`);
         for (const relation of result.entityRelations) {
           console.log(

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/beginAnalyzeHealthcareEntities.js
@@ -60,7 +60,7 @@ async function main() {
           }
         }
       }
-      if (result.entityRelations?.length > 0) {
+      if (result.entityRelations.length !== undefined && result.entityRelations.length > 0) {
         console.log(`\tRecognized relations between entities:`);
         for (const relation of result.entityRelations) {
           console.log(

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/recognizePii.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/recognizePii.js
@@ -25,28 +25,26 @@ async function main() {
   const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
 
   const textOnePii = "My phone number is 555-5555";
-  const textNoPHI =
-    "FIFA is a non-profit organization which describes itself as an international governing body of association football.";
+  const textNoPHI = "His EU passport number is X65097105";
   const textMultiplePIIs = "Patient name is Joe and SSN is 859-98-0987";
 
   const [result] = await client.recognizePiiEntities([textOnePii]);
 
   if (!result.error) {
     console.log(
-      `The redacted text is "${result.redactedText}" and found the following PII entities`
+      `The redacted text is \"${result.redactedText}\" and found the following PII entities`
     );
     for (const entity of result.entities) {
-      console.log(`\t- "${entity.text}" of type ${entity.category}`);
+      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
     }
   }
 
-  console.log(`There are no PHI entities in this text: ${textNoPHI}`);
-  const [resultWithPHI] = await client.recognizePiiEntities(
-    [{ id: "0", text: textNoPHI, language: "en" }],
-    { domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION }
-  );
+  console.log(`There are no PHI entities in this text: \"${textNoPHI}\"`);
+  const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
+    domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
+  });
   if (!resultWithPHI.error) {
-    console.log(`Also there is nothing to redact: ${resultWithPHI.redactedText}`);
+    console.log(`Also there is nothing to redact: \"${resultWithPHI.redactedText}\"`);
     assert(resultWithPHI.entities.length === 0, "did not expect any entities but got some");
   }
 
@@ -54,16 +52,18 @@ async function main() {
   const [resultWithoutPHI] = await client.recognizePiiEntities([textNoPHI]);
   if (!resultWithoutPHI.error) {
     for (const entity of resultWithoutPHI.entities) {
-      console.log(`\t- "${entity.text}" of type ${entity.category}`);
+      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
     }
   }
   const [resultWithSSNPII] = await client.recognizePiiEntities([textMultiplePIIs], "en", {
     categoriesFilter: ["USSocialSecurityNumber"]
   });
   if (!resultWithSSNPII.error) {
-    console.log("The service was asked to return just SSN entities:");
+    console.log(
+      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: \"${textMultiplePIIs}\", this is the SSN number:`
+    );
     for (const entity of resultWithSSNPII.entities) {
-      console.log(`\t- "${entity.text}"`);
+      console.log(`\t- \"${entity.text}\"`);
       assert(entity.category === "USSocialSecurityNumber");
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/javascript/recognizePii.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/javascript/recognizePii.js
@@ -32,19 +32,19 @@ async function main() {
 
   if (!result.error) {
     console.log(
-      `The redacted text is \"${result.redactedText}\" and found the following PII entities`
+      `The redacted text is "${result.redactedText}" and found the following PII entities`
     );
     for (const entity of result.entities) {
-      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
+      console.log(`\t- "${entity.text}" of type ${entity.category}`);
     }
   }
 
-  console.log(`There are no PHI entities in this text: \"${textNoPHI}\"`);
+  console.log(`There are no PHI entities in this text: "${textNoPHI}"`);
   const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
     domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
   });
   if (!resultWithPHI.error) {
-    console.log(`Also there is nothing to redact: \"${resultWithPHI.redactedText}\"`);
+    console.log(`Also there is nothing to redact: "${resultWithPHI.redactedText}"`);
     assert(resultWithPHI.entities.length === 0, "did not expect any entities but got some");
   }
 
@@ -52,7 +52,7 @@ async function main() {
   const [resultWithoutPHI] = await client.recognizePiiEntities([textNoPHI]);
   if (!resultWithoutPHI.error) {
     for (const entity of resultWithoutPHI.entities) {
-      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
+      console.log(`\t- "${entity.text}" of type ${entity.category}`);
     }
   }
   const [resultWithSSNPII] = await client.recognizePiiEntities([textMultiplePIIs], "en", {
@@ -60,10 +60,10 @@ async function main() {
   });
   if (!resultWithSSNPII.error) {
     console.log(
-      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: \"${textMultiplePIIs}\", this is the SSN number:`
+      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: "${textMultiplePIIs}", this is the SSN number:`
     );
     for (const entity of resultWithSSNPII.entities) {
-      console.log(`\t- \"${entity.text}\"`);
+      console.log(`\t- "${entity.text}"`);
       assert(entity.category === "USSocialSecurityNumber");
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/package.json
@@ -36,6 +36,6 @@
   "devDependencies": {
     "@types/node": "^8.0.0",
     "rimraf": "^3.0.0",
-    "typescript": "~3.6.4"
+    "typescript": "4.1.2"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/package.json
@@ -36,6 +36,6 @@
   "devDependencies": {
     "@types/node": "^8.0.0",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "latest"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/recognizePii.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/recognizePii.ts
@@ -33,19 +33,19 @@ export async function main() {
 
   if (!result.error) {
     console.log(
-      `The redacted text is \"${result.redactedText}\" and found the following PII entities`
+      `The redacted text is "${result.redactedText}" and found the following PII entities`
     );
     for (const entity of result.entities) {
-      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
+      console.log(`\t- "${entity.text}" of type ${entity.category}`);
     }
   }
 
-  console.log(`There are no PHI entities in this text: \"${textNoPHI}\"`);
+  console.log(`There are no PHI entities in this text: "${textNoPHI}"`);
   const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
     domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
   });
   if (!resultWithPHI.error) {
-    console.log(`Also there is nothing to redact: \"${resultWithPHI.redactedText}\"`);
+    console.log(`Also there is nothing to redact: "${resultWithPHI.redactedText}"`);
     assert(resultWithPHI.entities.length === 0, "did not expect any entities but got some");
   }
 
@@ -53,7 +53,7 @@ export async function main() {
   const [resultWithoutPHI] = await client.recognizePiiEntities([textNoPHI]);
   if (!resultWithoutPHI.error) {
     for (const entity of resultWithoutPHI.entities) {
-      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
+      console.log(`\t- "${entity.text}" of type ${entity.category}`);
     }
   }
   const [resultWithSSNPII] = await client.recognizePiiEntities([textMultiplePIIs], "en", {
@@ -61,10 +61,10 @@ export async function main() {
   });
   if (!resultWithSSNPII.error) {
     console.log(
-      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: \"${textMultiplePIIs}\", this is the SSN number:`
+      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: "${textMultiplePIIs}", this is the SSN number:`
     );
     for (const entity of resultWithSSNPII.entities) {
-      console.log(`\t- \"${entity.text}\"`);
+      console.log(`\t- "${entity.text}"`);
       assert(entity.category === "USSocialSecurityNumber");
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/src/recognizePii.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/src/recognizePii.ts
@@ -26,28 +26,26 @@ export async function main() {
   const client = new TextAnalyticsClient(endpoint, new AzureKeyCredential(apiKey));
 
   const textOnePii = "My phone number is 555-5555";
-  const textNoPHI =
-    "FIFA is a non-profit organization which describes itself as an international governing body of association football.";
+  const textNoPHI = "His EU passport number is X65097105";
   const textMultiplePIIs = "Patient name is Joe and SSN is 859-98-0987";
 
   const [result] = await client.recognizePiiEntities([textOnePii]);
 
   if (!result.error) {
     console.log(
-      `The redacted text is "${result.redactedText}" and found the following PII entities`
+      `The redacted text is \"${result.redactedText}\" and found the following PII entities`
     );
     for (const entity of result.entities) {
-      console.log(`\t- "${entity.text}" of type ${entity.category}`);
+      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
     }
   }
 
-  console.log(`There are no PHI entities in this text: ${textNoPHI}`);
-  const [resultWithPHI] = await client.recognizePiiEntities(
-    [{ id: "0", text: textNoPHI, language: "en" }],
-    { domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION }
-  );
+  console.log(`There are no PHI entities in this text: \"${textNoPHI}\"`);
+  const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
+    domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
+  });
   if (!resultWithPHI.error) {
-    console.log(`Also there is nothing to redact: ${resultWithPHI.redactedText}`);
+    console.log(`Also there is nothing to redact: \"${resultWithPHI.redactedText}\"`);
     assert(resultWithPHI.entities.length === 0, "did not expect any entities but got some");
   }
 
@@ -55,16 +53,18 @@ export async function main() {
   const [resultWithoutPHI] = await client.recognizePiiEntities([textNoPHI]);
   if (!resultWithoutPHI.error) {
     for (const entity of resultWithoutPHI.entities) {
-      console.log(`\t- "${entity.text}" of type ${entity.category}`);
+      console.log(`\t- \"${entity.text}\" of type ${entity.category}`);
     }
   }
   const [resultWithSSNPII] = await client.recognizePiiEntities([textMultiplePIIs], "en", {
     categoriesFilter: ["USSocialSecurityNumber"]
   });
   if (!resultWithSSNPII.error) {
-    console.log("The service was asked to return just SSN entities:");
+    console.log(
+      `You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: \"${textMultiplePIIs}\", this is the SSN number:`
+    );
     for (const entity of resultWithSSNPII.entities) {
-      console.log(`\t- "${entity.text}"`);
+      console.log(`\t- \"${entity.text}\"`);
       assert(entity.category === "USSocialSecurityNumber");
     }
   }

--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/tsconfig.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/tsconfig.json
@@ -8,6 +8,8 @@
     "strict": true,
     "alwaysStrict": true,
 
+    "target": "ES6",
+
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
This PR does the following:
- updates samples so the typescript ones can run with `node8` with no issues by setting the compilation target to `ES6`.
- fixes the recognize PII sample where a the behavior for the protected healthcare information parameter changed in the service. This PR updates the input text used with this parameter to one that does not have protected healthcare information according to the new update. More information can be found [here](https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/named-entity-types?tabs=personal#government-and-countryregion-specific-identification). Also, this is the output of the updated sample:
```
Running recognizePii sample

The redacted text is "My phone number is ********" and found the following PII entities
       - "555-5555" of type PhoneNumber
There are no PHI entities in this text: "His EU passport number is X65097105"
Also there is nothing to redact: "His EU passport number is X65097105"
But there are other PII entities in that text:
       - "X65097105" of type EUPassportNumber
You can choose to get SSN entities only, or any other PII category or a combination of them. For example, in this text: "Patient name is Joe and SSN is 859-98-0987", this is the SSN number:
       - "859-98-0987"
```
- adds a new npm script `execute:sample` to run individual samples.
- fixes a bug in the javascript sample for beginAnalyzeHealthcareEntities.
- re-enable text analytics samples in smoke tests.

The javascript samples still fail with `node8` because of the lack of support for `ES6`, but this is fine because we should always write our samples using the recent features of the language and we do not want them to look outdated.