### PR TITLE
[Identity] DefaultAzureCredential to use InteractiveBrowserCredential

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0-beta.2 (Unreleased)
 
+- Breaking change: The parameter `tenantId` of the `DefaultAzureCredential` options has been removed. To specify tenant Ids, users can continue to set the `AZURE_TENANT_ID` environment variable, or send an options bag to the `DefaultAzureCredential` constructor with any of these new optional properties: `visualStudioCodeTenantId` to customize the tenant Id for the `VisualStudioCodeCredential`, and `InteractiveBrowserTenantId` to customize the tenant ID for the `InteractiveBrowserCredential`.
+- `DefaultAzureCredential` now offers users the ability to exclude credentials by setting any of the following optional properties on the constructor options: `excludeEnviornmentCredential`, `excludeManagedIdentityCredential`, `excludeAzureCliCredential`, `excludeVisualStudioCodeCredential` and `excludeInteractiveBrowserCredential`.
 
 ## 2.0.0-beta.1 (2021-03-24)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 2.0.0-beta.2 (Unreleased)
 
-- Breaking change: The parameter `tenantId` of the `DefaultAzureCredential` options has been removed. To specify tenant Ids, users can continue to set the `AZURE_TENANT_ID` environment variable, or send an options bag to the `DefaultAzureCredential` constructor with any of these new optional properties: `visualStudioCodeTenantId` to customize the tenant Id for the `VisualStudioCodeCredential`, and `InteractiveBrowserTenantId` to customize the tenant ID for the `InteractiveBrowserCredential`.
-- `DefaultAzureCredential` now offers users the ability to exclude credentials by setting any of the following optional properties on the constructor options: `excludeEnviornmentCredential`, `excludeManagedIdentityCredential`, `excludeAzureCliCredential`, `excludeVisualStudioCodeCredential` and `excludeInteractiveBrowserCredential`.
+- Added a new option to the constructor of `DefaultAzureCredential`, `includeInteractiveCredentials`, which enables `InteractiveBrowserCredential` as a last resource if no other credential is available.
 
 ## 2.0.0-beta.1 (2021-03-24)
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -87,8 +87,7 @@ If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate v
 - Managed Identity - If the application is deployed to an Azure host with Managed Identity enabled, the `DefaultAzureCredential` will authenticate with that account.
 - Visual Studio Code - If the developer has authenticated via the Visual Studio Code Azure Account plugin, the `DefaultAzureCredential` will authenticate with that account.
 - Azure CLI - If the developer has authenticated an account via the Azure CLI `az login` command, the `DefaultAzureCredential` will authenticate with that account.
-
-If the `DefaultAzureCredential` is used from a browser, it will only use the `InteractiveBrowserCredential`.
+- If no other credential is available, and if the option `includeInteractiveCredentials` is asigned on the constructor, `DefaultAzureCredential` will open a browser window to authenticate as a last resource.
 
 ## Environment Variables
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -87,7 +87,7 @@ If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate v
 - Managed Identity - If the application is deployed to an Azure host with Managed Identity enabled, the `DefaultAzureCredential` will authenticate with that account.
 - Visual Studio Code - If the developer has authenticated via the Visual Studio Code Azure Account plugin, the `DefaultAzureCredential` will authenticate with that account.
 - Azure CLI - If the developer has authenticated an account via the Azure CLI `az login` command, the `DefaultAzureCredential` will authenticate with that account.
-- If no other credential is available, and if the option `includeInteractiveCredentials` is asigned on the constructor, `DefaultAzureCredential` will open a browser window to authenticate as a last resource.
+- Finally, an application may include the `InteractiveBrowserCredential` authentication flow by setting the `includeInteractiveCredentials` option when constructing a `DefaultAzureCredential` instance.
 
 ## Environment Variables
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -116,14 +116,9 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
 // @public
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
-    excludeAzureCliCredential?: boolean;
-    excludeEnviornmentCredential?: boolean;
-    excludeInteractiveBrowserCredential?: boolean;
-    excludeManagedIdentityCredential?: boolean;
-    excludeVisualStudioCodeCredential?: boolean;
-    interactiveBrowserTenantId?: string;
+    includeInteractiveCredentials?: boolean;
     managedIdentityClientId?: string;
-    visualStudioCodeTenantId?: string;
+    tenantId?: string;
 }
 
 // @public

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -111,13 +111,19 @@ export const CredentialUnavailableName = "CredentialUnavailable";
 
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
-    constructor(tokenCredentialOptions?: DefaultAzureCredentialOptions);
+    constructor(options?: DefaultAzureCredentialOptions);
 }
 
 // @public
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
+    excludeAzureCliCredential?: boolean;
+    excludeEnviornmentCredential?: boolean;
+    excludeInteractiveBrowserCredential?: boolean;
+    excludeManagedIdentityCredential?: boolean;
+    excludeVisualStudioCodeCredential?: boolean;
+    interactiveBrowserTenantId?: string;
     managedIdentityClientId?: string;
-    tenantId?: string;
+    visualStudioCodeTenantId?: string;
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -7,21 +7,45 @@ import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 import { AzureCliCredential } from "./azureCliCredential";
 import { VisualStudioCodeCredential } from "./visualStudioCodeCredential";
+import { InteractiveBrowserCredential } from "./interactiveBrowserCredential";
 
 /**
  * Provides options to configure the {@link DefaultAzureCredential} class.
  */
 export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
   /**
-   * Optionally pass in a Tenant ID to be used as part of the credential.
-   * By default it may use a generic tenant ID depending on the underlying credential.
+   * If set to true, {@link DefaultAzureCredential} will not try to authenticate with {@link EnviornmentCredential}.
    */
-  tenantId?: string;
+  excludeEnviornmentCredential?: boolean;
+  /**
+   * If set to true, {@link DefaultAzureCredential} will not try to authenticate with {@link ManagedIdentityCredential}.
+   */
+  excludeManagedIdentityCredential?: boolean;
+  /**
+   * If set to true, {@link DefaultAzureCredential} will not try to authenticate with {@link AzureCliCredential}.
+   */
+  excludeAzureCliCredential?: boolean;
+  /**
+   * If set to true, {@link DefaultAzureCredential} will not try to authenticate with {@link VisualStudioCodeCredential}.
+   */
+  excludeVisualStudioCodeCredential?: boolean;
+  /**
+   * If set to true, {@link DefaultAzureCredential} will not try to authenticate with {@link InteractiveBrowserCredential}.
+   */
+  excludeInteractiveBrowserCredential?: boolean;
   /**
    * Optionally pass in a user assigned client ID to be used by the {@link ManagedIdentityCredential}.
    * This client ID can also be passed through to the {@link ManagedIdentityCredential} through the environment variable: AZURE_CLIENT_ID.
    */
   managedIdentityClientId?: string;
+  /**
+   * Optionally pass in a Tenant ID to be used as part of the {@link VisualStudioCodeCredential}.
+   */
+  visualStudioCodeTenantId?: string;
+  /**
+   * Optionally pass in a Tenant ID to be used as part of the {@link InteractiveBrowserCredential}.
+   */
+  interactiveBrowserTenantId?: string;
 }
 
 /**
@@ -32,6 +56,7 @@ export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
  * - {@link ManagedIdentityCredential}
  * - {@link AzureCliCredential}
  * - {@link VisualStudioCodeCredential}
+ * - {@link InteractiveBrowserCredential}
  *
  * Consult the documentation of these credential types for more information
  * on how they attempt authentication.
@@ -42,26 +67,46 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
    *
    * @param options - Optional parameters. See {@link DefaultAzureCredentialOptions}.
    */
-  constructor(tokenCredentialOptions?: DefaultAzureCredentialOptions) {
+  constructor(options?: DefaultAzureCredentialOptions) {
     const credentials = [];
-    credentials.push(new EnvironmentCredential(tokenCredentialOptions));
 
-    // A client ID for the ManagedIdentityCredential
-    // can be provided either through the optional parameters or through the environment variables.
-    const managedIdentityClientId =
-      tokenCredentialOptions?.managedIdentityClientId || process.env.AZURE_CLIENT_ID;
-
-    // If a client ID is not provided, we will try with the system assigned ID.
-    if (managedIdentityClientId) {
-      credentials.push(
-        new ManagedIdentityCredential(managedIdentityClientId, tokenCredentialOptions)
-      );
-    } else {
-      credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
+    if (!options?.excludeEnviornmentCredential) {
+      credentials.push(new EnvironmentCredential(options));
     }
 
-    credentials.push(new AzureCliCredential());
-    credentials.push(new VisualStudioCodeCredential(tokenCredentialOptions));
+    if (!options?.excludeManagedIdentityCredential) {
+      // A client ID for the ManagedIdentityCredential
+      // can be provided either through the optional parameters or through the environment variables.
+      const managedIdentityClientId =
+        options?.managedIdentityClientId || process.env.AZURE_CLIENT_ID;
+
+      // If a client ID is not provided, we will try with the system assigned ID.
+      if (managedIdentityClientId) {
+        credentials.push(new ManagedIdentityCredential(managedIdentityClientId, options));
+      } else {
+        credentials.push(new ManagedIdentityCredential(options));
+      }
+    }
+
+    if (!options?.excludeAzureCliCredential) {
+      credentials.push(new AzureCliCredential());
+    }
+    if (!options?.excludeVisualStudioCodeCredential) {
+      credentials.push(
+        new VisualStudioCodeCredential({
+          ...options,
+          tenantId: options?.visualStudioCodeTenantId
+        })
+      );
+    }
+    if (!options?.excludeInteractiveBrowserCredential) {
+      credentials.push(
+        new InteractiveBrowserCredential({
+          ...options,
+          tenantId: options?.interactiveBrowserTenantId
+        })
+      );
+    }
 
     super(...credentials);
     this.UnavailableMessage =

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -122,11 +122,11 @@ export class VisualStudioCodeCredential implements TokenCredential {
 
     if (options && options.tenantId) {
       checkTenantId(logger, options.tenantId);
-
       this.tenantId = options.tenantId;
     } else {
       this.tenantId = CommonTenantId;
     }
+
     checkUnsupportedTenant(this.tenantId);
   }
 


### PR DESCRIPTION
`DefaultAzureCredential` in other languages uses `InteractiveBrowserCredential` as a last measure. This PR aims to bridge the gap and enable `InteractiveBrowserCredential` in `DefaultAzureCredential`.

Fixes #14445