### PR TITLE
[KeyVault] - KeyVault Certificates tests against multiple service versions

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -99,7 +99,8 @@
     "@azure/core-tracing": "1.0.0-preview.10",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^0.10.2",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "@azure/test-utils-multi-version": "^1.0.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -83,7 +83,7 @@ export class CertificateClient {
 
 // @public
 export interface CertificateClientOptions extends coreHttp.PipelineOptions {
-    serviceVersion?: "7.0" | "7.1" | "7.2";
+    serviceVersion?: "7.0" | "7.1" | "7.2" | string;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -83,7 +83,7 @@ export class CertificateClient {
 
 // @public
 export interface CertificateClientOptions extends coreHttp.PipelineOptions {
-    serviceVersion?: "7.0" | "7.1" | "7.2" | string;
+    serviceVersion?: string;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -21,7 +21,7 @@ export interface CertificateClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2";
+  serviceVersion?: "7.0" | "7.1" | "7.2" | string;
 }
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -19,9 +19,8 @@ export const LATEST_API_VERSION = "7.2";
  */
 export interface CertificateClientOptions extends coreHttp.PipelineOptions {
   /**
-   * The Key Vault API version. By default requests will be sent to the latest API version.
-   * You may specify a different API version to make requests against by providing a valid
-   * value here.
+   * The Key Vault API version. By default requests will be sent to the latest API version we currently support.
+   * You may specify a different API version to make requests against by providing a valid value here.
    */
   serviceVersion?: string;
 }

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -19,9 +19,11 @@ export const LATEST_API_VERSION = "7.2";
  */
 export interface CertificateClientOptions extends coreHttp.PipelineOptions {
   /**
-   * The accepted versions of the KeyVault's service API.
+   * The Key Vault API version. By default requests will be sent to the latest API version.
+   * You may specify a different API version to make requests against by providing a valid
+   * value here.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2" | string;
+  serviceVersion?: string;
 }
 
 /**

--- a/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -14,144 +14,148 @@ import { CertificateClient } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).
 // Once we move to a common folder, and after some refactoring,
 // we will be able to unit test the insides in detail.
 
-describe("Challenge based authentication tests", () => {
-  const certificatePrefix = `challengeAuth${env.KEY_NAME || "CertificateName"}`;
-  let certificateSuffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Challenge based authentication tests", () => {
+    const certificatePrefix = `challengeAuth${env.KEY_NAME || "CertificateName"}`;
+    let certificateSuffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  const basicCertificatePolicy = {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  };
+    const basicCertificatePolicy = {
+      issuerName: "Self",
+      subject: "cn=MyCert"
+    };
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    certificateSuffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("Authentication should work for parallel requests", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const certificateNames = [`${certificateName}-0`, `${certificateName}-1`];
-
-    const sandbox = createSandbox();
-    const spy = sandbox.spy(AuthenticationChallengeCache.prototype, "setCachedChallenge");
-    const spyEqualTo = sandbox.spy(AuthenticationChallenge.prototype, "equalTo");
-
-    const promises = certificateNames.map((name) => {
-      const promise = client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      return { promise, name };
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      certificateSuffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
     });
 
-    for (const promise of promises) {
-      const poller = await promise.promise;
-      await poller.pollUntilDone();
-      await testClient.flushCertificate(promise.name);
-    }
-
-    // Even though we had parallel requests, only one authentication should have happened.
-
-    // This is determined by the comparison between the cached challenge and the new receive challenge.
-    // So, AuthenticationChallenge's equalTo should have returned true at least once.
-    assert.ok(spyEqualTo.returned(true));
-
-    // The challenge should have been written to the cache exactly ONCE.
-    assert.equal(spy.getCalls().length, 1);
-
-    // Back to normal.
-    sandbox.restore();
-  });
-
-  it("Once authenticated, new requests should not authenticate again", async function() {
-    // Our goal is to intercept how our pipelines are storing the challenge.
-    // The first network call should indeed set the challenge in memory.
-    // Subsequent network calls should not set new challenges.
-
-    const sandbox = createSandbox();
-    const spy = sandbox.spy(AuthenticationChallengeCache.prototype, "setCachedChallenge");
-
-    // Now we run what would be a normal use of the client.
-    // Here we will create two keys, then flush them.
-    // testClient.flushCertificate deletes, then purges the keys.
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const certificateNames = [`${certificateName}-0`, `${certificateName}-1`];
-    for (const name of certificateNames) {
-      const poller = await client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      await poller.pollUntilDone();
-    }
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
-
-    // The challenge should have been written to the cache exactly ONCE.
-    assert.equal(spy.getCalls().length, 1);
-
-    // Back to normal.
-    sandbox.restore();
-
-    // Note: Failing to authenticate will make network requests throw.
-  });
-
-  describe("parseWWWAuthenticate tests", () => {
-    it("Should work for known shapes of the WWW-Authenticate header", () => {
-      const wwwAuthenticate1 = `Bearer authorization="some_authorization", resource="https://some.url"`;
-      const parsed1 = parseWWWAuthenticate(wwwAuthenticate1);
-      assert.deepEqual(parsed1, {
-        authorization: "some_authorization",
-        resource: "https://some.url"
-      });
-
-      const wwwAuthenticate2 = `Bearer authorization="some_authorization", scope="https://some.url"`;
-      const parsed2 = parseWWWAuthenticate(wwwAuthenticate2);
-      assert.deepEqual(parsed2, {
-        authorization: "some_authorization",
-        scope: "https://some.url"
-      });
+    afterEach(async function() {
+      await recorder.stop();
     });
 
-    it("Should skip unexpected properties on the WWW-Authenticate header", () => {
-      const wwwAuthenticate1 = `Bearer authorization="some_authorization", a="a", b="b"`;
-      const parsed1 = parseWWWAuthenticate(wwwAuthenticate1);
-      assert.deepEqual(parsed1, {
-        authorization: "some_authorization",
-        a: "a",
-        b: "b"
+    // The tests follow
+
+    it("Authentication should work for parallel requests", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const certificateNames = [`${certificateName}-0`, `${certificateName}-1`];
+
+      const sandbox = createSandbox();
+      const spy = sandbox.spy(AuthenticationChallengeCache.prototype, "setCachedChallenge");
+      const spyEqualTo = sandbox.spy(AuthenticationChallenge.prototype, "equalTo");
+
+      const promises = certificateNames.map((name) => {
+        const promise = client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        return { promise, name };
       });
 
-      const wwwAuthenticate2 = `scope="https://some.url", a="a", c="c"`;
-      const parsed2 = parseWWWAuthenticate(wwwAuthenticate2);
-      assert.deepEqual(parsed2, {
-        scope: "https://some.url",
-        a: "a",
-        c: "c"
+      for (const promise of promises) {
+        const poller = await promise.promise;
+        await poller.pollUntilDone();
+        await testClient.flushCertificate(promise.name);
+      }
+
+      // Even though we had parallel requests, only one authentication should have happened.
+
+      // This is determined by the comparison between the cached challenge and the new receive challenge.
+      // So, AuthenticationChallenge's equalTo should have returned true at least once.
+      assert.ok(spyEqualTo.returned(true));
+
+      // The challenge should have been written to the cache exactly ONCE.
+      assert.equal(spy.getCalls().length, 1);
+
+      // Back to normal.
+      sandbox.restore();
+    });
+
+    it("Once authenticated, new requests should not authenticate again", async function() {
+      // Our goal is to intercept how our pipelines are storing the challenge.
+      // The first network call should indeed set the challenge in memory.
+      // Subsequent network calls should not set new challenges.
+
+      const sandbox = createSandbox();
+      const spy = sandbox.spy(AuthenticationChallengeCache.prototype, "setCachedChallenge");
+
+      // Now we run what would be a normal use of the client.
+      // Here we will create two keys, then flush them.
+      // testClient.flushCertificate deletes, then purges the keys.
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const certificateNames = [`${certificateName}-0`, `${certificateName}-1`];
+      for (const name of certificateNames) {
+        const poller = await client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await poller.pollUntilDone();
+      }
+      for (const name of certificateNames) {
+        await testClient.flushCertificate(name);
+      }
+
+      // The challenge should have been written to the cache exactly ONCE.
+      assert.equal(spy.getCalls().length, 1);
+
+      // Back to normal.
+      sandbox.restore();
+
+      // Note: Failing to authenticate will make network requests throw.
+    });
+
+    describe("parseWWWAuthenticate tests", () => {
+      it("Should work for known shapes of the WWW-Authenticate header", () => {
+        const wwwAuthenticate1 = `Bearer authorization="some_authorization", resource="https://some.url"`;
+        const parsed1 = parseWWWAuthenticate(wwwAuthenticate1);
+        assert.deepEqual(parsed1, {
+          authorization: "some_authorization",
+          resource: "https://some.url"
+        });
+
+        const wwwAuthenticate2 = `Bearer authorization="some_authorization", scope="https://some.url"`;
+        const parsed2 = parseWWWAuthenticate(wwwAuthenticate2);
+        assert.deepEqual(parsed2, {
+          authorization: "some_authorization",
+          scope: "https://some.url"
+        });
+      });
+
+      it("Should skip unexpected properties on the WWW-Authenticate header", () => {
+        const wwwAuthenticate1 = `Bearer authorization="some_authorization", a="a", b="b"`;
+        const parsed1 = parseWWWAuthenticate(wwwAuthenticate1);
+        assert.deepEqual(parsed1, {
+          authorization: "some_authorization",
+          a: "a",
+          b: "b"
+        });
+
+        const wwwAuthenticate2 = `scope="https://some.url", a="a", c="c"`;
+        const parsed2 = parseWWWAuthenticate(wwwAuthenticate2);
+        assert.deepEqual(parsed2, {
+          scope: "https://some.url",
+          a: "a",
+          c: "c"
+        });
       });
     });
   });

--- a/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
@@ -8,63 +8,61 @@ import { LATEST_API_VERSION } from "../../src/certificatesModels";
 import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
-describe("The Certificates client should set the serviceVersion", () => {
-  const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("The Certificates client should set the serviceVersion", () => {
+    const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
 
-  const mockHttpClient: HttpClient = {
-    async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
-      return {
-        status: 200,
-        headers: new HttpHeaders(),
-        request: httpRequest,
-        parsedBody: {
-          id: `${keyVaultUrl}/certificates/certificateName/id`,
-          attributes: {}
-        }
-      };
-    }
-  };
+    const mockHttpClient: HttpClient = {
+      async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
+        return {
+          status: 200,
+          headers: new HttpHeaders(),
+          request: httpRequest,
+          parsedBody: {
+            id: `${keyVaultUrl}/certificates/certificateName/id`,
+            attributes: {}
+          }
+        };
+      }
+    };
 
-  let sandbox: SinonSandbox;
-  let spy: SinonSpy<[WebResourceLike], Promise<HttpOperationResponse>>;
-  let credential: ClientSecretCredential;
-  beforeEach(async () => {
-    sandbox = createSandbox();
-    spy = sandbox.spy(mockHttpClient, "sendRequest");
+    let sandbox: SinonSandbox;
+    let spy: SinonSpy<[WebResourceLike], Promise<HttpOperationResponse>>;
+    let credential: ClientSecretCredential;
+    beforeEach(async () => {
+      sandbox = createSandbox();
+      spy = sandbox.spy(mockHttpClient, "sendRequest");
 
-    credential = await new ClientSecretCredential(
-      env.AZURE_TENANT_ID!,
-      env.AZURE_CLIENT_ID!,
-      env.AZURE_CLIENT_SECRET!
-    );
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("it should default to the latest API version", async function() {
-    const client = new CertificateClient(keyVaultUrl, credential, {
-      httpClient: mockHttpClient
+      credential = await new ClientSecretCredential(
+        env.AZURE_TENANT_ID!,
+        env.AZURE_CLIENT_ID!,
+        env.AZURE_CLIENT_SECRET!
+      );
     });
-    await client.getCertificate("certificateName");
 
-    const calls = spy.getCalls();
-    assert.equal(
-      calls[0].args[0].url,
-      `https://keyVaultName.vault.azure.net/certificates/certificateName/?api-version=${LATEST_API_VERSION}`
-    );
-  });
+    afterEach(() => {
+      sandbox.restore();
+    });
 
-  // Adding this to the source would change the public API.
-  type ApIVersions = "7.0" | "7.1" | "7.2";
-
-  it("it should allow us to specify an API version from a specific set of versions", async function() {
-    const versions: ApIVersions[] = ["7.0", "7.1", "7.2"];
-    for (const serviceVersion in versions) {
+    it("it should default to the latest API version", async function() {
       const client = new CertificateClient(keyVaultUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        httpClient: mockHttpClient
+      });
+      await client.getCertificate("certificateName");
+
+      const calls = spy.getCalls();
+      assert.equal(
+        calls[0].args[0].url,
+        `https://keyVaultName.vault.azure.net/certificates/certificateName/?api-version=${LATEST_API_VERSION}`
+      );
+    });
+
+    it("it should allow us to specify an API version from a specific set of versions", async function() {
+      const client = new CertificateClient(keyVaultUrl, credential, {
+        serviceVersion: serviceVersion,
         httpClient: mockHttpClient
       });
       await client.getCertificate("certificateName");
@@ -75,6 +73,6 @@ describe("The Certificates client should set the serviceVersion", () => {
         lastCall.args[0].url,
         `https://keyVaultName.vault.azure.net/certificates/certificateName/?api-version=${serviceVersion}`
       );
-    }
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -12,409 +12,324 @@ import { ClientSecretCredential } from "@azure/identity";
 import { isNode } from "@azure/core-http";
 
 import { CertificateClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, serviceVersions } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
 
-describe("Certificates client - create, read, update and delete", () => {
-  const prefix = `CRUD${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let suffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
-  let keyVaultUrl: string;
-  let credential: ClientSecretCredential;
-  let secretClient: SecretClient;
+versionsToTest(serviceVersions, {}, (serviceVersion: string) => {
+  describe("Certificates client - create, read, update and delete", () => {
+    const prefix = `CRUD${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let suffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
+    let keyVaultUrl: string;
+    let credential: ClientSecretCredential;
+    let secretClient: SecretClient;
 
-  const basicCertificatePolicy = {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  };
+    const basicCertificatePolicy = {
+      issuerName: "Self",
+      subject: "cn=MyCert"
+    };
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    suffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-    keyVaultUrl = authentication.keyVaultUrl;
-    credential = authentication.credential;
-    secretClient = new SecretClient(keyVaultUrl, credential);
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("can create a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const pendingCertificate = poller.getResult(); // Pending certificate
-    assert.equal(
-      pendingCertificate!.properties.name,
-      certificateName,
-      "Unexpected name in result from beginCreateCertificate()."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can abort creating a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const controller = new AbortController();
-
-    await assertThrowsAbortError(async () => {
-      const poller = await client.beginCreateCertificate(certificateName, basicCertificatePolicy, {
-        ...testPollerProperties,
-        abortSignal: controller.signal
-      });
-      controller.abort();
-      await poller.pollUntilDone();
-    });
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work - in browsers
-  it("can create a certificate with requestOptions timeout", async function() {
-    recorder.skip("browser", "Timeout tests don't work on playback mode.");
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    await assertThrowsAbortError(async () => {
-      await client.beginCreateCertificate(certificateName, basicCertificatePolicy, {
-        ...testPollerProperties,
-        requestOptions: {
-          timeout: 1
-        }
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      suffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
+      keyVaultUrl = authentication.keyVaultUrl;
+      credential = authentication.credential;
+      secretClient = new SecretClient(keyVaultUrl, credential, {
+        serviceVersion: serviceVersion as any
       });
     });
-  });
 
-  it("cannot create a certificate with an empty name", async function() {
-    const certificateName = "";
-    let error;
-    try {
+    afterEach(async function() {
+      await recorder.stop();
+    });
+
+    // The tests follow
+
+    it("can create a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      const pendingCertificate = poller.getResult(); // Pending certificate
+      assert.equal(
+        pendingCertificate!.properties.name,
+        certificateName,
+        "Unexpected name in result from beginCreateCertificate()."
+      );
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can abort creating a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const controller = new AbortController();
+
+      await assertThrowsAbortError(async () => {
+        const poller = await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          {
+            ...testPollerProperties,
+            abortSignal: controller.signal
+          }
+        );
+        controller.abort();
+        await poller.pollUntilDone();
+      });
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work - in browsers
+    it("can create a certificate with requestOptions timeout", async function() {
+      recorder.skip("browser", "Timeout tests don't work on playback mode.");
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+      await assertThrowsAbortError(async () => {
+        await client.beginCreateCertificate(certificateName, basicCertificatePolicy, {
+          ...testPollerProperties,
+          requestOptions: {
+            timeout: 1
+          }
+        });
+      });
+    });
+
+    it("cannot create a certificate with an empty name", async function() {
+      const certificateName = "";
+      let error;
+      try {
+        await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(
+        error.message,
+        `"certificateName" with value "" should satisfy the constraint "Pattern": /^[0-9a-zA-Z-]+$/.`,
+        "Unexpected error while running beginCreateCertificate with an empty string as the name."
+      );
+    });
+
+    it("can update the tags of a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
       await client.beginCreateCertificate(
         certificateName,
         basicCertificatePolicy,
         testPollerProperties
       );
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(
-      error.message,
-      `"certificateName" with value "" should satisfy the constraint "Pattern": /^[0-9a-zA-Z-]+$/.`,
-      "Unexpected error while running beginCreateCertificate with an empty string as the name."
-    );
-  });
-
-  it("can update the tags of a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await client.updateCertificateProperties(certificateName, "", {
-      tags: {
-        customTag: "value"
-      }
-    });
-
-    const updated = await client.getCertificate(certificateName);
-    assert.equal(
-      updated!.properties.tags!.customTag!,
-      "value",
-      "Expect attribute 'tags' to be updated."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can disable a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-
-    let result = await poller.pollUntilDone();
-    assert.equal(result.properties.enabled, true);
-
-    result = await client.updateCertificateProperties(certificateName, "", {
-      enabled: false
-    });
-    assert.equal(result.properties.enabled, false);
-
-    result = await client.getCertificate(certificateName);
-    assert.equal(result.properties.enabled, false);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can disable a certificate version", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-
-    let result = await poller.pollUntilDone();
-
-    const version = result.properties.version!;
-    assert.equal(result.properties.enabled, true);
-
-    result = await client.updateCertificateProperties(certificateName, version, {
-      enabled: false
-    });
-    assert.equal(result.properties.enabled, false);
-
-    result = await client.getCertificateVersion(certificateName, version);
-    assert.equal(result.properties.enabled, false);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can update certificate with requestOptions timeout", async function() {
-    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const { version } = poller.getResult()!.properties;
-
-    await assertThrowsAbortError(async () => {
-      await client.updateCertificateProperties(certificateName, version || "", {
+      await client.updateCertificateProperties(certificateName, "", {
         tags: {
           customTag: "value"
-        },
-        requestOptions: { timeout: 1 }
-      });
-    });
-  });
-
-  it("can get a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const result = await client.getCertificate(certificateName);
-    assert.equal(
-      result.properties.name,
-      certificateName,
-      "Unexpected certificate name in result from beginCreateCertificate()."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can get a certificate's secret in PKCS 12 format", async function() {
-    recorder.skip("browser", "This test uses the file system.");
-    // Skipping this test from the live browser test runs, because we use the file system.
-    if (!isNode) {
-      this.skip();
-    }
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-
-    await createPoller.pollUntilDone();
-    const keyVaultCertificate = await client.getCertificate(certificateName);
-    const base64CER = Buffer.from(keyVaultCertificate.cer!).toString("base64");
-
-    const certificateSecret = await secretClient.getSecret(certificateName);
-    const base64PKCS12 = certificateSecret.value!;
-    fs.writeFileSync("pkcs12.p12", Buffer.from(base64PKCS12, "base64"));
-
-    // Obtaining only the public certificate.
-    // We send "-passin 'pass:'" because our self-signed certificate doesn't specify a password on its issuer.
-    childProcess.execSync(
-      "openssl pkcs12 -in pkcs12.p12 -out pkcs12.crt.pem -clcerts -nokeys -passin pass:"
-    );
-
-    // To generate a PEM private key out of a KeyVault Certificate
-    // created with the default (or "application/x-pkcs12") content type,
-    // use:
-    //
-    //     openssl pkcs12 -in file_name.p12 -out file_name.key.pem -nocerts -nodes
-    //
-
-    const PEMPublicCertificate = fs.readFileSync("pkcs12.crt.pem");
-
-    // The PEM encoded public certificate should be the same as the Base64 encoded CER
-    assert.equal(
-      base64CER,
-      PEMPublicCertificate.toString()
-        .split(/-----(BEGIN|END) CERTIFICATE-----/g)[2]
-        .split(os.EOL)
-        .join("")
-        .replace(/\n/g, "")
-    );
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can get a certificate's secret in PEM format", async function() {
-    recorder.skip("browser", "This test uses the file system.");
-    // Skipping this test from the live browser test runs, because we use the file system.
-    if (!isNode) {
-      this.skip();
-    }
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      {
-        issuerName: "Self",
-        subject: "cn=MyCert",
-        contentType: "application/x-pem-file"
-      },
-      testPollerProperties
-    );
-
-    await createPoller.pollUntilDone();
-    const keyVaultCertificate = await client.getCertificate(certificateName);
-    const base64CER = Buffer.from(keyVaultCertificate.cer!).toString("base64");
-
-    const certificateSecret = await secretClient.getSecret(certificateName);
-    const base64PublicCertificate = certificateSecret
-      .value!.split("\n")
-      .slice(0, -2) // Removing -----END CERTIFICATE-----
-      .join("")
-      .split("-----BEGIN CERTIFICATE-----") // Removing the PEM header
-      .slice(-1);
-
-    // The PEM encoded public certificate should be the same as the Base64 encoded CER
-    assert.equal(base64CER, base64PublicCertificate);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get a certificate with requestOptions timeout", async function() {
-    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await assertThrowsAbortError(async () => {
-      await client.getCertificate(certificateName, { requestOptions: { timeout: 1 } });
-    });
-  });
-
-  it("can retrieve the latest version of a certificate value", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-
-    const result = await client.getCertificate(certificateName);
-
-    assert.equal(
-      result.properties.name,
-      certificateName,
-      "Unexpected certificate name in result from beginCreateCertificate()."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can get a certificate (Non Existing)", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    let error;
-    try {
-      await client.getCertificate(certificateName);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.code, "CertificateNotFound");
-    assert.equal(error.statusCode, 404);
-  });
-
-  it("can delete a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    const result = poller.getResult()!;
-
-    assert.equal(typeof result.recoveryId, "string");
-    assert.ok(result.deletedOn instanceof Date);
-    assert.ok(result.scheduledPurgeDate instanceof Date);
-
-    try {
-      await client.getCertificate(certificateName);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      if (e.statusCode === 404) {
-        assert.equal(e.code, "CertificateNotFound");
-      } else {
-        throw e;
-      }
-    }
-
-    await poller.pollUntilDone();
-    await testClient.purgeCertificate(certificateName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can delete a certificate with requestOptions timeout", async function() {
-    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteCertificate(certificateName, {
-        ...testPollerProperties,
-        requestOptions: {
-          timeout: 1
         }
       });
+
+      const updated = await client.getCertificate(certificateName);
+      assert.equal(
+        updated!.properties.tags!.customTag!,
+        "value",
+        "Expect attribute 'tags' to be updated."
+      );
+      await testClient.flushCertificate(certificateName);
     });
-  });
 
-  it("can delete a certificate (Non Existing)", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    let error;
-    try {
-      await client.beginDeleteCertificate(certificateName, testPollerProperties);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.code, "CertificateNotFound");
-    assert.equal(error.statusCode, 404);
-  });
+    it("can disable a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
 
-  describe("can get a deleted certificate", () => {
-    it("using beginDeleteCertificate's poller", async function() {
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+
+      let result = await poller.pollUntilDone();
+      assert.equal(result.properties.enabled, true);
+
+      result = await client.updateCertificateProperties(certificateName, "", {
+        enabled: false
+      });
+      assert.equal(result.properties.enabled, false);
+
+      result = await client.getCertificate(certificateName);
+      assert.equal(result.properties.enabled, false);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can disable a certificate version", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+
+      let result = await poller.pollUntilDone();
+
+      const version = result.properties.version!;
+      assert.equal(result.properties.enabled, true);
+
+      result = await client.updateCertificateProperties(certificateName, version, {
+        enabled: false
+      });
+      assert.equal(result.properties.enabled, false);
+
+      result = await client.getCertificateVersion(certificateName, version);
+      assert.equal(result.properties.enabled, false);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work
+    it("can update certificate with requestOptions timeout", async function() {
+      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      const { version } = poller.getResult()!.properties;
+
+      await assertThrowsAbortError(async () => {
+        await client.updateCertificateProperties(certificateName, version || "", {
+          tags: {
+            customTag: "value"
+          },
+          requestOptions: { timeout: 1 }
+        });
+      });
+    });
+
+    it("can get a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      const result = await client.getCertificate(certificateName);
+      assert.equal(
+        result.properties.name,
+        certificateName,
+        "Unexpected certificate name in result from beginCreateCertificate()."
+      );
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can get a certificate's secret in PKCS 12 format", async function() {
+      recorder.skip("browser", "This test uses the file system.");
+      // Skipping this test from the live browser test runs, because we use the file system.
+      if (!isNode) {
+        this.skip();
+      }
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+
+      await createPoller.pollUntilDone();
+      const keyVaultCertificate = await client.getCertificate(certificateName);
+      const base64CER = Buffer.from(keyVaultCertificate.cer!).toString("base64");
+
+      const certificateSecret = await secretClient.getSecret(certificateName);
+      const base64PKCS12 = certificateSecret.value!;
+      fs.writeFileSync("pkcs12.p12", Buffer.from(base64PKCS12, "base64"));
+
+      // Obtaining only the public certificate.
+      // We send "-passin 'pass:'" because our self-signed certificate doesn't specify a password on its issuer.
+      childProcess.execSync(
+        "openssl pkcs12 -in pkcs12.p12 -out pkcs12.crt.pem -clcerts -nokeys -passin pass:"
+      );
+
+      // To generate a PEM private key out of a KeyVault Certificate
+      // created with the default (or "application/x-pkcs12") content type,
+      // use:
+      //
+      //     openssl pkcs12 -in file_name.p12 -out file_name.key.pem -nocerts -nodes
+      //
+
+      const PEMPublicCertificate = fs.readFileSync("pkcs12.crt.pem");
+
+      // The PEM encoded public certificate should be the same as the Base64 encoded CER
+      assert.equal(
+        base64CER,
+        PEMPublicCertificate.toString()
+          .split(/-----(BEGIN|END) CERTIFICATE-----/g)[2]
+          .split(os.EOL)
+          .join("")
+          .replace(/\n/g, "")
+      );
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can get a certificate's secret in PEM format", async function() {
+      recorder.skip("browser", "This test uses the file system.");
+      // Skipping this test from the live browser test runs, because we use the file system.
+      if (!isNode) {
+        this.skip();
+      }
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        {
+          issuerName: "Self",
+          subject: "cn=MyCert",
+          contentType: "application/x-pem-file"
+        },
+        testPollerProperties
+      );
+
+      await createPoller.pollUntilDone();
+      const keyVaultCertificate = await client.getCertificate(certificateName);
+      const base64CER = Buffer.from(keyVaultCertificate.cer!).toString("base64");
+
+      const certificateSecret = await secretClient.getSecret(certificateName);
+      const base64PublicCertificate = certificateSecret
+        .value!.split("\n")
+        .slice(0, -2) // Removing -----END CERTIFICATE-----
+        .join("")
+        .split("-----BEGIN CERTIFICATE-----") // Removing the PEM header
+        .slice(-1);
+
+      // The PEM encoded public certificate should be the same as the Base64 encoded CER
+      assert.equal(base64CER, base64PublicCertificate);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work
+    it("can get a certificate with requestOptions timeout", async function() {
+      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      await assertThrowsAbortError(async () => {
+        await client.getCertificate(certificateName, { requestOptions: { timeout: 1 } });
+      });
+    });
+
+    it("can retrieve the latest version of a certificate value", async function() {
       const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
       await client.beginCreateCertificate(
         certificateName,
@@ -422,45 +337,78 @@ describe("Certificates client - create, read, update and delete", () => {
         testPollerProperties
       );
 
-      const deletePoller = await client.beginDeleteCertificate(
-        certificateName,
-        testPollerProperties
-      );
-      const deletedCertificate = await deletePoller.pollUntilDone();
-      assert.equal(
-        deletedCertificate.name,
-        certificateName,
-        "Unexpected certificate name in result from pollUntilDone()."
-      );
+      const result = await client.getCertificate(certificateName);
 
-      await testClient.purgeCertificate(certificateName);
+      assert.equal(
+        result.properties.name,
+        certificateName,
+        "Unexpected certificate name in result from beginCreateCertificate()."
+      );
+      await testClient.flushCertificate(certificateName);
     });
 
-    it("using getDeletedCertificate", async function() {
+    it("can get a certificate (Non Existing)", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      let error;
+      try {
+        await client.getCertificate(certificateName);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error.code, "CertificateNotFound");
+      assert.equal(error.statusCode, 404);
+    });
+
+    it("can delete a certificate", async function() {
       const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
       await client.beginCreateCertificate(
         certificateName,
         basicCertificatePolicy,
         testPollerProperties
       );
+      const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
+      const result = poller.getResult()!;
 
-      const deletePoller = await client.beginDeleteCertificate(
-        certificateName,
-        testPollerProperties
-      );
-      await deletePoller.pollUntilDone();
+      assert.equal(typeof result.recoveryId, "string");
+      assert.ok(result.deletedOn instanceof Date);
+      assert.ok(result.scheduledPurgeDate instanceof Date);
 
-      const deletedCertificate = await client.getDeletedCertificate(certificateName);
-      assert.equal(
-        deletedCertificate.name,
-        certificateName,
-        "Unexpected certificate name in result from getDeletedCertificate()."
-      );
+      try {
+        await client.getCertificate(certificateName);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        if (e.statusCode === 404) {
+          assert.equal(e.code, "CertificateNotFound");
+        } else {
+          throw e;
+        }
+      }
 
+      await poller.pollUntilDone();
       await testClient.purgeCertificate(certificateName);
     });
 
-    it("can not get a certificate that never existed", async function() {
+    // On playback mode, the tests happen too fast for the timeout to work
+    it("can delete a certificate with requestOptions timeout", async function() {
+      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      await assertThrowsAbortError(async () => {
+        await client.beginDeleteCertificate(certificateName, {
+          ...testPollerProperties,
+          requestOptions: {
+            timeout: 1
+          }
+        });
+      });
+    });
+
+    it("can delete a certificate (Non Existing)", async function() {
       const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
       let error;
       try {
@@ -472,167 +420,228 @@ describe("Certificates client - create, read, update and delete", () => {
       assert.equal(error.code, "CertificateNotFound");
       assert.equal(error.statusCode, 404);
     });
-  });
 
-  it("can create, read, and delete a certificate issuer", async function() {
-    const issuerName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+    describe("can get a deleted certificate", () => {
+      it("using beginDeleteCertificate's poller", async function() {
+        const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+        await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
 
-    // Create
-    const createResponse = await client.createIssuer(issuerName, "Test", {
-      accountId: "keyvaultuser",
-      administratorContacts: [
-        {
-          firstName: "John",
-          lastName: "Doe",
-          email: "admin@microsoft.com",
-          phone: "4255555555"
+        const deletePoller = await client.beginDeleteCertificate(
+          certificateName,
+          testPollerProperties
+        );
+        const deletedCertificate = await deletePoller.pollUntilDone();
+        assert.equal(
+          deletedCertificate.name,
+          certificateName,
+          "Unexpected certificate name in result from pollUntilDone()."
+        );
+
+        await testClient.purgeCertificate(certificateName);
+      });
+
+      it("using getDeletedCertificate", async function() {
+        const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+        await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+
+        const deletePoller = await client.beginDeleteCertificate(
+          certificateName,
+          testPollerProperties
+        );
+        await deletePoller.pollUntilDone();
+
+        const deletedCertificate = await client.getDeletedCertificate(certificateName);
+        assert.equal(
+          deletedCertificate.name,
+          certificateName,
+          "Unexpected certificate name in result from getDeletedCertificate()."
+        );
+
+        await testClient.purgeCertificate(certificateName);
+      });
+
+      it("can not get a certificate that never existed", async function() {
+        const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+        let error;
+        try {
+          await client.beginDeleteCertificate(certificateName, testPollerProperties);
+          throw Error("Expecting an error but not catching one.");
+        } catch (e) {
+          error = e;
         }
-      ]
+        assert.equal(error.code, "CertificateNotFound");
+        assert.equal(error.statusCode, 404);
+      });
     });
-    assert.equal(createResponse.administratorContacts![0].email, "admin@microsoft.com");
 
-    // Creating a certificate with that issuer
-    await client.beginCreateCertificate(
-      certificateName,
-      {
-        issuerName,
-        subject: "cn=MyCert"
-      },
-      testPollerProperties
-    );
+    it("can create, read, and delete a certificate issuer", async function() {
+      const issuerName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
 
-    // Reading the issuer from the certificate
-    const certificate = await client.getCertificate(certificateName);
-    assert.equal(certificate.policy!.issuerName, issuerName);
+      // Create
+      const createResponse = await client.createIssuer(issuerName, "Test", {
+        accountId: "keyvaultuser",
+        administratorContacts: [
+          {
+            firstName: "John",
+            lastName: "Doe",
+            email: "admin@microsoft.com",
+            phone: "4255555555"
+          }
+        ]
+      });
+      assert.equal(createResponse.administratorContacts![0].email, "admin@microsoft.com");
 
-    let getResponse: any;
-
-    // Read
-    getResponse = await client.getIssuer(issuerName);
-    assert.equal(getResponse.provider, "Test");
-
-    // Update
-    await client.updateIssuer(issuerName, {
-      administratorContacts: [
+      // Creating a certificate with that issuer
+      await client.beginCreateCertificate(
+        certificateName,
         {
-          firstName: "John",
-          lastName: "Doe",
-          email: "admin@microsoft.com",
-          phone: "4255555555"
-        }
-      ]
-    });
-    getResponse = await client.getIssuer(issuerName);
-    assert.equal(getResponse.administratorContacts![0].email, "admin@microsoft.com");
+          issuerName,
+          subject: "cn=MyCert"
+        },
+        testPollerProperties
+      );
 
-    // Delete
-    await client.deleteIssuer(issuerName);
-    let error;
-    try {
-      await client.getIssuer(issuerName);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.message, "Issuer not found");
+      // Reading the issuer from the certificate
+      const certificate = await client.getCertificate(certificateName);
+      assert.equal(certificate.policy!.issuerName, issuerName);
 
-    await testClient.flushCertificate(certificateName);
-  });
+      let getResponse: any;
 
-  it("can update a certificate's policy", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      // Read
+      getResponse = await client.getIssuer(issuerName);
+      assert.equal(getResponse.provider, "Test");
 
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const result = await client.getCertificate(certificateName);
-    assert.equal(result.policy!.issuerName, "Self");
-    assert.equal(result.policy!.subject, "cn=MyCert");
+      // Update
+      await client.updateIssuer(issuerName, {
+        administratorContacts: [
+          {
+            firstName: "John",
+            lastName: "Doe",
+            email: "admin@microsoft.com",
+            phone: "4255555555"
+          }
+        ]
+      });
+      getResponse = await client.getIssuer(issuerName);
+      assert.equal(getResponse.administratorContacts![0].email, "admin@microsoft.com");
 
-    await client.updateCertificatePolicy(certificateName, {
-      issuerName: "Self",
-      subject: "cn=MyOtherCert"
-    });
-    const updated = await client.getCertificate(certificateName);
-    assert.equal(updated.policy!.subject, "cn=MyOtherCert");
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can read, cancel and delete a certificate's operation", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-
-    let certificateOperation: any;
-
-    // Read
-    const operationPoller = await client.getCertificateOperation(certificateName);
-    certificateOperation = operationPoller.getOperationState().certificateOperation!;
-    assert.equal(certificateOperation.status, "inProgress");
-    assert.equal(certificateOperation.cancellationRequested, false);
-
-    // Cancel
-    await operationPoller.cancelOperation();
-    certificateOperation = operationPoller.getOperationState().certificateOperation!;
-    assert.equal(certificateOperation.cancellationRequested, true);
-
-    // Delete
-    await client.deleteCertificateOperation(certificateName);
-
-    let error;
-    try {
-      await client.getCertificateOperation(certificateName);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.message, `Pending certificate not found: ${certificateName}`);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can set, read and delete a certificate's contacts", async function() {
-    const contacts = [
-      {
-        email: "a@a.com",
-        name: "a",
-        phone: "111111111111"
-      },
-      {
-        email: "b@b.com",
-        name: "b",
-        phone: "222222222222"
+      // Delete
+      await client.deleteIssuer(issuerName);
+      let error;
+      try {
+        await client.getIssuer(issuerName);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
       }
-    ];
+      assert.equal(error.message, "Issuer not found");
 
-    await client.setContacts(contacts);
+      await testClient.flushCertificate(certificateName);
+    });
 
-    const getResponse = await client.getContacts();
-    assert.equal(
-      getResponse && getResponse[0] && getResponse[0].name ? getResponse[0].name : undefined,
-      "a"
-    );
-    assert.equal(
-      getResponse && getResponse[1] && getResponse[1].name ? getResponse[1].name : undefined,
-      "b"
-    );
+    it("can update a certificate's policy", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
 
-    await client.deleteContacts();
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      const result = await client.getCertificate(certificateName);
+      assert.equal(result.policy!.issuerName, "Self");
+      assert.equal(result.policy!.subject, "cn=MyCert");
 
-    let error;
-    try {
-      await client.getContacts();
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.code, "ContactsNotFound");
+      await client.updateCertificatePolicy(certificateName, {
+        issuerName: "Self",
+        subject: "cn=MyOtherCert"
+      });
+      const updated = await client.getCertificate(certificateName);
+      assert.equal(updated.policy!.subject, "cn=MyOtherCert");
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can read, cancel and delete a certificate's operation", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+
+      let certificateOperation: any;
+
+      // Read
+      const operationPoller = await client.getCertificateOperation(certificateName);
+      certificateOperation = operationPoller.getOperationState().certificateOperation!;
+      assert.equal(certificateOperation.status, "inProgress");
+      assert.equal(certificateOperation.cancellationRequested, false);
+
+      // Cancel
+      await operationPoller.cancelOperation();
+      certificateOperation = operationPoller.getOperationState().certificateOperation!;
+      assert.equal(certificateOperation.cancellationRequested, true);
+
+      // Delete
+      await client.deleteCertificateOperation(certificateName);
+
+      let error;
+      try {
+        await client.getCertificateOperation(certificateName);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error.message, `Pending certificate not found: ${certificateName}`);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can set, read and delete a certificate's contacts", async function() {
+      const contacts = [
+        {
+          email: "a@a.com",
+          name: "a",
+          phone: "111111111111"
+        },
+        {
+          email: "b@b.com",
+          name: "b",
+          phone: "222222222222"
+        }
+      ];
+
+      await client.setContacts(contacts);
+
+      const getResponse = await client.getContacts();
+      assert.equal(
+        getResponse && getResponse[0] && getResponse[0].name ? getResponse[0].name : undefined,
+        "a"
+      );
+      assert.equal(
+        getResponse && getResponse[1] && getResponse[1].name ? getResponse[1].name : undefined,
+        "b"
+      );
+
+      await client.deleteContacts();
+
+      let error;
+      try {
+        await client.getContacts();
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error.code, "ContactsNotFound");
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -7,267 +7,279 @@ import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure/test-utils-r
 import { isNode } from "@azure/core-http";
 
 import { CertificateClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, serviceVersions } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
 
 const { expect } = chai;
 
-describe("Certificates client - list certificates in various ways", () => {
-  const prefix = `list${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let suffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - list certificates in various ways", () => {
+    const prefix = `list${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let suffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  const basicCertificatePolicy = {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  };
+    const basicCertificatePolicy = {
+      issuerName: "Self",
+      subject: "cn=MyCert"
+    };
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    suffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      suffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
+    });
 
-  afterEach(async function() {
-    await recorder.stop();
-  });
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-  // The tests follow
+    // The tests follow
 
-  // Use this while recording to make sure the target keyvault is clean.
-  // The next tests will produce a more consistent output.
-  // This test is only useful while developing locally.
-  it("can purge all certificates", async function(): Promise<void> {
-    // WARNING: When TEST_MODE equals "record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    if (!isRecordMode()) {
-      return this.skip();
-    }
-    for await (const certificate of client.listPropertiesOfCertificates({
-      includePending: true
-    })) {
-      try {
-        await testClient.flushCertificate(certificate.name!);
-      } catch (e) {
-        // Nothing to do here
+    // Use this while recording to make sure the target keyvault is clean.
+    // The next tests will produce a more consistent output.
+    // This test is only useful while developing locally.
+    it("can purge all certificates", async function(): Promise<void> {
+      // WARNING: When TEST_MODE equals "record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
+      if (!isRecordMode()) {
+        return this.skip();
       }
-    }
-    for await (const certificate of client.listDeletedCertificates({ includePending: true })) {
-      try {
-        await testClient.purgeCertificate(certificate.name!);
-      } catch (e) {
-        // Nothing to do here
+      for await (const certificate of client.listPropertiesOfCertificates({
+        includePending: true
+      })) {
+        try {
+          await testClient.flushCertificate(certificate.name!);
+        } catch (e) {
+          // Nothing to do here
+        }
       }
-    }
-  });
+      for await (const certificate of client.listDeletedCertificates({ includePending: true })) {
+        try {
+          await testClient.purgeCertificate(certificate.name!);
+        } catch (e) {
+          // Nothing to do here
+        }
+      }
+    });
 
-  it("can list certificates", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    for (const name of certificateNames) {
-      const createPoller = await client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      await createPoller.pollUntilDone();
-    }
+    it("can list certificates", async function() {
+      console.log(`Running list certificates with serviceVersion ${serviceVersion}`);
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      for (const name of certificateNames) {
+        const createPoller = await client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+      }
 
-    let found = 0;
-    for await (const certificate of client.listPropertiesOfCertificates({ includePending: true })) {
-      // The vault might contain more certificates than the ones we inserted.
-      if (!certificateNames.includes(certificate.name!)) continue;
-      found += 1;
-    }
-
-    assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
-
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
-  });
-
-  it("can list deleted certificates", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    for (const name of certificateNames) {
-      const createPoller = await client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      await createPoller.pollUntilDone();
-    }
-    for (const name of certificateNames) {
-      const deletePoller = await client.beginDeleteCertificate(name, testPollerProperties);
-      await deletePoller.pollUntilDone();
-    }
-
-    let found = 0;
-    for await (const certificate of client.listDeletedCertificates({ includePending: true })) {
-      // The vault might contain more certificates than the ones we inserted.
-      if (!certificateNames.includes(certificate.properties.name!)) continue;
-      found += 1;
-    }
-
-    assert.equal(found, 2, "Unexpected number of certificates found by getDeletedCertificates.");
-
-    for (const name of certificateNames) {
-      await testClient.purgeCertificate(name);
-    }
-  });
-
-  it("can list certificates by page", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    for (const name of certificateNames) {
-      const createPoller = await client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      await createPoller.pollUntilDone();
-    }
-    let found = 0;
-    for await (const page of client
-      .listPropertiesOfCertificates({ includePending: true })
-      .byPage()) {
-      for (const certificate of page) {
+      let found = 0;
+      for await (const certificate of client.listPropertiesOfCertificates({
+        includePending: true
+      })) {
         // The vault might contain more certificates than the ones we inserted.
         if (!certificateNames.includes(certificate.name!)) continue;
         found += 1;
       }
-    }
-    assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
-  });
 
-  if (isNode && !isPlaybackMode()) {
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can get several inserted certificates with requestOptions timeout", async function() {
-      const iter = client.listPropertiesOfCertificates({ requestOptions: { timeout: 1 } });
+      assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
+
+      for (const name of certificateNames) {
+        await testClient.flushCertificate(name);
+      }
+    });
+
+    it("can list deleted certificates", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      for (const name of certificateNames) {
+        const createPoller = await client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+      }
+      for (const name of certificateNames) {
+        const deletePoller = await client.beginDeleteCertificate(name, testPollerProperties);
+        await deletePoller.pollUntilDone();
+      }
+
+      let found = 0;
+      for await (const certificate of client.listDeletedCertificates({ includePending: true })) {
+        // The vault might contain more certificates than the ones we inserted.
+        if (!certificateNames.includes(certificate.properties.name!)) continue;
+        found += 1;
+      }
+
+      assert.equal(found, 2, "Unexpected number of certificates found by getDeletedCertificates.");
+
+      for (const name of certificateNames) {
+        await testClient.purgeCertificate(name);
+      }
+    });
+
+    it("can list certificates by page", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      for (const name of certificateNames) {
+        const createPoller = await client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+      }
+      let found = 0;
+      for await (const page of client
+        .listPropertiesOfCertificates({ includePending: true })
+        .byPage()) {
+        for (const certificate of page) {
+          // The vault might contain more certificates than the ones we inserted.
+          if (!certificateNames.includes(certificate.name!)) continue;
+          found += 1;
+        }
+      }
+      assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
+      for (const name of certificateNames) {
+        await testClient.flushCertificate(name);
+      }
+    });
+
+    if (isNode && !isPlaybackMode()) {
+      // On playback mode, the tests happen too fast for the timeout to work
+      it("can get several inserted certificates with requestOptions timeout", async function() {
+        const iter = client.listPropertiesOfCertificates({ requestOptions: { timeout: 1 } });
+        await assertThrowsAbortError(async () => {
+          await iter.next();
+        });
+      });
+    }
+
+    it("can list deleted certificates by page", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      for (const name of certificateNames) {
+        const createPoller = await client.beginCreateCertificate(
+          name,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+      }
+      for (const name of certificateNames) {
+        const deletePoller = await client.beginDeleteCertificate(name, testPollerProperties);
+        await deletePoller.pollUntilDone();
+      }
+
+      let found = 0;
+      for await (const page of client.listDeletedCertificates({ includePending: true }).byPage()) {
+        for (const deleteCertificate of page) {
+          // The vault might contain more certificates than the ones we inserted.
+          if (!certificateNames.includes(deleteCertificate.properties.name!)) continue;
+          found += 1;
+        }
+      }
+      assert.equal(found, 2, "Unexpected number of certificates found by getDeletedCertificates.");
+      for (const name of certificateNames) {
+        await testClient.purgeCertificate(name);
+      }
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work - in browsers only
+    it("list deleted certificates with requestOptions timeout", async function() {
+      recorder.skip("browser", "Timeout tests don't work on playback mode.");
+      const iter = client.listDeletedCertificates({ requestOptions: { timeout: 1 } });
       await assertThrowsAbortError(async () => {
         await iter.next();
       });
     });
-  }
 
-  it("can list deleted certificates by page", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    for (const name of certificateNames) {
-      const createPoller = await client.beginCreateCertificate(
-        name,
-        basicCertificatePolicy,
-        testPollerProperties
-      );
-      await createPoller.pollUntilDone();
-    }
-    for (const name of certificateNames) {
-      const deletePoller = await client.beginDeleteCertificate(name, testPollerProperties);
-      await deletePoller.pollUntilDone();
-    }
+    it("can retrieve all versions of a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
 
-    let found = 0;
-    for await (const page of client.listDeletedCertificates({ includePending: true }).byPage()) {
-      for (const deleteCertificate of page) {
-        // The vault might contain more certificates than the ones we inserted.
-        if (!certificateNames.includes(deleteCertificate.properties.name!)) continue;
-        found += 1;
+      const certificateTags = ["tag01", "tag02", "tag03"];
+
+      interface VersionTagPair {
+        // version: string;
+        tag: string;
       }
-    }
-    assert.equal(found, 2, "Unexpected number of certificates found by getDeletedCertificates.");
-    for (const name of certificateNames) {
-      await testClient.purgeCertificate(name);
-    }
-  });
 
-  // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it("list deleted certificates with requestOptions timeout", async function() {
-    recorder.skip("browser", "Timeout tests don't work on playback mode.");
-    const iter = client.listDeletedCertificates({ requestOptions: { timeout: 1 } });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
-
-  it("can retrieve all versions of a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    const certificateTags = ["tag01", "tag02", "tag03"];
-
-    interface VersionTagPair {
-      // version: string;
-      tag: string;
-    }
-
-    const versions: VersionTagPair[] = [];
-    for (const tag of certificateTags) {
-      // One can't re-create a certificate while it's pending,
-      // so we're retrying until Azure allows us to do this.
-      const createPoller = await client.beginCreateCertificate(
-        certificateName,
-        basicCertificatePolicy,
-        {
-          ...testPollerProperties,
-          tags: { tag },
-          enabled: true
-        }
-      );
-      const response = await createPoller.pollUntilDone();
-      // Versions don't match. Something must be happening under the hood.
-      // versions.push({ version: response.version!, tag: response.properties.tags!.tag });
-      versions.push({ tag: response.properties.tags!.tag });
-    }
-
-    const results: VersionTagPair[] = [];
-    for await (const item of client.listPropertiesOfCertificateVersions(certificateName, {})) {
-      const version = item.version!;
-      const certificate = await client.getCertificateVersion(certificateName, version);
-      // Versions don't match. Something must be happening under the hood.
-      // results.push({ version: item.properties.version!, tag: certificate.properties.tags!.tag! });
-      results.push({ tag: certificate.properties.tags!.tag! });
-    }
-
-    const comp = (a: VersionTagPair, b: VersionTagPair): number => a.tag.localeCompare(b.tag);
-    results.sort(comp);
-    versions.sort(comp);
-
-    expect(results).to.deep.equal(versions);
-    await testClient.flushCertificate(certificateName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work - in browsers only
-  it("can get the versions of a certificate with requestOptions timeout", async function() {
-    recorder.skip("browser", "Timeout tests don't work on playback mode.");
-    const iter = client.listPropertiesOfCertificateVersions("doesn't matter", {
-      requestOptions: { timeout: 1 }
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
-
-  it("can list certificate versions (non existing)", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    let totalVersions = 0;
-    for await (const page of client.listPropertiesOfCertificateVersions(certificateName).byPage()) {
-      for (const version of page) {
-        assert.equal(
-          version.name,
+      const versions: VersionTagPair[] = [];
+      for (const tag of certificateTags) {
+        // One can't re-create a certificate while it's pending,
+        // so we're retrying until Azure allows us to do this.
+        const createPoller = await client.beginCreateCertificate(
           certificateName,
-          "Unexpected certificate name in result from listKeyVersions()."
+          basicCertificatePolicy,
+          {
+            ...testPollerProperties,
+            tags: { tag },
+            enabled: true
+          }
         );
-        totalVersions += 1;
+        const response = await createPoller.pollUntilDone();
+        // Versions don't match. Something must be happening under the hood.
+        // versions.push({ version: response.version!, tag: response.properties.tags!.tag });
+        versions.push({ tag: response.properties.tags!.tag });
       }
-    }
-    assert.equal(totalVersions, 0, `Unexpected total versions for certificate ${certificateName}`);
+
+      const results: VersionTagPair[] = [];
+      for await (const item of client.listPropertiesOfCertificateVersions(certificateName, {})) {
+        const version = item.version!;
+        const certificate = await client.getCertificateVersion(certificateName, version);
+        // Versions don't match. Something must be happening under the hood.
+        // results.push({ version: item.properties.version!, tag: certificate.properties.tags!.tag! });
+        results.push({ tag: certificate.properties.tags!.tag! });
+      }
+
+      const comp = (a: VersionTagPair, b: VersionTagPair): number => a.tag.localeCompare(b.tag);
+      results.sort(comp);
+      versions.sort(comp);
+
+      expect(results).to.deep.equal(versions);
+      await testClient.flushCertificate(certificateName);
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work - in browsers only
+    it("can get the versions of a certificate with requestOptions timeout", async function() {
+      recorder.skip("browser", "Timeout tests don't work on playback mode.");
+      const iter = client.listPropertiesOfCertificateVersions("doesn't matter", {
+        requestOptions: { timeout: 1 }
+      });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
+    });
+
+    it("can list certificate versions (non existing)", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      let totalVersions = 0;
+      for await (const page of client
+        .listPropertiesOfCertificateVersions(certificateName)
+        .byPage()) {
+        for (const version of page) {
+          assert.equal(
+            version.name,
+            certificateName,
+            "Unexpected certificate name in result from listKeyVersions()."
+          );
+          totalVersions += 1;
+        }
+      }
+      assert.equal(
+        totalVersions,
+        0,
+        `Unexpected total versions for certificate ${certificateName}`
+      );
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
@@ -9,89 +9,93 @@ import { CertificateClient, KeyVaultCertificate, DefaultCertificatePolicy } from
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
-describe("Certificates client - LRO - create", () => {
-  const certificatePrefix = `lroCreate${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let certificateSuffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - LRO - create", () => {
+    const certificatePrefix = `lroCreate${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let certificateSuffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    certificateSuffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("can wait until a certificate is created", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    assert.ok(poller.getOperationState().isStarted);
-
-    // The pending certificate can be obtained this way:
-    assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    const createdCertificate: KeyVaultCertificate = await poller.pollUntilDone();
-    assert.equal(createdCertificate.name, certificateName);
-    assert.ok(poller.getOperationState().isCompleted);
-
-    // The final certificate can also be obtained this way:
-    assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can resume from a stopped poller", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    assert.ok(poller.getOperationState().isStarted);
-
-    poller.pollUntilDone().catch((e) => {
-      assert.ok(e instanceof PollerStoppedError);
-      assert.equal(e.name, "PollerStoppedError");
-      assert.equal(e.message, "This poller is already stopped");
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      certificateSuffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
     });
 
-    poller.stopPolling();
-    assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().isCompleted);
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-    const serialized = poller.toString();
+    // The tests follow
 
-    const resumePoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      {
-        resumeFrom: serialized,
-        ...testPollerProperties
-      }
-    );
+    it("can wait until a certificate is created", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      assert.ok(poller.getOperationState().isStarted);
 
-    assert.ok(resumePoller.getOperationState().isStarted);
-    const createdCertificate: KeyVaultCertificate = await resumePoller.pollUntilDone();
-    assert.equal(createdCertificate.name, certificateName);
-    assert.ok(resumePoller.getOperationState().isCompleted);
+      // The pending certificate can be obtained this way:
+      assert.equal(poller.getOperationState().result!.name, certificateName);
 
-    await testClient.flushCertificate(certificateName);
+      const createdCertificate: KeyVaultCertificate = await poller.pollUntilDone();
+      assert.equal(createdCertificate.name, certificateName);
+      assert.ok(poller.getOperationState().isCompleted);
+
+      // The final certificate can also be obtained this way:
+      assert.equal(poller.getOperationState().result!.name, certificateName);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can resume from a stopped poller", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const poller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      assert.ok(poller.getOperationState().isStarted);
+
+      poller.pollUntilDone().catch((e) => {
+        assert.ok(e instanceof PollerStoppedError);
+        assert.equal(e.name, "PollerStoppedError");
+        assert.equal(e.message, "This poller is already stopped");
+      });
+
+      poller.stopPolling();
+      assert.ok(poller.isStopped());
+      assert.ok(!poller.getOperationState().isCompleted);
+
+      const serialized = poller.toString();
+
+      const resumePoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        {
+          resumeFrom: serialized,
+          ...testPollerProperties
+        }
+      );
+
+      assert.ok(resumePoller.getOperationState().isStarted);
+      const createdCertificate: KeyVaultCertificate = await resumePoller.pollUntilDone();
+      assert.equal(createdCertificate.name, certificateName);
+      assert.ok(resumePoller.getOperationState().isCompleted);
+
+      await testClient.flushCertificate(certificateName);
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
@@ -9,97 +9,101 @@ import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from 
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
-describe("Certificates client - lro - delete", () => {
-  const certificatePrefix = `lroDelete${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let certificateSuffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - lro - delete", () => {
+    const certificatePrefix = `lroDelete${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let certificateSuffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    certificateSuffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("can wait until a certificate is deleted", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    assert.ok(poller.getOperationState().isStarted);
-
-    // The pending deleted certificate can be obtained this way:
-    assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    let deletedCertificate: DeletedCertificate = await poller.pollUntilDone();
-    assert.equal(deletedCertificate.name, certificateName);
-    assert.ok(poller.getOperationState().isCompleted);
-
-    // Retrieving it without the poller
-    deletedCertificate = await client.getDeletedCertificate(certificateName);
-    assert.equal(deletedCertificate.name, certificateName);
-
-    // The final deleted certificate can also be obtained this way:
-    assert.equal(poller.getOperationState().result!.name, certificateName);
-
-    await testClient.purgeCertificate(certificateName);
-  });
-
-  it("can resume from a stopped poller", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    assert.ok(poller.getOperationState().isStarted);
-
-    poller.pollUntilDone().catch((e) => {
-      assert.ok(e instanceof PollerStoppedError);
-      assert.equal(e.name, "PollerStoppedError");
-      assert.equal(e.message, "This poller is already stopped");
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      certificateSuffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
     });
 
-    poller.stopPolling();
-    assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().isCompleted);
-
-    const serialized = poller.toString();
-
-    const resumePoller = await client.beginDeleteCertificate(certificateName, {
-      resumeFrom: serialized,
-      ...testPollerProperties
+    afterEach(async function() {
+      await recorder.stop();
     });
 
-    assert.ok(resumePoller.getOperationState().isStarted);
+    // The tests follow
 
-    let deletedCertificate: DeletedCertificate = await resumePoller.pollUntilDone();
-    assert.equal(deletedCertificate.name, certificateName);
+    it("can wait until a certificate is deleted", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
+      assert.ok(poller.getOperationState().isStarted);
 
-    // Retrieving it without the poller
-    deletedCertificate = await client.getDeletedCertificate(certificateName);
-    assert.equal(deletedCertificate.name, certificateName);
+      // The pending deleted certificate can be obtained this way:
+      assert.equal(poller.getOperationState().result!.name, certificateName);
 
-    await testClient.purgeCertificate(certificateName);
+      let deletedCertificate: DeletedCertificate = await poller.pollUntilDone();
+      assert.equal(deletedCertificate.name, certificateName);
+      assert.ok(poller.getOperationState().isCompleted);
+
+      // Retrieving it without the poller
+      deletedCertificate = await client.getDeletedCertificate(certificateName);
+      assert.equal(deletedCertificate.name, certificateName);
+
+      // The final deleted certificate can also be obtained this way:
+      assert.equal(poller.getOperationState().result!.name, certificateName);
+
+      await testClient.purgeCertificate(certificateName);
+    });
+
+    it("can resume from a stopped poller", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
+      assert.ok(poller.getOperationState().isStarted);
+
+      poller.pollUntilDone().catch((e) => {
+        assert.ok(e instanceof PollerStoppedError);
+        assert.equal(e.name, "PollerStoppedError");
+        assert.equal(e.message, "This poller is already stopped");
+      });
+
+      poller.stopPolling();
+      assert.ok(poller.isStopped());
+      assert.ok(!poller.getOperationState().isCompleted);
+
+      const serialized = poller.toString();
+
+      const resumePoller = await client.beginDeleteCertificate(certificateName, {
+        resumeFrom: serialized,
+        ...testPollerProperties
+      });
+
+      assert.ok(resumePoller.getOperationState().isStarted);
+
+      let deletedCertificate: DeletedCertificate = await resumePoller.pollUntilDone();
+      assert.equal(deletedCertificate.name, certificateName);
+
+      // Retrieving it without the poller
+      deletedCertificate = await client.getDeletedCertificate(certificateName);
+      assert.equal(deletedCertificate.name, certificateName);
+
+      await testClient.purgeCertificate(certificateName);
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.operation.spec.ts
@@ -13,87 +13,92 @@ import {
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
-describe("Certificates client - LRO - certificate operation", () => {
-  const certificatePrefix = `lroOperation${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let certificateSuffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - LRO - certificate operation", () => {
+    const certificatePrefix = `lroOperation${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let certificateSuffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    certificateSuffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("can wait until a certificate is created by getting the poller from getCertificateOperation", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    createPoller.stopPolling();
-    const poller = await client.getCertificateOperation(certificateName, testPollerProperties);
-    assert.ok(poller.getOperationState().isStarted);
-
-    // The pending certificate operation can be obtained this way:
-    assert.equal(poller.getOperationState().certificateOperation!.status, "inProgress");
-
-    const completeCertificate: KeyVaultCertificateWithPolicy = await poller.pollUntilDone();
-    assert.equal(completeCertificate.name, certificateName);
-
-    const operation: CertificateOperation = poller.getOperationState().certificateOperation!;
-    assert.equal(operation.status, "completed");
-    assert.ok(poller.getOperationState().isCompleted);
-
-    // The final certificate operation can also be obtained this way:
-    assert.equal(poller.getOperationState().certificateOperation!.status, "completed");
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can resume from a stopped poller", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-
-    createPoller.stopPolling();
-
-    const poller = await client.getCertificateOperation(certificateName, testPollerProperties);
-    assert.ok(poller.getOperationState().isStarted);
-
-    const serialized = poller.toString();
-
-    const resumePoller = await client.getCertificateOperation(certificateName, {
-      resumeFrom: serialized,
-      ...testPollerProperties
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      certificateSuffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
     });
-    assert.ok(resumePoller.getOperationState().isStarted);
 
-    const completeCertificate: KeyVaultCertificateWithPolicy = await resumePoller.pollUntilDone();
-    assert.equal(completeCertificate.name, certificateName);
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-    const operation: CertificateOperation = resumePoller.getOperationState().certificateOperation!;
-    assert.equal(operation.status, "completed");
-    assert.ok(resumePoller.getOperationState().isCompleted);
+    // The tests follow
 
-    await testClient.flushCertificate(certificateName);
+    it("can wait until a certificate is created by getting the poller from getCertificateOperation", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      createPoller.stopPolling();
+      const poller = await client.getCertificateOperation(certificateName, testPollerProperties);
+      assert.ok(poller.getOperationState().isStarted);
+
+      // The pending certificate operation can be obtained this way:
+      assert.equal(poller.getOperationState().certificateOperation!.status, "inProgress");
+
+      const completeCertificate: KeyVaultCertificateWithPolicy = await poller.pollUntilDone();
+      assert.equal(completeCertificate.name, certificateName);
+
+      const operation: CertificateOperation = poller.getOperationState().certificateOperation!;
+      assert.equal(operation.status, "completed");
+      assert.ok(poller.getOperationState().isCompleted);
+
+      // The final certificate operation can also be obtained this way:
+      assert.equal(poller.getOperationState().certificateOperation!.status, "completed");
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can resume from a stopped poller", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+
+      createPoller.stopPolling();
+
+      const poller = await client.getCertificateOperation(certificateName, testPollerProperties);
+      assert.ok(poller.getOperationState().isStarted);
+
+      const serialized = poller.toString();
+
+      const resumePoller = await client.getCertificateOperation(certificateName, {
+        resumeFrom: serialized,
+        ...testPollerProperties
+      });
+      assert.ok(resumePoller.getOperationState().isStarted);
+
+      const completeCertificate: KeyVaultCertificateWithPolicy = await resumePoller.pollUntilDone();
+      assert.equal(completeCertificate.name, certificateName);
+
+      const operation: CertificateOperation = resumePoller.getOperationState()
+        .certificateOperation!;
+      assert.equal(operation.status, "completed");
+      assert.ok(resumePoller.getOperationState().isCompleted);
+
+      await testClient.flushCertificate(certificateName);
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
@@ -6,129 +6,141 @@ import { env, Recorder } from "@azure/test-utils-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, serviceVersions } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
 
-describe("Certificates client - LRO - recoverDelete", () => {
-  const certificatePrefix = `lroRecover${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let certificateSuffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - LRO - recoverDelete", () => {
+    const certificatePrefix = `lroRecover${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let certificateSuffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    certificateSuffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
-
-  afterEach(async function() {
-    await recorder.stop();
-  });
-
-  // The tests follow
-
-  it("can wait until a certificate is recovered", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-
-    const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-
-    const recoverPoller = await client.beginRecoverDeletedCertificate(
-      certificateName,
-      testPollerProperties
-    );
-    assert.ok(recoverPoller.getOperationState().isStarted);
-
-    // The pending certificate can be obtained this way:
-    assert.equal(recoverPoller.getOperationState().result!.name, certificateName);
-
-    const deletedCertificate: DeletedCertificate = await recoverPoller.pollUntilDone();
-    assert.equal(deletedCertificate.name, certificateName);
-    assert.ok(recoverPoller.getOperationState().isCompleted);
-
-    // The final certificate can also be obtained this way:
-    assert.equal(recoverPoller.getOperationState().result!.name, certificateName);
-
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can resume from a stopped poller", async function() {
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-
-    const recoverPoller = await client.beginRecoverDeletedCertificate(
-      certificateName,
-      testPollerProperties
-    );
-    assert.ok(recoverPoller.getOperationState().isStarted);
-
-    recoverPoller.pollUntilDone().catch((e) => {
-      assert.ok(e instanceof PollerStoppedError);
-      assert.equal(e.name, "PollerStoppedError");
-      assert.equal(e.message, "This poller is already stopped");
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      certificateSuffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
     });
 
-    await recoverPoller.poll(); // Making sure it has some data
-
-    recoverPoller.stopPolling();
-    assert.ok(recoverPoller.isStopped());
-    assert.ok(!recoverPoller.getOperationState().isCompleted);
-
-    const serialized = recoverPoller.toString();
-
-    const resumePoller = await client.beginRecoverDeletedCertificate(certificateName, {
-      resumeFrom: serialized,
-      ...testPollerProperties
+    afterEach(async function() {
+      await recorder.stop();
     });
 
-    assert.ok(recoverPoller.getOperationState().isStarted);
-    const deletedCertificate: DeletedCertificate = await resumePoller.pollUntilDone();
-    assert.equal(deletedCertificate.name, certificateName);
-    assert.ok(resumePoller.getOperationState().isCompleted);
+    // The tests follow
 
-    await testClient.flushCertificate(certificateName);
-  });
+    it("can wait until a certificate is recovered", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can recover a deleted certificate with requestOptions timeout", async function() {
-    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedCertificate(certificateName, {
-        requestOptions: { timeout: 1 },
+      const deletePoller = await client.beginDeleteCertificate(
+        certificateName,
+        testPollerProperties
+      );
+      await deletePoller.pollUntilDone();
+
+      const recoverPoller = await client.beginRecoverDeletedCertificate(
+        certificateName,
+        testPollerProperties
+      );
+      assert.ok(recoverPoller.getOperationState().isStarted);
+
+      // The pending certificate can be obtained this way:
+      assert.equal(recoverPoller.getOperationState().result!.name, certificateName);
+
+      const deletedCertificate: DeletedCertificate = await recoverPoller.pollUntilDone();
+      assert.equal(deletedCertificate.name, certificateName);
+      assert.ok(recoverPoller.getOperationState().isCompleted);
+
+      // The final certificate can also be obtained this way:
+      assert.equal(recoverPoller.getOperationState().result!.name, certificateName);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    it("can resume from a stopped poller", async function() {
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const deletePoller = await client.beginDeleteCertificate(
+        certificateName,
+        testPollerProperties
+      );
+      await deletePoller.pollUntilDone();
+
+      const recoverPoller = await client.beginRecoverDeletedCertificate(
+        certificateName,
+        testPollerProperties
+      );
+      assert.ok(recoverPoller.getOperationState().isStarted);
+
+      recoverPoller.pollUntilDone().catch((e) => {
+        assert.ok(e instanceof PollerStoppedError);
+        assert.equal(e.name, "PollerStoppedError");
+        assert.equal(e.message, "This poller is already stopped");
+      });
+
+      await recoverPoller.poll(); // Making sure it has some data
+
+      recoverPoller.stopPolling();
+      assert.ok(recoverPoller.isStopped());
+      assert.ok(!recoverPoller.getOperationState().isCompleted);
+
+      const serialized = recoverPoller.toString();
+
+      const resumePoller = await client.beginRecoverDeletedCertificate(certificateName, {
+        resumeFrom: serialized,
         ...testPollerProperties
+      });
+
+      assert.ok(recoverPoller.getOperationState().isStarted);
+      const deletedCertificate: DeletedCertificate = await resumePoller.pollUntilDone();
+      assert.equal(deletedCertificate.name, certificateName);
+      assert.ok(resumePoller.getOperationState().isCompleted);
+
+      await testClient.flushCertificate(certificateName);
+    });
+
+    // On playback mode, the tests happen too fast for the timeout to work
+    it("can recover a deleted certificate with requestOptions timeout", async function() {
+      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+      const certificateName = testClient.formatName(
+        `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+      );
+      const createPoller = await client.beginCreateCertificate(
+        certificateName,
+        DefaultCertificatePolicy,
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const deletePoller = await client.beginDeleteCertificate(
+        certificateName,
+        testPollerProperties
+      );
+      await deletePoller.pollUntilDone();
+      await assertThrowsAbortError(async () => {
+        await client.beginRecoverDeletedCertificate(certificateName, {
+          requestOptions: { timeout: 1 },
+          ...testPollerProperties
+        });
       });
     });
   });

--- a/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
@@ -13,132 +13,136 @@ import { base64ToUint8Array, stringToUint8Array } from "../../src/utils";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { serviceVersions } from "../utils/utils.common";
 
-describe("Certificates client - merge and import certificates", () => {
-  const prefix = `merge${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let suffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
-  let keyVaultUrl: string;
-  let credential: ClientSecretCredential;
-  let secretClient: SecretClient;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - merge and import certificates", () => {
+    const prefix = `merge${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let suffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
+    let keyVaultUrl: string;
+    let credential: ClientSecretCredential;
+    let secretClient: SecretClient;
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    suffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-    keyVaultUrl = authentication.keyVaultUrl;
-    credential = authentication.credential;
-    secretClient = new SecretClient(keyVaultUrl, credential);
-  });
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      suffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
+      keyVaultUrl = authentication.keyVaultUrl;
+      credential = authentication.credential;
+      secretClient = new SecretClient(keyVaultUrl, credential);
+    });
 
-  afterEach(async function() {
-    await recorder.stop();
-  });
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-  // The tests follow
+    // The tests follow
 
-  it("can import a certificate from a certificate's non base64 secret value", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    const createPoller = await client.beginCreateCertificate(
-      certificateNames[0],
-      {
-        issuerName: "Self",
-        subject: "cn=MyCert"
-      },
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const certificateSecret = await secretClient.getSecret(certificateNames[0]);
-    const base64EncodedCertificate = certificateSecret.value!;
+    it("can import a certificate from a certificate's non base64 secret value", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      const createPoller = await client.beginCreateCertificate(
+        certificateNames[0],
+        {
+          issuerName: "Self",
+          subject: "cn=MyCert"
+        },
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const certificateSecret = await secretClient.getSecret(certificateNames[0]);
+      const base64EncodedCertificate = certificateSecret.value!;
 
-    const buffer = base64ToUint8Array(base64EncodedCertificate);
+      const buffer = base64ToUint8Array(base64EncodedCertificate);
 
-    await client.importCertificate(certificateNames[1], buffer);
+      await client.importCertificate(certificateNames[1], buffer);
 
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
-  });
-
-  it("can import a certificate from a certificate's base64 secret value", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const certificateNames = [`${certificateName}0`, `${certificateName}1`];
-    const createPoller = await client.beginCreateCertificate(
-      certificateNames[0],
-      {
-        issuerName: "Self",
-        subject: "cn=MyCert"
-      },
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const certificateSecret = await secretClient.getSecret(certificateNames[0]);
-    const base64EncodedCertificate = certificateSecret.value!;
-
-    const buffer = stringToUint8Array(base64EncodedCertificate);
-
-    await client.importCertificate(certificateNames[1], buffer, {
-      policy: {
-        contentType: "application/x-pem-file"
+      for (const name of certificateNames) {
+        await testClient.flushCertificate(name);
       }
     });
 
-    for (const name of certificateNames) {
-      await testClient.flushCertificate(name);
-    }
-  });
+    it("can import a certificate from a certificate's base64 secret value", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const certificateNames = [`${certificateName}0`, `${certificateName}1`];
+      const createPoller = await client.beginCreateCertificate(
+        certificateNames[0],
+        {
+          issuerName: "Self",
+          subject: "cn=MyCert"
+        },
+        testPollerProperties
+      );
+      await createPoller.pollUntilDone();
+      const certificateSecret = await secretClient.getSecret(certificateNames[0]);
+      const base64EncodedCertificate = certificateSecret.value!;
 
-  // The signed certificate will never be the same, so we can't play it back.
-  // This test is only designed to work on NodeJS, since we use child_process to interact with openssl.
-  it("can merge a self signed certificate", async function(): Promise<void> {
-    recorder.skip(
-      undefined,
-      "The signed certificate will never be the same, so we can't play it back."
-    );
-    if (!isNode) {
-      // recorder.skip is not meant for TEST_MODE=live
-      return this.skip();
-    }
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      const buffer = stringToUint8Array(base64EncodedCertificate);
 
-    await client.beginCreateCertificate(
-      certificateName,
-      {
-        issuerName: "Unknown",
-        certificateTransparency: false,
-        subject: "cn=MyCert"
-      },
-      testPollerProperties
-    );
+      await client.importCertificate(certificateNames[1], buffer, {
+        policy: {
+          contentType: "application/x-pem-file"
+        }
+      });
 
-    const certificateOperationPoller = await client.getCertificateOperation(certificateName);
-    const { csr } = await certificateOperationPoller.getOperationState().certificateOperation!;
-    const base64Csr = Buffer.from(csr!).toString("base64");
-    const wrappedCsr = `-----BEGIN CERTIFICATE REQUEST-----
+      for (const name of certificateNames) {
+        await testClient.flushCertificate(name);
+      }
+    });
+
+    // The signed certificate will never be the same, so we can't play it back.
+    // This test is only designed to work on NodeJS, since we use child_process to interact with openssl.
+    it("can merge a self signed certificate", async function(): Promise<void> {
+      recorder.skip(
+        undefined,
+        "The signed certificate will never be the same, so we can't play it back."
+      );
+      if (!isNode) {
+        // recorder.skip is not meant for TEST_MODE=live
+        return this.skip();
+      }
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+      await client.beginCreateCertificate(
+        certificateName,
+        {
+          issuerName: "Unknown",
+          certificateTransparency: false,
+          subject: "cn=MyCert"
+        },
+        testPollerProperties
+      );
+
+      const certificateOperationPoller = await client.getCertificateOperation(certificateName);
+      const { csr } = await certificateOperationPoller.getOperationState().certificateOperation!;
+      const base64Csr = Buffer.from(csr!).toString("base64");
+      const wrappedCsr = `-----BEGIN CERTIFICATE REQUEST-----
 ${base64Csr}
 -----END CERTIFICATE REQUEST-----`;
-    fs.writeFileSync("test.csr", wrappedCsr);
+      fs.writeFileSync("test.csr", wrappedCsr);
 
-    // Certificate available locally made using:
-    //   openssl genrsa -out ca.key 2048
-    //   openssl req -new -x509 -key ca.key -out ca.crt
-    childProcess.execSync(
-      "openssl x509 -req -in test.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out test.crt"
-    );
-    const base64Crt = fs
-      .readFileSync("test.crt")
-      .toString()
-      .split("\n")
-      .slice(1, -1)
-      .join("");
+      // Certificate available locally made using:
+      //   openssl genrsa -out ca.key 2048
+      //   openssl req -new -x509 -key ca.key -out ca.crt
+      childProcess.execSync(
+        "openssl x509 -req -in test.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out test.crt"
+      );
+      const base64Crt = fs
+        .readFileSync("test.crt")
+        .toString()
+        .split("\n")
+        .slice(1, -1)
+        .join("");
 
-    await client.mergeCertificate(certificateName, [Buffer.from(base64Crt)]);
+      await client.mergeCertificate(certificateName, [Buffer.from(base64Crt)]);
 
-    await testClient.flushCertificate(certificateName);
+      await testClient.flushCertificate(certificateName);
+    });
   });
 });

--- a/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/recoverBackupRestore.spec.ts
@@ -7,81 +7,39 @@ import { isNode } from "@azure/core-http";
 
 import { CertificateClient } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, serviceVersions } from "../utils/utils.common";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { versionsToTest } from "@azure/test-utils-multi-version";
 
-describe("Certificates client - restore certificates and recover backups", () => {
-  const prefix = `backupRestore${env.CERTIFICATE_NAME || "CertificateName"}`;
-  let suffix: string;
-  let client: CertificateClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+versionsToTest(serviceVersions, {}, (serviceVersion) => {
+  describe("Certificates client - restore certificates and recover backups", () => {
+    const prefix = `backupRestore${env.CERTIFICATE_NAME || "CertificateName"}`;
+    let suffix: string;
+    let client: CertificateClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  const basicCertificatePolicy = {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  };
+    const basicCertificatePolicy = {
+      issuerName: "Self",
+      subject: "cn=MyCert"
+    };
 
-  beforeEach(async function() {
-    const authentication = await authenticate(this);
-    suffix = authentication.suffix;
-    client = authentication.client;
-    testClient = authentication.testClient;
-    recorder = authentication.recorder;
-  });
+    beforeEach(async function() {
+      const authentication = await authenticate(this, serviceVersion);
+      suffix = authentication.suffix;
+      client = authentication.client;
+      testClient = authentication.testClient;
+      recorder = authentication.recorder;
+    });
 
-  afterEach(async function() {
-    await recorder.stop();
-  });
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-  // The tests follow
+    // The tests follow
 
-  it("can recover a deleted certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    const getDeletedResult = await deletePoller.pollUntilDone();
-    assert.equal(
-      getDeletedResult.properties.name,
-      certificateName,
-      "Unexpected certificate name in result from getCertificate()."
-    );
-    const recoverPoller = await client.beginRecoverDeletedCertificate(
-      certificateName,
-      testPollerProperties
-    );
-    const getResult = await recoverPoller.pollUntilDone();
-    assert.equal(
-      getResult.properties.name,
-      certificateName,
-      "Unexpected certificate name in result from getCertificate()."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
-
-  it("can recover a deleted certificate (non existing)", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    let error;
-    try {
-      await client.beginRecoverDeletedCertificate(certificateName, testPollerProperties);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.code, "CertificateNotFound");
-    assert.equal(error.statusCode, 404);
-  });
-
-  if (isRecordMode() || isPlaybackMode()) {
-    // This test can't run live,
-    // since the purge operation currently can't be expected to finish anytime soon.
-    it("can restore a certificate", async function() {
+    it("can recover a deleted certificate", async function() {
       const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
       const createPoller = await client.beginCreateCertificate(
         certificateName,
@@ -89,72 +47,120 @@ describe("Certificates client - restore certificates and recover backups", () =>
         testPollerProperties
       );
       await createPoller.pollUntilDone();
-      const backup = await client.backupCertificate(certificateName);
       const deletePoller = await client.beginDeleteCertificate(
         certificateName,
         testPollerProperties
       );
-      await deletePoller.pollUntilDone();
-      await client.purgeDeletedCertificate(certificateName);
-
-      // One would normally do this, but this can't immediately happen after the resource is purged:
-      // await client.restoreCertificateBackup(backup as Uint8Array);
-
-      // This test implementation of a restore poller only applies for backups that have been recently deleted.
-      // Backups might not be ready to be restored in an unknown amount of time.
-      // If this is useful to you, please open an issue at: https://github.com/Azure/azure-sdk-for-js/issues
-      const restorePoller = await testClient.beginRestoreCertificateBackup(
-        backup as Uint8Array,
-        testPollerProperties
-      );
-      const restoredCertificate = await restorePoller.pollUntilDone();
-
-      assert.equal(restoredCertificate.name, certificateName);
-      await testClient.flushCertificate(certificateName);
-    });
-  }
-
-  if (isNode && !isPlaybackMode()) {
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can generate a backup of a certificate with requestOptions timeout", async function() {
-      await assertThrowsAbortError(async () => {
-        await client.backupCertificate("doesn't matter", { requestOptions: { timeout: 1 } });
-      });
-    });
-  }
-
-  it("can restore a certificate (Malformed Backup Bytes)", async function() {
-    const backup = new Uint8Array(4728);
-    let error;
-    try {
-      await client.restoreCertificateBackup(backup);
-      throw Error("Expecting an error but not catching one.");
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(
-      error.message,
-      "Backup blob contains invalid or corrupt version.",
-      "Unexpected error from restoreCertificate()"
-    );
-  });
-
-  if (isNode && !isPlaybackMode()) {
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can restore a key with requestOptions timeout", async function() {
-      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-      const createPoller = await client.beginCreateCertificate(
+      const getDeletedResult = await deletePoller.pollUntilDone();
+      assert.equal(
+        getDeletedResult.properties.name,
         certificateName,
-        basicCertificatePolicy,
+        "Unexpected certificate name in result from getCertificate()."
+      );
+      const recoverPoller = await client.beginRecoverDeletedCertificate(
+        certificateName,
         testPollerProperties
       );
-      await createPoller.pollUntilDone();
-      const backup = await client.backupCertificate(certificateName);
+      const getResult = await recoverPoller.pollUntilDone();
+      assert.equal(
+        getResult.properties.name,
+        certificateName,
+        "Unexpected certificate name in result from getCertificate()."
+      );
       await testClient.flushCertificate(certificateName);
-
-      await assertThrowsAbortError(async () => {
-        await client.restoreCertificateBackup(backup!, { requestOptions: { timeout: 1 } });
-      });
     });
-  }
+
+    it("can recover a deleted certificate (non existing)", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      let error;
+      try {
+        await client.beginRecoverDeletedCertificate(certificateName, testPollerProperties);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error.code, "CertificateNotFound");
+      assert.equal(error.statusCode, 404);
+    });
+
+    if (isRecordMode() || isPlaybackMode()) {
+      // This test can't run live,
+      // since the purge operation currently can't be expected to finish anytime soon.
+      it("can restore a certificate", async function() {
+        const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+        const createPoller = await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+        const backup = await client.backupCertificate(certificateName);
+        const deletePoller = await client.beginDeleteCertificate(
+          certificateName,
+          testPollerProperties
+        );
+        await deletePoller.pollUntilDone();
+        await client.purgeDeletedCertificate(certificateName);
+
+        // One would normally do this, but this can't immediately happen after the resource is purged:
+        // await client.restoreCertificateBackup(backup as Uint8Array);
+
+        // This test implementation of a restore poller only applies for backups that have been recently deleted.
+        // Backups might not be ready to be restored in an unknown amount of time.
+        // If this is useful to you, please open an issue at: https://github.com/Azure/azure-sdk-for-js/issues
+        const restorePoller = await testClient.beginRestoreCertificateBackup(
+          backup as Uint8Array,
+          testPollerProperties
+        );
+        const restoredCertificate = await restorePoller.pollUntilDone();
+
+        assert.equal(restoredCertificate.name, certificateName);
+        await testClient.flushCertificate(certificateName);
+      });
+    }
+
+    if (isNode && !isPlaybackMode()) {
+      // On playback mode, the tests happen too fast for the timeout to work
+      it("can generate a backup of a certificate with requestOptions timeout", async function() {
+        await assertThrowsAbortError(async () => {
+          await client.backupCertificate("doesn't matter", { requestOptions: { timeout: 1 } });
+        });
+      });
+    }
+
+    it("can restore a certificate (Malformed Backup Bytes)", async function() {
+      const backup = new Uint8Array(4728);
+      let error;
+      try {
+        await client.restoreCertificateBackup(backup);
+        throw Error("Expecting an error but not catching one.");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(
+        error.message,
+        "Backup blob contains invalid or corrupt version.",
+        "Unexpected error from restoreCertificate()"
+      );
+    });
+
+    if (isNode && !isPlaybackMode()) {
+      // On playback mode, the tests happen too fast for the timeout to work
+      it("can restore a key with requestOptions timeout", async function() {
+        const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+        const createPoller = await client.beginCreateCertificate(
+          certificateName,
+          basicCertificatePolicy,
+          testPollerProperties
+        );
+        await createPoller.pollUntilDone();
+        const backup = await client.backupCertificate(certificateName);
+        await testClient.flushCertificate(certificateName);
+
+        await assertThrowsAbortError(async () => {
+          await client.restoreCertificateBackup(backup!, { requestOptions: { timeout: 1 } });
+        });
+      });
+    }
+  });
 });

--- a/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
@@ -8,7 +8,8 @@ import { env, record, RecorderEnvironmentSetup } from "@azure/test-utils-recorde
 import TestClient from "./testClient";
 import { Context } from "mocha";
 
-export async function authenticate(that: Context): Promise<any> {
+export async function authenticate(that: Context, serviceVersion: string): Promise<any> {
+  console.log(`authenticate called with serviceVersion ${serviceVersion}`);
   const suffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
@@ -38,7 +39,7 @@ export async function authenticate(that: Context): Promise<any> {
     throw new Error("Missing KEYVAULT_URI environment variable.");
   }
 
-  const client = new CertificateClient(keyVaultUrl, credential);
+  const client = new CertificateClient(keyVaultUrl, credential, { serviceVersion });
   const testClient = new TestClient(client);
 
   return { recorder, client, credential, testClient, suffix, keyVaultUrl };

--- a/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/utils.common.ts
@@ -3,6 +3,7 @@
 
 import { env } from "@azure/test-utils-recorder";
 import * as assert from "assert";
+import { LATEST_API_VERSION } from "../../src/certificatesModels";
 
 // Async iterator's polyfill for Node 8
 if (!Symbol || !(Symbol as any).asyncIterator) {
@@ -34,3 +35,5 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
     throw new Error("Expected cb to throw an AbortError");
   }
 }
+
+export const serviceVersions = ["7.0", "7.1", LATEST_API_VERSION];


### PR DESCRIPTION
## What

Incorporates Jeremy's work on multi-version-testing into KeyVault Certificates and adds support to test all currently 
supported API versions.

## Why

Since we commit to support the last N versions of a service's API we want to add tests that ensure that we are actually 
supporting them correctly. Jeremy added that capability via the @azure/test-utils-multi-version package so this PR 
just dogfoods it by adding those tests to KeyVault Certificates.