### PR TITLE
[EventGrid] Update documentation link

### DIFF
--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -10,7 +10,7 @@ Use the client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventgrid/eventgrid/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/eventgrid/v/next) |
-[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/eventgrid/?view=azure-node-preview) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/eventgrid/) |
 [Product documentation](https://docs.microsoft.com/azure/event-grid/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventgrid/eventgrid/samples)
 


### PR DESCRIPTION
Now that the library has GA'd, we can remove the query parameter and
point at the latest docs.