### PR TITLE
[EventGrid] Move Samples to `latest`

### DIFF
--- a/sdk/eventgrid/eventgrid/samples/javascript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/javascript/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/sdk/eventgrid/samples/javascript/#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/eventgrid": "next",
+    "@azure/eventgrid": "latest",
     "@azure/service-bus": "^7.0.0",
     "dotenv": "^8.2.0"
   },

--- a/sdk/eventgrid/eventgrid/samples/typescript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/typescript/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/sdk/eventgrid/eventgrid/samples/typescript/#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/eventgrid": "next",
+    "@azure/eventgrid": "latest",
     "@azure/service-bus": "^7.0.0",
     "dotenv": "^8.2.0"
   },


### PR DESCRIPTION
Now that we have GA'd we can use `latest` for our samples instead of `next`.