### PR TITLE
[core-rest-pipeline] Fix an issue where timeout was ignored on Node

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.1 (Unreleased)
 
+- Fixed an issue where `timeout` and `abortSignal` of requests was not honored on Node after requests had already been issued to the server.
 
 ## 1.0.0 (2021-03-15)
 

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -156,10 +156,8 @@ class NodeHttpClient implements HttpClient {
           reject(new RestError(err.message, { code: RestError.REQUEST_SEND_ERROR, request }));
         });
         abortController.signal.addEventListener("abort", () => {
-          if (!req.finished) {
-            req.abort();
-            reject(new AbortError("The operation was aborted."));
-          }
+          req.abort();
+          reject(new AbortError("The operation was aborted."));
         });
         if (body && isReadableStream(body)) {
           body.pipe(req);

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -81,6 +81,21 @@ describe("NodeHttpClient", function() {
     }
   });
 
+  it("shouldn't be affected by requests cancelled late", async function() {
+    const client = createDefaultHttpClient();
+    const controller = new AbortController();
+    stubbedHttpsRequest.returns(createRequest());
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      abortSignal: controller.signal
+    });
+    const promise = client.sendRequest(request);
+    stubbedHttpsRequest.yield(createResponse(200));
+    const response = await promise;
+    controller.abort();
+    assert.strictEqual(response.status, 200);
+  });
+
   it("should allow canceling of requests before the request is made", async function() {
     const client = createDefaultHttpClient();
     const controller = new AbortController();


### PR DESCRIPTION
Apparently Node marks HTTP requests as `finished` extremely aggressively, which meant we weren't able to timeout/abort slow HTTP responses. 

This fix removes the check we were doing to not abort a finished request, which doesn't seem to cause any problems in my testing, and does resolve the issue @zfoster was seeing with timeouts not working properly.