### PR TITLE
[core-amqp] improve translateError to handle non-error types

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.0 (Unreleased)
 
+- Updates `translateError` to convert non-object type parameters to errors.
+  The parameter will be part of the error's `message` property unless the parameter is null or undefined.
+  Fixes issue [14499](https://github.com/Azure/azure-sdk-for-js/issues/14499).
+
 - Addresses issue [9988](https://github.com/Azure/azure-sdk-for-js/issues/9988)
   by updating the following operations to accept an `abortSignal` to allow cancellation:
   - CbsClient.init()

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -4,7 +4,7 @@
 
 import { AmqpError, AmqpResponseStatusCode, isAmqpError as rheaIsAmqpError } from "rhea-promise";
 import { isNode, isNumber, isString } from "../src/util/utils";
-import { isObjectWithProperties } from "./util/typeGuards";
+import { isDefined, isObjectWithProperties } from "./util/typeGuards";
 
 /**
  * Maps the conditions to the numeric AMQP Response status codes.
@@ -636,6 +636,12 @@ const rheaPromiseErrors = [
  * @returns MessagingError object.
  */
 export function translate(err: AmqpError | Error): MessagingError | Error {
+  if (!isDefined(err)) {
+    return new Error(`Unknown error encountered.`);
+  } else if (typeof err !== "object") {
+    // The error is a scalar type, make it the message of an actual error.
+    return new Error(err);
+  }
   // Built-in errors like TypeError and RangeError should not be retryable as these indicate issues
   // with user input and not an issue with the Messaging process.
   if (err instanceof TypeError || err instanceof RangeError) {

--- a/sdk/core/core-amqp/test/errors.spec.ts
+++ b/sdk/core/core-amqp/test/errors.spec.ts
@@ -26,6 +26,26 @@ describe("Errors", function() {
       translatedError.should.deep.equal(testError);
     });
 
+    it("Wraps non-object inputs in errors", function() {
+      const cases = [
+        { input: "test", outputErrorMessage: "test" },
+        { input: 1234, outputErrorMessage: "1234" },
+        { input: null, outputErrorMessage: "Unknown error encountered." },
+        { input: undefined, outputErrorMessage: "Unknown error encountered." }
+      ];
+
+      for (let i = 0; i < cases.length; i++) {
+        const translatedError = Errors.translate(cases[i].input as any);
+
+        should.equal(translatedError.name, "Error");
+        should.equal(
+          translatedError.message,
+          cases[i].outputErrorMessage,
+          "Unexpected error message."
+        );
+      }
+    });
+
     it("Does not touch TypeError", function() {
       const testError = new TypeError("This is a wrong type!!");
       const translatedError = Errors.translate(testError);


### PR DESCRIPTION
Fixes #14499 

## Description

This PR updates the `translateError` function in `@azure/core-amqp` to handle non-error parameter types.

With this change, if a scalar parameter (string, number, boolean) is passed to `translateError`, an `Error` will be created with that parameter as its message.

So if you called `translateError("foo");`, you'd get back an `Error` where `error.message` equals "foo".

## Why is this change needed?

Throughout the service-bus and event-hubs code bases, we call `translateError` to transform AMQP errors into `MessagingErrors`, and determine if they are retryable. However, JavaScript allows you to throw _anything_; you may not get something that extends `Error`.

We _could_ add a conditional check around each `translateError` callsite to ensure we're passing an object to `translateError`, but this is an easy thing to forget to do. TypeScript also doesn't help us here as it gives the `error` parameter in a `catch` block the `any` type, so the compiler won't ask us to narrow the type when passing it to `translateError`.

Since JavaScript lets you throw _anything_, and TypeScript can't enforce that we narrow the error's `any` type before calling `translateError`, I feel the safest course is to have `translateError` convert these non-object/null/undefined inputs to an Error.

## Why not just return the input parameter instead of converting it into an error?

I thought about this, but there are ultimately 2 issues.
1. Our return type on `translateError` is no longer accurate if we go this route, as it can essentially return _any_ type.
2. We have a lot of code that (correctly) assumes that `translateError` returns an object today, and references fields on the returned error that may not exist if we just return the scalar type (especially for the `null`/`undefined` inputs).