### PR TITLE
[dev-tool] Fix relative import of prettier options.

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/tsToJs.ts
+++ b/common/tools/dev-tool/src/commands/samples/tsToJs.ts
@@ -18,8 +18,9 @@ export const commandInfo = makeCommandInfo(
   "ts-to-js",
   "convert a TypeScript sample to a JavaScript equivalent using our conventions for samples"
 );
+
 const prettierOptions: prettier.Options = {
-  ...(require("../eslint-plugin-azure-sdk/prettier.json") as prettier.Options),
+  ...(require("../../../../eslint-plugin-azure-sdk/prettier.json") as prettier.Options),
   parser: "typescript"
 };
 


### PR DESCRIPTION
The import path isn't quite correct and `ts-to-js` throws.