### PR TITLE
[dev-tool] Fix newline sigil in ts-to-js to accept CRLF

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/tsToJs.ts
+++ b/common/tools/dev-tool/src/commands/samples/tsToJs.ts
@@ -30,8 +30,8 @@ const compilerOptions: ts.CompilerOptions = {
   module: ts.ModuleKind.ES2015
 };
 
-const NEWLINE_SIGIL = "\n//@@TS-MAGIC-NEWLINE@@\n";
-const NEWLINE_SIGIL_SEARCH = /\n\s*\/\/@@TS-MAGIC-NEWLINE@@\n/;
+const NEWLINE_SIGIL = `${EOL}//@@TS-MAGIC-NEWLINE@@${EOL}`;
+const NEWLINE_SIGIL_SEARCH = /\r?\n\s*\/\/@@TS-MAGIC-NEWLINE@@\r?\n/;
 
 /**
  * A set of replacements to perform. Structured as an array of doubles:


### PR DESCRIPTION
The dev-tool ts-to-js pretty transpilation system uses this kind of hack-ish system to compensate for the fact that the TypeScript compiler strips out whitespace in its emit (basically we just replace empty lines with `//@@TS-MAGIC-NEWLINE@@` and then un-replace them when writing the output file.

The current implementation doesn't handle CRLF correctly (https://github.com/Azure/azure-sdk-for-js/pull/14488#discussion_r600946994), so this PR fixes that.