### PR TITLE
[dev-tool] Added declarative spec for extra files

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -425,7 +425,15 @@ async function makeSamplesFactory(
         ...info.moduleInfos.map(({ filePath, jsModuleText }) =>
           file(path.basename(filePath).replace(/\.ts$/, ".js"), () => postProcess(jsModuleText))
         )
-      ])
+      ]),
+      // Copy extraFiles by reducing all configured destinations for each input file
+      ...Object.entries(info.extraFiles ?? {}).reduce(
+        (accum, [source, destinations]) => [
+          ...accum,
+          ...destinations.map((dest) => copy(dest, source))
+        ],
+        [] as FileTreeFactory[]
+      )
     ])
   );
 }

--- a/common/tools/dev-tool/src/util/sampleConfiguration.ts
+++ b/common/tools/dev-tool/src/util/sampleConfiguration.ts
@@ -56,6 +56,28 @@ export interface SampleConfiguration {
    * included.
    */
   requiredResources?: Record<string, string>;
+
+  /**
+   * Specify extra files or directories that should be copied into the samples
+   * directory, represented as a map from source files (relative to the package
+   * root), to destination paths (relative to the samples output path, e.g.
+   * `samples/v1`).
+   *
+   * @example
+   *
+   * ```javascript
+   * {
+   *   "//sampleConfiguration": {
+   *     ...,
+   *     "extraFiles": {
+   *       "./assets": ["typescript/assets", "javascript/assets"]
+   *     }
+   *   },
+   *   ...
+   * }
+   * ```
+   */
+  extraFiles?: Record<string, string[]>;
 }
 
 export const SAMPLE_CONFIGURATION_KEY = "//sampleConfiguration";


### PR DESCRIPTION
This adds a little feature to the samples publication system that both Event Hubs and Form Recognizer need. It allows us to copy extra files into the output directory using an `extraFiles` field in the sample configuration.

`extraFiles` is a `Record<string, string[]>` that specifies a map from source file to an array of destinations to which that file should be copied. For example, if you have an extra sample directory (for browser samples or any other special use case), you can specify it like this:

```javascript
{
  "//sampleConfiguration": {
    ...,
    "extraFiles": {
      "./samples-browser": ["browser"]
    },
    ...
  }
}
```

or to copy static assets:

```javascript
{
  "//sampleConfiguration": {
    ...,
    "extraFiles": {
      "./assets": ["javascript/assets", "typescript/assets"]
    },
    ...
  }
}
```