### PR TITLE
[communication-identity] fix missing import in README

### DIFF
--- a/sdk/communication/communication-identity/README.md
+++ b/sdk/communication/communication-identity/README.md
@@ -55,6 +55,7 @@ const client = new CommunicationIdentityClient(connectionString);
 ### Using a `TokenCredential`
 
 ```typescript
+import { DefaultAzureCredential } from "@azure/identity";
 import { CommunicationIdentityClient } from "@azure/communication-identity";
 
 const credential = new DefaultAzureCredential();


### PR DESCRIPTION
Fixes #13997 

The samples don't need fixing as they don't use `DefaultAzureCredential`