### PR TITLE
Fix order of parameters supplied to sendTelemetry

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/digitalTwinsClient.ts
@@ -637,8 +637,8 @@ export class DigitalTwinsClient {
     try {
       return this.client.digitalTwins.sendTelemetry(
         digitalTwinId,
-        payload,
         messageId,
+        payload,
         updatedOptions
       );
     } catch (e) {


### PR DESCRIPTION
Upon inspection, it seems like the parameters to `sendTelemetry()` were supplied in the wrong order. This PR corrects that. 