### PR TITLE
Update TypeScript version to use ~

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -69,6 +69,7 @@
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typedoc": "0.15.2"
+    "typedoc": "0.15.2",
+    "typescript": "~4.1.2"
   }
 }

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -44,7 +44,7 @@
     "minimist": "~1.2.5",
     "prettier": "^1.16.4",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -93,7 +93,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "mocha-junit-reporter": "^1.18.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -74,7 +74,7 @@
     "eslint-config-prettier": "^7.0.0",
     "glob": "^7.1.2",
     "json-schema": "^0.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -109,7 +109,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "@azure/test-utils-recorder": "^1.0.0",
     "typedoc": "0.15.2"

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -137,7 +137,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "uglify-js": "^3.4.9",
     "cross-env": "^7.0.2",
     "typedoc": "0.15.2"

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -64,7 +64,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "safe-buffer": "^5.2.1",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/attestation/attestation/README.md",

--- a/sdk/communication/communication-administration/package.json
+++ b/sdk/communication/communication-administration/package.json
@@ -124,7 +124,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "//sampleConfiguration": {

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -120,7 +120,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -112,7 +112,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -122,7 +122,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -122,7 +122,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "//sampleConfiguration": {

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -120,7 +120,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -114,7 +114,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typedoc": "0.15.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1"
   },
   "//sampleConfiguration": {

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -116,7 +116,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -125,7 +125,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "ws": "^7.1.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^8.0.0",
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -92,7 +92,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -122,7 +122,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-crypto/package.json
+++ b/sdk/core/core-crypto/package.json
@@ -115,7 +115,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -194,7 +194,7 @@
     "shx": "^0.3.2",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "uglify-js": "^3.4.9",
     "xhr-mock": "^2.4.1",
     "typedoc": "0.15.2"

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -138,7 +138,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "uglify-js": "^3.4.9",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -76,7 +76,7 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -141,7 +141,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2",
     "sinon": "^9.0.2",

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -108,7 +108,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -116,7 +116,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -112,7 +112,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -135,6 +135,6 @@
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
     "typedoc": "0.15.2",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   }
 }

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -41,7 +41,7 @@
     "rollup": "^1.16.3",
     "source-map-support": "^0.5.9",
     "typedoc": "0.15.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "uglify-js": "^3.4.9",
     "uuid": "^8.3.0"
   },

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -117,7 +117,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -134,7 +134,7 @@
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/eventgrid/perf-tests/eventgrid/package.json
+++ b/sdk/eventgrid/perf-tests/eventgrid/package.json
@@ -18,7 +18,7 @@
     "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "private": true,
   "scripts": {

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -162,7 +162,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "ws": "^7.1.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -119,7 +119,7 @@
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "ws": "^7.1.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -116,7 +116,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -57,7 +57,7 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -51,6 +51,7 @@
     "yargs": "^15.0.0"
   },
   "devDependencies": {
-    "eslint": "^7.15.0"
+    "eslint": "^7.15.0",
+    "typescript": "~4.1.2"
   }
 }

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -37,21 +37,20 @@
   "dependencies": {
     "@azure/event-hubs": "^2.1.4",
     "@azure/event-processor-host": "^2.0.0",
-    "@types/node": "^8.0.0",
-    "@types/uuid": "^8.0.0",
-    "@types/yargs": "^15.0.5",
     "async-lock": "^1.1.3",
     "death": "^1.1.0",
     "debug": "^4.1.1",
     "rhea": "^1.0.24",
-    "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
-    "typescript": "4.1.2",
     "uuid": "^8.3.0",
     "yargs": "^15.0.0"
   },
   "devDependencies": {
+    "@types/node": "^8.0.0",
+    "@types/uuid": "^8.0.0",
+    "@types/yargs": "^15.0.5",
     "eslint": "^7.15.0",
+    "rimraf": "^3.0.0",
     "typescript": "~4.1.2"
   }
 }

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -123,7 +123,7 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "//sampleConfiguration": {

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -136,7 +136,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "sinon": "^9.0.2",
     "@types/sinon": "^9.0.4",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -123,7 +123,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "uuid": "^8.3.0",
     "typedoc": "0.15.2"
   }

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -151,7 +151,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "url": "^0.11.0",
     "typedoc": "0.15.2"
   }

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -67,6 +67,6 @@
     "eslint": "^7.15.0",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   }
 }

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -147,7 +147,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "url": "^0.11.0",
     "typedoc": "0.15.2"
   }

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -149,7 +149,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "url": "^0.11.0",
     "typedoc": "0.15.2"
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -123,7 +123,7 @@
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "//sampleConfiguration": {

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -108,7 +108,7 @@
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -81,7 +81,7 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   },
   "dependencies": {

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -115,7 +115,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -115,7 +115,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -126,7 +126,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "typedoc": "0.15.2"
   }
 }

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -128,7 +128,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -170,7 +170,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "ws": "^7.1.1",
     "sinon": "^9.0.2",
     "@types/sinon": "^9.0.4",

--- a/sdk/storage/perf-tests/storage-blob/package.json
+++ b/sdk/storage/perf-tests/storage-blob/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "private": true,
   "scripts": {

--- a/sdk/storage/perf-tests/storage-file-datalake/package.json
+++ b/sdk/storage/perf-tests/storage-file-datalake/package.json
@@ -20,7 +20,7 @@
     "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "private": true,
   "scripts": {

--- a/sdk/storage/perf-tests/storage-file-share/package.json
+++ b/sdk/storage/perf-tests/storage-file-share/package.json
@@ -20,7 +20,7 @@
     "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "private": true,
   "scripts": {

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -152,7 +152,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "sinon": "^9.0.2",
     "typedoc": "0.15.2"

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -179,7 +179,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -159,7 +159,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -165,7 +165,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -111,7 +111,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1"
   }
 }

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -159,7 +159,7 @@
     "rollup-plugin-visualizer": "^4.0.4",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   }

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -31,7 +31,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/synapse-access-control.d.ts",
   "devDependencies": {
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -33,7 +33,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/synapse-artifacts.d.ts",
   "devDependencies": {
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -32,7 +32,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/synapse-managed-private-endpoints.d.ts",
   "devDependencies": {
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -31,7 +31,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/synapse-monitoring.d.ts",
   "devDependencies": {
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -31,7 +31,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/synapse-spark.d.ts",
   "devDependencies": {
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "eslint": "^7.15.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -117,7 +117,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
     "sinon": "^9.0.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1",
     "dotenv": "^8.2.0",
     "@azure/test-utils-recorder": "^1.0.0",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -124,7 +124,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "typedoc": "0.15.2",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "util": "^0.12.1"
   },
   "//sampleConfiguration": {

--- a/sdk/test-utils/multi-version/package.json
+++ b/sdk/test-utils/multi-version/package.json
@@ -80,6 +80,6 @@
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   }
 }

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -82,6 +82,6 @@
     "karma-env-preprocessor": "^0.1.1",
     "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   }
 }

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -115,7 +115,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "xhr-mock": "^2.4.1"
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -131,7 +131,7 @@
     "rollup": "^1.16.3",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.9",
-    "typescript": "4.1.2",
+    "typescript": "~4.1.2",
     "ts-node": "^8.3.0",
     "karma-source-map-support": "~1.4.0",
     "typedoc": "0.15.2"

--- a/sdk/textanalytics/perf-tests/text-analytics/package.json
+++ b/sdk/textanalytics/perf-tests/text-analytics/package.json
@@ -19,7 +19,7 @@
     "rimraf": "^3.0.0",
     "tslib": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "4.1.2"
+    "typescript": "~4.1.2"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
I confirmed with the TypeScript team that patch releases should not introduce breaking changes. This PR uses tilde in TypeScript version we use so get the latest patch releases for v4.1.