### PR TITLE
[identity] Replace use of `child_process.exec` with `execFile`.

### DIFF
--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -39,8 +39,9 @@ export class AzureCliCredential implements TokenCredential {
   ): Promise<{ stdout: string; stderr: string; error: Error | null }> {
     return new Promise((resolve, reject) => {
       try {
-        child_process.exec(
-          `az account get-access-token --output json --resource ${resource}`,
+        child_process.execFile(
+          "az",
+          ["account", "get-access-token", "--output", "json", "--resource", resource],
           { cwd: getSafeWorkingDir() },
           (error, stdout, stderr) => {
             resolve({ stdout: stdout, stderr: stderr, error });


### PR DESCRIPTION
Looking at the code, it seems that we are doing a pretty good job of making sure scopes can't escape out into the shell, so I don't think there is currently an issue here. However, since `exec` can be very tricky to use diligently, this PR hardens the code a little to use the somewhat safer `execFile` which doesn't invoke an entire shell by default.