### PR TITLE
[core-client] Allow setting empty query parameter values

### DIFF
--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -169,13 +169,10 @@ function calculateQueryParameters(
           queryParameterValue = queryParameterValue.join(delimiter);
         }
 
-        // ignore empty values
-        if (queryParameterValue) {
-          result.set(
-            queryParameter.mapper.serializedName || getPathStringFromParameter(queryParameter),
-            queryParameterValue
-          );
-        }
+        result.set(
+          queryParameter.mapper.serializedName || getPathStringFromParameter(queryParameter),
+          queryParameterValue
+        );
       }
     }
   }

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -3,7 +3,12 @@
 
 import { assert } from "chai";
 import { getRequestUrl } from "../src/urlHelpers";
-import { OperationSpec, OperationURLParameter, createSerializer } from "../src";
+import {
+  OperationSpec,
+  OperationURLParameter,
+  createSerializer,
+  OperationQueryParameter
+} from "../src";
 
 describe("getRequestUrl", function() {
   const urlParameter: OperationURLParameter = {
@@ -82,5 +87,32 @@ describe("getRequestUrl", function() {
       result,
       "https://test.com/Tables('TestTable')?superSecretKey=Qai%2B4%2FIM%3D&extraValue=%27blah%27"
     );
+  });
+
+  it.only("should allow empty query parameter value", function() {
+    const stringQuery: OperationQueryParameter = {
+      parameterPath: "stringQuery",
+      mapper: {
+        defaultValue: "",
+        isConstant: true,
+        serializedName: "stringQuery",
+        type: {
+          name: "String"
+        }
+      }
+    };
+    const result = getRequestUrl(
+      "https://test.com",
+      {
+        path: "/path",
+        httpMethod: "GET",
+        responses: {},
+        queryParameters: [stringQuery],
+        serializer
+      },
+      {},
+      {}
+    );
+    assert.strictEqual(result, "https://test.com/path?stringQuery=");
   });
 });

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -89,7 +89,7 @@ describe("getRequestUrl", function() {
     );
   });
 
-  it.only("should allow empty query parameter value", function() {
+  it("should allow empty query parameter value", function() {
     const stringQuery: OperationQueryParameter = {
       parameterPath: "stringQuery",
       mapper: {


### PR DESCRIPTION
This is caught by autorest typescript tests that it is a valid scenario to send
requsts with query parameters having empty values. This PR changes the behavior
to match core-http's.