### PR TITLE
[service-bus] Adding back null type for tracing

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -569,7 +569,7 @@ export interface TopicRuntimeProperties {
 // @public
 export interface TryAddOptions {
     // @deprecated (undocumented)
-    parentSpan?: Span | SpanContext;
+    parentSpan?: Span | SpanContext | null;
     tracingOptions?: OperationTracingOptions;
 }
 

--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -26,7 +26,7 @@ export interface TryAddOptions {
   /**
    * @deprecated Tracing options have been moved to the `tracingOptions` property.
    */
-  parentSpan?: Span | SpanContext;
+  parentSpan?: Span | SpanContext | null;
 }
 
 /**


### PR DESCRIPTION
When I restored the legacy option I didn't restore the option for the caller to pass in `null` as well.