### PR TITLE
[Core v2] Return null when the response is empty and nullable

### DIFF
--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -163,19 +163,10 @@ export function flattenResponse(
     }
   }
 
-  if (isPrimitiveType(fullResponse.parsedBody)) {
-    return handleNullableResponseAndWrappableBody({
-      body: fullResponse.parsedBody,
-      headers: parsedHeaders,
-      hasNullableType: isNullable,
-      shouldWrapBody: true
-    });
-  }
-
   return handleNullableResponseAndWrappableBody({
     body: fullResponse.parsedBody,
     headers: parsedHeaders,
     hasNullableType: isNullable,
-    shouldWrapBody: false
+    shouldWrapBody: isPrimitiveType(fullResponse.parsedBody)
   });
 }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -47,7 +47,7 @@ export function isValidUuid(uuid: string): boolean {
  *
  * @internal
  */
-function returnNullResponse(
+function returnNullResponseIfApplicable(
   isNullable: boolean,
   checkedForEmpty: unknown,
   response: unknown,
@@ -115,7 +115,7 @@ export function flattenResponse(
         ...parsedHeaders,
         ...fullResponse.parsedBody
       };
-      return returnNullResponse(isNullable, response, response);
+      return returnNullResponseIfApplicable(isNullable, response, response);
     }
   }
 
@@ -129,7 +129,7 @@ export function flattenResponse(
     fullResponse.request.method === "HEAD" ||
     isPrimitiveType(fullResponse.parsedBody)
   ) {
-    return returnNullResponse(
+    return returnNullResponseIfApplicable(
       isNullable,
       response,
       {
@@ -140,5 +140,5 @@ export function flattenResponse(
     );
   }
 
-  return returnNullResponse(isNullable, response, response);
+  return returnNullResponseIfApplicable(isNullable, response, response);
 }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -134,8 +134,8 @@ export function flattenResponse(
       (k) => modelProperties[k].serializedName === ""
     );
     if (typeName === "Sequence" || isPageableResponse) {
-      const emptyArray = ([] as unknown) as { [key: string]: unknown };
-      const arrayResponse: { [key: string]: unknown } = fullResponse.parsedBody ?? emptyArray;
+      const arrayResponse: { [key: string]: unknown } =
+        fullResponse.parsedBody ?? (([] as unknown) as { [key: string]: unknown });
 
       for (const key of Object.keys(modelProperties)) {
         if (modelProperties[key].serializedName) {
@@ -148,7 +148,7 @@ export function flattenResponse(
           arrayResponse[key] = parsedHeaders[key];
         }
       }
-      return !fullResponse.parsedBody && isNullable && arrayResponse === emptyArray
+      return isNullable && Object.getOwnPropertyNames(arrayResponse).length === 0
         ? null
         : arrayResponse;
     }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -113,7 +113,7 @@ export function flattenResponse(
   }
 
   const bodyMapper = responseSpec && responseSpec.bodyMapper;
-  const isNullable = bodyMapper?.nullable ?? false;
+  const isNullable = Boolean(bodyMapper?.nullable);
 
   /** If the body is asked for, we look at the mapper to handle it */
   if (bodyMapper) {

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -47,7 +47,7 @@ export function isValidUuid(uuid: string): boolean {
 interface ResponseObjectWithMetadata {
   /** whether the mapper allows nullable body */
   hasNullableType: boolean;
-  /** whether the type of the response body is primitive */
+  /** whether the response's body should be wrapped */
   shouldWrapBody: boolean;
   /** parsed headers of the response */
   headers:

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -115,7 +115,7 @@ export function flattenResponse(
   const bodyMapper = responseSpec && responseSpec.bodyMapper;
   const isNullable = bodyMapper?.nullable ?? false;
 
-  /** If the body is asked for, we look at the mapper to deserialize it */
+  /** If the body is asked for, we look at the mapper to handle it */
   if (bodyMapper) {
     const typeName = bodyMapper.type.name;
     if (typeName === "Stream") {

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -148,7 +148,10 @@ export function flattenResponse(
           arrayResponse[key] = parsedHeaders[key];
         }
       }
-      return isNullable && Object.getOwnPropertyNames(arrayResponse).length === 0
+      return isNullable &&
+        !fullResponse.parsedBody &&
+        !parsedHeaders &&
+        Object.getOwnPropertyNames(modelProperties).length === 0
         ? null
         : arrayResponse;
     }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -77,17 +77,19 @@ function handleNullableResponseAndWrappableBody(
     ...responseObject.headers,
     ...responseObject.body
   };
-  return responseObject.hasNullableType &&
+  if (
+    responseObject.hasNullableType &&
     Object.getOwnPropertyNames(combinedHeadersAndBody).length === 0
-    ? responseObject.shouldWrapBody
-      ? { body: null }
-      : null
-    : responseObject.shouldWrapBody
-    ? {
-        ...responseObject.headers,
-        body: responseObject.body
-      }
-    : combinedHeadersAndBody;
+  ) {
+    return responseObject.shouldWrapBody ? { body: null } : null;
+  } else {
+    return responseObject.shouldWrapBody
+      ? {
+          ...responseObject.headers,
+          body: responseObject.body
+        }
+      : combinedHeadersAndBody;
+  }
 }
 
 /**

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -385,15 +385,17 @@ describe("ServiceClient", function() {
 
   it("should deserialize array response as null if it is empty and nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: true,
-          type: {
-            name: MapperTypeNames.Sequence,
-            element: {
-              type: {
-                name: "Number"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: true,
+            type: {
+              name: MapperTypeNames.Sequence,
+              element: {
+                type: {
+                  name: "Number"
+                }
               }
             }
           }
@@ -405,15 +407,17 @@ describe("ServiceClient", function() {
 
   it("should deserialize array response as empty array if it is empty and not nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: false,
-          type: {
-            name: MapperTypeNames.Sequence,
-            element: {
-              type: {
-                name: "Number"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: false,
+            type: {
+              name: MapperTypeNames.Sequence,
+              element: {
+                type: {
+                  name: "Number"
+                }
               }
             }
           }
@@ -425,15 +429,17 @@ describe("ServiceClient", function() {
 
   it("should deserialize dictionary response as null if it is empty and nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: true,
-          type: {
-            name: MapperTypeNames.Dictionary,
-            value: {
-              type: {
-                name: "String"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: true,
+            type: {
+              name: MapperTypeNames.Dictionary,
+              value: {
+                type: {
+                  name: "String"
+                }
               }
             }
           }
@@ -445,15 +451,17 @@ describe("ServiceClient", function() {
 
   it("should deserialize dictionary response as empty if it is empty and not nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: false,
-          type: {
-            name: MapperTypeNames.Dictionary,
-            value: {
-              type: {
-                name: "String"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: false,
+            type: {
+              name: MapperTypeNames.Dictionary,
+              value: {
+                type: {
+                  name: "String"
+                }
               }
             }
           }
@@ -465,16 +473,18 @@ describe("ServiceClient", function() {
 
   it("should deserialize object response as null if it is empty and nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: true,
-          type: {
-            name: MapperTypeNames.Composite,
-            modelProperties: {
-              message: {
-                type: {
-                  name: "String"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: true,
+            type: {
+              name: MapperTypeNames.Composite,
+              modelProperties: {
+                message: {
+                  type: {
+                    name: "String"
+                  }
                 }
               }
             }
@@ -487,16 +497,18 @@ describe("ServiceClient", function() {
 
   it("should deserialize object response as empty if it is empty and not nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: false,
-          type: {
-            name: MapperTypeNames.Composite,
-            modelProperties: {
-              message: {
-                type: {
-                  name: "String"
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: false,
+            type: {
+              name: MapperTypeNames.Composite,
+              modelProperties: {
+                message: {
+                  type: {
+                    name: "String"
+                  }
                 }
               }
             }
@@ -509,12 +521,14 @@ describe("ServiceClient", function() {
 
   it("should deserialize primitive response as null if it is empty and nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: true,
-          type: {
-            name: MapperTypeNames.Boolean
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: true,
+            type: {
+              name: MapperTypeNames.Boolean
+            }
           }
         }
       },
@@ -526,18 +540,38 @@ describe("ServiceClient", function() {
 
   it("should deserialize primitive response as undefined if it is empty and not nullable", async function() {
     await assertServiceClientResponse(
-      "",
       {
-        bodyMapper: {
-          nullable: false,
-          type: {
-            name: MapperTypeNames.Boolean
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: false,
+            type: {
+              name: MapperTypeNames.Boolean
+            }
           }
         }
       },
       {
         body: undefined
       }
+    );
+  });
+
+  it("should deserialize a head request with no body even if the mapper says the body is nullable", async function() {
+    await assertServiceClientResponse(
+      {
+        httpRequestMethod: "HEAD",
+        responseBodyAsText: "",
+        responseMapper: {
+          bodyMapper: {
+            nullable: true,
+            type: {
+              name: MapperTypeNames.Boolean
+            }
+          }
+        }
+      },
+      {}
     );
   });
 

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -31,6 +31,7 @@ import {
 import { deserializationPolicy } from "../src/deserializationPolicy";
 import { TokenCredential } from "@azure/core-auth";
 import { getCachedDefaultHttpClient } from "../src/httpClientCache";
+import { assertServiceClientResponse } from "./utils/serviceClient";
 
 describe("ServiceClient", function() {
   describe("Auth scopes", () => {
@@ -380,6 +381,164 @@ describe("ServiceClient", function() {
 
     assert.strictEqual(rawResponse?.status, 200);
     assert.deepStrictEqual(res.slice(), [1, 2, 3]);
+  });
+
+  it("should deserialize array response as null if it is empty and nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: true,
+          type: {
+            name: MapperTypeNames.Sequence,
+            element: {
+              type: {
+                name: "Number"
+              }
+            }
+          }
+        }
+      },
+      null
+    );
+  });
+
+  it("should deserialize array response as empty array if it is empty and not nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: false,
+          type: {
+            name: MapperTypeNames.Sequence,
+            element: {
+              type: {
+                name: "Number"
+              }
+            }
+          }
+        }
+      },
+      []
+    );
+  });
+
+  it("should deserialize dictionary response as null if it is empty and nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: true,
+          type: {
+            name: MapperTypeNames.Dictionary,
+            value: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      },
+      null
+    );
+  });
+
+  it("should deserialize dictionary response as empty if it is empty and not nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: false,
+          type: {
+            name: MapperTypeNames.Dictionary,
+            value: {
+              type: {
+                name: "String"
+              }
+            }
+          }
+        }
+      },
+      {}
+    );
+  });
+
+  it("should deserialize object response as null if it is empty and nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: true,
+          type: {
+            name: MapperTypeNames.Composite,
+            modelProperties: {
+              message: {
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          }
+        }
+      },
+      null
+    );
+  });
+
+  it("should deserialize object response as empty if it is empty and not nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: false,
+          type: {
+            name: MapperTypeNames.Composite,
+            modelProperties: {
+              message: {
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          }
+        }
+      },
+      {}
+    );
+  });
+
+  it("should deserialize primitive response as null if it is empty and nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: true,
+          type: {
+            name: MapperTypeNames.Boolean
+          }
+        }
+      },
+      {
+        body: null
+      }
+    );
+  });
+
+  it("should deserialize primitive response as undefined if it is empty and not nullable", async function() {
+    await assertServiceClientResponse(
+      "",
+      {
+        bodyMapper: {
+          nullable: false,
+          type: {
+            name: MapperTypeNames.Boolean
+          }
+        }
+      },
+      {
+        body: undefined
+      }
+    );
   });
 
   describe("getOperationArgumentValueFromParameter()", () => {

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -571,7 +571,7 @@ describe("ServiceClient", function() {
           }
         }
       },
-      {}
+      undefined
     );
   });
 

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -560,7 +560,7 @@ describe("ServiceClient", function() {
   it("should deserialize a head request with no body even if the mapper says the body is nullable", async function() {
     await assertServiceClientResponse(
       {
-        httpRequestMethod: "HEAD",
+        requestMethod: "HEAD",
         responseBodyAsText: "",
         responseMapper: {
           bodyMapper: {

--- a/sdk/core/core-client/test/utils/serviceClient.ts
+++ b/sdk/core/core-client/test/utils/serviceClient.ts
@@ -24,7 +24,7 @@ import {
  */
 export interface ServiceClientTestSpec {
   /** The HTTP request method */
-  httpRequestMethod?: HttpMethods;
+  requestMethod?: HttpMethods;
   /** The request headers */
   requestHeaders?: HttpHeaders;
   /** The request serializer */
@@ -48,7 +48,7 @@ export async function assertServiceClientResponse(
       return Promise.resolve({
         request,
         status: 200,
-        headers: createHttpHeaders(),
+        headers: testSpec.responseHeaders ?? createHttpHeaders(),
         bodyAsText: testSpec.responseBodyAsText
       });
     }
@@ -72,7 +72,7 @@ export async function assertServiceClientResponse(
     },
     {
       serializer: testSpec.requestSerializer ?? createSerializer(),
-      httpMethod: testSpec.httpRequestMethod ?? "GET",
+      httpMethod: testSpec.requestMethod ?? "GET",
       baseUrl: "https://example.com",
       responses: {
         200: testSpec.responseMapper

--- a/sdk/core/core-client/test/utils/serviceClient.ts
+++ b/sdk/core/core-client/test/utils/serviceClient.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { createEmptyPipeline, createHttpHeaders, HttpClient } from "@azure/core-rest-pipeline";
+import {
+  createSerializer,
+  deserializationPolicy,
+  FullOperationResponse,
+  OperationRequest,
+  OperationResponseMap,
+  ServiceClient
+} from "../../src";
+
+export async function assertServiceClientResponse(
+  bodyAsText: string,
+  mapper: OperationResponseMap,
+  expectedResult: unknown
+): Promise<void> {
+  let request: OperationRequest;
+  const httpClient: HttpClient = {
+    sendRequest: (req) => {
+      request = req;
+      return Promise.resolve({
+        request,
+        status: 200,
+        headers: createHttpHeaders(),
+        bodyAsText: bodyAsText
+      });
+    }
+  };
+
+  const pipeline = createEmptyPipeline();
+  pipeline.addPolicy(deserializationPolicy());
+  const client1 = new ServiceClient({
+    httpClient,
+    pipeline
+  });
+
+  let rawResponse: FullOperationResponse | undefined;
+  const res = await client1.sendOperationRequest<Array<number>>(
+    {
+      options: {
+        onResponse: (response) => {
+          rawResponse = response;
+        }
+      }
+    },
+    {
+      serializer: createSerializer(),
+      httpMethod: "GET",
+      baseUrl: "https://example.com",
+      responses: {
+        200: mapper
+      }
+    }
+  );
+
+  assert.strictEqual(rawResponse?.status, 200);
+  assert.deepStrictEqual(res, expectedResult);
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/12009.

# Scenario

When the service does not return a body ([Example in our test server](https://github.com/Azure/autorest.testserver/blob/4b994be5fd68b3ac009af30399ad6b817630dbc8/legacy/routes/dictionary.js#L24)).

# Expectation

Response will be `null` if the mapper says it is `nullable`.

# Current State

Response is an empty object or array ([Example](https://github.com/Azure/autorest.typescript/blob/c8e68b845ccc3780d8c4be3787eb2c5e74272697/test/integration/bodyArray.spec.ts#L21)).

# Fix

Implements the expectation by doing case analysis and adds test cases.