### PR TITLE
[KeyVault] - Demonstrate querying an existing LRO

### DIFF
--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -43,6 +43,17 @@ describe("KeyVaultBackupClient", () => {
         blobSasToken,
         testPollerProperties
       );
+      await backupPoller.poll();
+
+      // A poller can be serialized and then resumed
+      const resumedPoller = await client.beginBackup(blobStorageUri, blobSasToken, {
+        resumeFrom: backupPoller.toString(),
+        ...testPollerProperties
+      });
+
+      assert.isTrue(resumedPoller.getOperationState().isStarted); // without polling
+      assert.equal(resumedPoller.getOperationState().jobId, backupPoller.getOperationState().jobId);
+
       const backupResult = await backupPoller.pollUntilDone();
       assert.notExists(backupPoller.getOperationState().error);
       assert.exists(backupResult.backupFolderUri);
@@ -85,6 +96,19 @@ describe("KeyVaultBackupClient", () => {
         folderName,
         testPollerProperties
       );
+      await restorePoller.poll();
+
+      // A poller can be serialized and then resumed
+      const resumedPoller = await client.beginRestore(blobStorageUri, blobSasToken, folderName, {
+        ...testPollerProperties,
+        resumeFrom: restorePoller.toString()
+      });
+      assert.isTrue(resumedPoller.getOperationState().isStarted); // without polling
+      assert.equal(
+        resumedPoller.getOperationState().jobId,
+        restorePoller.getOperationState().jobId
+      );
+
       const restoreResult = await restorePoller.pollUntilDone();
       const operationState = restorePoller.getOperationState();
       assert.equal(restoreResult.startTime, operationState.startTime);
@@ -94,7 +118,9 @@ describe("KeyVaultBackupClient", () => {
       // Restore is eventually consistent so while we work
       // through the retry operations adding a delay here allows
       // tests to pass the 5s polling delay.
-      await delay(5000);
+      if (!isPlaybackMode()) {
+        await delay(5000);
+      }
     });
 
     it("selectiveRestore completes successfully", async function() {
@@ -125,6 +151,25 @@ describe("KeyVaultBackupClient", () => {
         keyName,
         testPollerProperties
       );
+      await selectiveRestorePoller.poll();
+
+      // A poller can be serialized and then resumed
+      const resumedPoller = await client.beginSelectiveRestore(
+        blobStorageUri,
+        blobSasToken,
+        folderName,
+        keyName,
+        {
+          ...testPollerProperties,
+          resumeFrom: selectiveRestorePoller.toString()
+        }
+      );
+      assert.isTrue(resumedPoller.getOperationState().isStarted); // without polling
+      assert.equal(
+        resumedPoller.getOperationState().jobId,
+        selectiveRestorePoller.getOperationState().jobId
+      );
+
       await selectiveRestorePoller.pollUntilDone();
       const operationState = selectiveRestorePoller.getOperationState();
       assert.equal(operationState.isCompleted, true);

--- a/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
@@ -25,11 +25,11 @@ export async function authenticate(that: any): Promise<any> {
   const suffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
-      AZURE_MANAGEDHSM_URI: "https://azure_managedhsm.managedhsm.azure.net",
+      AZURE_MANAGEDHSM_URI: "https://azure_managedhsm.managedhsm.azure.net/",
       AZURE_CLIENT_ID: "azure_client_id",
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net",
+      KEYVAULT_URI: "https://keyvault_name.vault.azure.net/",
       BLOB_CONTAINER_NAME: "uri",
       BLOB_STORAGE_ACCOUNT_NAME: "blob_storage_account_name",
       BLOB_STORAGE_SAS_TOKEN: "blob_storage_sas_token",

--- a/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-certificates/test/utils/testAuthentication.ts
@@ -16,7 +16,7 @@ export async function authenticate(that: Context): Promise<any> {
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
       KEYVAULT_NAME: "keyvault_name",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net"
+      KEYVAULT_URI: "https://keyvault_name.vault.azure.net/"
     },
     customizationsOnRecordings: [
       (recording: any): any =>

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -19,8 +19,8 @@ export async function authenticate(that: Context, version?: string): Promise<any
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
       KEYVAULT_NAME: "keyvault_name",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net",
-      AZURE_MANAGEDHSM_URI: "https://azure_managedhsm.managedhsm.azure.net"
+      KEYVAULT_URI: "https://keyvault_name.vault.azure.net/",
+      AZURE_MANAGEDHSM_URI: "https://azure_managedhsm.managedhsm.azure.net/"
     },
     customizationsOnRecordings: [
       (recording: any): any =>

--- a/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
@@ -16,7 +16,7 @@ export async function authenticate(that: Context): Promise<any> {
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
       KEYVAULT_NAME: "keyvault_name",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net"
+      KEYVAULT_URI: "https://keyvault_name.vault.azure.net/"
     },
     customizationsOnRecordings: [
       (recording: any): any =>


### PR DESCRIPTION
This PR updates the existing LRO tests for KV admin with the ability to serialize & resume an existing LRO in order to both 
demonstrate and test the scenario of resuming from a serialized poller.

In passing, add trailing slashes to the recorder replacements for URIs since that's the default format of ARM template outputs.

Resolves #11183