### PR TITLE
[core-client] Fix `appendPath()` issue when path value to append contains `?` 

### DIFF
--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -103,7 +103,15 @@ function appendPath(url: string, pathToAppend?: string): string {
     pathToAppend = pathToAppend.substring(1);
   }
 
-  newPath = newPath + pathToAppend;
+  const searchStart = pathToAppend.indexOf("?");
+  if (searchStart !== -1) {
+    let path = pathToAppend.substr(0, searchStart);
+    const search = pathToAppend.substr(searchStart + 1);
+    newPath = newPath + path;
+    parsedUrl.search = parsedUrl.search ? parsedUrl.search + "&" + search : search;
+  } else {
+    newPath = newPath + pathToAppend;
+  }
 
   parsedUrl.pathname = newPath;
 

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -105,10 +105,10 @@ function appendPath(url: string, pathToAppend?: string): string {
 
   const searchStart = pathToAppend.indexOf("?");
   if (searchStart !== -1) {
-    const path = pathToAppend.substr(0, searchStart);
-    const search = pathToAppend.substr(searchStart + 1);
+    const path = pathToAppend.substring(0, searchStart);
+    const search = pathToAppend.substring(searchStart + 1);
     newPath = newPath + path;
-    parsedUrl.search = parsedUrl.search ? parsedUrl.search + "&" + search : search;
+    parsedUrl.search = parsedUrl.search ? `${parsedUrl.search}&${search}` : search;
   } else {
     newPath = newPath + pathToAppend;
   }

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -105,7 +105,7 @@ function appendPath(url: string, pathToAppend?: string): string {
 
   const searchStart = pathToAppend.indexOf("?");
   if (searchStart !== -1) {
-    let path = pathToAppend.substr(0, searchStart);
+    const path = pathToAppend.substr(0, searchStart);
     const search = pathToAppend.substr(searchStart + 1);
     newPath = newPath + path;
     parsedUrl.search = parsedUrl.search ? parsedUrl.search + "&" + search : search;

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -108,7 +108,9 @@ function appendPath(url: string, pathToAppend?: string): string {
     const path = pathToAppend.substring(0, searchStart);
     const search = pathToAppend.substring(searchStart + 1);
     newPath = newPath + path;
-    parsedUrl.search = parsedUrl.search ? `${parsedUrl.search}&${search}` : search;
+    if (search) {
+      parsedUrl.search = parsedUrl.search ? `${parsedUrl.search}&${search}` : search;
+    }
   } else {
     newPath = newPath + pathToAppend;
   }

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -115,4 +115,31 @@ describe("getRequestUrl", function() {
     );
     assert.strictEqual(result, "https://test.com/path?stringQuery=");
   });
+
+  it("should work with replacement having both path and search part", function() {
+    const result = getRequestUrl(
+      "https://test.com/",
+      {
+        path: "{nextLink}",
+        httpMethod: "GET",
+        responses: {},
+        serializer,
+        urlParameters: [
+          {
+            parameterPath: "nextLink",
+            mapper: {
+              serializedName: "nextLink",
+              required: true,
+              type: {
+                name: "String"
+              }
+            }
+          }
+        ]
+      },
+      { nextLink: "/path?abc=def" },
+      {}
+    );
+    assert.strictEqual(result, "https://test.com/path?abc=def");
+  });
 });

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -133,13 +133,14 @@ describe("getRequestUrl", function() {
               type: {
                 name: "String"
               }
-            }
+            },
+            skipEncoding: true
           }
         ]
       },
-      { nextLink: "/path?abc=def" },
+      { nextLink: "/path?abc%3Ddef" },
       {}
     );
-    assert.strictEqual(result, "https://test.com/path?abc=def");
+    assert.strictEqual(result, "https://test.com/path?abc%3Ddef");
   });
 });


### PR DESCRIPTION
There's an issue in appending to path when the value to append
contains `?`. For example,

```ts
  const parsedUrl = new URL("https://example.com");
  parsedUrl.pathname = "/path?abc%3Ddef";
```

will cause the question mark to be encoded, then `parsedUrl.toString()`
would give us unexpected `'https://example.com/path%3Fabc%3Ddef'`

This PR fixes the issue by appending path and search part separately
when `?` is included in the value to append to path.