### PR TITLE
Pass ReleaseDate by argument name to allow addition of more arguments

### DIFF
--- a/eng/tools/versioning/VersionUtils.js
+++ b/eng/tools/versioning/VersionUtils.js
@@ -57,7 +57,7 @@ function updateChangelog(
     "--ReplaceLatestEntryTitle:$" + replaceLatestVersionTitle
   ];
   if (releaseDate != null) {
-    args.push(releaseDate);
+    args.push("--ReleaseDate:" + releaseDate);
   }
   child = spawnSync("pwsh", args);
   const out = child.stdout.toString();


### PR DESCRIPTION
- This is to allow me add `ChangelogPath` argument to the `Update-Changelog.ps1` script.