### PR TITLE
[service-bus] Allow null as a type for applicationProperties

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Re-exports `RetryMode` for use when setting the `RetryOptions.mode` field
   in `ServiceBusClientOptions`.
   Resolves [#13166](https://github.com/Azure/azure-sdk-for-js/issues/13166).
+- Allow null as a value for the `ServiceBusMessage.applicationProperties`.
+  Fixes [#14329](https://github.com/Azure/azure-sdk-for-js/issues/14329)
 
 ### Tracing updates
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -373,7 +373,7 @@ export type ServiceBusErrorCode =
 // @public
 export interface ServiceBusMessage {
     applicationProperties?: {
-        [key: string]: number | boolean | string | Date;
+        [key: string]: number | boolean | string | Date | null;
     };
     body: any;
     contentType?: string;

--- a/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
+++ b/sdk/servicebus/service-bus/src/diagnostics/tracing.ts
@@ -96,7 +96,7 @@ export interface InstrumentableMessage {
    * The application specific properties which can be
    * used for custom message metadata.
    */
-  applicationProperties?: { [key: string]: number | boolean | string | Date };
+  applicationProperties?: { [key: string]: number | boolean | string | Date | null };
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -210,7 +210,7 @@ export interface ServiceBusMessage {
    * The application specific properties which can be
    * used for custom message metadata.
    */
-  applicationProperties?: { [key: string]: number | boolean | string | Date };
+  applicationProperties?: { [key: string]: number | boolean | string | Date | null };
 }
 
 /**

--- a/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
@@ -498,7 +498,11 @@ describe("Send Batch", () => {
     assert.deepEqual(
       {
         messageId: receivedMessage.messageId,
-        applicationProperties: receivedMessage.applicationProperties
+        applicationProperties: {
+          nullProperty: receivedMessage.applicationProperties?.nullProperty,
+          undefinedProperty: receivedMessage.applicationProperties?.undefinedProperty,
+          canary: receivedMessage.applicationProperties?.canary
+        }
       },
       {
         messageId,

--- a/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
@@ -3,6 +3,7 @@
 
 import chai from "chai";
 const should = chai.should();
+const assert = chai.assert;
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import { OperationOptions, ServiceBusMessage } from "../../src";
@@ -470,5 +471,43 @@ describe("Send Batch", () => {
 
     await sender.sendMessages(batch);
     await serviceBusClient.test.verifyAndDeleteAllSentMessages(entityNames, messagesToSend);
+  });
+
+  it("send() with null/undefined properties", async () => {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+
+    const messageId = `null/undefined properties: ${Date.now()}`;
+
+    await sender.sendMessages({
+      messageId,
+      body: undefined,
+      applicationProperties: {
+        nullProperty: null,
+        // the type definition hasn't opened up to allow undefined (we do allow)
+        // null, however.
+        undefinedProperty: undefined as any,
+        canary: "hello"
+      }
+    });
+
+    // round trip documentation
+    const receiver = await serviceBusClient.test.createReceiveAndDeleteReceiver(entityNames);
+    const messageWithNullProperties = await receiver.receiveMessages(1);
+    const receivedMessage = messageWithNullProperties[0]!;
+
+    assert.deepEqual(
+      {
+        messageId: receivedMessage.messageId,
+        applicationProperties: receivedMessage.applicationProperties
+      },
+      {
+        messageId,
+        applicationProperties: {
+          nullProperty: null,
+          undefinedProperty: null, // NOTE, undefined just gets squashed to null,
+          canary: "hello"
+        }
+      }
+    );
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusMessage.spec.ts
@@ -15,168 +15,173 @@ const assert = chai.assert;
 
 const fakeDelivery = {} as Delivery;
 
-describe("ServiceBusMessageImpl LockToken unit tests", () => {
-  const message_annotations: MessageAnnotations = {};
-  message_annotations[Constants.enqueuedTime] = Date.now();
-  const amqpMessage: RheaMessage = {
-    body: "hello",
-    message_annotations
-  };
+describe("ServiceBusMessageImpl unit tests", () => {
+  describe("ServiceBusMessageImpl LockToken unit tests", () => {
+    const message_annotations: MessageAnnotations = {};
+    message_annotations[Constants.enqueuedTime] = Date.now();
+    const amqpMessage: RheaMessage = {
+      body: "hello",
+      message_annotations
+    };
 
-  const fakeDeliveryTag = new Buffer(16);
-  for (let i = 0; i < fakeDeliveryTag.length; i++) {
-    fakeDeliveryTag[i] = Math.floor(Math.random() * 255);
-  }
-  const expectedLockToken = uuid_to_string(fakeDeliveryTag);
-
-  it("Lock token in peekLock mode", () => {
-    const sbMessage = new ServiceBusMessageImpl(
-      amqpMessage,
-      { tag: fakeDeliveryTag } as Delivery,
-      false,
-      "peekLock"
-    );
-
-    assert.equal(sbMessage.lockToken, expectedLockToken, "Unexpected lock token found");
-  });
-
-  it("Lock token in receiveAndDelete mode", () => {
-    const sbMessage = new ServiceBusMessageImpl(
-      amqpMessage,
-      { tag: fakeDeliveryTag } as Delivery,
-      false,
-      "receiveAndDelete"
-    );
-
-    assert.equal(!!sbMessage.lockToken, false, "Unexpected lock token found");
-  });
-});
-
-describe("ServiceBusMessageImpl AmqpAnnotations unit tests", () => {
-  const message_annotations: MessageAnnotations = {};
-  message_annotations[Constants.enqueuedTime] = Date.now();
-  message_annotations[Constants.partitionKey] = "dummy-partition-key";
-  // message_annotations[Constants.viaPartitionKey] = "dummy-via-partition-key";
-  message_annotations["random-msg-annotation-key"] = "random-msg-annotation-value";
-
-  const delivery_annotations: DeliveryAnnotations = {
-    delivery_annotations_one: "delivery_annotations_one_value",
-    delivery_annotations_two: "delivery_annotations_two_value",
-    delivery_annotations_three: "delivery_annotations_three_value"
-  };
-
-  const amqpMessage: RheaMessage = {
-    body: "hello",
-    message_annotations,
-    delivery_annotations,
-    delivery_count: 2,
-    first_acquirer: true,
-    ttl: 123456,
-    durable: true,
-    priority: 9876,
-    message_id: "random_messageId",
-    reply_to: "random_replyTo",
-    to: "random_to",
-    correlation_id: "random_correlationId",
-    content_type: "random_contentType",
-    content_encoding: "random_contentEncoding",
-    absolute_expiry_time: 123908745,
-    creation_time: 45612349,
-    group_id: "random_groupId",
-    group_sequence: 98723560,
-    reply_to_group_id: "random_replyToGroupId",
-    subject: "random_subject",
-    user_id: "random_user_id"
-  };
-
-  const sbMessage = new ServiceBusMessageImpl(amqpMessage, fakeDelivery, false, "peekLock");
-
-  it("headers match", () => {
-    assert.equal(sbMessage._rawAmqpMessage.header?.firstAcquirer, amqpMessage.first_acquirer);
-    assert.equal(sbMessage._rawAmqpMessage.header?.timeToLive, amqpMessage.ttl);
-    assert.equal(sbMessage._rawAmqpMessage.header?.durable, amqpMessage.durable);
-    assert.equal(sbMessage._rawAmqpMessage.header?.priority, amqpMessage.priority);
-    assert.equal(sbMessage._rawAmqpMessage.header?.deliveryCount, amqpMessage.delivery_count);
-
-    assert.equal(sbMessage.deliveryCount, amqpMessage.delivery_count);
-    assert.equal(sbMessage.timeToLive, amqpMessage.ttl);
-  });
-
-  it("message annotations match", () => {
-    if (!sbMessage._rawAmqpMessage.messageAnnotations) {
-      throw new Error("Message Annotations should not be empty");
+    const fakeDeliveryTag = new Buffer(16);
+    for (let i = 0; i < fakeDeliveryTag.length; i++) {
+      fakeDeliveryTag[i] = Math.floor(Math.random() * 255);
     }
+    const expectedLockToken = uuid_to_string(fakeDeliveryTag);
 
-    for (const key in message_annotations) {
-      if (Object.prototype.hasOwnProperty.call(message_annotations, key)) {
-        assert.equal(
-          sbMessage._rawAmqpMessage.messageAnnotations[key],
-          message_annotations[key],
-          `Unexpected value for key: ${key}`
-        );
+    it("Lock token in peekLock mode", () => {
+      const sbMessage = new ServiceBusMessageImpl(
+        amqpMessage,
+        { tag: fakeDeliveryTag } as Delivery,
+        false,
+        "peekLock"
+      );
+
+      assert.equal(sbMessage.lockToken, expectedLockToken, "Unexpected lock token found");
+    });
+
+    it("Lock token in receiveAndDelete mode", () => {
+      const sbMessage = new ServiceBusMessageImpl(
+        amqpMessage,
+        { tag: fakeDeliveryTag } as Delivery,
+        false,
+        "receiveAndDelete"
+      );
+
+      assert.equal(!!sbMessage.lockToken, false, "Unexpected lock token found");
+    });
+  });
+
+  describe("ServiceBusMessageImpl AmqpAnnotations unit tests", () => {
+    const message_annotations: MessageAnnotations = {};
+    message_annotations[Constants.enqueuedTime] = Date.now();
+    message_annotations[Constants.partitionKey] = "dummy-partition-key";
+    // message_annotations[Constants.viaPartitionKey] = "dummy-via-partition-key";
+    message_annotations["random-msg-annotation-key"] = "random-msg-annotation-value";
+
+    const delivery_annotations: DeliveryAnnotations = {
+      delivery_annotations_one: "delivery_annotations_one_value",
+      delivery_annotations_two: "delivery_annotations_two_value",
+      delivery_annotations_three: "delivery_annotations_three_value"
+    };
+
+    const amqpMessage: RheaMessage = {
+      body: "hello",
+      message_annotations,
+      delivery_annotations,
+      delivery_count: 2,
+      first_acquirer: true,
+      ttl: 123456,
+      durable: true,
+      priority: 9876,
+      message_id: "random_messageId",
+      reply_to: "random_replyTo",
+      to: "random_to",
+      correlation_id: "random_correlationId",
+      content_type: "random_contentType",
+      content_encoding: "random_contentEncoding",
+      absolute_expiry_time: 123908745,
+      creation_time: 45612349,
+      group_id: "random_groupId",
+      group_sequence: 98723560,
+      reply_to_group_id: "random_replyToGroupId",
+      subject: "random_subject",
+      user_id: "random_user_id"
+    };
+
+    const sbMessage = new ServiceBusMessageImpl(amqpMessage, fakeDelivery, false, "peekLock");
+
+    it("headers match", () => {
+      assert.equal(sbMessage._rawAmqpMessage.header?.firstAcquirer, amqpMessage.first_acquirer);
+      assert.equal(sbMessage._rawAmqpMessage.header?.timeToLive, amqpMessage.ttl);
+      assert.equal(sbMessage._rawAmqpMessage.header?.durable, amqpMessage.durable);
+      assert.equal(sbMessage._rawAmqpMessage.header?.priority, amqpMessage.priority);
+      assert.equal(sbMessage._rawAmqpMessage.header?.deliveryCount, amqpMessage.delivery_count);
+
+      assert.equal(sbMessage.deliveryCount, amqpMessage.delivery_count);
+      assert.equal(sbMessage.timeToLive, amqpMessage.ttl);
+    });
+
+    it("message annotations match", () => {
+      if (!sbMessage._rawAmqpMessage.messageAnnotations) {
+        throw new Error("Message Annotations should not be empty");
       }
-    }
 
-    assert.equal(
-      sbMessage.partitionKey,
-      message_annotations[Constants.partitionKey],
-      "Unexpected Partition Key"
-    );
-
-    // assert.equal(
-    //   sbMessage.viaPartitionKey,
-    //   message_annotations[Constants.viaPartitionKey],
-    //   "Unexpected Via Partition Key"
-    // );
-  });
-
-  it("delivery annotations match", () => {
-    if (!sbMessage._rawAmqpMessage.deliveryAnnotations) {
-      throw new Error("Delivery Annotations should not be empty");
-    }
-
-    for (const key in delivery_annotations) {
-      if (Object.prototype.hasOwnProperty.call(delivery_annotations, key)) {
-        assert.equal(
-          sbMessage._rawAmqpMessage.deliveryAnnotations[key],
-          delivery_annotations[key],
-          `Unexpected value for key: ${key}`
-        );
+      for (const key in message_annotations) {
+        if (Object.prototype.hasOwnProperty.call(message_annotations, key)) {
+          assert.equal(
+            sbMessage._rawAmqpMessage.messageAnnotations[key],
+            message_annotations[key],
+            `Unexpected value for key: ${key}`
+          );
+        }
       }
-    }
-  });
 
-  it("properties match", () => {
-    assert.equal(sbMessage._rawAmqpMessage.properties?.messageId, amqpMessage.message_id);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.replyTo, amqpMessage.reply_to);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.to, amqpMessage.to);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.correlationId, amqpMessage.correlation_id);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.contentType, amqpMessage.content_type);
-    assert.equal(
-      sbMessage._rawAmqpMessage.properties?.contentEncoding,
-      amqpMessage.content_encoding
-    );
-    assert.equal(
-      sbMessage._rawAmqpMessage.properties?.absoluteExpiryTime,
-      amqpMessage.absolute_expiry_time
-    );
-    assert.equal(sbMessage._rawAmqpMessage.properties?.creationTime, amqpMessage.creation_time);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.groupId, amqpMessage.group_id);
-    assert.equal(
-      sbMessage._rawAmqpMessage.properties?.replyToGroupId,
-      amqpMessage.reply_to_group_id
-    );
-    assert.equal(sbMessage._rawAmqpMessage.properties?.groupSequence, amqpMessage.group_sequence);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.subject, amqpMessage.subject);
-    // assert.equal(sbMessage._rawAmqpMessage.properties?.userId, amqpMessage.user_id);
+      assert.equal(
+        sbMessage.partitionKey,
+        message_annotations[Constants.partitionKey],
+        "Unexpected Partition Key"
+      );
 
-    assert.equal(sbMessage._rawAmqpMessage.properties?.messageId, sbMessage.messageId);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.replyTo, sbMessage.replyTo);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.to, sbMessage.to);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.correlationId, sbMessage.correlationId);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.contentType, sbMessage.contentType);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.groupId, sbMessage.sessionId);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.replyToGroupId, sbMessage.replyToSessionId);
-    assert.equal(sbMessage._rawAmqpMessage.properties?.subject, sbMessage.subject);
+      // assert.equal(
+      //   sbMessage.viaPartitionKey,
+      //   message_annotations[Constants.viaPartitionKey],
+      //   "Unexpected Via Partition Key"
+      // );
+    });
+
+    it("delivery annotations match", () => {
+      if (!sbMessage._rawAmqpMessage.deliveryAnnotations) {
+        throw new Error("Delivery Annotations should not be empty");
+      }
+
+      for (const key in delivery_annotations) {
+        if (Object.prototype.hasOwnProperty.call(delivery_annotations, key)) {
+          assert.equal(
+            sbMessage._rawAmqpMessage.deliveryAnnotations[key],
+            delivery_annotations[key],
+            `Unexpected value for key: ${key}`
+          );
+        }
+      }
+    });
+
+    it("properties match", () => {
+      assert.equal(sbMessage._rawAmqpMessage.properties?.messageId, amqpMessage.message_id);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.replyTo, amqpMessage.reply_to);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.to, amqpMessage.to);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.correlationId, amqpMessage.correlation_id);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.contentType, amqpMessage.content_type);
+      assert.equal(
+        sbMessage._rawAmqpMessage.properties?.contentEncoding,
+        amqpMessage.content_encoding
+      );
+      assert.equal(
+        sbMessage._rawAmqpMessage.properties?.absoluteExpiryTime,
+        amqpMessage.absolute_expiry_time
+      );
+      assert.equal(sbMessage._rawAmqpMessage.properties?.creationTime, amqpMessage.creation_time);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.groupId, amqpMessage.group_id);
+      assert.equal(
+        sbMessage._rawAmqpMessage.properties?.replyToGroupId,
+        amqpMessage.reply_to_group_id
+      );
+      assert.equal(sbMessage._rawAmqpMessage.properties?.groupSequence, amqpMessage.group_sequence);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.subject, amqpMessage.subject);
+      // assert.equal(sbMessage._rawAmqpMessage.properties?.userId, amqpMessage.user_id);
+
+      assert.equal(sbMessage._rawAmqpMessage.properties?.messageId, sbMessage.messageId);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.replyTo, sbMessage.replyTo);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.to, sbMessage.to);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.correlationId, sbMessage.correlationId);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.contentType, sbMessage.contentType);
+      assert.equal(sbMessage._rawAmqpMessage.properties?.groupId, sbMessage.sessionId);
+      assert.equal(
+        sbMessage._rawAmqpMessage.properties?.replyToGroupId,
+        sbMessage.replyToSessionId
+      );
+      assert.equal(sbMessage._rawAmqpMessage.properties?.subject, sbMessage.subject);
+    });
   });
 });


### PR DESCRIPTION
Expanding the types for applicationProperties to allow `null` (and not `undefined`).

`null` and `undefined` both get mapped to 'null' if you round-trip through JavaScript. Sending through .net will properly map to null as well. 

Fixes #14329 