### PR TITLE
[core-rest-pipeline] Add opt-in HTTP support

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -962,6 +962,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+  /@tootallnate/once/1.1.2:
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
   /@types/argparse/1.0.33:
     dev: false
     resolution:
@@ -3749,6 +3755,16 @@ packages:
       node: '>= 4.5.0'
     resolution:
       integrity: sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  /http-proxy-agent/4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.3.1
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -8056,7 +8072,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-administration'
     resolution:
-      integrity: sha512-whG+7mmbnOf6EaKIV++fJN9KVUD3ILO3cUHOLqAQKDlFtmj69QDy6qsbHyTyIOGsKSHHB8KyPPZItGgULngPpw==
+      integrity: sha512-DDT0w71HvXCS7Ww3gM2HO5GXtm8CtitIpHAtGU00lKdFohfzINn7onva3zBKyvLfVMTvv+1TsRrXti5UTu3biA==
       tarball: file:projects/communication-administration.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:
@@ -8113,7 +8129,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-GeSjm0QX1D7rgFhTlH7X8STkmD5h5fP3S6OEOyPY/pRbVHSbf10Qe1yRYrhroA1Ziyh2MCERCkG/0uuah4wg8w==
+      integrity: sha512-P3psB6ukRXVXT/9OHJ+e1euw1S4HOuFBbvPhqGIMlBZuiBXyEqicw6PaG4oVKgjdGJtaOTyvY3E6OXW0hm+9/A==
       tarball: file:projects/communication-chat.tgz
     version: 0.0.0
   file:projects/communication-common.tgz:
@@ -8223,7 +8239,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-Nvy14vvoy4ekaOHptUflWXpEeGuYVNZr6NWBe2Xue1qc4gf9ovl/t41QqlJcpSvIUE8UzC3eH1arEytc8oWaMA==
+      integrity: sha512-y1ywIYptiMuH4NREzzPxXJQg6Gt+zSwp3WJDUGEu99tQcpyToc8oz+4l1FBgq0Dlnxzg0RINJd90sc/SUGisUw==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-phone-numbers.tgz:
@@ -8279,7 +8295,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-4hBuz3yoYH2R0qzZGW+TdpIAvEkGL6pWaHdaNI3PA2ikBCKYuHsCZarHgy8Vx//tsLEGb9aJcRgeX68U98BKxQ==
+      integrity: sha512-KNLkg6N1OQAvBSsdOc/XTNn5DV8mz2wWvq2X28FhvYPEbIl1R2L5mw6uvYBpVzrC+/QHo5l2ET+MlEudm+c+PQ==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
@@ -8333,7 +8349,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-OG8/pwUCKSVDjLzSgPNGBtZdRvdDdMiq2BJ1WSwjCZSAwkhsIAwo2vgh6ZwwAntxJ6QnCTtO6nZ4Vw1fdjDtRA==
+      integrity: sha512-ctnXT8NoEAG2J/IqdPc0qYMmRqtBP6Ceg0owV0b4gVT/AhWURQGDW8nPAXzmeqQWqr5QxfJt4CMnyZchw5gB2w==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -8732,6 +8748,7 @@ packages:
       downlevel-dts: 0.4.0
       eslint: 7.21.0
       form-data: 3.0.1
+      http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.0
       inherits: 2.0.4
       karma: 6.2.0
@@ -8763,7 +8780,7 @@ packages:
     dev: false
     name: '@rush-temp/core-rest-pipeline'
     resolution:
-      integrity: sha512-1vwJ5AIVkR2uVtqj2Dw9E1sDzMHmbjLVA5Ain7mEtujf2tyPtyWoErJVz6hhpm2W1kLeTulUDsXRLQCPZKUjsg==
+      integrity: sha512-p4qdp1hAaSWTIKefHo0o3joYfve2NTPc1J9HvTm6+jevW4l3NI/GSgL3Nxe2i+7uN/teW8gS//OEIDJ8vgT0Gg==
       tarball: file:projects/core-rest-pipeline.tgz
     version: 0.0.0
   file:projects/core-tracing.tgz:

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -98,6 +98,7 @@
     "@opentelemetry/api": "^0.10.2",
     "form-data": "^3.0.0",
     "tslib": "^2.0.0",
+    "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
     "uuid": "^8.3.0"
   },

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -153,6 +153,7 @@ export interface PipelinePolicy {
 // @public
 export interface PipelineRequest {
     abortSignal?: AbortSignalLike;
+    allowInsecureConnection?: boolean;
     body?: RequestBodyType;
     disableKeepAlive?: boolean;
     formData?: FormDataMap;
@@ -172,6 +173,7 @@ export interface PipelineRequest {
 // @public
 export interface PipelineRequestOptions {
     abortSignal?: AbortSignalLike;
+    allowInsecureConnection?: boolean;
     body?: RequestBodyType;
     disableKeepAlive?: boolean;
     formData?: FormDataMap;

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -135,6 +135,9 @@ export interface PipelineRequest {
 
   /** Callback which fires upon download progress. */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+
+  /** Set to true if the request is sent over HTTP instead of HTTPS */
+  allowInsecureConnection?: boolean;
 }
 
 /**

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as http from "http";
 import * as https from "https";
 import * as zlib from "zlib";
 import { Transform } from "stream";
 import { HttpsProxyAgent, HttpsProxyAgentOptions } from "https-proxy-agent";
+import { HttpProxyAgent, HttpProxyAgentOptions } from "http-proxy-agent";
 import { AbortController, AbortError } from "@azure/abort-controller";
 import {
   HttpClient,
@@ -12,7 +14,8 @@ import {
   PipelineResponse,
   TransferProgressEvent,
   HttpHeaders,
-  RequestBodyType
+  RequestBodyType,
+  ProxySettings
 } from "./interfaces";
 import { createHttpHeaders } from "./httpHeaders";
 import { RestError } from "./restError";
@@ -63,8 +66,10 @@ class ReportTransform extends Transform {
  * @internal
  */
 class NodeHttpClient implements HttpClient {
-  private keepAliveAgent?: https.Agent;
-  private proxyAgent?: https.Agent;
+  private httpsKeepAliveAgent?: http.Agent;
+  private httpsProxyAgent?: http.Agent;
+  private httpKeepAliveAgent?: http.Agent;
+  private httpProxyAgent?: http.Agent;
 
   /**
    * Makes a request over an underlying transport layer and returns the response.
@@ -119,8 +124,7 @@ class NodeHttpClient implements HttpClient {
 
           body = uploadReportStream;
         }
-        const options = this.getRequestOptions(request);
-        const req = https.request(options, async (res) => {
+        const req = this.makeRequest(request, async (res) => {
           const headers = getResponseHeaders(res);
 
           const status = res.statusCode ?? 0;
@@ -191,51 +195,20 @@ class NodeHttpClient implements HttpClient {
     }
   }
 
-  private getOrCreateAgent(request: PipelineRequest): https.Agent {
-    // At the moment, proxy settings and keepAlive are mutually
-    // exclusive because the proxy library currently lacks the
-    // ability to create a proxy with keepAlive turned on.
-    const proxySettings = request.proxySettings;
-    if (proxySettings) {
-      if (!this.proxyAgent) {
-        let parsedUrl: URL;
-        try {
-          parsedUrl = new URL(proxySettings.host);
-        } catch (_error) {
-          throw new Error(
-            `Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`
-          );
-        }
-
-        const proxyAgentOptions: HttpsProxyAgentOptions = {
-          hostname: parsedUrl.hostname,
-          port: proxySettings.port,
-          protocol: parsedUrl.protocol,
-          headers: request.headers.toJSON()
-        };
-        if (proxySettings.username && proxySettings.password) {
-          proxyAgentOptions.auth = `${proxySettings.username}:${proxySettings.password}`;
-        }
-        this.proxyAgent = (new HttpsProxyAgent(proxyAgentOptions) as unknown) as https.Agent;
-      }
-      return this.proxyAgent;
-    } else if (!request.disableKeepAlive) {
-      if (!this.keepAliveAgent) {
-        this.keepAliveAgent = new https.Agent({
-          keepAlive: true
-        });
-      }
-
-      return this.keepAliveAgent;
-    } else {
-      return https.globalAgent;
-    }
-  }
-
-  private getRequestOptions(request: PipelineRequest): https.RequestOptions {
-    const agent = this.getOrCreateAgent(request);
+  private makeRequest(
+    request: PipelineRequest,
+    callback: (res: http.IncomingMessage) => void
+  ): http.ClientRequest {
     const url = new URL(request.url);
-    const options: https.RequestOptions = {
+
+    const isInsecure = url.protocol !== "https:";
+
+    if (isInsecure && !request.allowInsecureConnection) {
+      throw new Error(`Cannot connect to ${request.url} while allowInsecureConnection is false.`);
+    }
+
+    const agent = this.getOrCreateAgent(request, isInsecure);
+    const options: http.RequestOptions = {
       agent,
       hostname: url.hostname,
       path: `${url.pathname}${url.search}`,
@@ -243,7 +216,78 @@ class NodeHttpClient implements HttpClient {
       method: request.method,
       headers: request.headers.toJSON()
     };
-    return options;
+    if (isInsecure) {
+      return http.request(options, callback);
+    } else {
+      return https.request(options, callback);
+    }
+  }
+
+  private getProxyAgentOptions(
+    proxySettings: ProxySettings,
+    requestHeaders: HttpHeaders
+  ): HttpProxyAgentOptions {
+    let parsedProxyUrl: URL;
+    try {
+      parsedProxyUrl = new URL(proxySettings.host);
+    } catch (_error) {
+      throw new Error(
+        `Expecting a valid host string in proxy settings, but found "${proxySettings.host}".`
+      );
+    }
+
+    const proxyAgentOptions: HttpsProxyAgentOptions = {
+      hostname: parsedProxyUrl.hostname,
+      port: proxySettings.port,
+      protocol: parsedProxyUrl.protocol,
+      headers: requestHeaders.toJSON()
+    };
+    if (proxySettings.username && proxySettings.password) {
+      proxyAgentOptions.auth = `${proxySettings.username}:${proxySettings.password}`;
+    }
+    return proxyAgentOptions;
+  }
+
+  private getOrCreateAgent(request: PipelineRequest, isInsecure: boolean): http.Agent {
+    // At the moment, proxy settings and keepAlive are mutually
+    // exclusive because the proxy library currently lacks the
+    // ability to create a proxy with keepAlive turned on.
+    const proxySettings = request.proxySettings;
+    if (proxySettings) {
+      if (isInsecure) {
+        if (!this.httpProxyAgent) {
+          const proxyAgentOptions = this.getProxyAgentOptions(proxySettings, request.headers);
+          this.httpProxyAgent = new HttpProxyAgent(proxyAgentOptions);
+        }
+        return this.httpProxyAgent;
+      } else {
+        if (!this.httpsProxyAgent) {
+          const proxyAgentOptions = this.getProxyAgentOptions(proxySettings, request.headers);
+          this.httpsProxyAgent = new HttpsProxyAgent(proxyAgentOptions);
+        }
+        return this.httpsProxyAgent;
+      }
+    } else if (!request.disableKeepAlive && !isInsecure) {
+      if (!this.httpsKeepAliveAgent) {
+        this.httpsKeepAliveAgent = new https.Agent({
+          keepAlive: true
+        });
+      }
+
+      return this.httpsKeepAliveAgent;
+    } else if (!request.disableKeepAlive && isInsecure) {
+      if (!this.httpKeepAliveAgent) {
+        this.httpKeepAliveAgent = new http.Agent({
+          keepAlive: true
+        });
+      }
+
+      return this.httpKeepAliveAgent;
+    } else if (isInsecure) {
+      return http.globalAgent;
+    } else {
+      return https.globalAgent;
+    }
   }
 }
 

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -66,8 +66,8 @@ class ReportTransform extends Transform {
  * @internal
  */
 class NodeHttpClient implements HttpClient {
-  private httpsKeepAliveAgent?: http.Agent;
-  private httpsProxyAgent?: http.Agent;
+  private httpsKeepAliveAgent?: https.Agent;
+  private httpsProxyAgent?: https.Agent;
   private httpKeepAliveAgent?: http.Agent;
   private httpProxyAgent?: http.Agent;
 

--- a/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
+++ b/sdk/core/core-rest-pipeline/src/pipelineRequest.ts
@@ -95,6 +95,9 @@ export interface PipelineRequestOptions {
 
   /** Callback which fires upon download progress. */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+
+  /** Set to true if the request is sent over HTTP instead of HTTPS */
+  allowInsecureConnection?: boolean;
 }
 
 class PipelineRequestImpl implements PipelineRequest {
@@ -111,6 +114,7 @@ class PipelineRequestImpl implements PipelineRequest {
   public abortSignal?: AbortSignalLike;
   public requestId: string;
   public tracingOptions?: OperationTracingOptions;
+  public allowInsecureConnection?: boolean;
   public onUploadProgress?: (progress: TransferProgressEvent) => void;
   public onDownloadProgress?: (progress: TransferProgressEvent) => void;
 
@@ -130,6 +134,7 @@ class PipelineRequestImpl implements PipelineRequest {
     this.onUploadProgress = options.onUploadProgress;
     this.onDownloadProgress = options.onDownloadProgress;
     this.requestId = options.requestId || generateUuid();
+    this.allowInsecureConnection = options.allowInsecureConnection ?? false;
   }
 }
 

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -28,6 +28,13 @@ class XhrHttpClient implements HttpClient {
    * @param request - The request to be made.
    */
   public async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
+    const url = new URL(request.url);
+    const isInsecure = url.protocol !== "https:";
+
+    if (isInsecure && !request.allowInsecureConnection) {
+      throw new Error(`Cannot connect to ${request.url} while allowInsecureConnection is false.`);
+    }
+
     const xhr = new XMLHttpRequest();
 
     if (request.proxySettings) {

--- a/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/xhrHttpClient.spec.ts
@@ -167,4 +167,31 @@ describe("XhrHttpClient", function() {
     assert.strictEqual(response.blobBody, undefined);
     assert.equal(response.bodyAsText, "body");
   });
+
+  it("should throw when accessing HTTP and allowInsecureConnection is false", async function() {
+    const client = createDefaultHttpClient();
+    const request = createPipelineRequest({
+      url: "http://example.com"
+    });
+    const promise = client.sendRequest(request);
+    try {
+      await promise;
+      assert.fail("Expected await to throw");
+    } catch (e) {
+      assert.match(e.message, /^Cannot connect/, "Error should refuse connection");
+    }
+  });
+
+  it("shouldn't throw when accessing HTTP and allowInsecureConnection is true", async function() {
+    const client = createDefaultHttpClient();
+    const request = createPipelineRequest({
+      allowInsecureConnection: true,
+      url: "http://example.com"
+    });
+    const promise = client.sendRequest(request);
+    assert.equal(requests.length, 1);
+    requests[0].respond(200, {}, "");
+    const response = await promise;
+    assert.strictEqual(response.status, 200);
+  });
 });


### PR DESCRIPTION
Add new option to allow insecure connections and support calling HTTP URLs, including calling through proxies.

This also adds security checks in the browser version for parity.