### PR TITLE
[core-auth] add isNamedKeyCredential and isSASCredential typeguards

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (Unreleased)
 
 - Adds the `AzureNamedKeyCredential` class which supports credential rotation and a corresponding `NamedKeyCredential` interface to support the use of static string-based names and keys in Azure clients.
+- Adds the `isNamedKeyCredential` and `isSASCredential` typeguard functions.
 
 ## 1.2.0 (2021-02-08)
 

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -46,6 +46,12 @@ export interface GetTokenOptions {
 }
 
 // @public
+export function isNamedKeyCredential(credential: unknown): credential is NamedKeyCredential;
+
+// @public
+export function isSASCredential(credential: unknown): credential is SASCredential;
+
+// @public
 export function isTokenCredential(credential: unknown): credential is TokenCredential;
 
 // @public

--- a/sdk/core/core-auth/src/azureNamedKeyCredential.ts
+++ b/sdk/core/core-auth/src/azureNamedKeyCredential.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isObjectWithProperties } from "./typeguards";
+
 /**
  * Represents a credential defined by a static API name and key.
  */
@@ -70,4 +72,17 @@ export class AzureNamedKeyCredential implements NamedKeyCredential {
     this._name = newName;
     this._key = newKey;
   }
+}
+
+/**
+ * Tests an object to determine whether it implements NamedKeyCredential.
+ *
+ * @param credential - The assumed NamedKeyCredential to be tested.
+ */
+export function isNamedKeyCredential(credential: unknown): credential is NamedKeyCredential {
+  return (
+    isObjectWithProperties(credential, ["name", "key"]) &&
+    typeof credential.key === "string" &&
+    typeof credential.name === "string"
+  );
 }

--- a/sdk/core/core-auth/src/azureSASCredential.ts
+++ b/sdk/core/core-auth/src/azureSASCredential.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isObjectWithProperties } from "./typeguards";
+
 /**
  * Represents a credential defined by a static shared access signature.
  */
@@ -54,4 +56,15 @@ export class AzureSASCredential implements SASCredential {
 
     this._signature = newSignature;
   }
+}
+
+/**
+ * Tests an object to determine whether it implements SASCredential.
+ *
+ * @param credential - The assumed SASCredential to be tested.
+ */
+export function isSASCredential(credential: unknown): credential is SASCredential {
+  return (
+    isObjectWithProperties(credential, ["signature"]) && typeof credential.signature === "string"
+  );
 }

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -2,8 +2,12 @@
 // Licensed under the MIT license.
 
 export { AzureKeyCredential, KeyCredential } from "./azureKeyCredential";
-export { AzureNamedKeyCredential, NamedKeyCredential } from "./azureNamedKeyCredential";
-export { AzureSASCredential, SASCredential } from "./azureSASCredential";
+export {
+  AzureNamedKeyCredential,
+  NamedKeyCredential,
+  isNamedKeyCredential
+} from "./azureNamedKeyCredential";
+export { AzureSASCredential, SASCredential, isSASCredential } from "./azureSASCredential";
 
 export {
   TokenCredential,

--- a/sdk/core/core-auth/src/typeguards.ts
+++ b/sdk/core/core-auth/src/typeguards.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Helper TypeGuard that checks if something is defined or not.
+ * @param thing - Anything
+ * @internal
+ */
+function isDefined<T>(thing: T | undefined | null): thing is T {
+  return typeof thing !== "undefined" && thing !== null;
+}
+
+/**
+ * Helper TypeGuard that checks if the input is an object with the specified properties.
+ * Note: The properties may be inherited.
+ * @param thing - Anything.
+ * @param properties - The name of the properties that should appear in the object.
+ * @internal
+ */
+export function isObjectWithProperties<Thing extends unknown, PropertyName extends string>(
+  thing: Thing,
+  properties: PropertyName[]
+): thing is Thing & Record<PropertyName, unknown> {
+  if (!isDefined(thing) || typeof thing !== "object") {
+    return false;
+  }
+
+  for (const property of properties) {
+    if (!objectHasProperty(thing, property)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Helper TypeGuard that checks if the input is an object with the specified property.
+ * Note: The property may be inherited.
+ * @param thing - Any object.
+ * @param property - The name of the property that should appear in the object.
+ * @internal
+ */
+function objectHasProperty<Thing extends unknown, PropertyName extends string>(
+  thing: Thing,
+  property: PropertyName
+): thing is Thing & Record<PropertyName, unknown> {
+  return typeof thing === "object" && property in (thing as Record<string, unknown>);
+}

--- a/sdk/core/core-auth/test/index.spec.ts
+++ b/sdk/core/core-auth/test/index.spec.ts
@@ -7,6 +7,8 @@ import {
   AzureKeyCredential,
   AzureNamedKeyCredential,
   AzureSASCredential,
+  isNamedKeyCredential,
+  isSASCredential,
   isTokenCredential
 } from "../src/index";
 
@@ -200,5 +202,25 @@ describe("isTokenCredential", function() {
       }),
       true
     );
+  });
+});
+
+describe("isNamedKeyCredential", function() {
+  it("should return true for an object that resembles a NamedKeyCredential", () => {
+    assert.ok(isNamedKeyCredential({ name: "foo", key: "bar" }));
+  });
+
+  it("should return false for an object that does not resemble a NamedKeyCredential", () => {
+    assert.strictEqual(isNamedKeyCredential({}), false);
+  });
+});
+
+describe("isSASCredential", function() {
+  it("should return true for an object that resembles a isSASCredential", () => {
+    assert.ok(isSASCredential({ signature: "sig" }));
+  });
+
+  it("should return false for an object that does not resemble a isSASCredential", () => {
+    assert.strictEqual(isSASCredential({}), false);
   });
 });


### PR DESCRIPTION
Based on feedback here:
https://github.com/Azure/azure-sdk-for-js/pull/14423#discussion_r602616375