### PR TITLE
[core-client] add back validation on operation argument values

### DIFF
--- a/sdk/core/core-client/src/operationHelpers.ts
+++ b/sdk/core/core-client/src/operationHelpers.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { getPathStringFromParameter } from "./interfaceHelpers";
 import {
   OperationArguments,
   OperationParameter,
@@ -8,7 +9,8 @@ import {
   CompositeMapper,
   ParameterPath,
   OperationRequestInfo,
-  OperationRequest
+  OperationRequest,
+  OperationSpec
 } from "./interfaces";
 
 /**
@@ -21,6 +23,7 @@ import {
  */
 export function getOperationArgumentValueFromParameter(
   operationArguments: OperationArguments,
+  operationSpec: OperationSpec,
   parameter: OperationParameter,
   fallbackObject?: { [parameterName: string]: any }
 ): any {
@@ -49,6 +52,10 @@ export function getOperationArgumentValueFromParameter(
         }
         value = useDefaultValue ? parameterMapper.defaultValue : propertySearchResult.propertyValue;
       }
+
+      // Serialize just for validation purposes.
+      const parameterPathString: string = getPathStringFromParameter(parameter);
+      operationSpec.serializer.serialize(parameterMapper, value, parameterPathString);
     }
   } else {
     if (parameterMapper.required) {
@@ -62,12 +69,17 @@ export function getOperationArgumentValueFromParameter(
       const propertyPath: ParameterPath = parameterPath[propertyName];
       const propertyValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath: propertyPath,
           mapper: propertyMapper
         },
         fallbackObject
       );
+      // Serialize just for validation purposes.
+      const parameterPathString: string = getPathStringFromParameter(parameter);
+      operationSpec.serializer.serialize(parameterMapper, value, parameterPathString);
+
       if (propertyValue !== undefined) {
         if (!value) {
           value = {};

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -72,7 +72,11 @@ export function serializeHeaders(
 ): void {
   if (operationSpec.headerParameters) {
     for (const headerParameter of operationSpec.headerParameters) {
-      let headerValue = getOperationArgumentValueFromParameter(operationArguments, headerParameter);
+      let headerValue = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        headerParameter
+      );
       if (headerValue !== null && headerValue !== undefined) {
         headerValue = operationSpec.serializer.serialize(
           headerParameter.mapper,
@@ -126,6 +130,7 @@ export function serializeRequestBody(
   if (operationSpec.requestBody && operationSpec.requestBody.mapper) {
     request.body = getOperationArgumentValueFromParameter(
       operationArguments,
+      operationSpec,
       operationSpec.requestBody
     );
 
@@ -210,6 +215,7 @@ export function serializeRequestBody(
     for (const formDataParameter of operationSpec.formDataParameters) {
       const formDataParameterValue = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         formDataParameter
       );
       if (formDataParameterValue !== undefined && formDataParameterValue !== null) {

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -62,6 +62,7 @@ function calculateUrlReplacements(
     for (const urlParameter of operationSpec.urlParameters) {
       let urlParameterValue: string = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         urlParameter,
         fallbackObject
       );
@@ -120,6 +121,7 @@ function calculateQueryParameters(
     for (const queryParameter of operationSpec.queryParameters) {
       let queryParameterValue: string | string[] = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         queryParameter,
         fallbackObject
       );

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -383,6 +383,14 @@ describe("ServiceClient", function() {
   });
 
   describe("getOperationArgumentValueFromParameter()", () => {
+    const operationSpec: OperationSpec = {
+      httpMethod: "GET",
+      responses: {
+        default: {}
+      },
+      baseUrl: "https://example.com",
+      serializer: createSerializer()
+    };
     it("should return undefined when the parameter path isn't found in the operation arguments or service client", () => {
       const operationArguments: OperationArguments = {};
       const parameterPath: ParameterPath = "myParameter";
@@ -392,10 +400,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, undefined);
     });
 
@@ -410,10 +422,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, undefined);
     });
 
@@ -428,10 +444,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
 
       assert.strictEqual(parameterValue, null);
     });
@@ -447,10 +467,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        mapper: parameterMapper,
-        parameterPath
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          mapper: parameterMapper,
+          parameterPath
+        }
+      );
       assert.strictEqual(parameterValue, 20);
     });
 
@@ -491,6 +515,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper
@@ -516,6 +541,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper
@@ -537,10 +563,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, 1);
     });
 
@@ -565,6 +595,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper
@@ -587,6 +618,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper
@@ -610,6 +642,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper
@@ -634,10 +667,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, 21);
     });
 
@@ -655,10 +692,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, undefined);
     });
 
@@ -672,10 +713,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, 21);
     });
 
@@ -689,10 +734,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
       assert.strictEqual(parameterValue, undefined);
     });
 
@@ -708,10 +757,14 @@ describe("ServiceClient", function() {
           name: MapperTypeNames.Number
         }
       };
-      const parameterValue: any = getOperationArgumentValueFromParameter(operationArguments, {
-        parameterPath,
-        mapper: parameterMapper
-      });
+      const parameterValue: any = getOperationArgumentValueFromParameter(
+        operationArguments,
+        operationSpec,
+        {
+          parameterPath,
+          mapper: parameterMapper
+        }
+      );
 
       assert.strictEqual(parameterValue, null);
     });
@@ -730,6 +783,7 @@ describe("ServiceClient", function() {
       };
       const parameterValue: any = getOperationArgumentValueFromParameter(
         operationArguments,
+        operationSpec,
         {
           parameterPath,
           mapper: parameterMapper


### PR DESCRIPTION
We have the validation in core-http. Without this validation some errors
expected by autorest typescript test are not thrown.