### PR TITLE
[Communication] Fix no-invalid-this linter errors

### DIFF
--- a/sdk/communication/communication-chat/test/chatClient.spec.ts
+++ b/sdk/communication/communication-chat/test/chatClient.spec.ts
@@ -8,6 +8,7 @@ import { createTestUser, createRecorder, createChatClient } from "./utils/record
 import { isNode } from "@azure/core-http";
 import sinon from "sinon";
 import { CommunicationIdentifier } from "@azure/communication-common";
+import { Context } from "mocha";
 
 describe("ChatClient", function() {
   let threadId: string;
@@ -18,18 +19,18 @@ describe("ChatClient", function() {
   let testUser: CommunicationIdentifier;
   let testUser2: CommunicationIdentifier;
 
-  this.afterAll(async function() {
+  after(async function() {
     // await deleteTestUser(testUser);
     // await deleteTestUser(testUser2);
     // await deleteTestUser(testUser3);
   });
 
   describe("Chat Operations", function() {
-    beforeEach(function() {
+    beforeEach(function(this: Context) {
       recorder = createRecorder(this);
     });
 
-    afterEach(async function() {
+    afterEach(async function(this: Context) {
       if (!this.currentTest?.isPending()) {
         await recorder.stop();
       }
@@ -71,7 +72,7 @@ describe("ChatClient", function() {
   });
 
   describe("Realtime Notifications", function() {
-    before(async function() {
+    before(async function(this: Context) {
       // Realtime notifications are browser only
       if (isNode || !isLiveMode()) {
         this.skip();

--- a/sdk/communication/communication-chat/test/chatThreadClient.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.spec.ts
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import { ChatClient, ChatThreadClient } from "../src";
 import { createTestUser, createRecorder, createChatClient } from "./utils/recordedClient";
 import { CommunicationIdentifier } from "@azure/communication-common";
+import { Context } from "mocha";
 
 describe("ChatThreadClient", function() {
   let messageId: string;
@@ -18,11 +19,11 @@ describe("ChatThreadClient", function() {
   let testUser2: CommunicationIdentifier;
   let testUser3: CommunicationIdentifier;
 
-  beforeEach(async function() {
+  beforeEach(async function(this: Context) {
     recorder = createRecorder(this);
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-identity/test/communicationIdentityClient.spec.ts
+++ b/sdk/communication/communication-identity/test/communicationIdentityClient.spec.ts
@@ -9,17 +9,18 @@ import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
 import { CommunicationIdentityClient } from "../src";
 import { createRecordedCommunicationIdentityClient } from "./utils/recordedClient";
+import { Context } from "mocha";
 
 describe("CommunicationIdentityClient [Playback/Live]", function() {
   let user: CommunicationUserIdentifier;
   let recorder: Recorder;
   let client: CommunicationIdentityClient;
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedCommunicationIdentityClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-identity/test/communicationIdentityClientWithToken.spec.ts
+++ b/sdk/communication/communication-identity/test/communicationIdentityClientWithToken.spec.ts
@@ -5,13 +5,14 @@ import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
 import { CommunicationIdentityClient } from "../src";
 import { createRecordedCommunicationIdentityClientWithToken } from "./utils/recordedClient";
+import { Context } from "mocha";
 
 describe("CommunicationIdentityClientWithToken [Playback/Live]", function() {
   let recorder: Recorder;
   let client: CommunicationIdentityClient;
   let shouldSkip = false;
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     const recordedClient = createRecordedCommunicationIdentityClientWithToken(this);
     if (!recordedClient) {
       shouldSkip = true;
@@ -21,13 +22,13 @@ describe("CommunicationIdentityClientWithToken [Playback/Live]", function() {
     }
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }
   });
 
-  it("successfully gets a token for a user [single scope]", async function() {
+  it("successfully gets a token for a user [single scope]", async function(this: Context) {
     if (shouldSkip) {
       this.skip();
     }
@@ -38,7 +39,7 @@ describe("CommunicationIdentityClientWithToken [Playback/Live]", function() {
     assert.instanceOf(expiresOn, Date);
   });
 
-  it("successfully gets a token for a user [multiple scopes]", async function() {
+  it("successfully gets a token for a user [multiple scopes]", async function(this: Context) {
     if (shouldSkip) {
       this.skip();
     }

--- a/sdk/communication/communication-phone-numbers/src/utils/tracing.ts
+++ b/sdk/communication/communication-phone-numbers/src/utils/tracing.ts
@@ -9,7 +9,7 @@ type OperationTracingOptions = OperationOptions["tracingOptions"];
 
 /**
  * Creates a span using the global tracer.
- * @ignore
+ * @internal
  * @param name - The name of the operation being performed.
  * @param tracingOptions - The options for the underlying http request.
  */

--- a/sdk/communication/communication-phone-numbers/test/ctor.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/ctor.spec.ts
@@ -5,6 +5,7 @@ import { AzureKeyCredential } from "@azure/core-auth";
 import { isNode } from "@azure/core-http";
 import { DefaultAzureCredential } from "@azure/identity";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumbersClient } from "../src";
 
 describe("PhoneNumbersClient - constructor", function() {
@@ -27,7 +28,7 @@ describe("PhoneNumbersClient - constructor", function() {
     assert.instanceOf(client, PhoneNumbersClient);
   });
 
-  it("successfully instantiates with with endpoint and managed identity", function() {
+  it("successfully instantiates with with endpoint and managed identity", function(this: Context) {
     if (!isNode) {
       this.skip();
     }

--- a/sdk/communication/communication-phone-numbers/test/get.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/get.spec.ts
@@ -3,6 +3,7 @@
 
 import { Recorder, env, isPlaybackMode } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient } from "./utils/recordedClient";
 
@@ -11,17 +12,17 @@ describe("PhoneNumbersClient - get phone number", function() {
   let client: PhoneNumbersClient;
   let includePhoneNumberLiveTests: boolean;
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder, includePhoneNumberLiveTests } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }
   });
 
-  it("can get a purchased phone number", async function() {
+  it("can get a purchased phone number", async function(this: Context) {
     if (!includePhoneNumberLiveTests && !isPlaybackMode()) {
       this.skip();
     }

--- a/sdk/communication/communication-phone-numbers/test/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/headers.spec.ts
@@ -10,6 +10,7 @@ import sinon from "sinon";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { getPhoneNumberHttpClient } from "./utils/mockHttpClients";
 import { SDK_VERSION } from "../src/utils/constants";
+import { Context } from "mocha";
 
 if (isNode) {
   require("dotenv").config();
@@ -35,7 +36,7 @@ describe("PhoneNumbersClient - headers", function() {
     request = spy.getCall(0).args[0];
   });
 
-  it("sets correct host", function() {
+  it("sets correct host", function(this: Context) {
     if (!isNode) {
       this.skip();
     }
@@ -80,7 +81,7 @@ describe("PhoneNumbersClient - headers", function() {
     );
   });
 
-  it("sets bearer authorization header with TokenCredential", async function() {
+  it("sets bearer authorization header with TokenCredential", async function(this: Context) {
     if (!isNode || isPlaybackMode()) {
       this.skip();
     }

--- a/sdk/communication/communication-phone-numbers/test/list.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/list.spec.ts
@@ -3,6 +3,7 @@
 
 import { Recorder } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient } from "./utils/recordedClient";
 
@@ -11,11 +12,11 @@ describe("PhoneNumbersClient - lists", function() {
   let client: PhoneNumbersClient;
   let all = 0;
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.purchase.spec.ts
@@ -3,6 +3,7 @@
 
 import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumberSearchResult, SearchAvailablePhoneNumbersRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient } from "./utils/recordedClient";
@@ -11,17 +12,17 @@ describe("PhoneNumbersClient - lro - purchase", function() {
   let recorder: Recorder;
   let client: PhoneNumbersClient;
 
-  this.beforeAll(function() {
+  before(function(this: Context) {
     if (!env.INCLUDE_PHONENUMBER_LIVE_TESTS && !isPlaybackMode()) {
       this.skip();
     }
   });
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-phone-numbers/test/lro.release.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.release.spec.ts
@@ -3,6 +3,7 @@
 
 import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient } from "./utils/recordedClient";
 
@@ -10,17 +11,17 @@ describe("PhoneNumbersClient - lro - release", function() {
   let recorder: Recorder;
   let client: PhoneNumbersClient;
 
-  this.beforeAll(function() {
+  before(function(this: Context) {
     if (!env.INCLUDE_PHONENUMBER_LIVE_TESTS && !isPlaybackMode()) {
       this.skip();
     }
   });
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.search.spec.ts
@@ -3,6 +3,7 @@
 
 import { isPlaybackMode, Recorder, env } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { SearchAvailablePhoneNumbersRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { createRecordedClient } from "./utils/recordedClient";
@@ -20,17 +21,17 @@ describe("PhoneNumbersClient - lro - search", function() {
     }
   };
 
-  this.beforeAll(function() {
+  before(function(this: Context) {
     if (!env.INCLUDE_PHONENUMBER_LIVE_TESTS && !isPlaybackMode()) {
       this.skip();
     }
   });
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }

--- a/sdk/communication/communication-phone-numbers/test/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/lro.update.spec.ts
@@ -3,6 +3,7 @@
 
 import { Recorder, env, isPlaybackMode } from "@azure/test-utils-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 import { PhoneNumberCapabilitiesRequest } from "../src";
 import { PhoneNumbersClient } from "../src/phoneNumbersClient";
 import { buildCapabilityUpdate } from "./utils";
@@ -13,17 +14,17 @@ describe("PhoneNumbersClient - lro - update", function() {
   let recorder: Recorder;
   let client: PhoneNumbersClient;
 
-  this.beforeAll(function() {
+  before(function(this: Context) {
     if (!env.INCLUDE_PHONENUMBER_LIVE_TESTS && !isPlaybackMode()) {
       this.skip();
     }
   });
 
-  beforeEach(function() {
+  beforeEach(function(this: Context) {
     ({ client, recorder } = createRecordedClient(this));
   });
 
-  afterEach(async function() {
+  afterEach(async function(this: Context) {
     if (!this.currentTest?.isPending()) {
       await recorder.stop();
     }


### PR DESCRIPTION
This PR fixes all the places where the linter rule `no-invalid-this` fails in the communication packages

Related to #13723