### PR TITLE
[Form Recognizer] Use internal configs for linting perf tests

### DIFF
--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
@@ -16,10 +16,11 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.0",
+    "eslint": "^7.15.0",
+    "prettier": "^1.16.4",
     "rimraf": "^3.0.0",
     "ts-node": "^9.0.0",
-    "typescript": "~4.2.0",
-    "prettier": "^1.16.4"
+    "typescript": "~4.2.0"
   },
   "scripts": {
     "perf-test:node": "ts-node test/index.spec.ts",
@@ -33,8 +34,8 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "echo skipped",
-    "lint:fix": "eslint package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json src test --ext .ts -f html -o perf-ai-form-recognizer-lintReport.html || exit 0",
+    "lint:fix": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "unit-test:browser": "echo skipped",

--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/test/custom.spec.ts
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/test/custom.spec.ts
@@ -60,7 +60,7 @@ export class CustomModelRecognitionTest extends PerfStressTest<BeginRecognizeCus
     this.documentUrl = getEnvVar("FORM_RECOGNIZER_TEST_DOCUMENT_URL");
   }
 
-  public async globalSetup() {
+  public async globalSetup(): Promise<void> {
     const trainingContainerSasUrl = getEnvVar("FORM_RECOGNIZER_TRAINING_CONTAINER_SAS_URL");
 
     try {
@@ -75,7 +75,7 @@ export class CustomModelRecognitionTest extends PerfStressTest<BeginRecognizeCus
     }
   }
 
-  public async globalCleanup() {
+  public async globalCleanup(): Promise<void> {
     const modelId = CustomModelRecognitionTest.sessionModel?.modelId;
     if (modelId) {
       console.log(`Deleting ${modelId}`);


### PR DESCRIPTION
Because perf tests should not use our eslint plugin. This PR applies the approach done here https://github.com/Azure/azure-sdk-for-js/pull/14322 to the newly added perf tests package for form recognizer.

Failure this PR fixes: https://dev.azure.com/azure-sdk/public/_build/results?buildId=806529&view=logs&j=58292cae-3c74-5729-4cfd-9ceee65fe129&t=3f037b94-2b49-5715-3208-309f8588a4cd