### PR TITLE
Run create API review step before publishing artifacts

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -68,11 +68,6 @@ jobs:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           TestPipeline: ${{ parameters.TestPipeline }}
 
-      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
-        parameters:
-          Artifacts: ${{ parameters.Artifacts }}
-          ArtifactPath: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}
-
   - job: "Analyze"
     dependsOn: "Build"
     variables:

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -84,5 +84,4 @@ steps:
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)/Documentation'
-      CustomCondition: ${{ parameters.BuildDocs }}
       ArtifactName: 'documentation'

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -72,20 +72,17 @@ steps:
       flattenFolders: true
     displayName: "Copy packages"
 
-  - task: PublishPipelineArtifact@1
-    condition: succeededOrFailed()
-    displayName: "Publish artifacts"
-    inputs:
-      artifactName: packages
-      path: $(Build.ArtifactStagingDirectory)
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'packages'
 
   - template: ../steps/generate-doc.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}
 
-  - task: PublishPipelineArtifact@1
-    condition: succeededOrFailed()
-    displayName: "Publish artifacts"
-    inputs:
-      artifactName: documentation
-      path: $(Build.ArtifactStagingDirectory)/Documentation
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)/Documentation'
+      CustomCondition: ${{ parameters.BuildDocs }}
+      ArtifactName: 'documentation'

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -55,6 +55,11 @@ steps:
       node eng/tools/rush-runner.js unlink
     displayName: "Unlink dependencies"
 
+  - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+    parameters:
+      Artifacts: ${{ parameters.Artifacts }}
+      ArtifactPath: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}
+
   # It's important for performance to pass "sdk" as "sourceFolder" rather than as a prefix in "contents".
   # The task first enumerates all files under "sourceFolder", then matches them against the "contents" pattern.
   - task: CopyFiles@2


### PR DESCRIPTION
Run API review create step before publishing artifact to support rerunning build job. Current rerun fails if initial failure is due to pending API approval since it tries to republish which is currently not supported.