### PR TITLE
[core-auth] Add AzureNamedKeyCredential class and NamedKeyCredential interface

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.2.1 (Unreleased)
+## 1.3.0 (Unreleased)
 
+- Adds the `AzureNamedKeyCredential` class which supports credential rotation and a corresponding `NamedKeyCredential` interface to support the use of static string-based names and keys in Azure clients.
 
 ## 1.2.0 (2021-02-08)
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -20,6 +20,14 @@ export class AzureKeyCredential implements KeyCredential {
 }
 
 // @public
+export class AzureNamedKeyCredential implements NamedKeyCredential {
+    constructor(name: string, key: string);
+    get key(): string;
+    get name(): string;
+    update(newName: string, newKey: string): void;
+}
+
+// @public
 export class AzureSASCredential implements SASCredential {
     constructor(signature: string);
     get signature(): string;
@@ -43,6 +51,12 @@ export function isTokenCredential(credential: unknown): credential is TokenCrede
 // @public
 export interface KeyCredential {
     readonly key: string;
+}
+
+// @public
+export interface NamedKeyCredential {
+    readonly key: string;
+    readonly name: string;
 }
 
 // @public

--- a/sdk/core/core-auth/src/azureNamedKeyCredential.ts
+++ b/sdk/core/core-auth/src/azureNamedKeyCredential.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Represents a credential defined by a static API name and key.
+ */
+export interface NamedKeyCredential {
+  /**
+   * The value of the API key represented as a string
+   */
+  readonly key: string;
+  /**
+   * The value of the API name represented as a string.
+   */
+  readonly name: string;
+}
+
+/**
+ * A static name/key-based credential that supports updating
+ * the underlying name and key values.
+ */
+export class AzureNamedKeyCredential implements NamedKeyCredential {
+  private _key: string;
+  private _name: string;
+
+  /**
+   * The value of the key to be used in authentication.
+   */
+  public get key(): string {
+    return this._key;
+  }
+
+  /**
+   * The value of the name to be used in authentication.
+   */
+  public get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Create an instance of an AzureNamedKeyCredential for use
+   * with a service client.
+   *
+   * @param name - The initial value of the name to use in authentication.
+   * @param key - The initial value of the key to use in authentication.
+   */
+  constructor(name: string, key: string) {
+    if (!name || !key) {
+      throw new TypeError("name and key must be non-empty strings");
+    }
+
+    this._name = name;
+    this._key = key;
+  }
+
+  /**
+   * Change the value of the key.
+   *
+   * Updates will take effect upon the next request after
+   * updating the key value.
+   *
+   * @param newName - The new name value to be used.
+   * @param newKey - The new key value to be used.
+   */
+  public update(newName: string, newKey: string): void {
+    if (!newName || !newKey) {
+      throw new TypeError("newName and newKey must be non-empty strings");
+    }
+
+    this._name = newName;
+    this._key = newKey;
+  }
+}

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export { AzureKeyCredential, KeyCredential } from "./azureKeyCredential";
+export { AzureNamedKeyCredential, NamedKeyCredential } from "./azureNamedKeyCredential";
 export { AzureSASCredential, SASCredential } from "./azureSASCredential";
 
 export {

--- a/sdk/core/core-auth/test/index.spec.ts
+++ b/sdk/core/core-auth/test/index.spec.ts
@@ -3,9 +3,12 @@
 
 import assert from "assert";
 
-import { AzureKeyCredential } from "../src/azureKeyCredential";
-import { AzureSASCredential } from "../src/azureSASCredential";
-import { isTokenCredential } from "../src/tokenCredential";
+import {
+  AzureKeyCredential,
+  AzureNamedKeyCredential,
+  AzureSASCredential,
+  isTokenCredential
+} from "../src/index";
 
 describe("AzureKeyCredential", () => {
   it("credential constructor throws on invalid key", () => {
@@ -25,6 +28,80 @@ describe("AzureKeyCredential", () => {
     assert.equal(credential.key, "credential1");
     credential.update("credential2");
     assert.equal(credential.key, "credential2");
+  });
+});
+
+describe("AzureNamedKeyCredential", () => {
+  it("credential constructor throws on invalid name or key", () => {
+    assert.throws(() => {
+      void new AzureNamedKeyCredential("name", "");
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential("name", (null as unknown) as string);
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential("name", (undefined as unknown) as string);
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential("", "key");
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential((null as unknown) as string, "key");
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential((undefined as unknown) as string, "key");
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential("", "");
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential((null as unknown) as string, (null as unknown) as string);
+    }, /name and key must be non-empty strings/);
+    assert.throws(() => {
+      void new AzureNamedKeyCredential(
+        (undefined as unknown) as string,
+        (undefined as unknown) as string
+      );
+    }, /name and key must be non-empty strings/);
+  });
+
+  it("credential correctly updates", () => {
+    const credential = new AzureNamedKeyCredential("name1", "credential1");
+    assert.equal(credential.name, "name1");
+    assert.equal(credential.key, "credential1");
+    credential.update("name2", "credential2");
+    assert.equal(credential.name, "name2");
+    assert.equal(credential.key, "credential2");
+  });
+
+  it("credential update throws on invalid name or key", () => {
+    const credential = new AzureNamedKeyCredential("name1", "credential1");
+    assert.equal(credential.name, "name1");
+    assert.equal(credential.key, "credential1");
+
+    // invalid name
+    assert.throws(() => {
+      credential.update("", "credential2");
+    }, /newName and newKey must be non-empty strings/);
+    // parameters unchanged
+    assert.equal(credential.name, "name1");
+    assert.equal(credential.key, "credential1");
+
+    // invalid key
+    assert.throws(() => {
+      credential.update("name2", "");
+    }, /newName and newKey must be non-empty strings/);
+    // parameters unchanged
+    assert.equal(credential.name, "name1");
+    assert.equal(credential.key, "credential1");
+
+    // invalid name and key
+    assert.throws(() => {
+      credential.update("", "");
+    }, /newName and newKey must be non-empty strings/);
+    // parameters unchanged
+    assert.equal(credential.name, "name1");
+    assert.equal(credential.key, "credential1");
   });
 });
 


### PR DESCRIPTION
Resolves #14303 

## Summary

This PR adds the `AzureNamedKeyCredential` class and `NamedKeyCredential` interface to the `@azure/core-auth` pacakge.

Details are listed in the linked issue, but the TL;DR is:
When using a shared key for authorization, some services require the name of the key be used as part of the algorithm to form the authorization token.

Since `AzureKeyCredential` and `AzureSasCredential` only track a single value, we've added `AzureNamedKeyCredential` that lets us track 2 values! (Let's hope there's never 3 values needed!)

This credential will be used by the event hubs and service bus packages to start.