### PR TITLE
[communication-phone-numbers] Replaced VoidResult and lint fixes

### DIFF
--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.0.0-beta.5 (Unreleased)
 
+### Breaking Changes
+
+- Renamed `AcquiredPhoneNumber` to `PurchasedPhoneNumber`.
+- Renamed `getPhoneNumber` to `getPurchasedPhoneNumber` on `PhoneNumbersClient`.
+- Renamed `listPhoneNumbers` to `listPurchasedPhoneNumbers` on `PhoneNumbersClient`.
+- Replaced `VoidResult` with method specific interfaces `PurchasePhoneNumbersResult` and `ReleasePhoneNumberResult`.
 
 ## 1.0.0-beta.4 (2021-03-09)
 

--- a/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
+++ b/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
@@ -67,8 +67,8 @@ export class PhoneNumbersClient {
     constructor(connectionString: string, options?: PhoneNumbersClientOptions);
     constructor(url: string, credential: KeyCredential, options?: PhoneNumbersClientOptions);
     constructor(url: string, credential: TokenCredential, options?: PhoneNumbersClientOptions);
-    beginPurchasePhoneNumbers(searchId: string, options?: BeginPurchasePhoneNumbersOptions): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>>;
-    beginReleasePhoneNumber(phoneNumber: string, options?: BeginReleasePhoneNumberOptions): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>>;
+    beginPurchasePhoneNumbers(searchId: string, options?: BeginPurchasePhoneNumbersOptions): Promise<PollerLike<PollOperationState<PurchasePhoneNumbersResult>, PurchasePhoneNumbersResult>>;
+    beginReleasePhoneNumber(phoneNumber: string, options?: BeginReleasePhoneNumberOptions): Promise<PollerLike<PollOperationState<ReleasePhoneNumberResult>, ReleasePhoneNumberResult>>;
     beginSearchAvailablePhoneNumbers(search: SearchAvailablePhoneNumbersRequest, options?: BeginSearchAvailablePhoneNumbersOptions): Promise<PollerLike<PollOperationState<PhoneNumberSearchResult>, PhoneNumberSearchResult>>;
     beginUpdatePhoneNumberCapabilities(phoneNumber: string, request: PhoneNumberCapabilitiesRequest, options?: BeginUpdatePhoneNumberCapabilitiesOptions): Promise<PollerLike<PollOperationState<PurchasedPhoneNumber>, PurchasedPhoneNumber>>;
     getPurchasedPhoneNumber(phoneNumber: string, options?: GetPurchasedPhoneNumberOptions): Promise<PurchasedPhoneNumber>;
@@ -115,12 +115,17 @@ export interface PurchasedPhoneNumber {
 }
 
 // @public
-export interface SearchAvailablePhoneNumbersRequest extends PhoneNumberSearchRequest {
-    countryCode: string;
+export interface PurchasePhoneNumbersResult {
 }
 
 // @public
-export type VoidResult = {};
+export interface ReleasePhoneNumberResult {
+}
+
+// @public
+export interface SearchAvailablePhoneNumbersRequest extends PhoneNumberSearchRequest {
+    countryCode: string;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/communication/communication-phone-numbers/src/models.ts
+++ b/sdk/communication/communication-phone-numbers/src/models.ts
@@ -5,9 +5,14 @@ import { OperationOptions } from "@azure/core-http";
 import { PhoneNumberSearchRequest } from "./generated/src/models/";
 
 /**
- * Represents a void result.
+ * The result of the phone numbers purchase operation.
  */
-export type VoidResult = {};
+export interface PurchasePhoneNumbersResult {}
+
+/**
+ * The result of the phone number release operation.
+ */
+export interface ReleasePhoneNumberResult {}
 
 /**
  * Additional options for the get phone number request.

--- a/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/phoneNumbersClient.ts
@@ -28,7 +28,8 @@ import {
   GetPurchasedPhoneNumberOptions,
   ListPurchasedPhoneNumbersOptions,
   SearchAvailablePhoneNumbersRequest,
-  VoidResult
+  PurchasePhoneNumbersResult,
+  ReleasePhoneNumberResult
 } from "./models";
 import {
   BeginPurchasePhoneNumbersOptions,
@@ -57,25 +58,25 @@ export class PhoneNumbersClient {
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class using a connection string.
    *
-   * @param connectionString Connection string to connect to an Azure Communication Service resource. (eg: endpoint=https://contoso.eastus.communications.azure.net/;accesskey=secret)
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param connectionString - Connection string to connect to an Azure Communication Service resource. (eg: endpoint=https://contoso.eastus.communications.azure.net/;accesskey=secret)
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(connectionString: string, options?: PhoneNumbersClientOptions);
 
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class using an Azure KeyCredential.
    *
-   * @param url The endpoint of the service (eg: https://contoso.eastus.communications.azure.net)
-   * @param credential An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (eg: https://contoso.eastus.communications.azure.net)
+   * @param credential - An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(url: string, credential: KeyCredential, options?: PhoneNumbersClientOptions);
 
   /**
    * Initializes a new instance of the PhoneNumberAdministrationClient class using a TokenCredential.
-   * @param url The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential TokenCredential that is used to authenticate requests to the service.
-   * @param options Optional. Options to configure the HTTP pipeline.
+   * @param url - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
+   * @param credential - TokenCredential that is used to authenticate requests to the service.
+   * @param options - Optional. Options to configure the HTTP pipeline.
    */
   public constructor(url: string, credential: TokenCredential, options?: PhoneNumbersClientOptions);
 
@@ -117,8 +118,8 @@ export class PhoneNumbersClient {
   /**
    * Gets the details of a purchased phone number. Includes phone number, cost, country code, etc.
    *
-   * @param {string} phoneNumber The E.164 formatted phone number being fetched. The leading plus can be either + or encoded as %2B.
-   * @param {GetPurchasedPhoneNumberOptions} options Additional request options.
+   * @param phoneNumber - The E.164 formatted phone number being fetched. The leading plus can be either + or encoded as %2B.
+   * @param options - Additional request options.
    */
   public async getPurchasedPhoneNumber(
     phoneNumber: string,
@@ -152,8 +153,8 @@ export class PhoneNumbersClient {
    *   console.log("phone number: ", purchased.phoneNumber);
    * }
    * ```
-   * @summary List all purchased phone numbers.
-   * @param {ListPurchasedPhoneNumbersOptions} [options] The optional parameters.
+   * List all purchased phone numbers.
+   * @param options - The optional parameters.
    */
   public listPurchasedPhoneNumbers(
     options: ListPurchasedPhoneNumbersOptions = {}
@@ -184,13 +185,13 @@ export class PhoneNumbersClient {
    * const results = await releasePoller.pollUntilDone();
    * console.log(results);
    * ```
-   * @param {string} phoneNumber The E.164 formatted phone number being released. The leading plus can be either + or encoded as %2B.
-   * @param {BeginReleasePhoneNumberOptions} options Additional request options.
+   * @param phoneNumber - The E.164 formatted phone number being released. The leading plus can be either + or encoded as %2B.
+   * @param options - Additional request options.
    */
   public async beginReleasePhoneNumber(
     phoneNumber: string,
     options: BeginReleasePhoneNumberOptions = {}
-  ): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>> {
+  ): Promise<PollerLike<PollOperationState<ReleasePhoneNumberResult>, ReleasePhoneNumberResult>> {
     const { span, updatedOptions } = createSpan(
       "PhoneNumbersClient-beginReleasePhoneNumber",
       options
@@ -228,8 +229,8 @@ export class PhoneNumbersClient {
    * console.log(results);
    * ```
    *
-   * @param {SearchAvailablePhoneNumbersRequest} search Request properties to constraint the search scope.
-   * @param {BeginReservePhoneNumbersOptions} options Additional request options.
+   * @param search - Request properties to constraint the search scope.
+   * @param options - Additional request options.
    */
   public async beginSearchAvailablePhoneNumbers(
     search: SearchAvailablePhoneNumbersRequest,
@@ -281,13 +282,15 @@ export class PhoneNumbersClient {
    * console.log(results);
    * ```
    *
-   * @param {string} searchId The id of the search to purchase. Returned from `beginSearchAvailablePhoneNumbers`
-   * @param {BeginPurchasePhoneNumbersOptions} options Additional request options.
+   * @param searchId - The id of the search to purchase. Returned from `beginSearchAvailablePhoneNumbers`
+   * @param options - Additional request options.
    */
   public async beginPurchasePhoneNumbers(
     searchId: string,
     options: BeginPurchasePhoneNumbersOptions = {}
-  ): Promise<PollerLike<PollOperationState<VoidResult>, VoidResult>> {
+  ): Promise<
+    PollerLike<PollOperationState<PurchasePhoneNumbersResult>, PurchasePhoneNumbersResult>
+  > {
     const { span, updatedOptions } = createSpan(
       "PhoneNumbersClient-beginPurchasePhoneNumbers",
       options
@@ -324,9 +327,9 @@ export class PhoneNumbersClient {
    * console.log(results);
    * ```
    *
-   * @param {string} phoneNumber The E.164 formatted phone number being updated. The leading plus can be either + or encoded as %2B.
-   * @param {PhoneNumberCapabilitiesRequest} request The updated properties which will be applied to the phone number.
-   * @param {BeginUpdatePhoneNumberCapabilitiesOptions} options Additional request options.
+   * @param phoneNumber - The E.164 formatted phone number being updated. The leading plus can be either + or encoded as %2B.
+   * @param request - The updated properties which will be applied to the phone number.
+   * @param options - Additional request options.
    */
   public async beginUpdatePhoneNumberCapabilities(
     phoneNumber: string,

--- a/sdk/communication/communication-phone-numbers/src/utils/logger.ts
+++ b/sdk/communication/communication-phone-numbers/src/utils/logger.ts
@@ -4,6 +4,6 @@
 import { createClientLogger } from "@azure/logger";
 
 /**
- * The @azure/logger configuration for this package.
+ * The \@azure\/logger configuration for this package.
  */
 export const logger = createClientLogger("communication-phone-numbers");

--- a/sdk/communication/communication-phone-numbers/src/utils/tracing.ts
+++ b/sdk/communication/communication-phone-numbers/src/utils/tracing.ts
@@ -10,8 +10,8 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 /**
  * Creates a span using the global tracer.
  * @ignore
- * @param name The name of the operation being performed.
- * @param tracingOptions The options for the underlying http request.
+ * @param name - The name of the operation being performed.
+ * @param tracingOptions - The options for the underlying http request.
  */
 export function createSpan<T extends OperationOptions>(
   operationName: string,

--- a/sdk/communication/communication-phone-numbers/test/utils/index.ts
+++ b/sdk/communication/communication-phone-numbers/test/utils/index.ts
@@ -3,17 +3,6 @@
 
 import { PhoneNumberCapabilitiesRequest, PhoneNumberCapabilityType } from "../../src";
 
-export const buildCapabilityUpdate = (
-  capabilities: PhoneNumberCapabilitiesRequest
-): PhoneNumberCapabilitiesRequest => {
-  const values: PhoneNumberCapabilityType[] = ["none", "inbound", "outbound", "inbound+outbound"];
-
-  return {
-    sms: shuffle(values).find((val) => val != capabilities.sms),
-    calling: shuffle(values).find((val) => val != capabilities.calling)
-  };
-};
-
 // Fisher-Yates Shuffle algo implementation
 const shuffle = <T>(list: T[]): T[] => {
   for (let i = list.length - 1; i > 0; i--) {
@@ -24,4 +13,15 @@ const shuffle = <T>(list: T[]): T[] => {
   }
 
   return list;
+};
+
+export const buildCapabilityUpdate = (
+  capabilities: PhoneNumberCapabilitiesRequest
+): PhoneNumberCapabilitiesRequest => {
+  const values: PhoneNumberCapabilityType[] = ["none", "inbound", "outbound", "inbound+outbound"];
+
+  return {
+    sms: shuffle(values).find((val) => val !== capabilities.sms),
+    calling: shuffle(values).find((val) => val !== capabilities.calling)
+  };
 };

--- a/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
@@ -4,7 +4,10 @@
 import { HttpClient, WebResourceLike, HttpOperationResponse } from "@azure/core-http";
 import { PurchasedPhoneNumber } from "../../src";
 
-export const createMockHttpClient = <T = Record<string, unknown>>(status: number = 200, parsedBody?: T): HttpClient => {
+export const createMockHttpClient = <T = Record<string, unknown>>(
+  status: number = 200,
+  parsedBody?: T
+): HttpClient => {
   return {
     async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
       return {

--- a/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-phone-numbers/test/utils/mockHttpClients.ts
@@ -4,7 +4,7 @@
 import { HttpClient, WebResourceLike, HttpOperationResponse } from "@azure/core-http";
 import { PurchasedPhoneNumber } from "../../src";
 
-export const createMockHttpClient = <T = {}>(status: number = 200, parsedBody?: T): HttpClient => {
+export const createMockHttpClient = <T = Record<string, unknown>>(status: number = 200, parsedBody?: T): HttpClient => {
   return {
     async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
       return {

--- a/sdk/communication/communication-phone-numbers/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/utils/recordedClient.ts
@@ -38,7 +38,7 @@ const replaceableVariables: { [k: string]: string } = {
 export const environmentSetup: RecorderEnvironmentSetup = {
   replaceableVariables,
   customizationsOnRecordings: [
-    (recording: string): string => recording.replace(/(https:\/\/)([^\/'",}]*)/, "$1endpoint"),
+    (recording: string): string => recording.replace(/(https:\/\/)([^/'",}]*)/, "$1endpoint"),
     (recording: string): string => recording.replace(/\d{1}\d{3}\d{3}\d{4}/g, "14155550100"),
     (recording: string): string =>
       recording.replace(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/gi, "sanitized")
@@ -56,7 +56,7 @@ export function createRecordedClient(
   return {
     client: new PhoneNumbersClient(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING),
     recorder,
-    includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS == "true"
+    includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS === "true"
   };
 }
 
@@ -81,7 +81,7 @@ export function createRecordedClientWithToken(
     return {
       client: new PhoneNumbersClient(endpoint, credential),
       recorder,
-      includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS == "true"
+      includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS === "true"
     };
   }
 
@@ -94,7 +94,7 @@ export function createRecordedClientWithToken(
   return {
     client: new PhoneNumbersClient(endpoint, credential),
     recorder,
-    includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS == "true"
+    includePhoneNumberLiveTests: env.INCLUDE_PHONENUMBER_LIVE_TESTS === "true"
   };
 }
 


### PR DESCRIPTION
https://apiview.dev/Assemblies/Review/317956c6833a462aa5478ade5dbde602?diffRevisionId=9c050fb29d0349ca9844fd53d86d4971&doc=False&diffOnly=False

Introduces named `PurchasePhoneNumbersResult` and `ReleasePhoneNumberResult` interfaces to allow API evolution if we want to return a final result for LROs in the future.

Also lint fixes.