### PR TITLE
Make tag as optional

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -85,7 +85,7 @@ stages:
                         inputs:
                           targetType: filePath
                           filePath: "eng/tools/publish-to-npm.ps1"
-                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $(Tag) -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
+                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "$(Tag)" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
 
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -85,7 +85,7 @@ stages:
                         inputs:
                           targetType: filePath
                           filePath: "eng/tools/publish-to-npm.ps1"
-                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "$(Tag)" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
+                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $env:Tag -additionalTag $env:AdditionalTag -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
 
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:

--- a/eng/tools/publish-to-npm.ps1
+++ b/eng/tools/publish-to-npm.ps1
@@ -1,7 +1,7 @@
 param (
   $pathToArtifacts,
   $accessLevel,
-  $tag,
+  $tag="",
   $additionalTag="",
   $registry,
   $npmToken,
@@ -124,8 +124,17 @@ try {
 
     foreach ($p in $packageList) {
         if($p.Publish) {
-            Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag"
-            npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag
+            if ($tag)
+            {
+              Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag"
+              npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag
+            }
+            else
+            {
+              Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true"
+              npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true
+            }
+
             if ($LastExitCode -ne 0) {
                 Write-Host "npm publish failed with exit code $LastExitCode"
                 exit 1


### PR DESCRIPTION
tag is not optional now to publish a package to npm. This causes an issue when a hotfix package is required to be released. So this version get released as latest and then manually needs to adjust the tag to flip it back to actual latest version. This PR is to support publishing package to npm without any tag. I have another issue in backlog to support setting latest and next tag automatically. This issue will be taken care separately.