### PR TITLE
Update Bundling.md

### DIFF
--- a/documentation/Bundling.md
+++ b/documentation/Bundling.md
@@ -320,9 +320,10 @@ export default {
       preferBuiltins: false,
       mainFields: ["module", "browser"]
     }),
-    cjs({
+   cjs({
       namedExports: {
-        events: ["EventEmitter"]
+        events: ["EventEmitter"],
+        "@opentelemetry/api": ["CanonicalCode", "SpanKind", "TraceFlags"]
       }
     }),
     json(),


### PR DESCRIPTION
Typescript now has proper telemetry types. Fixes: https://github.com/Azure/azure-sdk-for-js/issues/7313