### PR TITLE
[Mgmt identity script] Detect operation name

### DIFF
--- a/common/tools/add-identity-mgmt-lib.js
+++ b/common/tools/add-identity-mgmt-lib.js
@@ -77,7 +77,7 @@ There are multiple credentials available in the \`@azure/identity\` package to s
 Read about them in detail in [readme for @azure/identity package](https://www.npmjs.com/package/@azure/identity).
 To get started you can use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential) which tries different credentials internally until one of them succeeds.
 Most of the credentials would require you to [create an Azure App Registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration) first.
-#### nodejs - Authentication, client creation, and get apps as an example written in JavaScript.
+#### nodejs - Authentication, client creation, and ${operation.split(".").reverse().join(" ")} as an example written in JavaScript.
 
 ##### Sample code
 
@@ -101,7 +101,7 @@ client.${operation}(resourceGroupName, resourceName).then((result) => {
 });
 \`\`\`
 
-#### browser - Authentication, client creation, and get apps as an example written in JavaScript.
+#### browser - Authentication, client creation, and ${operation.split(".").reverse().join(" ")} as an example written in JavaScript.
 
 In browser applications, we recommend using the \`InteractiveBrowserCredential\` that interactively authenticates using the default system browser.
 It is necessary to [create an Azure App Registration](https://docs.microsoft.com/azure/active-directory/develop/scenario-spa-app-registration) in the portal for your web application first.

--- a/common/tools/add-identity-mgmt-lib.js
+++ b/common/tools/add-identity-mgmt-lib.js
@@ -42,6 +42,12 @@ function updateREADME(mainModule, relativePath, namespace) {
       "README file"
     );
 
+    const operation = getMatch(
+      content.match(/client\.(.+?)\(resourceGroupName, resourceName\).*$/ms),
+      "operation",
+      "README file"
+    );
+
     return `## Azure ${clientName} SDK for JavaScript
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ${clientName}.
@@ -86,7 +92,7 @@ const creds = new DefaultAzureCredential();
 const client = new ${clientName}(creds, subscriptionId);
 const resourceGroupName = "testresourceGroupName";
 const resourceName = "testresourceName";
-client.apps.get(resourceGroupName, resourceName).then((result) => {
+client.${operation}(resourceGroupName, resourceName).then((result) => {
   console.log("The result is:");
   console.log(result);
 }).catch((err) => {
@@ -124,7 +130,7 @@ It is necessary to [create an Azure App Registration](https://docs.microsoft.com
       const client = new ${namespace}.${clientName}(creds, subscriptionId);
       const resourceGroupName = "testresourceGroupName";
       const resourceName = "testresourceName";
-      client.apps.get(resourceGroupName, resourceName).then((result) => {
+      client.${operation}(resourceGroupName, resourceName).then((result) => {
         console.log("The result is:");
         console.log(result);
       }).catch((err) => {

--- a/common/tools/add-identity-mgmt-lib.js
+++ b/common/tools/add-identity-mgmt-lib.js
@@ -48,6 +48,11 @@ function updateREADME(mainModule, relativePath, namespace) {
       "README file"
     );
 
+    const operationHeader = operation
+      .split(".")
+      .reverse()
+      .join(" ");
+
     return `## Azure ${clientName} SDK for JavaScript
 
 This package contains an isomorphic SDK (runs both in node.js and in browsers) for ${clientName}.
@@ -77,7 +82,7 @@ There are multiple credentials available in the \`@azure/identity\` package to s
 Read about them in detail in [readme for @azure/identity package](https://www.npmjs.com/package/@azure/identity).
 To get started you can use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential) which tries different credentials internally until one of them succeeds.
 Most of the credentials would require you to [create an Azure App Registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration) first.
-#### nodejs - Authentication, client creation, and ${operation.split(".").reverse().join(" ")} as an example written in JavaScript.
+#### nodejs - Authentication, client creation, and ${operationHeader} as an example written in JavaScript.
 
 ##### Sample code
 
@@ -101,7 +106,7 @@ client.${operation}(resourceGroupName, resourceName).then((result) => {
 });
 \`\`\`
 
-#### browser - Authentication, client creation, and ${operation.split(".").reverse().join(" ")} as an example written in JavaScript.
+#### browser - Authentication, client creation, and ${operationHeader} as an example written in JavaScript.
 
 In browser applications, we recommend using the \`InteractiveBrowserCredential\` that interactively authenticates using the default system browser.
 It is necessary to [create an Azure App Registration](https://docs.microsoft.com/azure/active-directory/develop/scenario-spa-app-registration) in the portal for your web application first.

--- a/common/tools/add-identity-mgmt-lib.js
+++ b/common/tools/add-identity-mgmt-lib.js
@@ -43,7 +43,7 @@ function updateREADME(mainModule, relativePath, namespace) {
     );
 
     const operation = getMatch(
-      content.match(/client\.(.+?)\(resourceGroupName, resourceName\).*$/ms),
+      content.match(/client\.(.+?)\(.*\).*$/ms),
       "operation",
       "README file"
     );


### PR DESCRIPTION
The script as is hardcodes the operation name in the sample in the readme file to be `apps.get` which is not available in every package. This PR updates the script so that it detects the operation name from the package's existing README.md file.