### PR TITLE
[communication] update sms samples to prevent breaking in pipeline

### DIFF
--- a/sdk/communication/communication-sms/samples/javascript/sendSms.js
+++ b/sdk/communication/communication-sms/samples/javascript/sendSms.js
@@ -13,12 +13,13 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 async function main() {
+  console.log("== Send SMS Message ==");
   const connectionString =
     process.env["COMMUNICATION_CONNECTION_STRING"] ||
     "endpoint=https://<resource-name>.communication.azure.com/;<access-key>";
   const client = new SmsClient(connectionString);
   const sendResults = await client.send({
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
     to: ["<to-phone-number-1>", "<to-phone-number-2>"], // The list of E.164 formatted phone numbers to which message is being sent
     message: "Hello World via SMS!" // The message being sent
   });

--- a/sdk/communication/communication-sms/samples/javascript/sendSmsWithOptions.js
+++ b/sdk/communication/communication-sms/samples/javascript/sendSmsWithOptions.js
@@ -19,7 +19,7 @@ async function main() {
   const client = new SmsClient(connectionString);
   const sendResults = await client.send(
     {
-      from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+      from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
       to: ["<to-phone-number-1>", "<to-phone-number-2>"], // The list of E.164 formatted phone numbers to which message is being sent
       message: "Weekly Promotion!" // The message being sent
     },

--- a/sdk/communication/communication-sms/samples/javascript/usingAadAuth.js
+++ b/sdk/communication/communication-sms/samples/javascript/usingAadAuth.js
@@ -31,6 +31,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 async function main() {
+  console.log("== Send SMS Message Using AAD Auth ==");
   const endpoint =
     process.env["COMMUNICATION_ENDPOINT"] || "https://<resource-name>.communication.azure.com";
   // Azure AD Credential information is required to run this sample:
@@ -47,7 +48,7 @@ async function main() {
 
   const client = new SmsClient(endpoint, new DefaultAzureCredential());
   const sendResults = await client.send({
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
     to: ["<to-phone-number-1>"], // The list of E.164 formatted phone numbers to which message is being sent
     message: "Hello World via SMS!" // The message being sent
   });
@@ -59,6 +60,7 @@ async function main() {
       console.error("Something went wrong when trying to send this message: ", sendResult);
     }
   }
+  console.log("== Done: Send SMS Message Using AAD Auth ==");
 }
 
 main().catch((error) => {

--- a/sdk/communication/communication-sms/samples/typescript/src/sendSms.ts
+++ b/sdk/communication/communication-sms/samples/typescript/src/sendSms.ts
@@ -13,12 +13,13 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 export const main = async () => {
+  console.log("== Send SMS Message ==");
   const connectionString =
     process.env["COMMUNICATION_CONNECTION_STRING"] ||
     "endpoint=https://<resource-name>.communication.azure.com/;<access-key>";
   const client = new SmsClient(connectionString);
   const sendResults = await client.send({
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
     to: ["<to-phone-number-1>", "<to-phone-number-2>"], // The list of E.164 formatted phone numbers to which message is being sent
     message: "Hello World via SMS!" // The message being sent
   });

--- a/sdk/communication/communication-sms/samples/typescript/src/sendSmsWithOptions.ts
+++ b/sdk/communication/communication-sms/samples/typescript/src/sendSmsWithOptions.ts
@@ -20,7 +20,7 @@ export const main = async () => {
   const client = new SmsClient(connectionString);
   const sendResults = await client.send(
     {
-      from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+      from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
       to: ["<to-phone-number-1>", "<to-phone-number-2>"], // The list of E.164 formatted phone numbers to which message is being sent
       message: "Weekly Promotion!" // The message being sent
     },

--- a/sdk/communication/communication-sms/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples/typescript/src/usingAadAuth.ts
@@ -32,6 +32,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 export async function main() {
+  console.log("== Send SMS Message Using AAD Auth ==");
   const endpoint =
     process.env["COMMUNICATION_ENDPOINT"] || "https://<resource-name>.communication.azure.com";
   // Azure AD Credential information is required to run this sample:
@@ -48,7 +49,7 @@ export async function main() {
 
   const client = new SmsClient(endpoint, new DefaultAzureCredential());
   const sendResults = await client.send({
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    from: process.env["AZURE_PHONE_NUMBER"] || "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
     to: ["<to-phone-number-1>"], // The list of E.164 formatted phone numbers to which message is being sent
     message: "Hello World via SMS!" // The message being sent
   });
@@ -60,6 +61,7 @@ export async function main() {
       console.error("Something went wrong when trying to send this message: ", sendResult);
     }
   }
+  console.log("== Done: Send SMS Message Using AAD Auth ==");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
A recent fix further upstream has now resulted in the samples being properly executed. Unfortunately they promptly broke.
After looking at other JS samples in comms package, they don't fail because:
- they're skipped
- they don't exist (chat)
- they're simplistic and use code that retrieves env values (identity)

I've changed the code to now pass in a the env value for the sender number.
Formatting isn't the greatest now, but this should at least allow the samples to execute. very much open to feedback