### PR TITLE
Add MatrixReplace parameter to tests, only run single test case for canary

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -45,6 +45,10 @@ parameters:
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
+        MatrixFilters:
+          - OSVmImage=.*Ubuntu.*
+          - NodeTestVersion=10.x
+          - DependencyVersion=^$
       UsGov:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
       China:
@@ -60,6 +64,9 @@ parameters:
     type: object
     default: []
   - name: MatrixFilters
+    type: object
+    default: []
+  - name: MatrixReplace
     type: object
     default: []
 
@@ -97,6 +104,10 @@ stages:
               - ${{ each cloudFilter in cloud.value.MatrixFilters }}:
                 - ${{ cloudFilter }}
               - ${{ parameters.MatrixFilters }}
+            MatrixReplace:
+              - ${{ each cloudReplace in cloud.value.MatrixReplace }}:
+                - ${{ cloudReplace }}
+              - ${{ parameters.MatrixReplace }}
             CloudConfig:
               SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}
               Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}


### PR DESCRIPTION
This trims down the number of canary live test runs to 1, as we are only trying to catch service regressions with these runs.