### PR TITLE
[communication] include umd bundle

### DIFF
--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist/",
+    "dist-browser/",
     "dist-esm/src/",
     "types/communication-phone-numbers.d.ts",
     "README.md",


### PR DESCRIPTION
This PR adds the UMD bundle to the npm package. This package is used in Azure portal and the only supports AMD.