### PR TITLE
[Cosmos] Pins abort controller version since we depend on it with 3.10.4

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Release History
 
+## 3.10.5 (2021-03-25)
+
+- BUGFIX: Pins node-abort-controller version as we depend on a type in v1.2.0.
+
 ## 3.10.4 (2021-03-23)
 
-- FEATURE: Adds Bulk continueOnError option
+- FEATURE: Adds Bulk continueOnError option.
 
 ## 3.10.3 (2021-03-12)
 

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for SQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -90,7 +90,7 @@
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "jsbi": "^3.1.3",
-    "node-abort-controller": "^1.0.4",
+    "node-abort-controller": "^1.2.0",
     "node-fetch": "^2.6.0",
     "priorityqueuejs": "^1.0.0",
     "semaphore": "^1.0.5",


### PR DESCRIPTION
We recently began importing { AbortSignal } as a type https://github.com/Azure/azure-sdk-for-js/pull/14433/files
which means we need users to have `node-abort-controller` v1.2.0 https://github.com/southpolesteve/node-abort-controller/blob/master/CHANGELOG.md