### PR TITLE
[KeyVault] - Add perf tests for KeyVault-Keys

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   '@rush-temp/perf-ai-form-recognizer': file:projects/perf-ai-form-recognizer.tgz
   '@rush-temp/perf-ai-text-analytics': file:projects/perf-ai-text-analytics.tgz
   '@rush-temp/perf-eventgrid': file:projects/perf-eventgrid.tgz
+  '@rush-temp/perf-keyvault-certificates': file:projects/perf-keyvault-certificates.tgz
+  '@rush-temp/perf-keyvault-keys': file:projects/perf-keyvault-keys.tgz
+  '@rush-temp/perf-keyvault-secrets': file:projects/perf-keyvault-secrets.tgz
   '@rush-temp/perf-storage-blob': file:projects/perf-storage-blob.tgz
   '@rush-temp/perf-storage-file-datalake': file:projects/perf-storage-file-datalake.tgz
   '@rush-temp/perf-storage-file-share': file:projects/perf-storage-file-share.tgz
@@ -7731,7 +7734,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-anomaly-detector'
     resolution:
-      integrity: sha512-fLujk4GeEPh81YMoeKhJ+nimHkIhCq0OQHuOjrIe7pp/IKgymM3hymkQGqSvjJTD20VcXi2UC2o3GM8UnYvIVQ==
+      integrity: sha512-CqM206moVTBiTWfWVs2HthK9xqREQvQgymi+50T76SyLXPRqnf28TW9UOAv7qFO+H+3abZAjsPLH76PlfuIJNQ==
       tarball: file:projects/ai-anomaly-detector.tgz
     version: 0.0.0
   file:projects/ai-form-recognizer.tgz:
@@ -7775,7 +7778,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-TW1u2375TghP+E6ot/7HtL4T1aQxrUmGqrfhAWnHU7vw9ojxVRh50Eh1TbAc6FILJNdSaRlncXUMmkw1W1eZbQ==
+      integrity: sha512-hNL6Bty73aWkXoL1OkGZH1TaLxlj2n92p6PBI1JcnktnQU2GuTh8xQCpGCCaqxbp4r8eqdBXuaGCKezrZ/iRLA==
       tarball: file:projects/ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/ai-metrics-advisor.tgz:
@@ -7820,7 +7823,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-metrics-advisor'
     resolution:
-      integrity: sha512-sCmSZfBY4jIYL3y5RSdlLu3L/otA57KTTpitPHzQlI49Ul8dBvAx6IWVoZCoKiYCrjoDEsxyVDXLdquM7mdNog==
+      integrity: sha512-IpgbtK5cpIPlvXDF4dsi4EEJWucSktxqX4Vmy5eT6t6bjSQw6MLjMEnqPEBpVf/Op8YSpQ1dBETmkM7DBc1clA==
       tarball: file:projects/ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/ai-text-analytics.tgz:
@@ -7867,7 +7870,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-XE9tQfEhV3OVJsp1TW4XcnYUzqaZjZF/RQ003FO4tv2EbSZhT3kYZOrYMsQcSuUe25qsUJqWULsXBlGgB170IQ==
+      integrity: sha512-RxsDBqyIFDyA2+G3XGKjAojQoYCoKl8R3O2JamKg9boQcAvqLMnmPttRxMqdjEOLJogS5U5hZe6N1Q7czarE1A==
       tarball: file:projects/ai-text-analytics.tgz
     version: 0.0.0
   file:projects/app-configuration.tgz:
@@ -7921,7 +7924,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-aPxnEKEPsp20iH46MgW9xd8MkqdhSrs0wVwAhOGq8vAwb5GJTImGfg93WZtp9Vi5yG76cm78SVMG41mOwpFC8g==
+      integrity: sha512-ksdMNr6vY3BD6hUVMO1FMu0v4lDP7Tz+irLVaQy0yd6rrZNJvOY3P6zUNpeRf49wqXx/R+M9upApADyaTBkKrA==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/attestation.tgz:
@@ -7969,7 +7972,7 @@ packages:
     dev: false
     name: '@rush-temp/attestation'
     resolution:
-      integrity: sha512-547u11oUnRnecbr2ne1QvZwNIx0NFllameFiWMI6dyN1raITM2Vv8Cnf1PLojKlLBEhoOtoa1hlSZUrNqvWlaQ==
+      integrity: sha512-2Taiyib9useo5CoBCZxVNUUMprMwMO8UoS7ewsc/Gn9b5UU2sepGLEH6U9EqNTB/dyiq7FGyGCLf5nabmPn3aQ==
       tarball: file:projects/attestation.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:
@@ -8025,7 +8028,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-chat'
     resolution:
-      integrity: sha512-JyAC5criEgdDhR+xftraP08gr8F5KLSbhfHcUkoLTzcuRqLJBUbXoEP+p643It8vn96DeV/5owOqR99xBpxmXA==
+      integrity: sha512-uNUyOe5H1V30+3isi2ONA/kcROGfdB+Hq58+WdfD3oDTEjmhaA5eXEnJ2FbSLK2cFlZndtff1IcAI8bHFGsMIg==
       tarball: file:projects/communication-chat.tgz
     version: 0.0.0
   file:projects/communication-common.tgz:
@@ -8079,7 +8082,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-common'
     resolution:
-      integrity: sha512-aVclvTJS84THVXex+KC1jBinzGAInkyhM934saBMDG1kN16/OJycfFmjAcQnSCjk9gWHYYVPw6WDo/8d3w985w==
+      integrity: sha512-fbg1/GbTWJWC30ijJM9BiYjSBC6pSi1+EKGdwTLSxT4ulpssfGKkWyGMDQ7ztxyd4zJ8vjP5rUXI0fx7RL/Sug==
       tarball: file:projects/communication-common.tgz
     version: 0.0.0
   file:projects/communication-identity.tgz:
@@ -8133,7 +8136,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-identity'
     resolution:
-      integrity: sha512-2kMQoVb25/2/THvCdMQMyIocK52eCLWOCHpsVKol7ooAattzI2Bk4URsbUZaamE3x1zmnfHT4RSsjuNzpCtgTw==
+      integrity: sha512-vk4xIDHh6HGu3FjNcGmLzl2SKUzZEPr3FNQo6mclktQIM/8vewgzIaYGtOSwd0yc1SL716eeNwhQynrlnPr81g==
       tarball: file:projects/communication-identity.tgz
     version: 0.0.0
   file:projects/communication-phone-numbers.tgz:
@@ -8187,7 +8190,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-phone-numbers'
     resolution:
-      integrity: sha512-9mRPS1ni+Mow96JnpfXk1rgaKbOAbpPE0FrWn/lixNjEGjWQ1+7HjWHM3O0XvqR/P2no8NSuOTokVyy1FN+a/g==
+      integrity: sha512-AvtmcSqtSr80B2+oSEn3e5fkyEQW4WV0u0f7EL2ILcok9klabKhNw+4X12+wh0OjZG1kFLRT+x8ujtLtXAW9eA==
       tarball: file:projects/communication-phone-numbers.tgz
     version: 0.0.0
   file:projects/communication-sms.tgz:
@@ -8240,7 +8243,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-sms'
     resolution:
-      integrity: sha512-c+AAOg2tg8vQ8makAfQynGO82GSuVnEtmVlzW+3YAhJHFNQktmXcOKVAht24PdDYgzl+UzlTy9VrGLbBYAv2LA==
+      integrity: sha512-g/AOUN1K64c0mJwNoH2cZmXV1D1nsjDbRfBsUSX/EcDTth/KXQuSlqLPYR+DbhqAHk5OC5Hjaj/FuDBRkSUuPQ==
       tarball: file:projects/communication-sms.tgz
     version: 0.0.0
   file:projects/container-registry.tgz:
@@ -8283,7 +8286,7 @@ packages:
     dev: false
     name: '@rush-temp/container-registry'
     resolution:
-      integrity: sha512-C2sz+vKQAVSzdAmtZ9gzoYxlqBVMO8Z+i9LAvib+OI6cIgNbLbT/XpLPQWTuk/9ryY69XawrNaQPCmcpLQkXTw==
+      integrity: sha512-6C+1BjMjidAhhafLRnTfCfP90FOYCrs9qL5IT+HzdAZtAcsJNLTglpFEC/KjL6dSiNkL1CCXutV9RnB/ccVyKw==
       tarball: file:projects/container-registry.tgz
     version: 0.0.0
   file:projects/core-amqp.tgz:
@@ -8345,7 +8348,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-AV+EimjOkKJL01rjKqsB2wN8Lkf8oxYc8pxRnRsUNSmSsbdf7E+dbIYEeYpgj2VeuiJ/uR7il3g7/yvwhpvqwQ==
+      integrity: sha512-sJYJQ0Y+WhmvT42SCKcWh9klwMSZcxUiIkZdsDqH4oYULnqCRkx643r36KDPPQHtXUTMCNYi6t9J+F1dqZIjkg==
       tarball: file:projects/core-amqp.tgz
     version: 0.0.0
   file:projects/core-asynciterator-polyfill.tgz:
@@ -8440,7 +8443,7 @@ packages:
     dev: false
     name: '@rush-temp/core-client'
     resolution:
-      integrity: sha512-cDnbtha+KXRB4sYaNSnzHaHeQqsjsKKJ7vRB2K/27F1tl6TyfpGSMx+gYhdn7BRStBHGaCBtXAIFjpchUmKhFw==
+      integrity: sha512-SLLl+T4cE095BXYKtxWv8WsQhFTnXN9yC38/NdTcHMCqW0j9U7Z4ebXTvIYE0hYdlw5xiIKNfAn3CqUU6Wptiw==
       tarball: file:projects/core-client.tgz
     version: 0.0.0
   file:projects/core-crypto.tgz:
@@ -8553,7 +8556,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-8WPutqR0104+m3m+HRGf6nSpw6gzuivRmRaLxewC7KbC2TIfzkcp6XSqpxw7UJXYisxbAA4T3qXA++2ST5tMQw==
+      integrity: sha512-xODyi27xnZIHQtcSN0w6ZXQ9hwgPRlckThHxBPNfjuE6QzQfZe1t1VjvygVNfFr+6tVw6turmm2CUxcvt1wSgQ==
       tarball: file:projects/core-http.tgz
     version: 0.0.0
   file:projects/core-lro.tgz:
@@ -8670,7 +8673,7 @@ packages:
     dev: false
     name: '@rush-temp/core-rest-pipeline'
     resolution:
-      integrity: sha512-el+/J6kAOoliPxm1y2WbHP9HvddRFY6Q1MtWQU81aFCR0obulEPx8l79ygb5EBJsTPqoxzKXXP1phjfcllva9w==
+      integrity: sha512-FoS4IMjTCb9W/3G38zaFTReLkRDAy6xZoWvCe2mfXWp89IDlrcslKCcpIvG53Cp+MpAHXRrWDQqT+BIegBuiTg==
       tarball: file:projects/core-rest-pipeline.tgz
     version: 0.0.0
   file:projects/core-tracing.tgz:
@@ -8706,7 +8709,7 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-GoS2woEiA9bDxMLYXCN7im5VRQz16yGD3C3MsD5u5jXj06uVYprqN2pTG8U6w0+gSzAtzX//Oik3j27cCo73Qg==
+      integrity: sha512-Tc2a/MYDRNdd0WnJm+5KhRblSFh/WyKj1V7LrK63PCNzSAgUfzjo2TFHV/2NB/Nvm3fy2UUbNldipZCo0Hdqbw==
       tarball: file:projects/core-tracing.tgz
     version: 0.0.0
   file:projects/core-util.tgz:
@@ -8855,7 +8858,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-kLZCrMInz5rcyIGnpoUPm3WJ0ihy1bG3DoirNysbhev48dyuEVGEGQQCtihcpNWmz0Juj+KaNi1qsgSktcuWoA==
+      integrity: sha512-qdewf9dbQB0fVzCvZBUzOMQgZi0s/Jmhpz3dQ0ivn24HmTso/tzbcOTj9I1DenPkSm33SQG1rv6ATvSqbEiJfw==
       tarball: file:projects/cosmos.tgz
     version: 0.0.0
   file:projects/data-tables.tgz:
@@ -8950,7 +8953,7 @@ packages:
     dev: false
     name: '@rush-temp/dev-tool'
     resolution:
-      integrity: sha512-MFQZmnuf8q7ZvEXEXDpNFFn2ZUBhNn7MPgAUg0etnL6Hu2RxL5eM1p74Qama+EfHkYJrwDvS8ZQGsWmRifK2pQ==
+      integrity: sha512-rGtMfFPo8M7iE/unoqu6pixlEPyvRqJvFT7CE8yAnJR0MzVLOv+joUAkAuzH+iAP86N20cqLtR0Cax0fqjzFhw==
       tarball: file:projects/dev-tool.tgz
     version: 0.0.0
   file:projects/digital-twins-core.tgz:
@@ -9003,7 +9006,7 @@ packages:
     dev: false
     name: '@rush-temp/digital-twins-core'
     resolution:
-      integrity: sha512-rGhiyGifoIQuBxNwtsVIX5+swPVu4pXlxpzyAu5sNFbyEVwlwaoaZ9W0JyqDRIyE9xU4dyMl2fIspFCESQ8Npg==
+      integrity: sha512-41a9tBzTMsLhNSCDUzfaHJjD71t6zeTlb+/k0oUhSU0+beqd74EL+a0kPJJJ40DkIJ6to6zq5PkXH6Lix7d9cg==
       tarball: file:projects/digital-twins-core.tgz
     version: 0.0.0
   file:projects/eslint-plugin-azure-sdk.tgz:
@@ -9112,7 +9115,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-gFzHoeUloR6Irlwg0MdUCnTbAZki2U3iYZTKV8i0Eki2ip5Byu3dPzL3vg/4MVFDklrtJcjQ4/9u6JcqfU12EA==
+      integrity: sha512-cPiEN81n6j/jXz5Rr5rkjhrkevv5+aCfdGiHnwTlP4wNHnG8rNDRvRUJ8qDnqKmB6xkRvOd4GenG8ZKFVeTf2Q==
       tarball: file:projects/event-hubs.tgz
     version: 0.0.0
   file:projects/event-processor-host.tgz:
@@ -9218,7 +9221,7 @@ packages:
     dev: false
     name: '@rush-temp/eventgrid'
     resolution:
-      integrity: sha512-P5XunlzDebG2i1lnbfxDbhP5AR/m30hEo7NFbS44FDHMfrQbIMp5tKqUQNU70SDuqbnZ8OgEEcCzwaAhJEJqhQ==
+      integrity: sha512-rov0SxZDGIsTND/jFm1nefK8Ck2JQC1JhtZh0sO/dX/pF9b5UJN8TW2K+p/qJOMHczDIh2nKa5tSTR55P/Y4qg==
       tarball: file:projects/eventgrid.tgz
     version: 0.0.0
   file:projects/eventhubs-checkpointstore-blob.tgz:
@@ -9367,7 +9370,7 @@ packages:
     dev: false
     name: '@rush-temp/iot-device-update'
     resolution:
-      integrity: sha512-jvn/CIZGQQCEpyCzQfnOp+pkgg70Ty93F3jWudIaT05M0s7+9a/JQczH/pBZdtAw9/TI97uA98ZA9GOkpY4bkA==
+      integrity: sha512-e8HUeceSU666GIq3D20Vy384WgQd/wp/uEsy57Ye9Ej7txJ3hs+RXSZ7rHFhv/l6XxEfcYN6/Y5mqgqGr28u5w==
       tarball: file:projects/iot-device-update.tgz
     version: 0.0.0
   file:projects/keyvault-admin.tgz:
@@ -9412,7 +9415,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-admin'
     resolution:
-      integrity: sha512-a7fAj43ka5Q+hrBi/hkhZXXmclBMnBRH9XZZ2bKPIVDef3b9hilJwT35hCTgJcNHW1MQpAlbRumLp2BmpWs5tg==
+      integrity: sha512-YRk0zCoJ01s007eNe07gwSBmheamsYH4taZr+bj4Qry7871DFusWvO90z8rCpM1bju8JBdwYisCoa19/D0EoAg==
       tarball: file:projects/keyvault-admin.tgz
     version: 0.0.0
   file:projects/keyvault-certificates.tgz:
@@ -9470,7 +9473,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-xCGUu7hbdSxarSl4G6s+RBU+3dbfhnw2nQ2pOJqTOF3Nw3oVpDVS1AuNFlExbAleTTjq3d8mkej2eogKms8zLQ==
+      integrity: sha512-DAEPx8C9MzF7tT3EKE1tk/JrO4wXsXK8jipE+gaJJxAA4ZJ0AhgGrCa177lSBHiNBa3oSnTm9mYSaIWvGx6Fbg==
       tarball: file:projects/keyvault-certificates.tgz
     version: 0.0.0
   file:projects/keyvault-common.tgz:
@@ -9544,7 +9547,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-UqgcF2EMspQyvzCmIaEBsmRr2wDQOZHpvxW9EsD2EZxL85b90gtJdvr/I/gkOGaAcxJTvyirK2NxvXjDee7WZg==
+      integrity: sha512-uSVbKRDgkf38P27d+iMyGZNESFMb1Lk7WfJlKS1m0mb+waBFDsVVeaswz+dFgssHeB1n1566GwZm8yf8G0o+ng==
       tarball: file:projects/keyvault-keys.tgz
     version: 0.0.0
   file:projects/keyvault-secrets.tgz:
@@ -9602,7 +9605,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-HZOPN4RLx9+FZm22fmZo5UwhA8bsgdqj8iTf7JV4CMao7ov1LxOQg0eg5AgRBJrllDe3pEHICuxou/qMrFJ3Xg==
+      integrity: sha512-sapzjz3bRHbx95KSD+S5A1TVN4kZe/Q7rkEab35G8q7zZQub9X+6aW2mCrj63eaYX6jjYIrJjYQxAioKyhYAlQ==
       tarball: file:projects/keyvault-secrets.tgz
     version: 0.0.0
   file:projects/logger.tgz:
@@ -9693,7 +9696,7 @@ packages:
     dev: false
     name: '@rush-temp/mixedreality-authentication'
     resolution:
-      integrity: sha512-4JJVb5vEEKbFgujwwjobskR5oNwVk5+SIHvXjHz+9eL66xnZ8cdaw4QcWTpSX96kSfaB/ZQ2YE2LloE2KOHU3A==
+      integrity: sha512-EVxjHWYFQnLzZ/GSQvRae3iCmxKAFwQq7G58kLYcEVdYmkAbCryITBvYAfyUuJ9n0iCkyIxD/quijaUaNsChdg==
       tarball: file:projects/mixedreality-authentication.tgz
     version: 0.0.0
   file:projects/mock-hub.tgz:
@@ -9756,7 +9759,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-ai-form-recognizer'
     resolution:
-      integrity: sha512-hSUKNydDVCVuJPykzAmShOx95PYd7SbPvu5BlY3HUA+16EfXawpwiTm/6QNGXjYE+BzNXJ5q83FbHVXabY3XkA==
+      integrity: sha512-gJ4nl8UAm254P0GWxcnaF5PpWatN2Ifio5wl3XfLknEEAYPDOYYxQcuXmCLE9oGdsb3SaujzdQnqHqetDfVHoA==
       tarball: file:projects/perf-ai-form-recognizer.tgz
     version: 0.0.0
   file:projects/perf-ai-text-analytics.tgz:
@@ -9773,7 +9776,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-ai-text-analytics'
     resolution:
-      integrity: sha512-XH3Kny9Y+W0Fr5/FeW/6JzWBPUwOKiftu/dD+3vEwq+OXUFehcfSxmXpAlto4NAd7arXWj+a+zVr78Ejfnmitw==
+      integrity: sha512-WRKlYq5E3/zAp5qMYA5yQagbJYlfuIUsxCBp+WSfENbW/m4WzpjkNC/01TLJ6tO2CEoLc+RRPXCDFpA30H432g==
       tarball: file:projects/perf-ai-text-analytics.tgz
     version: 0.0.0
   file:projects/perf-eventgrid.tgz:
@@ -9791,6 +9794,60 @@ packages:
     resolution:
       integrity: sha512-IQoql5tEhOX/8VOIA+TIl95RGaqZpGF73Xho9DxQuJjcv1vpVKYUFh4tnWlsrFP3P4E64MbDFsVvCPd27mw3dQ==
       tarball: file:projects/perf-eventgrid.tgz
+    version: 0.0.0
+  file:projects/perf-keyvault-certificates.tgz:
+    dependencies:
+      '@azure/identity': 1.2.4
+      '@types/uuid': 8.3.0
+      dotenv: 8.2.0
+      eslint: 7.22.0
+      prettier: 1.19.1
+      rimraf: 3.0.2
+      ts-node: 9.1.1_typescript@4.2.3
+      tslib: 2.1.0
+      typescript: 4.2.3
+      uuid: 8.3.2
+    dev: false
+    name: '@rush-temp/perf-keyvault-certificates'
+    resolution:
+      integrity: sha512-8ZoWbt0i2I1ShnxusGsulAuKsliaJZa5a8PfI1la354d+C8iaNCCzZD+CNafCFaGK2CE0KUwy3pnVfOrnMJNhA==
+      tarball: file:projects/perf-keyvault-certificates.tgz
+    version: 0.0.0
+  file:projects/perf-keyvault-keys.tgz:
+    dependencies:
+      '@azure/identity': 1.2.4
+      '@types/uuid': 8.3.0
+      dotenv: 8.2.0
+      eslint: 7.22.0
+      prettier: 1.19.1
+      rimraf: 3.0.2
+      ts-node: 9.1.1_typescript@4.2.3
+      tslib: 2.1.0
+      typescript: 4.2.3
+      uuid: 8.3.2
+    dev: false
+    name: '@rush-temp/perf-keyvault-keys'
+    resolution:
+      integrity: sha512-SNFFr2ahj1tJkoCp54GL8F+WghCR+zOco41nIyDOVRTGYgf4txYUgD8aXShnlcvykuHVxwDAmXwm2kkaWVbQMw==
+      tarball: file:projects/perf-keyvault-keys.tgz
+    version: 0.0.0
+  file:projects/perf-keyvault-secrets.tgz:
+    dependencies:
+      '@azure/identity': 1.2.4
+      '@types/uuid': 8.3.0
+      dotenv: 8.2.0
+      eslint: 7.22.0
+      prettier: 1.19.1
+      rimraf: 3.0.2
+      ts-node: 9.1.1_typescript@4.2.3
+      tslib: 2.1.0
+      typescript: 4.2.3
+      uuid: 8.3.2
+    dev: false
+    name: '@rush-temp/perf-keyvault-secrets'
+    resolution:
+      integrity: sha512-lCvynZ7C5J6guvAPecUQFD6j7qvFY4eu9Q2Fd1FjkBI+76Qc9HOG3QNRVb/OoR+rGmH4pDnaaj3Z0Lm7GfZbrw==
+      tarball: file:projects/perf-keyvault-secrets.tgz
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:
     dependencies:
@@ -9899,7 +9956,7 @@ packages:
     dev: false
     name: '@rush-temp/quantum-jobs'
     resolution:
-      integrity: sha512-+CIEqOPLhtP1A49IQ4MDDiOGvHx+5dYpqloN2MPficOZ66WPvvGCFdz/lfMLb0RURA1kavl/j+FXsZ8ezhdCFA==
+      integrity: sha512-+E5pcIdYcdzqp9mqlVxtd1PbFiBhzQ8znXSUTIJU79giZBErS30yMZJtvqsnmiG1748WvfcOTjBWeRcCK2mBsw==
       tarball: file:projects/quantum-jobs.tgz
     version: 0.0.0
   file:projects/schema-registry-avro.tgz:
@@ -9955,7 +10012,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry-avro'
     resolution:
-      integrity: sha512-xH9mmI6algfKF9vdD46hBzGjm9QugrKxPEW4yMR2v9BHqgDSScI4CUP4CzHICxvsc8Qmr/RFqQnTyutzukUeyg==
+      integrity: sha512-5p/PRjccoXZoqbxCNle8yH3aq0ouibRCo/pKVQNj/zxTBN5wUlaCutgPJXcKiFLACreW9Ooz9cd4D6lfNMDaeg==
       tarball: file:projects/schema-registry-avro.tgz
     version: 0.0.0
   file:projects/schema-registry.tgz:
@@ -10007,7 +10064,7 @@ packages:
     dev: false
     name: '@rush-temp/schema-registry'
     resolution:
-      integrity: sha512-p8VStnHYzxGqWj7aes3+903EBwjNePmL6dtl1E0xmsl355gmdN5KGwyj2SHU1T//SLeR3aZY4lz7Lzo7ln38Cg==
+      integrity: sha512-gwMs6ODMLfdc7Z6cfWKBkbQd/ONjPOPDLTDPn/iKhgykK7RgstSNEESXkD/avi3I7u99Fm91ZwLtyAhHa1wjLg==
       tarball: file:projects/schema-registry.tgz
     version: 0.0.0
   file:projects/search-documents.tgz:
@@ -10061,7 +10118,7 @@ packages:
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-Ls/oriVdcgfiPSnS74n6MLM+vOhk3S9JUCK56fOIa/MuZ57lAkkxKz52siPHZERbnW7aCVcP777zDpjggU0WOg==
+      integrity: sha512-t331XY//rTlt8RDhrZwFzPlvo/CupJBJostnctFjVQ/nxSXEHgclhr4gR8nJfolymomBZLV+HaonFU1Vk7zn6Q==
       tarball: file:projects/search-documents.tgz
     version: 0.0.0
   file:projects/service-bus.tgz:
@@ -10137,7 +10194,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-b+ehLgrwL7+NoEODKF5G9p9NFtlF+aUM0N33LibjwNOhmqu+ZDDkTHDdlDlGN3bird9wDvPlWG+igYdXhomR7Q==
+      integrity: sha512-aTdBQXkIukgKD6AkCLUrJqm2M8+3NQeeeHB7kHs31Mi0978UOSJLTtSm+u5G/tC5asfTH9PoGejDSiZ/ZMurQg==
       tarball: file:projects/service-bus.tgz
     version: 0.0.0
   file:projects/storage-blob-changefeed.tgz:
@@ -10195,7 +10252,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob-changefeed'
     resolution:
-      integrity: sha512-9/99olvQQhKfPShBZOqm8pfkiU+IH4Gzlo5cDnekjgrdO1tiAsC6ynV8OqdHdl9hglwNBxKAVCMnzgMxhgXVEQ==
+      integrity: sha512-haBeUwCCfwFyyVa6spRyVmFypTweDme1mZ1WmZHuiN3ypbHDAqSYfvzr+qIJAcpvd69HpVOizCVwfElJ+j/WBQ==
       tarball: file:projects/storage-blob-changefeed.tgz
     version: 0.0.0
   file:projects/storage-blob.tgz:
@@ -10254,7 +10311,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-Bpyg2yBAICi3e7WoYClB1RSheQVUDiZ/zBz7zRizq2Mo8kqCaVovtrjsh1N4yYjwn6YOMxF187au/Wlz+EzTig==
+      integrity: sha512-AN8PpGvsQw2yWQVdB7Ac0AfG7SZbevoLWd9B1fr5t9z4cdfXSmGNPgz2YmBO6O5Zlp04W7VYJA/VrQqVdsJ0Yw==
       tarball: file:projects/storage-blob.tgz
     version: 0.0.0
   file:projects/storage-file-datalake.tgz:
@@ -10314,7 +10371,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-51BA/Os5RLNMjKFZUeQB9FdhYL3TVkBxXM30FxuxgpdONwOTQ2txKMiw+oF/25bFEE+dPvA7y6brhObKYH7yeA==
+      integrity: sha512-McZlcNlm7C4g6faGhOVd9NIiys1TeEivcWvrfPE+NhuvsgKBc4XzHvhx79KqCJ/WxH3xG2RMgYpNcSTxWtA+Gw==
       tarball: file:projects/storage-file-datalake.tgz
     version: 0.0.0
   file:projects/storage-file-share.tgz:
@@ -10475,7 +10532,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-PgtE3lhN0S2XPxJEiSnvNJqE/w2z2MWKBMtjNTd4uWK2C87t6lgd0hcy6fMWFUcbQ+lCjnhCCFTRhjNpVyHKhg==
+      integrity: sha512-N+OGkUjcpSIsOF790GsBfWO7WWg6HtIV6vBKSXGR0AwQ4vnSaaBIyVN4PLNhCuhlT4smwzNBWYfQuxAbxwlyfA==
       tarball: file:projects/storage-queue.tgz
     version: 0.0.0
   file:projects/synapse-access-control.tgz:
@@ -10621,7 +10678,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-yPkuhb6nFHoblr+RbhJGL+u7JkbtLbFKLq0bTco3yvj87EcyYxelQYT2sZQ1Ovk8tqoFaAV1rJdhOeuox5bI4w==
+      integrity: sha512-8YMqEfJwuQXfWiy39gEMd6cfA6urwXPpBmwk3NIhOTUYecT3y4U/fA00bXQi+YFbjSM0LfWm6AIY5Zhl+KUiQA==
       tarball: file:projects/template.tgz
     version: 0.0.0
   file:projects/test-utils-multi-version.tgz:
@@ -10801,6 +10858,9 @@ specifiers:
   '@rush-temp/perf-ai-form-recognizer': file:./projects/perf-ai-form-recognizer.tgz
   '@rush-temp/perf-ai-text-analytics': file:./projects/perf-ai-text-analytics.tgz
   '@rush-temp/perf-eventgrid': file:./projects/perf-eventgrid.tgz
+  '@rush-temp/perf-keyvault-certificates': file:./projects/perf-keyvault-certificates.tgz
+  '@rush-temp/perf-keyvault-keys': file:./projects/perf-keyvault-keys.tgz
+  '@rush-temp/perf-keyvault-secrets': file:./projects/perf-keyvault-secrets.tgz
   '@rush-temp/perf-storage-blob': file:./projects/perf-storage-blob.tgz
   '@rush-temp/perf-storage-file-datalake': file:./projects/perf-storage-file-datalake.tgz
   '@rush-temp/perf-storage-file-share': file:./projects/perf-storage-file-share.tgz

--- a/rush.json
+++ b/rush.json
@@ -673,6 +673,21 @@
       "versionPolicyName": "test"
     },
     {
+      "packageName": "@azure-tests/perf-keyvault-keys",
+      "projectFolder": "sdk/keyvault/perf-tests/keyvault-keys",
+      "versionPolicyName": "test"
+    },
+    {
+      "packageName": "@azure-tests/perf-keyvault-certificates",
+      "projectFolder": "sdk/keyvault/perf-tests/keyvault-certificates",
+      "versionPolicyName": "test"
+    },
+    {
+      "packageName": "@azure-tests/perf-keyvault-secrets",
+      "projectFolder": "sdk/keyvault/perf-tests/keyvault-secrets",
+      "versionPolicyName": "test"
+    },
+    {
       "packageName": "@azure/mixedreality-authentication",
       "projectFolder": "sdk/mixedreality/mixedreality-authentication",
       "versionPolicyName": "client"

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -89,7 +89,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
-    "@azure/keyvault-keys": "~4.2.0-beta.5",
+    "@azure/keyvault-keys": "^4.2.0-beta.5",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -89,7 +89,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
-    "@azure/keyvault-keys": "~4.2.0-beta.3",
+    "@azure/keyvault-keys": "~4.2.0-beta.5",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -104,7 +104,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0",
-    "@azure/keyvault-secrets": "^4.2.0-beta.1",
+    "@azure/keyvault-secrets": "^4.2.0-beta.4",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/keyvault/perf-tests/keyvault-certificates/README.md
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/README.md
@@ -1,0 +1,10 @@
+### Guide
+
+1. Build the keyvault-certificates perf tests package `rush build -t perf-keyvault-certificates`.
+2. Copy the `sample.env` file and name it as `.env`.
+3. Create an Azure KeyVault and populate the `.env` file with `KEYVAULT_URI` variable.
+4. Populate the `.env` file with your Azure Credentials.
+5. Refer to the [rate limits](https://docs.microsoft.com/azure/key-vault/general/service-limits) and then run the tests as follows:
+
+- Get Certificate
+  - `npm run perf-test:node -- GetCertificateTest --warmup 1 --iterations 1 --parallel 5`

--- a/sdk/keyvault/perf-tests/keyvault-certificates/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@azure-tests/perf-keyvault-certificates",
+  "version": "1.0.0",
+  "description": "",
+  "main": "",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/test-utils-perfstress": "^1.0.0",
+    "dotenv": "^8.2.0",
+    "@azure/identity": "^1.1.0",
+    "uuid": "^8.3.0",
+    "@azure/keyvault-certificates": "^4.2.0-beta.3"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "prettier": "^1.16.4",
+    "rimraf": "^3.0.0",
+    "tslib": "^2.0.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~4.2.0",
+    "@types/uuid": "^8.0.0"
+  },
+  "private": true,
+  "scripts": {
+    "perf-test:node": "ts-node test/index.spec.ts",
+    "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
+    "build": "tsc -p .",
+    "build:samples": "echo skipped",
+    "build:test": "echo skipped",
+    "check-format": "prettier --list-different --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
+    "format": "prettier --write --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
+    "lint:fix": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts",
+    "pack": "npm pack 2>&1",
+    "prebuild": "npm run clean",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "echo skipped",
+    "unit-test": "echo skipped",
+    "test:browser": "echo skipped",
+    "test:node": "echo skipped",
+    "test": "echo skipped"
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-certificates/sample.env
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/sample.env
@@ -1,0 +1,10 @@
+# Used to authenticate using Azure AD as a service principal for role-based authentication
+# in the tokenAuth sample.
+#
+# See the documentation for `EnvironmentCredential` at the following link:
+# https://docs.microsoft.com/javascript/api/@azure/identity/environmentcredential
+AZURE_TENANT_ID=<AD tenant id or name>
+AZURE_CLIENT_ID=<ID of the user/service principal to authenticate as>
+AZURE_CLIENT_SECRET=<client secret used to authenticate to Azure AD>
+
+KEYVAULT_URI=<keyvault uri>

--- a/sdk/keyvault/perf-tests/keyvault-certificates/test/getCertificate.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/test/getCertificate.spec.ts
@@ -1,0 +1,41 @@
+import { PerfStressTest } from "@azure/test-utils-perfstress";
+import { credential, keyVaultUri } from "./utils";
+import { CertificateClient, WellKnownIssuer } from "@azure/keyvault-certificates";
+import { v4 as uuid } from "uuid";
+
+export abstract class CertificateTest extends PerfStressTest {
+  options = {};
+  certificateClient: CertificateClient;
+  static certificateName = `c-${uuid()}`;
+
+  constructor() {
+    super();
+    this.certificateClient = new CertificateClient(keyVaultUri, credential);
+  }
+
+  async globalSetup() {
+    const poller = await this.certificateClient.beginCreateCertificate(
+      CertificateTest.certificateName,
+      { issuerName: WellKnownIssuer.Self, subject: "CN=Azure SDK" }
+    );
+    await poller.pollUntilDone();
+  }
+
+  async globalCleanup() {
+    const poller = await this.certificateClient.beginDeleteCertificate(
+      CertificateTest.certificateName
+    );
+    const result = await poller.pollUntilDone();
+    if (result.recoveryId) {
+      await this.certificateClient.purgeDeletedCertificate(CertificateTest.certificateName);
+    }
+  }
+}
+
+export class GetCertificateTest extends CertificateTest {
+  public options = {};
+
+  async runAsync(): Promise<void> {
+    await this.certificateClient.getCertificate(CertificateTest.certificateName);
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-certificates/test/index.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/test/index.spec.ts
@@ -1,0 +1,8 @@
+import { PerfStressProgram, selectPerfStressTest } from "@azure/test-utils-perfstress";
+import { GetCertificateTest } from "./getCertificate.spec";
+
+console.log("=== Starting the perfStress test ===");
+
+const perfStressProgram = new PerfStressProgram(selectPerfStressTest([GetCertificateTest]));
+
+perfStressProgram.run();

--- a/sdk/keyvault/perf-tests/keyvault-certificates/test/utils.ts
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/test/utils.ts
@@ -1,0 +1,13 @@
+import { ClientSecretCredential } from "@azure/identity";
+import { getEnvVar } from "@azure/test-utils-perfstress";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export const credential = new ClientSecretCredential(
+  getEnvVar("AZURE_TENANT_ID"),
+  getEnvVar("AZURE_CLIENT_ID"),
+  getEnvVar("AZURE_CLIENT_SECRET")
+);
+
+export const keyVaultUri = getEnvVar("KEYVAULT_URI");

--- a/sdk/keyvault/perf-tests/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/perf-tests/keyvault-certificates/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.package",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "lib": ["ES6", "ESNext.AsyncIterable"],
+    "noEmit": true
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules"],
+  "include": ["./test/**/*.ts"]
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/README.md
+++ b/sdk/keyvault/perf-tests/keyvault-keys/README.md
@@ -1,0 +1,16 @@
+### Guide
+
+1. Build the keyvault-keys perf tests package `rush build -t perf-keyvault-keys`.
+2. Copy the `sample.env` file and name it as `.env`.
+3. Create an Azure KeyVault and populate the `.env` file with `KEYVAULT_URI` variable.
+4. Populate the `.env` file with your Azure Credentials.
+5. Refer to the [rate limits](https://docs.microsoft.com/azure/key-vault/general/service-limits) and then run the tests as follows:
+
+- Get Key
+  - `npm run perf-test:node -- GetKeyTest --warmup 1 --iterations 1 --parallel 5`
+- Decrypt
+  - `npm run perf-test:node -- DecryptTest --warmup 1 --iterations 1 --parallel 5`
+- Sign
+  - `npm run perf-test:node -- SignTest --warmup 1 --iterations 1 --parallel 5`
+- UnwrapKey
+  - `npm run perf-test:node -- UnwrapKeyTest --warmup 1 --iterations 1 --parallel 5`

--- a/sdk/keyvault/perf-tests/keyvault-keys/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-keys/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@azure-tests/perf-keyvault-keys",
+  "version": "1.0.0",
+  "description": "",
+  "main": "",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/test-utils-perfstress": "^1.0.0",
+    "@azure/keyvault-keys": "~4.2.0-beta.5",
+    "dotenv": "^8.2.0",
+    "@azure/identity": "^1.1.0",
+    "uuid": "^8.3.0"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "prettier": "^1.16.4",
+    "rimraf": "^3.0.0",
+    "tslib": "^2.0.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~4.2.0",
+    "@types/uuid": "^8.0.0"
+  },
+  "private": true,
+  "scripts": {
+    "perf-test:node": "ts-node test/index.spec.ts",
+    "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
+    "build": "tsc -p .",
+    "build:samples": "echo skipped",
+    "build:test": "echo skipped",
+    "check-format": "prettier --list-different --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
+    "format": "prettier --write --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
+    "lint:fix": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts",
+    "pack": "npm pack 2>&1",
+    "prebuild": "npm run clean",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "echo skipped",
+    "unit-test": "echo skipped",
+    "test:browser": "echo skipped",
+    "test:node": "echo skipped",
+    "test": "echo skipped"
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-keys/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "@azure/test-utils-perfstress": "^1.0.0",
-    "@azure/keyvault-keys": "~4.2.0-beta.5",
+    "@azure/keyvault-keys": "^4.2.0-beta.5",
     "dotenv": "^8.2.0",
     "@azure/identity": "^1.1.0",
     "uuid": "^8.3.0"

--- a/sdk/keyvault/perf-tests/keyvault-keys/sample.env
+++ b/sdk/keyvault/perf-tests/keyvault-keys/sample.env
@@ -1,0 +1,10 @@
+# Used to authenticate using Azure AD as a service principal for role-based authentication
+# in the tokenAuth sample.
+#
+# See the documentation for `EnvironmentCredential` at the following link:
+# https://docs.microsoft.com/javascript/api/@azure/identity/environmentcredential
+AZURE_TENANT_ID=<AD tenant id or name>
+AZURE_CLIENT_ID=<ID of the user/service principal to authenticate as>
+AZURE_CLIENT_SECRET=<client secret used to authenticate to Azure AD>
+
+KEYVAULT_URI=<keyvault uri>

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/cryptography.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/cryptography.spec.ts
@@ -1,0 +1,45 @@
+import { PerfStressOptionDictionary, PerfStressTest } from "@azure/test-utils-perfstress";
+import { CryptographyClient, KeyClient } from "@azure/keyvault-keys";
+import { v4 as uuid } from "uuid";
+import { credential, keyVaultUri } from "../utils";
+
+interface CryptographyPerfTestOptions {
+  keySize: number;
+}
+
+export abstract class CryptographyTest extends PerfStressTest<CryptographyPerfTestOptions> {
+  options: PerfStressOptionDictionary<CryptographyPerfTestOptions> = {
+    keySize: {
+      required: false,
+      description: "The size of the key to be created",
+      shortName: "ks",
+      longName: "key-size",
+      defaultValue: 2048
+    }
+  };
+
+  keyClient: KeyClient;
+  static cryptoClient?: CryptographyClient;
+  static keyName = `k-${uuid()}`;
+
+  constructor() {
+    super();
+    this.keyClient = new KeyClient(keyVaultUri, credential);
+  }
+
+  async globalSetup() {
+    // Create a single shared key for all tests
+    const key = await this.keyClient.createRsaKey(CryptographyTest.keyName, {
+      keySize: this.parsedOptions.keySize.value!
+    });
+    CryptographyTest.cryptoClient = new CryptographyClient(key, credential);
+  }
+
+  async globalCleanup() {
+    const poller = await this.keyClient.beginDeleteKey(CryptographyTest.keyName);
+    const result = await poller.pollUntilDone();
+    if (result.properties.recoveryId) {
+      await this.keyClient.purgeDeletedKey(CryptographyTest.keyName);
+    }
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/decrypt.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/decrypt.spec.ts
@@ -1,0 +1,23 @@
+import { RsaEncryptionAlgorithm } from "@azure/keyvault-keys";
+import { randomBytes } from "crypto";
+import { CryptographyTest } from "./cryptography.spec";
+
+export class DecryptTest extends CryptographyTest {
+  private cipherText?: Uint8Array;
+  private algorithm: RsaEncryptionAlgorithm = "RSA-OAEP-256";
+
+  async setup(): Promise<void> {
+    const encryptResult = await CryptographyTest.cryptoClient!.encrypt({
+      algorithm: this.algorithm,
+      plaintext: randomBytes(32)
+    });
+    this.cipherText = encryptResult.result!;
+  }
+
+  async runAsync(): Promise<void> {
+    await CryptographyTest.cryptoClient!.decrypt({
+      algorithm: this.algorithm,
+      ciphertext: this.cipherText!
+    });
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/sign.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/sign.spec.ts
@@ -1,0 +1,17 @@
+import { createHash, randomBytes } from "crypto";
+import { CryptographyTest } from "./cryptography.spec";
+
+export class SignTest extends CryptographyTest {
+  private digest?: Uint8Array;
+
+  async setup() {
+    const plaintext = randomBytes(32);
+    this.digest = createHash("SHA256")
+      .update(plaintext)
+      .digest();
+  }
+
+  async runAsync(): Promise<void> {
+    await CryptographyTest.cryptoClient!.sign("RS256", this.digest!);
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/unwrapKey.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/cryptography/unwrapKey.spec.ts
@@ -1,0 +1,20 @@
+import { RsaEncryptionAlgorithm } from "@azure/keyvault-keys";
+import { randomBytes } from "crypto";
+import { CryptographyTest } from "./cryptography.spec";
+
+export class UnwrapKeyTest extends CryptographyTest {
+  encryptedKey?: Uint8Array;
+  private wrapAlgorithm: RsaEncryptionAlgorithm = "RSA-OAEP-256";
+
+  async setup() {
+    const wrapResult = await CryptographyTest.cryptoClient!.wrapKey(
+      this.wrapAlgorithm,
+      randomBytes(32)
+    );
+    this.encryptedKey = wrapResult.result;
+  }
+
+  async runAsync(): Promise<void> {
+    await CryptographyTest.cryptoClient!.unwrapKey(this.wrapAlgorithm, this.encryptedKey!);
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/index.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/index.spec.ts
@@ -1,0 +1,13 @@
+import { PerfStressProgram, selectPerfStressTest } from "@azure/test-utils-perfstress";
+import { GetKeyTest } from "./keys/get.spec";
+import { DecryptTest } from "./cryptography/decrypt.spec";
+import { SignTest } from "./cryptography/sign.spec";
+import { UnwrapKeyTest } from "./cryptography/unwrapKey.spec";
+
+console.log("=== Starting the perfStress test ===");
+
+const perfStressProgram = new PerfStressProgram(
+  selectPerfStressTest([GetKeyTest, DecryptTest, SignTest, UnwrapKeyTest])
+);
+
+perfStressProgram.run();

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/keys/get.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/keys/get.spec.ts
@@ -1,0 +1,37 @@
+import { PerfStressTest } from "@azure/test-utils-perfstress";
+import { KeyClient } from "@azure/keyvault-keys";
+import { credential, keyVaultUri } from "../utils";
+import { v4 as uuid } from "uuid";
+
+export abstract class KeyTest extends PerfStressTest {
+  keyClient: KeyClient;
+  static keyName = `k-${uuid()}`;
+
+  constructor() {
+    super();
+    this.keyClient = new KeyClient(keyVaultUri, credential);
+  }
+
+  async globalSetup() {
+    // Create a single shared key for all tests
+    await this.keyClient.createRsaKey(KeyTest.keyName, {
+      keySize: 2048
+    });
+  }
+
+  async globalCleanup() {
+    const poller = await this.keyClient.beginDeleteKey(KeyTest.keyName);
+    const result = await poller.pollUntilDone();
+    if (result.properties.recoveryId) {
+      await this.keyClient.purgeDeletedKey(KeyTest.keyName);
+    }
+  }
+}
+
+export class GetKeyTest extends KeyTest {
+  public options = {};
+
+  async runAsync(): Promise<void> {
+    await this.keyClient.getKey(KeyTest.keyName);
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/keys/get.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/keys/get.spec.ts
@@ -1,9 +1,23 @@
-import { PerfStressTest } from "@azure/test-utils-perfstress";
+import { PerfStressOptionDictionary, PerfStressTest } from "@azure/test-utils-perfstress";
 import { KeyClient } from "@azure/keyvault-keys";
 import { credential, keyVaultUri } from "../utils";
 import { v4 as uuid } from "uuid";
 
-export abstract class KeyTest extends PerfStressTest {
+interface KeyPerfTestOptions {
+  keySize: number;
+}
+
+export abstract class KeyTest extends PerfStressTest<KeyPerfTestOptions> {
+  options: PerfStressOptionDictionary<KeyPerfTestOptions> = {
+    keySize: {
+      required: false,
+      description: "The size of the key to be created",
+      shortName: "ks",
+      longName: "key-size",
+      defaultValue: 2048
+    }
+  };
+
   keyClient: KeyClient;
   static keyName = `k-${uuid()}`;
 
@@ -15,7 +29,7 @@ export abstract class KeyTest extends PerfStressTest {
   async globalSetup() {
     // Create a single shared key for all tests
     await this.keyClient.createRsaKey(KeyTest.keyName, {
-      keySize: 2048
+      keySize: this.parsedOptions.keySize.value!
     });
   }
 
@@ -29,8 +43,6 @@ export abstract class KeyTest extends PerfStressTest {
 }
 
 export class GetKeyTest extends KeyTest {
-  public options = {};
-
   async runAsync(): Promise<void> {
     await this.keyClient.getKey(KeyTest.keyName);
   }

--- a/sdk/keyvault/perf-tests/keyvault-keys/test/utils.ts
+++ b/sdk/keyvault/perf-tests/keyvault-keys/test/utils.ts
@@ -1,0 +1,13 @@
+import { ClientSecretCredential } from "@azure/identity";
+import { getEnvVar } from "@azure/test-utils-perfstress";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export const credential = new ClientSecretCredential(
+  getEnvVar("AZURE_TENANT_ID"),
+  getEnvVar("AZURE_CLIENT_ID"),
+  getEnvVar("AZURE_CLIENT_SECRET")
+);
+
+export const keyVaultUri = getEnvVar("KEYVAULT_URI");

--- a/sdk/keyvault/perf-tests/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/perf-tests/keyvault-keys/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.package",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "lib": ["ES6", "ESNext.AsyncIterable"],
+    "noEmit": true
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules"],
+  "include": ["./test/**/*.ts"]
+}

--- a/sdk/keyvault/perf-tests/keyvault-secrets/README.md
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/README.md
@@ -1,0 +1,12 @@
+### Guide
+
+1. Build the keyvault-secrets perf tests package `rush build -t perf-keyvault-secrets`.
+2. Copy the `sample.env` file and name it as `.env`.
+3. Create an Azure KeyVault and populate the `.env` file with `KEYVAULT_URI` variable.
+4. Populate the `.env` file with your Azure Credentials.
+5. Refer to the [rate limits](https://docs.microsoft.com/azure/key-vault/general/service-limits) and then run the tests as follows:
+
+- Get Secret
+  - `npm run perf-test:node -- GetSecretTest --warmup 1 --iterations 1 --parallel 5`
+- List Secrets
+  - `npm run perf-test:node -- ListSecretsTest --warmup 1 --iterations 1 --parallel 5 --count 10`

--- a/sdk/keyvault/perf-tests/keyvault-secrets/package.json
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@azure-tests/perf-keyvault-secrets",
+  "version": "1.0.0",
+  "description": "",
+  "main": "",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/test-utils-perfstress": "^1.0.0",
+    "dotenv": "^8.2.0",
+    "@azure/identity": "^1.1.0",
+    "uuid": "^8.3.0",
+    "@azure/keyvault-secrets": "^4.2.0-beta.4"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "prettier": "^1.16.4",
+    "rimraf": "^3.0.0",
+    "tslib": "^2.0.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~4.2.0",
+    "@types/uuid": "^8.0.0"
+  },
+  "private": true,
+  "scripts": {
+    "perf-test:node": "ts-node test/index.spec.ts",
+    "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
+    "build": "tsc -p .",
+    "build:samples": "echo skipped",
+    "build:test": "echo skipped",
+    "check-format": "prettier --list-different --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
+    "format": "prettier --write --config ../../../../.prettierrc.json --ignore-path ../../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
+    "lint:fix": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint --no-eslintrc -c ../../../.eslintrc.internal.json package.json test --ext .ts",
+    "pack": "npm pack 2>&1",
+    "prebuild": "npm run clean",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "echo skipped",
+    "unit-test": "echo skipped",
+    "test:browser": "echo skipped",
+    "test:node": "echo skipped",
+    "test": "echo skipped"
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-secrets/sample.env
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/sample.env
@@ -1,0 +1,10 @@
+# Used to authenticate using Azure AD as a service principal for role-based authentication
+# in the tokenAuth sample.
+#
+# See the documentation for `EnvironmentCredential` at the following link:
+# https://docs.microsoft.com/javascript/api/@azure/identity/environmentcredential
+AZURE_TENANT_ID=<AD tenant id or name>
+AZURE_CLIENT_ID=<ID of the user/service principal to authenticate as>
+AZURE_CLIENT_SECRET=<client secret used to authenticate to Azure AD>
+
+KEYVAULT_URI=<keyvault uri>

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/getSecret.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/getSecret.spec.ts
@@ -1,80 +1,9 @@
-import { PerfStressOptionDictionary, PerfStressTest } from "@azure/test-utils-perfstress";
-import { credential, keyVaultUri } from "./utils";
-import { v4 as uuid } from "uuid";
-import { SecretClient } from "@azure/keyvault-secrets";
-
-export abstract class SecretTest<TOptions = Record<string, unknown>> extends PerfStressTest<
-  TOptions
-> {
-  secretClient: SecretClient;
-  static secretName = `s-${uuid()}`;
-
-  constructor() {
-    super();
-    this.secretClient = new SecretClient(keyVaultUri, credential);
-  }
-
-  async globalSetup() {
-    await this.secretClient.setSecret(SecretTest.secretName, "value");
-  }
-
-  async globalCleanup() {
-    const poller = await this.secretClient.beginDeleteSecret(SecretTest.secretName);
-    const deletedSecret = await poller.pollUntilDone();
-    if (deletedSecret.recoveryId) {
-      await this.secretClient.purgeDeletedSecret(SecretTest.secretName);
-    }
-  }
-}
+import { SecretTest } from "./secretTest";
 
 export class GetSecretTest extends SecretTest {
   public options = {};
 
   async runAsync(): Promise<void> {
     await this.secretClient.getSecret(SecretTest.secretName);
-  }
-}
-
-interface ListSecretPerfTestOptions {
-  count: number;
-}
-
-export class ListSecretsTest extends SecretTest<ListSecretPerfTestOptions> {
-  static secretsToDelete: string[] = [];
-  options: PerfStressOptionDictionary<ListSecretPerfTestOptions> = {
-    count: {
-      required: false,
-      description: "The number of secrets to create",
-      shortName: "c",
-      longName: "count",
-      defaultValue: 10
-    }
-  };
-
-  async globalSetup() {
-    await super.globalSetup();
-    const secretToCreate = Array.from({ length: this.parsedOptions.count.value! }, (_x, i) => {
-      const name = `s${i}-${uuid()}`;
-      ListSecretsTest.secretsToDelete.push(name);
-      return this.secretClient.setSecret(name, "value");
-    });
-
-    await Promise.all(secretToCreate);
-  }
-
-  async globalCleanup() {
-    await super.globalCleanup();
-
-    const startDeletePromises = ListSecretsTest.secretsToDelete.map((name) =>
-      this.secretClient.beginDeleteSecret(name)
-    );
-    await Promise.all(startDeletePromises);
-  }
-
-  async runAsync(): Promise<void> {
-    let count = 0;
-    for await (const _secret of this.secretClient.listPropertiesOfSecrets()) {
-      count++;
-    }
   }
 }

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/getSecret.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/getSecret.spec.ts
@@ -1,0 +1,80 @@
+import { PerfStressOptionDictionary, PerfStressTest } from "@azure/test-utils-perfstress";
+import { credential, keyVaultUri } from "./utils";
+import { v4 as uuid } from "uuid";
+import { SecretClient } from "@azure/keyvault-secrets";
+
+export abstract class SecretTest<TOptions = Record<string, unknown>> extends PerfStressTest<
+  TOptions
+> {
+  secretClient: SecretClient;
+  static secretName = `s-${uuid()}`;
+
+  constructor() {
+    super();
+    this.secretClient = new SecretClient(keyVaultUri, credential);
+  }
+
+  async globalSetup() {
+    await this.secretClient.setSecret(SecretTest.secretName, "value");
+  }
+
+  async globalCleanup() {
+    const poller = await this.secretClient.beginDeleteSecret(SecretTest.secretName);
+    const deletedSecret = await poller.pollUntilDone();
+    if (deletedSecret.recoveryId) {
+      await this.secretClient.purgeDeletedSecret(SecretTest.secretName);
+    }
+  }
+}
+
+export class GetSecretTest extends SecretTest {
+  public options = {};
+
+  async runAsync(): Promise<void> {
+    await this.secretClient.getSecret(SecretTest.secretName);
+  }
+}
+
+interface ListSecretPerfTestOptions {
+  count: number;
+}
+
+export class ListSecretsTest extends SecretTest<ListSecretPerfTestOptions> {
+  static secretsToDelete: string[] = [];
+  options: PerfStressOptionDictionary<ListSecretPerfTestOptions> = {
+    count: {
+      required: false,
+      description: "The number of secrets to create",
+      shortName: "c",
+      longName: "count",
+      defaultValue: 10
+    }
+  };
+
+  async globalSetup() {
+    await super.globalSetup();
+    const secretToCreate = Array.from({ length: this.parsedOptions.count.value! }, (_x, i) => {
+      const name = `s${i}-${uuid()}`;
+      ListSecretsTest.secretsToDelete.push(name);
+      return this.secretClient.setSecret(name, "value");
+    });
+
+    await Promise.all(secretToCreate);
+  }
+
+  async globalCleanup() {
+    await super.globalCleanup();
+
+    const startDeletePromises = ListSecretsTest.secretsToDelete.map((name) =>
+      this.secretClient.beginDeleteSecret(name)
+    );
+    await Promise.all(startDeletePromises);
+  }
+
+  async runAsync(): Promise<void> {
+    let count = 0;
+    for await (const _secret of this.secretClient.listPropertiesOfSecrets()) {
+      count++;
+    }
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/index.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/index.spec.ts
@@ -1,0 +1,10 @@
+import { PerfStressProgram, selectPerfStressTest } from "@azure/test-utils-perfstress";
+import { GetSecretTest, ListSecretsTest } from "./getSecret.spec";
+
+console.log("=== Starting the perfStress test ===");
+
+const perfStressProgram = new PerfStressProgram(
+  selectPerfStressTest([GetSecretTest, ListSecretsTest])
+);
+
+perfStressProgram.run();

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/index.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { PerfStressProgram, selectPerfStressTest } from "@azure/test-utils-perfstress";
-import { GetSecretTest, ListSecretsTest } from "./getSecret.spec";
+import { GetSecretTest } from "./getSecret.spec";
+import { ListSecretsTest } from "./listSecrets.spec";
 
 console.log("=== Starting the perfStress test ===");
 

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/listSecrets.spec.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/listSecrets.spec.ts
@@ -1,0 +1,46 @@
+import { PerfStressOptionDictionary } from "@azure/test-utils-perfstress";
+import { SecretTest } from "./secretTest";
+import { v4 as uuid } from "uuid";
+
+interface ListSecretPerfTestOptions {
+  count: number;
+}
+
+export class ListSecretsTest extends SecretTest<ListSecretPerfTestOptions> {
+  static secretsToDelete: string[] = [];
+  options: PerfStressOptionDictionary<ListSecretPerfTestOptions> = {
+    count: {
+      required: false,
+      description: "The number of secrets to create",
+      shortName: "c",
+      longName: "count",
+      defaultValue: 10
+    }
+  };
+
+  async globalSetup() {
+    await super.globalSetup();
+    const secretToCreate = Array.from({ length: this.parsedOptions.count.value! }, (_x, i) => {
+      const name = `s${i}-${uuid()}`;
+      ListSecretsTest.secretsToDelete.push(name);
+      return this.secretClient.setSecret(name, "value");
+    });
+
+    await Promise.all(secretToCreate);
+  }
+
+  async globalCleanup() {
+    await super.globalCleanup();
+
+    const startDeletePromises = ListSecretsTest.secretsToDelete.map((name) =>
+      this.secretClient.beginDeleteSecret(name)
+    );
+    await Promise.all(startDeletePromises);
+  }
+
+  async runAsync(): Promise<void> {
+    // eslint-disable-next-line no-empty
+    for await (const _secret of this.secretClient.listPropertiesOfSecrets()) {
+    }
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/secretTest.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/secretTest.ts
@@ -1,0 +1,28 @@
+import { SecretClient } from "@azure/keyvault-secrets";
+import { PerfStressTest } from "@azure/test-utils-perfstress";
+import { keyVaultUri, credential } from "./utils";
+import { v4 as uuid } from "uuid";
+
+export abstract class SecretTest<TOptions = Record<string, unknown>> extends PerfStressTest<
+  TOptions
+> {
+  secretClient: SecretClient;
+  static secretName = `s-${uuid()}`;
+
+  constructor() {
+    super();
+    this.secretClient = new SecretClient(keyVaultUri, credential);
+  }
+
+  async globalSetup() {
+    await this.secretClient.setSecret(SecretTest.secretName, "value");
+  }
+
+  async globalCleanup() {
+    const poller = await this.secretClient.beginDeleteSecret(SecretTest.secretName);
+    const deletedSecret = await poller.pollUntilDone();
+    if (deletedSecret.recoveryId) {
+      await this.secretClient.purgeDeletedSecret(SecretTest.secretName);
+    }
+  }
+}

--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/utils.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/utils.ts
@@ -1,0 +1,13 @@
+import { ClientSecretCredential } from "@azure/identity";
+import { getEnvVar } from "@azure/test-utils-perfstress";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export const credential = new ClientSecretCredential(
+  getEnvVar("AZURE_TENANT_ID"),
+  getEnvVar("AZURE_CLIENT_ID"),
+  getEnvVar("AZURE_CLIENT_SECRET")
+);
+
+export const keyVaultUri = getEnvVar("KEYVAULT_URI");

--- a/sdk/keyvault/perf-tests/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.package",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "lib": ["ES6", "ESNext.AsyncIterable"],
+    "noEmit": true
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules"],
+  "include": ["./test/**/*.ts"]
+}


### PR DESCRIPTION
This PR adds performance tests for the KeyVault Keys package using the perf framework.

I still have some work to do but it's probably at a point where I can get some initial feedback.

Todo:

- [x] Add perf tests for secrets: List, Get 
- [x] Add perf tests for certs: Get 
- [ ] Decide on the correct limits / use the http-proxy when it's available
- [x] Sync up on next steps: where do these run, and what do I need to do to run them with the rest of the perf tests

Resolves #14031