### PR TITLE
Revert set dev version code

### DIFF
--- a/eng/tools/versioning/set-dev.js
+++ b/eng/tools/versioning/set-dev.js
@@ -56,22 +56,6 @@ const updatePackageVersion = (rushPackages, package, buildId) => {
   return rushPackages;
 };
 
-const shouldUpdateVersion = (packageVersion, depVersionRange) => {
-  // Update dependent pacakge version to daily dev if dependency requirement is either 'dev' or if it matches semver
-  let updateDependent = (depVersionRange === "dev");
-  if (!updateDependent) {
-    const parsedPackageVersion = semver.parse(packageVersion);
-    const parsedDepMinVersion = semver.minVersion(depVersionRange);
-    if (
-      parsedDepMinVersion.major == parsedPackageVersion.major &&
-      parsedDepMinVersion.minor == parsedPackageVersion.minor &&
-      parsedDepMinVersion.patch == parsedPackageVersion.patch) {
-      updateDependent = true;
-    }
-  }
-  return updateDependent;
-}
-
 const updateDependencySection = (rushPackages, dependencySection, buildId) => {
   //console.log(dependencySection);
   if (dependencySection) {
@@ -91,7 +75,14 @@ const updateDependencySection = (rushPackages, dependencySection, buildId) => {
       console.log(`version in package's dep = ${depVersionRange}`); //^1.0.0
       console.log(`dep's version = ${packageVersion}`); //1.0.0
 
-      if (shouldUpdateVersion(packageVersion, depVersionRange) && !rushPackages[depName].json["private"]) {
+      const parsedPackageVersion = semver.parse(packageVersion);
+      const parsedDepMinVersion = semver.minVersion(depVersionRange);
+
+      if (
+        parsedDepMinVersion.major == parsedPackageVersion.major &&
+        parsedDepMinVersion.minor == parsedPackageVersion.minor &&
+        parsedDepMinVersion.patch == parsedPackageVersion.patch
+      ) {
         rushPackages = updatePackageVersion(rushPackages, depName, buildId);
       }
     }
@@ -106,6 +97,13 @@ const updateInternalDependencyVersions = (rushPackages, package, buildId) => {
   rushPackages = updateDependencySection(
     rushPackages,
     rushPackages[package].json.dependencies,
+    buildId
+  );
+
+  console.log("checking devDependencies ..");
+  rushPackages = updateDependencySection(
+    rushPackages,
+    rushPackages[package].json.devDependencies,
     buildId
   );
 
@@ -135,17 +133,20 @@ const makeDependencySectionConsistentForPackage = (rushPackages, dependencySecti
 
     console.log(`version in package's dep = ${depVersionRange}`);
     console.log(`dep's version = ${packageVersion}`);
+    const parsedPackageVersion = semver.parse(packageVersion);
+    const parsedDepMinVersion = semver.minVersion(depVersionRange);
     // If the dependency range is satisfied by the package's current version,
     // replace it with an exact match to the package's new version
     if (
-      shouldUpdateVersion(packageVersion, depVersionRange) &&
-      rushPackages[depName].newVer !== undefined &&
-      !rushPackages[depName].json["private"]
+      parsedDepMinVersion.major == parsedPackageVersion.major &&
+      parsedDepMinVersion.minor == parsedPackageVersion.minor &&
+      parsedDepMinVersion.patch == parsedPackageVersion.patch &&
+      rushPackages[depName].newVer !== undefined
     ) {
 
       // Setting version to ^[major.minor.patch]-alpha so that this automatically matches 
       // with the latest dev version published on npm
-      dependencySection[depName] = `dev`;
+      dependencySection[depName] = `^${parsedPackageVersion.major}.${parsedPackageVersion.minor}.${parsedPackageVersion.patch}-alpha`;
     }
   }
   return rushPackages;


### PR DESCRIPTION
Version requirement was set to `dev` tag to use latest daily dev version for dependency packages but this has caused an issue when there is a breaking change from last published dev version. Tag also refers package in npm and this causes additional issue if dev version package is not yet available on npm.

Ideal solution is to pin correct alpha version instead of version range. This PR is to revert current changes to resolve CI failures.