### PR TITLE
[Identity] Removing the null return type on getToken()

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -49,7 +49,7 @@ export class AuthenticationRequired extends CredentialUnavailable {
 export class AuthorizationCodeCredential implements TokenCredential {
     constructor(tenantId: string | "common", clientId: string, clientSecret: string, authorizationCode: string, redirectUri: string, options?: TokenCredentialOptions);
     constructor(tenantId: string | "common", clientId: string, authorizationCode: string, redirectUri: string, options?: TokenCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     }
 
 // @public
@@ -67,7 +67,7 @@ export class AzureCliCredential implements TokenCredential {
         stderr: string;
         error: Error | null;
     }>;
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
 }
 
 // @public
@@ -76,7 +76,7 @@ export type BrowserLoginStyle = "redirect" | "popup";
 // @public
 export class ChainedTokenCredential implements TokenCredential {
     constructor(...sources: TokenCredential[]);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     protected UnavailableMessage: string;
 }
 
@@ -151,7 +151,7 @@ export type DeviceCodePromptCallback = (deviceCodeInfo: DeviceCodeInfo) => void;
 // @public
 export class EnvironmentCredential implements TokenCredential {
     constructor(options?: TokenCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
 }
 
 // @public
@@ -208,7 +208,7 @@ export const logger: AzureLogger;
 export class ManagedIdentityCredential implements TokenCredential {
     constructor(clientId: string, options?: TokenCredentialOptions);
     constructor(options?: TokenCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     }
 
 // @public
@@ -243,7 +243,7 @@ export interface UsernamePasswordCredentialOptions extends InteractiveCredential
 // @public
 export class VisualStudioCodeCredential implements TokenCredential {
     constructor(options?: VisualStudioCodeCredentialOptions);
-    getToken(scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken>;
     }
 
 // @public

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -184,9 +184,9 @@ export class AuthorizationCodeCredential implements TokenCredential {
 
       this.lastTokenResponse = tokenResponse;
       logger.getToken.info(formatSuccess(scopes));
-      const token = (tokenResponse && tokenResponse.accessToken) || null;
+      const token = tokenResponse && tokenResponse.accessToken;
 
-      if (token === null) {
+      if (!token) {
         throw new CredentialUnavailable("Failed to retrieve a valid token");
       }
       return token;

--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -65,7 +65,7 @@ export class AzureCliCredential implements TokenCredential {
   public async getToken(
     scopes: string | string[],
     options?: GetTokenOptions
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     return new Promise((resolve, reject) => {
       const scope = typeof scopes === "string" ? scopes : scopes[0];
       logger.getToken.info(`Using the scope ${scope}`);

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -51,10 +51,7 @@ export class ChainedTokenCredential implements TokenCredential {
    * @param options - The options used to configure any requests this
    *                `TokenCredential` implementation might make.
    */
-  async getToken(
-    scopes: string | string[],
-    options?: GetTokenOptions
-  ): Promise<AccessToken> {
+  async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken> {
     let token = null;
     const errors = [];
 

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
-import { AggregateAuthenticationError } from "../client/errors";
+import { AggregateAuthenticationError, CredentialUnavailable } from "../client/errors";
 import { createSpan } from "../util/tracing";
 import { CanonicalCode } from "@opentelemetry/api";
 import { credentialLogger, formatSuccess, formatError } from "../util/logging";
@@ -54,7 +54,7 @@ export class ChainedTokenCredential implements TokenCredential {
   async getToken(
     scopes: string | string[],
     options?: GetTokenOptions
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     let token = null;
     const errors = [];
 
@@ -86,6 +86,10 @@ export class ChainedTokenCredential implements TokenCredential {
     span.end();
 
     logger.getToken.info(formatSuccess(scopes));
+
+    if (token === null) {
+      throw new CredentialUnavailable("Failed to retrieve a valid token");
+    }
     return token;
   }
 }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
@@ -29,7 +29,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     throw BrowserNotSupportedError;
   }
 
-  public getToken(): Promise<AccessToken | null> {
+  public getToken(): Promise<AccessToken> {
     logger.getToken.info(formatError("", BrowserNotSupportedError));
     throw BrowserNotSupportedError;
   }

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -109,10 +109,7 @@ export class EnvironmentCredential implements TokenCredential {
    * @param scopes - The list of scopes for which the token will have access.
    * @param options - Optional parameters. See {@link GetTokenOptions}.
    */
-  async getToken(
-    scopes: string | string[],
-    options: GetTokenOptions = {}
-  ): Promise<AccessToken> {
+  async getToken(scopes: string | string[], options: GetTokenOptions = {}): Promise<AccessToken> {
     return trace("EnvironmentCredential.getToken", options, async (newOptions) => {
       if (this._credential) {
         try {

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -42,7 +42,10 @@ const logger = credentialLogger("EnvironmentCredential");
  * documentation of that class for more details.
  */
 export class EnvironmentCredential implements TokenCredential {
-  private _credential?: TokenCredential = undefined;
+  private _credential?:
+    | ClientSecretCredential
+    | ClientCertificateCredential
+    | UsernamePasswordCredential = undefined;
   /**
    * Creates an instance of the EnvironmentCredential class and reads
    * client secret details from environment variables.  If the expected
@@ -115,9 +118,6 @@ export class EnvironmentCredential implements TokenCredential {
         try {
           const result = await this._credential.getToken(scopes, newOptions);
           logger.getToken.info(formatSuccess(scopes));
-          if (result === null) {
-            throw new CredentialUnavailable("The credential couldn't retrieve a token.");
-          }
           return result;
         } catch (err) {
           const authenticationError = new AuthenticationError(400, {

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -131,7 +131,9 @@ export class EnvironmentCredential implements TokenCredential {
           throw authenticationError;
         }
       }
-      throw new CredentialUnavailable("No underlying credential could be used.");
+      throw new CredentialUnavailable(
+        "EnvironmentCredential is unavailable. No underlying credential could be used."
+      );
     });
   }
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -135,7 +135,7 @@ export class ManagedIdentityCredential implements TokenCredential {
   public async getToken(
     scopes: string | string[],
     options?: GetTokenOptions
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     let result: AccessToken | null = null;
 
     const { span, updatedOptions } = createSpan("ManagedIdentityCredential-getToken", options);

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -169,7 +169,7 @@ export class VisualStudioCodeCredential implements TokenCredential {
   public async getToken(
     scopes: string | string[],
     _options?: GetTokenOptions
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     await this.prepareOnce();
     if (!keytar) {
       throw new CredentialUnavailable(

--- a/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
@@ -217,7 +217,7 @@ describe("EnvironmentCredential", function() {
       credential.getToken(scope),
       (error: CredentialUnavailable) =>
         error.message.indexOf(
-          "EnvironmentCredential is unavailable. Environment variables are not fully configured."
+          "EnvironmentCredential is unavailable. No underlying credential could be used."
         ) > -1
     );
   });


### PR DESCRIPTION
This PR removes the `null` return type on the `getToken()` of the Identity credentials.

Identity credentials extend TokenCredential, which continues to have `null` as a possibility.

While TokenCredentials may return null, Identity does not need to return null since it will throw at least a `CredentialUnavailable` error instead of returning null.

This decision doesn't necessarily need to impact the the base type TokenCredential because other TokenCredential implementations may use `null` reasonably outside of Identity.

It also does not necessarily need to impact the rest of our codebase since outside of Identity we compare the credential against the TokenCredential base class, which means that the null possibility exists if we ever decide to implement credentials outside of Identity, as we have done so.

The changelog entries will be available here: https://github.com/Azure/azure-sdk-for-js/pull/14405

Fixes #14421