### PR TITLE
[core-client] Add a test case for serializing a false body

### DIFF
--- a/sdk/core/core-client/test/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/serializationPolicy.spec.ts
@@ -44,6 +44,33 @@ describe("serializationPolicy", function() {
       );
     });
 
+    it("should serialize a JSON false request body", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          boolBody: false
+        },
+        {
+          httpMethod: "PUT",
+          requestBody: {
+            parameterPath: "boolBody",
+            mapper: {
+              defaultValue: false,
+              isConstant: true,
+              serializedName: "boolBody",
+              type: {
+                name: "Boolean"
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, `false`);
+    });
+
     it("should serialize a JSON String request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(

--- a/sdk/core/core-client/test/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/serializationPolicy.spec.ts
@@ -71,6 +71,34 @@ describe("serializationPolicy", function() {
       assert.strictEqual(httpRequest.body, `false`);
     });
 
+    it("should serialize a JSON null request body", () => {
+      const httpRequest = createPipelineRequest({ url: "https://example.com" });
+      serializeRequestBody(
+        httpRequest,
+        {
+          boolBody: null
+        },
+        {
+          httpMethod: "PUT",
+          requestBody: {
+            parameterPath: "nullBody",
+            mapper: {
+              defaultValue: null,
+              isConstant: true,
+              serializedName: "nullBody",
+              nullable: true,
+              type: {
+                name: "String"
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: createSerializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, `null`);
+    });
+
     it("should serialize a JSON String request body", () => {
       const httpRequest = createPipelineRequest({ url: "https://example.com" });
       serializeRequestBody(


### PR DESCRIPTION
Adds a test case for a JSON body that is
- false
- null [according to the spec](https://www.json.org/json-en.html)

Those tests were missed in https://github.com/Azure/azure-sdk-for-js/pull/14218.