### PR TITLE
[Service Bus] Update perf tests to use a single sender for all instances

### DIFF
--- a/sdk/servicebus/service-bus/test/perf/track-1/package.json
+++ b/sdk/servicebus/service-bus/test/perf/track-1/package.json
@@ -8,6 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "@azure/service-bus": "^1.1.10",
+    "@azure/service-bus-v7": "npm:@azure/service-bus@^7.0.3",
     "@azure/test-utils-perfstress": "file:../../../../../test-utils/perfstress/azure-test-utils-perfstress-1.0.0.tgz"
   },
   "scripts": {

--- a/sdk/servicebus/service-bus/test/perf/track-1/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/perf/track-1/sendBatch.spec.ts
@@ -11,7 +11,7 @@ interface SendTestOptions {
 }
 
 export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
-  sender: Sender;
+  static sender = ServiceBusTest.sbClient.createQueueClient(BatchSendTest.queueName).createSender();
   batch: SendableMessageInfo[];
   public options: PerfStressOptionDictionary<SendTestOptions> = {
     messageBodySize: {
@@ -32,7 +32,6 @@ export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
 
   constructor() {
     super();
-    this.sender = this.sbClient.createQueueClient(BatchSendTest.queueName).createSender();
     const sbMessage = {
       body: Buffer.alloc(this.parsedOptions.messageBodySize.value!)
     };
@@ -40,6 +39,6 @@ export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
   }
 
   async runAsync(): Promise<void> {
-    await this.sender.sendBatch(this.batch);
+    await BatchSendTest.sender.sendBatch(this.batch);
   }
 }

--- a/sdk/servicebus/service-bus/test/perf/track-2/README.md
+++ b/sdk/servicebus/service-bus/test/perf/track-2/README.md
@@ -5,7 +5,6 @@
 3. Create a service-bus namespace and populate the .env file at `servicebus\service-bus` folder with `SERVICEBUS_CONNECTION_STRING` variables.
 4. Run the tests as follows
 
-   - simple send
-     - `npm run perf-test:node -- SimpleSendTest --warmup 2 --duration 7 --iterations 2 --parallel 2`
    - batch send
      - `npm run perf-test:node -- BatchSendTest --warmup 2 --duration 7 --parallel 2`
+     - `npm run perf-test:node -- BatchSendTest --warmup 1 --duration 25 --iterations 2 --parallel 32 --messageBodySize 10240 --numberOfMessages 10`

--- a/sdk/servicebus/service-bus/test/perf/track-2/sbBase.spec.ts
+++ b/sdk/servicebus/service-bus/test/perf/track-2/sbBase.spec.ts
@@ -9,16 +9,14 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const connectionString = getEnvVar("SERVICEBUS_CONNECTION_STRING");
-const sbClient = new ServiceBusClient(connectionString);
 
 export abstract class ServiceBusTest<TOptions> extends PerfStressTest<TOptions> {
-  sbClient: ServiceBusClient;
+  static sbClient: ServiceBusClient = new ServiceBusClient(connectionString);
   static sbAdminClient = new ServiceBusAdministrationClient(connectionString);
   static queueName = `newqueue-${Math.ceil(Math.random() * 1000)}`;
 
   constructor() {
     super();
-    this.sbClient = sbClient;
   }
 
   public async globalSetup(): Promise<void> {
@@ -26,7 +24,7 @@ export abstract class ServiceBusTest<TOptions> extends PerfStressTest<TOptions> 
   }
 
   public async globalCleanup(): Promise<void> {
+    await ServiceBusTest.sbClient.close();
     await ServiceBusTest.sbAdminClient.deleteQueue(ServiceBusTest.queueName);
-    await this.sbClient.close();
   }
 }

--- a/sdk/servicebus/service-bus/test/perf/track-2/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/perf/track-2/sendBatch.spec.ts
@@ -11,7 +11,7 @@ interface SendTestOptions {
 }
 
 export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
-  sender: ServiceBusSender;
+  static sender: ServiceBusSender = ServiceBusTest.sbClient.createSender(BatchSendTest.queueName);
   batch: ServiceBusMessage[];
   public options: PerfStressOptionDictionary<SendTestOptions> = {
     messageBodySize: {
@@ -32,7 +32,6 @@ export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
 
   constructor() {
     super();
-    this.sender = this.sbClient.createSender(BatchSendTest.queueName);
     const sbMessage = {
       body: Buffer.alloc(this.parsedOptions.messageBodySize.value!)
     };
@@ -40,6 +39,6 @@ export class BatchSendTest extends ServiceBusTest<SendTestOptions> {
   }
 
   async runAsync(): Promise<void> {
-    await this.sender.sendMessages(this.batch);
+    await BatchSendTest.sender.sendMessages(this.batch);
   }
 }


### PR DESCRIPTION
- Imports v7 in the v1 tests to allow creating the resources
- Makes sender static in both v1 and v7