### PR TITLE
Read dev files as raw to replace versions properly

### DIFF
--- a/eng/tools/publish-to-npm.ps1
+++ b/eng/tools/publish-to-npm.ps1
@@ -12,7 +12,7 @@ param (
 )
 
 function replaceText($oldText,$newText,$filePath){
-    $content = Get-Content -Path $filePath
+    $content = Get-Content -Path $filePath -Raw
     $newContent = $content -replace $oldText,$newText
     if((-join $newContent) -ne (-join $content)){
         Set-Content -Path $filePath -Value $newContent

--- a/eng/tools/publish-to-npm.ps1
+++ b/eng/tools/publish-to-npm.ps1
@@ -14,8 +14,9 @@ param (
 function replaceText($oldText,$newText,$filePath){
     $content = Get-Content -Path $filePath -Raw
     $newContent = $content -replace $oldText,$newText
-    if((-join $newContent) -ne (-join $content)){
-        Set-Content -Path $filePath -Value $newContent
+    if ($newContent -ne $content)
+    {
+        Set-Content -Path $filePath -Value $newContent -NoNewLine
         Write-Host "replaceText [$oldText] [$newText] [$filePath]"
     }
 }


### PR DESCRIPTION
Package files are read using Get-Content without `-Raw` so string matching to replace version is not finding version properly. We have seen similar issue with Get-Content in similar place and reading content as Raw is the best option to pattern match within the content.