### PR TITLE
[Form Recognizer] Fix linter errors in perf tests

### DIFF
--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.0",
+    "eslint": "^7.15.0",
     "rimraf": "^3.0.0",
     "ts-node": "^9.0.0",
     "typescript": "~4.2.0",
@@ -33,8 +34,8 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "echo skipped",
-    "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json src test --ext .ts -f html -o perf-ai-form-recognizer-lintReport.html || exit 0",
+    "lint:fix": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "unit-test:browser": "echo skipped",

--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/test/custom.spec.ts
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/test/custom.spec.ts
@@ -60,7 +60,7 @@ export class CustomModelRecognitionTest extends PerfStressTest<BeginRecognizeCus
     this.documentUrl = getEnvVar("FORM_RECOGNIZER_TEST_DOCUMENT_URL");
   }
 
-  public async globalSetup() {
+  public async globalSetup(): void {
     const trainingContainerSasUrl = getEnvVar("FORM_RECOGNIZER_TRAINING_CONTAINER_SAS_URL");
 
     try {
@@ -75,7 +75,7 @@ export class CustomModelRecognitionTest extends PerfStressTest<BeginRecognizeCus
     }
   }
 
-  public async globalCleanup() {
+  public async globalCleanup(): Promise<void> {
     const modelId = CustomModelRecognitionTest.sessionModel?.modelId;
     if (modelId) {
       console.log(`Deleting ${modelId}`);


### PR DESCRIPTION
Turns out we want a separate set of linter rules for our perf tests. See #14322 for details
This PR updates the lint script for the FR perf tests as per the above linked item