### PR TITLE
[communication] skip phone number samples

### DIFF
--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -125,13 +125,13 @@
     "typescript": "4.1.2",
     "typedoc": "0.15.2"
   },
-  "//sampleConfiguration": { 
-    "skip": [ 
+  "//sampleConfiguration": {
+    "skip": [
       "getPurchasedPhoneNumber.js",
       "getPurchasedPhoneNumbers.js",
       "purchasePhoneNumber.js",
       "releasePhoneNumber.js",
       "updatePhoneNumberCapabilities.js"
     ]
-  } 
+  }
 }

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -125,9 +125,13 @@
     "typescript": "4.1.2",
     "typedoc": "0.15.2"
   },
-  "//smokeTestConfiguration": {
-    "skip": [
-      "purchasePhoneNumber.js"
+  "//sampleConfiguration": { 
+    "skip": [ 
+      "getPurchasedPhoneNumber.js",
+      "getPurchasedPhoneNumbers.js",
+      "purchasePhoneNumber.js",
+      "releasePhoneNumber.js",
+      "updatePhoneNumberCapabilities.js"
     ]
-  }
+  } 
 }


### PR DESCRIPTION
This PR updates the sample config of the phone numbers library to skip its samples. Samples are causing the smoke test pipeline to fail because the samples need more configuration.

Resolves #14312