### PR TITLE
[core-rest-pipeline] Fix issue with multibyte characters in chunked responses

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2021-03-25)
 
+- Fixed an issue where chunked HTTP responses would sometimes be decoded incorrectly when multibyte characters were used. [PR 14517](https://github.com/Azure/azure-sdk-for-js/pull/14517)
 
 ## 1.0.1 (2021-03-18)
 

--- a/sdk/core/core-rest-pipeline/rollup.base.config.js
+++ b/sdk/core/core-rest-pipeline/rollup.base.config.js
@@ -14,7 +14,7 @@ const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["os", "stream", "https", "zlib", "url", "util"];
+  const externalNodeBuiltins = ["os", "stream", "http", "https", "zlib", "url", "util"];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -281,7 +281,11 @@ function streamToText(stream: NodeJS.ReadableStream): Promise<string> {
     const buffer: Buffer[] = [];
 
     stream.on("data", (chunk) => {
-      buffer.push(Buffer.from(chunk));
+      if (Buffer.isBuffer(chunk)) {
+        buffer.push(chunk);
+      } else {
+        buffer.push(Buffer.from(chunk));
+      }
     });
     stream.on("end", () => {
       resolve(Buffer.concat(buffer).toString("utf8"));

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -278,17 +278,13 @@ function getDecodedResponseStream(
 
 function streamToText(stream: NodeJS.ReadableStream): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    const buffer: string[] = [];
+    const buffer: Buffer[] = [];
 
     stream.on("data", (chunk) => {
-      if (typeof chunk === "string") {
-        buffer.push(chunk);
-      } else {
-        buffer.push(chunk.toString());
-      }
+      buffer.push(Buffer.from(chunk));
     });
     stream.on("end", () => {
-      resolve(buffer.join(""));
+      resolve(Buffer.concat(buffer).toString("utf8"));
     });
     stream.on("error", (e) => {
       reject(

--- a/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/nodeHttpClient.spec.ts
@@ -233,4 +233,30 @@ describe("NodeHttpClient", function() {
     const response = await promise;
     assert.strictEqual(response.status, 200);
   });
+
+  it("Should decode chunked responses properly", async function() {
+    const client = createDefaultHttpClient();
+    stubbedHttpsRequest.returns(createRequest());
+    const request = createPipelineRequest({
+      url: "https://example.com"
+    });
+    const promise = client.sendRequest(request);
+
+    const inputString = "€€€€";
+    const streamResponse = new FakeResponse();
+    streamResponse.headers = {};
+    streamResponse.statusCode = 200;
+    const buffer = Buffer.from(inputString);
+    let buffer2 = Buffer.alloc(4);
+    buffer.copy(buffer2, 0, 0, 4);
+    streamResponse.write(buffer2);
+    buffer2 = Buffer.alloc(buffer.length - 4);
+    buffer.copy(buffer2, 0, 4);
+    streamResponse.write(buffer2);
+    streamResponse.end();
+    stubbedHttpsRequest.yield(streamResponse);
+    const response = await promise;
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.bodyAsText, inputString);
+  });
 });


### PR DESCRIPTION
Our cosmos friends noticed that if multibyte characters happened to occur along a chunked response boundary, we were not properly reconstituting the response body as text.

This PR uses buffer magic to properly re-assemble a string that faithfully represents the body text.