### PR TITLE
Update native dependency install to install msal-node-extensions

### DIFF
--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -8,22 +8,48 @@ steps:
 
   # Packages with native dependencies must be reinstalled after changing Node versions
   - pwsh: |
-      $KeytarSymlinkPath = "common/temp/node_modules/.pnpm/node_modules/keytar"
+      $nativeDependencySymlinkPaths = "common/temp/node_modules/.pnpm/node_modules/keytar,common/temp/node_modules/.pnpm/node_modules/@azure/msal-node-extensions"
+      $currentLocation = Get-Location
+      $dependencySynlinks = $nativeDependencySymlinkPaths.Split(",")
 
-      # Map from the symlink path to the target path (npm has issues installing into symlink dirs)
-      # Example: common/temp/node_modules/.pnpm/keytar@5.6.0/node_modules/keytar
-      $KeytarTargetPath = (Get-Item $KeytarSymlinkPath).Target
+      foreach ($symlink in $dependencySynlinks)
+      {
+        Write-Host "Reinstalling native dependency $($symlink)"
 
-      # Need to run "npm install" at path containing "node_modules" folder
-      # Example: common/temp/node_modules/.pnpm/keytar@5.6.0
-      $KeytarInstallPath = Join-Path $KeytarTargetPath "../.."
+        # Map from the symlink path to the target path (npm has issues installing into symlink dirs)
+        # Example: common/temp/node_modules/.pnpm/keytar@5.6.0/node_modules/keytar
+        $targetPath = (Get-Item $symlink).Target
 
-      # <pkg>@<version> is the leaf node of the path
-      # Example: keytar@5.6.0
-      $KeytarPackageAtVersion = Split-Path -Leaf $KeytarInstallPath
+        # Need to run "npm install" at path containing "node_modules" folder
+        # Example: common/temp/node_modules/.pnpm/keytar@5.6.0
+        $packageInstallPath = Join-Path $targetPath "../.."
 
-      Set-Location $KeytarInstallPath
+        # <pkg>@<version> is the leaf node of the path
+        # Example: keytar@5.6.0
+        # Move one more level up if package has org name
+        # for e.g. node_modules\.pnpm\@azure\msal-node-extensions@1.0.0-alpha.6\node_modules\@azure\msal-node-extensions
+        if ((Split-Path -Leaf $packageInstallPath) -eq "node_modules") {
+          $packageInstallPath = Join-Path $packageInstallPath ".."
+        }
 
-      # Install matching version of package
-      npm install --no-package-lock $KeytarPackageAtVersion
+        $packageAtVersion = Split-Path -Leaf $packageInstallPath
+
+        # Check if package has org name. for e.g @azure/msal-node-enxtensions
+        # This returns either @azure or .pnpm( if no org is present)
+        $packageParentName = Split-path -Leaf (Split-Path -Parent -Resolve $packageInstallPath)
+        if ($packageParentName.StartsWith("@"))
+        {
+          # Include org name in package name to install
+          $packageAtVersion = $packageParentName + "/" + $packageAtVersion
+        }
+
+        Set-Location $packageInstallPath
+
+        Write-Host "Installing $($packageAtVersion)"
+        # Install matching version of package
+        npm install --no-package-lock $packageAtVersion
+
+        Set-Location $currentLocation
+      }
+
     displayName: Reinstall native dependencies

--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -16,6 +16,11 @@ steps:
       {
         Write-Host "Reinstalling native dependency $($symlink)"
 
+        if(-not (Test-Path $symlink))
+        {
+          Write-Host "Path $($symlink) doesn't exist. Skipping reinstall of this dependency."
+          continue
+        }
         # Map from the symlink path to the target path (npm has issues installing into symlink dirs)
         # Example: common/temp/node_modules/.pnpm/keytar@5.6.0/node_modules/keytar
         $targetPath = (Get-Item $symlink).Target

--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -10,9 +10,9 @@ steps:
   - pwsh: |
       $nativeDependencySymlinkPaths = "common/temp/node_modules/.pnpm/node_modules/keytar,common/temp/node_modules/.pnpm/node_modules/@azure/msal-node-extensions"
       $currentLocation = Get-Location
-      $dependencySynlinks = $nativeDependencySymlinkPaths.Split(",")
+      $dependencySymlinks = $nativeDependencySymlinkPaths.Split(",")
 
-      foreach ($symlink in $dependencySynlinks)
+      foreach ($symlink in $dependencySymlinks)
       {
         Write-Host "Reinstalling native dependency $($symlink)"
 


### PR DESCRIPTION
msal-node-extension has native dependency in the same way keytar package has. So this package needs to be reinstalled before running test. PR modified current native dep install code to support more dependency.