### PR TITLE
[KeyVault] - Add multi-version tests for KeyVault Keys

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -132,6 +132,7 @@ jobs:
         condition: and(succeededOrFailed(),ne(variables['TestType'],'sample'),eq(variables['DependencyVersion'],''))
         env:
           TEST_MODE: "live"
+          SERVICE_VERSION: $(ServiceVersion)
           ${{ insert }}: ${{ parameters.EnvVars }}
 
       - script: |
@@ -141,6 +142,7 @@ jobs:
         condition: and(succeeded(),ne(variables['TestType'],'sample'),ne(variables['DependencyVersion'],''))
         env:
           TEST_MODE: "live"
+          SERVICE_VERSION: $(ServiceVersion)
           ${{ insert }}: ${{ parameters.EnvVars }}
 
       - ${{ parameters.PostSteps }}

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,8 @@
     },
     "NodeTestVersion": [ "8.x", "10.x", "12.x", "14.x", "15.x" ],
     "TestType": "node",
-    "TestResultsFiles": "**/test-results.xml"
+    "TestResultsFiles": "**/test-results.xml",
+    "ServiceVersion": ""
   },
   "include": [
     {
@@ -20,14 +21,16 @@
         "sample": { "TestType": "sample", "TestResultsFiles": "**/test-results.xml" },
         "browser": { "TestType": "browser", "TestResultsFiles": "**/test-results.browser.xml" }
       },
-      "NodeTestVersion": "12.x"
+      "NodeTestVersion": "12.x",
+      "ServiceVersion": ""
     },
     {
       "Agent": { "ubuntu-18.04": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" } },
       "TestType": "node",
       "NodeTestVersion": "12.x",
       "DependencyVersion": [ "max", "min" ],
-      "TestResultsFiles": "**/test-results.xml"
+      "TestResultsFiles": "**/test-results.xml",
+      "ServiceVersion": ""
     }
   ]
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,7 @@
     },
     "NodeTestVersion": [ "8.x", "10.x", "12.x", "14.x", "15.x" ],
     "TestType": "node",
-    "TestResultsFiles": "**/test-results.xml",
+    "TestResultsFiles": "**/test-results.xml"
   },
   "include": [
     {
@@ -20,14 +20,14 @@
         "sample": { "TestType": "sample", "TestResultsFiles": "**/test-results.xml" },
         "browser": { "TestType": "browser", "TestResultsFiles": "**/test-results.browser.xml" }
       },
-      "NodeTestVersion": "12.x",
+      "NodeTestVersion": "12.x"
     },
     {
       "Agent": { "ubuntu-18.04": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" } },
       "TestType": "node",
       "NodeTestVersion": "12.x",
       "DependencyVersion": [ "max", "min" ],
-      "TestResultsFiles": "**/test-results.xml",
+      "TestResultsFiles": "**/test-results.xml"
     }
   ]
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -11,7 +11,6 @@
     "NodeTestVersion": [ "8.x", "10.x", "12.x", "14.x", "15.x" ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml",
-    "ServiceVersion": ""
   },
   "include": [
     {
@@ -22,7 +21,6 @@
         "browser": { "TestType": "browser", "TestResultsFiles": "**/test-results.browser.xml" }
       },
       "NodeTestVersion": "12.x",
-      "ServiceVersion": ""
     },
     {
       "Agent": { "ubuntu-18.04": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" } },
@@ -30,7 +28,6 @@
       "NodeTestVersion": "12.x",
       "DependencyVersion": [ "max", "min" ],
       "TestResultsFiles": "**/test-results.xml",
-      "ServiceVersion": ""
     }
   ]
 }

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -4,3 +4,4 @@ variables:
   OSVmImage: "ubuntu-18.04"
   skipComponentGovernanceDetection: true
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]
+  ServiceVersion: ""

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,8 +9,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x",
-      "ServiceVersion": "7.2"
+      "NodeTestVersion": "10.x"
     },
     {
       "Agent": {

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -16,8 +16,7 @@
       "Agent": {
         "ubuntu-18.04_service_version_7_0": {
           "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
-          "ArmTemplateParameters": "@{ enableHsm = $true }"
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general"
         }
       },
       "TestType": "node",
@@ -28,8 +27,7 @@
       "Agent": {
         "ubuntu-18.04_service_version_7_1": {
           "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
-          "ArmTemplateParameters": "@{ enableHsm = $true }"
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general"
         }
       },
       "TestType": "node",

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,7 +9,32 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x"
+      "NodeTestVersion": "10.x",
+      "ServiceVersion": "7.2"
+    },
+    {
+      "Agent": {
+        "ubuntu-18.04_service_version_7_0": {
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+          "ArmTemplateParameters": "@{ enableHsm = $true }"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "10.x",
+      "ServiceVersion": "7.0"
+    },
+    {
+      "Agent": {
+        "ubuntu-18.04_service_version_7_1": {
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+          "ArmTemplateParameters": "@{ enableHsm = $true }"
+        }
+      },
+      "TestType": "node",
+      "NodeTestVersion": "10.x",
+      "ServiceVersion": "7.1"
     }
   ]
 }

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,7 +9,8 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x"
+      "NodeTestVersion": "10.x",
+      "ServiceVersion": ""
     },
     {
       "Agent": {

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -14,25 +14,18 @@
     },
     {
       "Agent": {
-        "ubuntu-18.04_service_version_7_0": {
+        "ubuntu-18.04": {
           "OSVmImage": "MMSUbuntu18.04",
           "Pool": "azsdk-pool-mms-ubuntu-1804-general"
         }
       },
       "TestType": "node",
       "NodeTestVersion": "10.x",
-      "ServiceVersion": "7.0"
-    },
-    {
-      "Agent": {
-        "ubuntu-18.04_service_version_7_1": {
-          "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general"
-        }
-      },
-      "TestType": "node",
-      "NodeTestVersion": "10.x",
-      "ServiceVersion": "7.1"
+      "ServiceVersion": ["7.0", "7.1"]
     }
-  ]
+  ],
+  "displayNames": {
+    "7.0": "service_version_7_0",
+    "7.1": "service_version_7_1"
+  }
 }

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,8 +9,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "10.x",
-      "ServiceVersion": ""
+      "NodeTestVersion": "10.x"
     },
     {
       "Agent": {

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -232,7 +232,7 @@ export class KeyClient {
 
 // @public
 export interface KeyClientOptions extends coreHttp.PipelineOptions {
-    serviceVersion?: "7.0" | "7.1" | "7.2";
+    serviceVersion?: string;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -23,9 +23,9 @@ export const LATEST_API_VERSION = "7.2";
  */
 export interface KeyClientOptions extends coreHttp.PipelineOptions {
   /**
-   * The accepted versions of the KeyVault's service API.
+   * The version of the KeyVault's service API to make calls against.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2";
+  serviceVersion?: string;
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/test/internal/aesCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/aesCryptography.spec.ts
@@ -18,6 +18,7 @@ import { authenticate } from "../utils/testAuthentication";
 import { env, Recorder } from "@azure/test-utils-recorder";
 import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
 import { ClientSecretCredential } from "@azure/identity";
+import { getServiceVersion } from "../utils/utils.common";
 
 describe("AesCryptographyProvider browser tests", function() {
   it("uses the browser replacement when running in the browser", async function(this: Context) {
@@ -134,7 +135,7 @@ describe("AesCryptographyProvider internal tests", function() {
         let remoteProvider: RemoteCryptographyProvider;
 
         beforeEach(async function(this: Context) {
-          const authentication = await authenticate(this);
+          const authentication = await authenticate(this, getServiceVersion());
           recorder = authentication.recorder;
 
           if (!authentication.hsmClient) {

--- a/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -14,6 +14,7 @@ import {
 import { KeyClient } from "../../src";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { getServiceVersion } from "../utils/utils.common";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).
@@ -28,7 +29,7 @@ describe("Challenge based authentication tests", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     keySuffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
@@ -8,6 +8,8 @@ import { LATEST_API_VERSION } from "../../src/keysModels";
 import { HttpClient, HttpOperationResponse, WebResourceLike, HttpHeaders } from "@azure/core-http";
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
+import { versionsToTest } from "@azure/test-utils-multi-version";
+import { supportedServiceVersions } from "../utils/utils.common";
 
 describe("The Keys client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
@@ -58,14 +60,10 @@ describe("The Keys client should set the serviceVersion", () => {
     );
   });
 
-  // Adding this to the source would change the public API.
-  type ApIVersions = "7.0" | "7.1" | "7.2";
-
-  it("it should allow us to specify an API version from a specific set of versions", async function() {
-    const versions: ApIVersions[] = ["7.0", "7.1", "7.2"];
-    for (const serviceVersion in versions) {
+  versionsToTest(supportedServiceVersions, {}, (serviceVersion) => {
+    it("it should allow us to specify an API version from a specific set of versions", async function() {
       const client = new KeyClient(keyVaultUrl, credential, {
-        serviceVersion: serviceVersion as ApIVersions,
+        serviceVersion: serviceVersion,
         httpClient: mockHttpClient
       });
       await client.createKey("keyName", "RSA");
@@ -76,6 +74,6 @@ describe("The Keys client should set the serviceVersion", () => {
         lastCall.args[0].url,
         `https://keyVaultName.vault.azure.net/keys/keyName/create?api-version=${serviceVersion}`
       );
-    }
+    });
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/serviceVersionParameter.spec.ts
@@ -9,7 +9,7 @@ import { HttpClient, HttpOperationResponse, WebResourceLike, HttpHeaders } from 
 import { ClientSecretCredential } from "@azure/identity";
 import { env } from "@azure/test-utils-recorder";
 import { versionsToTest } from "@azure/test-utils-multi-version";
-import { supportedServiceVersions } from "../utils/utils.common";
+import { serviceVersions } from "../utils/utils.common";
 
 describe("The Keys client should set the serviceVersion", () => {
   const keyVaultUrl = `https://keyVaultName.vault.azure.net`;
@@ -60,7 +60,7 @@ describe("The Keys client should set the serviceVersion", () => {
     );
   });
 
-  versionsToTest(supportedServiceVersions, {}, (serviceVersion) => {
+  versionsToTest(serviceVersions, {}, (serviceVersion) => {
     it("it should allow us to specify an API version from a specific set of versions", async function() {
       const client = new KeyClient(keyVaultUrl, credential, {
         serviceVersion: serviceVersion,

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -11,7 +11,7 @@ import TestClient from "../utils/testClient";
 import { CreateOctKeyOptions } from "../../src/keysModels";
 import { getServiceVersion, onVersions } from "../utils/utils.common";
 
-onVersions(["7.2"]).describe(
+onVersions({ minVer: "7.2" }).describe(
   "Keys client - create, read, update and delete operations for managed HSM",
   () => {
     const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -9,41 +9,45 @@ import { KeyClient } from "../../src";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
 import { CreateOctKeyOptions } from "../../src/keysModels";
+import { getServiceVersion, onVersions } from "../utils/utils.common";
 
-describe("Keys client - create, read, update and delete operations for managed HSM", () => {
-  const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
-  let keySuffix: string;
-  let hsmClient: KeyClient;
-  let testClient: TestClient;
-  let recorder: Recorder;
+onVersions(["7.2"]).describe(
+  "Keys client - create, read, update and delete operations for managed HSM",
+  () => {
+    const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;
+    let keySuffix: string;
+    let hsmClient: KeyClient;
+    let testClient: TestClient;
+    let recorder: Recorder;
 
-  beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
-    recorder = authentication.recorder;
+    beforeEach(async function(this: Context) {
+      const authentication = await authenticate(this, getServiceVersion());
+      recorder = authentication.recorder;
 
-    if (!authentication.hsmClient) {
-      // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
-      // This is only necessary while Managed HSM is in preview.
-      this.skip();
-    }
+      if (!authentication.hsmClient) {
+        // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
+        // This is only necessary while Managed HSM is in preview.
+        this.skip();
+      }
 
-    hsmClient = authentication.hsmClient;
-    keySuffix = authentication.keySuffix;
-    testClient = new TestClient(authentication.hsmClient);
-  });
+      hsmClient = authentication.hsmClient;
+      keySuffix = authentication.keySuffix;
+      testClient = new TestClient(authentication.hsmClient);
+    });
 
-  afterEach(async function() {
-    await recorder.stop();
-  });
+    afterEach(async function() {
+      await recorder.stop();
+    });
 
-  it("can create an OCT key with options", async function(this: Context) {
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    const options: CreateOctKeyOptions = {
-      hsm: true
-    };
-    const result = await hsmClient.createOctKey(keyName, options);
-    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
-    assert.equal(result.keyType, "oct-HSM");
-    await testClient.flushKey(keyName);
-  });
-});
+    it("can create an OCT key with options", async function(this: Context) {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      const options: CreateOctKeyOptions = {
+        hsm: true
+      };
+      const result = await hsmClient.createOctKey(keyName, options);
+      assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
+      assert.equal(result.keyType, "oct-HSM");
+      await testClient.flushKey(keyName);
+    });
+  }
+);

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -13,7 +13,7 @@ import {
   UpdateKeyPropertiesOptions,
   GetKeyOptions
 } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -26,7 +26,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     keySuffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -13,21 +13,10 @@ import {
   UpdateKeyPropertiesOptions,
   GetKeyOptions
 } from "../../src";
-import { assertThrowsAbortError, getServiceVersion, onVersions } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
-
-// note, onVersions call this will not remain, just need to ensure it works
-onVersions({ minVer: "7.2" }).it("should only run on 7.2", () => {
-  console.log("getServiceVersion()", getServiceVersion());
-});
-
-onVersions({ maxVer: "7.1" }).describe("these should only run on 7.0 and 7.1", () => {
-  it("lets read the service version", () => {
-    console.log("getServiceVersion()", getServiceVersion());
-  });
-});
 
 describe("Keys client - create, read, update and delete operations", () => {
   const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -13,10 +13,21 @@ import {
   UpdateKeyPropertiesOptions,
   GetKeyOptions
 } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion, onVersions } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+
+// note, onVersions call this will not remain, just need to ensure it works
+onVersions({ minVer: "7.2" }).it("should only run on 7.2", () => {
+  console.log("getServiceVersion()", getServiceVersion());
+});
+
+onVersions({ maxVer: "7.1" }).describe("these should only run on 7.0 and 7.1", () => {
+  it("lets read the service version", () => {
+    console.log("getServiceVersion()", getServiceVersion());
+  });
+});
 
 describe("Keys client - create, read, update and delete operations", () => {
   const keyPrefix = `CRUD${env.KEY_NAME || "KeyName"}`;

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -10,81 +10,85 @@ import { CryptographyClient, KeyVaultKey, KeyClient } from "../../src";
 import { authenticate } from "../utils/testAuthentication";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import TestClient from "../utils/testClient";
+import { getServiceVersion, onVersions } from "../utils/utils.common";
 
-describe("CryptographyClient for managed HSM (skipped if MHSM is not deployed)", () => {
-  let hsmClient: KeyClient;
-  let testClient: TestClient;
-  let cryptoClient: CryptographyClient;
-  let recorder: Recorder;
-  let credential: ClientSecretCredential;
-  let keyName: string;
-  let keyVaultKey: KeyVaultKey;
-  let keySuffix: string;
+onVersions(["7.2"]).describe(
+  "CryptographyClient for managed HSM (skipped if MHSM is not deployed)",
+  () => {
+    let hsmClient: KeyClient;
+    let testClient: TestClient;
+    let cryptoClient: CryptographyClient;
+    let recorder: Recorder;
+    let credential: ClientSecretCredential;
+    let keyName: string;
+    let keyVaultKey: KeyVaultKey;
+    let keySuffix: string;
 
-  beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
-    recorder = authentication.recorder;
+    beforeEach(async function(this: Context) {
+      const authentication = await authenticate(this, getServiceVersion());
+      recorder = authentication.recorder;
 
-    if (!authentication.hsmClient) {
-      // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
-      // This is only necessary while Managed HSM is in preview.
-      this.skip();
-    }
+      if (!authentication.hsmClient) {
+        // Managed HSM is not deployed for this run due to service resource restrictions so we skip these tests.
+        // This is only necessary while Managed HSM is in preview.
+        this.skip();
+      }
 
-    hsmClient = authentication.hsmClient;
-    testClient = new TestClient(authentication.hsmClient);
-    credential = authentication.credential;
-    keySuffix = authentication.keySuffix;
-    keyName = testClient.formatName("cryptography-client-test" + keySuffix);
-  });
-
-  afterEach(async function() {
-    await testClient?.flushKey(keyName);
-    await recorder.stop();
-  });
-
-  describe("with AES crypto algorithms", async function() {
-    it("encrypts and decrypts using AES-GCM", async function(this: Context) {
-      keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
-      cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
-      const text = this.test!.title;
-      const encryptResult = await cryptoClient.encrypt({
-        algorithm: "A256GCM",
-        plaintext: stringToUint8Array(text)
-      });
-      assert.exists(encryptResult.iv);
-      assert.exists(encryptResult.authenticationTag);
-
-      const decryptResult = await cryptoClient.decrypt({
-        algorithm: "A256GCM",
-        ciphertext: encryptResult.result!,
-        iv: encryptResult.iv!,
-        authenticationTag: encryptResult.authenticationTag
-      });
-      assert.equal(text, uint8ArrayToString(decryptResult.result));
+      hsmClient = authentication.hsmClient;
+      testClient = new TestClient(authentication.hsmClient);
+      credential = authentication.credential;
+      keySuffix = authentication.keySuffix;
+      keyName = testClient.formatName("cryptography-client-test" + keySuffix);
     });
 
-    it("encrypts and decrypts using AES-CBC", async function(this: Context) {
-      keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
-      cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
-      const text = this.test!.title;
-      const encryptResult = await cryptoClient.encrypt({
-        algorithm: "A256CBCPAD",
-        plaintext: stringToUint8Array(text),
-        iv: stringToUint8Array(text)
-      });
-      // There is a service-level issue where `iv` is not returned
-      // from the service as part of the result. Until it's resolved
-      // we have to pend this and just pass the same iv
-      // back to decrypt for now.
-      // assert.exists(encryptResult.iv);
-
-      const decryptResult = await cryptoClient.decrypt({
-        algorithm: "A256CBCPAD",
-        ciphertext: encryptResult.result!,
-        iv: stringToUint8Array(text) // Replace with `encryptResult.iv!` once ADO 9361749 is resolved.
-      });
-      assert.equal(uint8ArrayToString(decryptResult.result), text);
+    afterEach(async function() {
+      await testClient?.flushKey(keyName);
+      await recorder.stop();
     });
-  });
-});
+
+    describe("with AES crypto algorithms", async function() {
+      it("encrypts and decrypts using AES-GCM", async function(this: Context) {
+        keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+        cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
+        const text = this.test!.title;
+        const encryptResult = await cryptoClient.encrypt({
+          algorithm: "A256GCM",
+          plaintext: stringToUint8Array(text)
+        });
+        assert.exists(encryptResult.iv);
+        assert.exists(encryptResult.authenticationTag);
+
+        const decryptResult = await cryptoClient.decrypt({
+          algorithm: "A256GCM",
+          ciphertext: encryptResult.result!,
+          iv: encryptResult.iv!,
+          authenticationTag: encryptResult.authenticationTag
+        });
+        assert.equal(text, uint8ArrayToString(decryptResult.result));
+      });
+
+      it("encrypts and decrypts using AES-CBC", async function(this: Context) {
+        keyVaultKey = await hsmClient.createKey(keyName, "AES", { keySize: 256 });
+        cryptoClient = new CryptographyClient(keyVaultKey.id!, credential);
+        const text = this.test!.title;
+        const encryptResult = await cryptoClient.encrypt({
+          algorithm: "A256CBCPAD",
+          plaintext: stringToUint8Array(text),
+          iv: stringToUint8Array(text)
+        });
+        // There is a service-level issue where `iv` is not returned
+        // from the service as part of the result. Until it's resolved
+        // we have to pend this and just pass the same iv
+        // back to decrypt for now.
+        // assert.exists(encryptResult.iv);
+
+        const decryptResult = await cryptoClient.decrypt({
+          algorithm: "A256CBCPAD",
+          ciphertext: encryptResult.result!,
+          iv: stringToUint8Array(text) // Replace with `encryptResult.iv!` once ADO 9361749 is resolved.
+        });
+        assert.equal(uint8ArrayToString(decryptResult.result), text);
+      });
+    });
+  }
+);

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -12,7 +12,7 @@ import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import TestClient from "../utils/testClient";
 import { getServiceVersion, onVersions } from "../utils/utils.common";
 
-onVersions(["7.2"]).describe(
+onVersions({ minVer: "7.2" }).describe(
   "CryptographyClient for managed HSM (skipped if MHSM is not deployed)",
   () => {
     let hsmClient: KeyClient;

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -13,6 +13,7 @@ import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "../utils/crypto";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
+import { getServiceVersion } from "../utils/utils.common";
 
 describe("CryptographyClient (all decrypts happen remotely)", () => {
   const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;
@@ -31,7 +32,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   }
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.client;
     recorder = authentication.recorder;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/import.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/import.spec.ts
@@ -9,6 +9,7 @@ import { isNode } from "@azure/core-http";
 import { KeyClient, JsonWebKey } from "../../src";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { getServiceVersion } from "../utils/utils.common";
 
 describe("Keys client - import keys", () => {
   const prefix = `import${env.CERTIFICATE_NAME || "KeyName"}`;
@@ -18,7 +19,7 @@ describe("Keys client - import keys", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     suffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
@@ -6,64 +6,89 @@ import { Context } from "mocha";
 import { env, Recorder, isRecordMode } from "@azure/test-utils-recorder";
 
 import { KeyClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
-import { versionsToTest } from "@azure/test-utils-multi-version";
 
-const serviceApiVersions = ["7.0", "7.1", "7.2"] as const;
-versionsToTest(serviceApiVersions, {}, (serviceVersion, onVersions) => {
-  onVersions(["7.0", "7.1", "7.2"]).describe("Keys client - list keys in various ways", () => {
-    const keyPrefix = `list${env.KEY_NAME || "KeyName"}`;
-    let keySuffix: string;
-    let client: KeyClient;
-    let testClient: TestClient;
-    let recorder: Recorder;
+describe("Keys client - list keys in various ways", () => {
+  const keyPrefix = `list${env.KEY_NAME || "KeyName"}`;
+  let keySuffix: string;
+  let client: KeyClient;
+  let testClient: TestClient;
+  let recorder: Recorder;
 
-    beforeEach(async function(this: Context) {
-      const authentication = await authenticate(this, serviceVersion);
-      keySuffix = authentication.keySuffix;
-      client = authentication.client;
-      testClient = authentication.testClient;
-      recorder = authentication.recorder;
-    });
+  beforeEach(async function(this: Context) {
+    const authentication = await authenticate(this, getServiceVersion());
+    keySuffix = authentication.keySuffix;
+    client = authentication.client;
+    testClient = authentication.testClient;
+    recorder = authentication.recorder;
+  });
 
-    afterEach(async function() {
-      await recorder.stop();
-    });
+  afterEach(async function() {
+    await recorder.stop();
+  });
 
-    // The tests follow
+  // The tests follow
 
-    // Use this while recording to make sure the target keyvault is clean.
-    // The next tests will produce a more consistent output.
-    // This test is only useful while developing locally.
-    it("can purge all keys", async function(this: Context): Promise<void> {
-      // WARNING: When TEST_MODE equals "record", all of the keys in the indicated KEYVAULT_URI will be deleted as part of this test.
-      if (!isRecordMode()) {
-        return this.skip();
+  // Use this while recording to make sure the target keyvault is clean.
+  // The next tests will produce a more consistent output.
+  // This test is only useful while developing locally.
+  it("can purge all keys", async function(this: Context): Promise<void> {
+    // WARNING: When TEST_MODE equals "record", all of the keys in the indicated KEYVAULT_URI will be deleted as part of this test.
+    if (!isRecordMode()) {
+      return this.skip();
+    }
+    for await (const properties of client.listPropertiesOfKeys()) {
+      try {
+        await testClient.flushKey(properties.name);
+      } catch {
+        // Nothing to do here.
       }
-      for await (const properties of client.listPropertiesOfKeys()) {
-        try {
-          await testClient.flushKey(properties.name);
-        } catch {
-          // Nothing to do here.
-        }
+    }
+    for await (const deletedKey of client.listDeletedKeys()) {
+      try {
+        await testClient.purgeKey(deletedKey.name);
+      } catch {
+        // Nothing to do here.
       }
-      for await (const deletedKey of client.listDeletedKeys()) {
-        try {
-          await testClient.purgeKey(deletedKey.name);
-        } catch {
-          // Nothing to do here.
-        }
-      }
-    });
+    }
+  });
 
-    it("can get the versions of a key", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      await client.createKey(keyName, "RSA");
-      let totalVersions = 0;
-      for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+  it("can get the versions of a key", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    await client.createKey(keyName, "RSA");
+    let totalVersions = 0;
+    for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+      assert.equal(
+        version.name,
+        keyName,
+        "Unexpected key name in result from listPropertiesOfKeyVersions()."
+      );
+      totalVersions += 1;
+    }
+    assert.equal(totalVersions, 1, `Unexpected total versions for key ${keyName}`);
+    await testClient.flushKey(keyName);
+  });
+
+  // On playback mode, the tests happen too fast for the timeout to work
+  it("can get the versions of a key with requestOptions timeout", async function() {
+    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+    const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
+      requestOptions: { timeout: 1 }
+    });
+    await assertThrowsAbortError(async () => {
+      await iter.next();
+    });
+  });
+
+  it("can get the versions of a key (paged)", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    await client.createKey(keyName, "RSA");
+    let totalVersions = 0;
+    for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
+      for (const version of page) {
         assert.equal(
           version.name,
           keyName,
@@ -71,43 +96,30 @@ versionsToTest(serviceApiVersions, {}, (serviceVersion, onVersions) => {
         );
         totalVersions += 1;
       }
-      assert.equal(totalVersions, 1, `Unexpected total versions for key ${keyName}`);
-      await testClient.flushKey(keyName);
-    });
+    }
+    assert.equal(totalVersions, 1, `Unexpected total versions for key ${keyName}`);
+    await testClient.flushKey(keyName);
+  });
 
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can get the versions of a key with requestOptions timeout", async function() {
-      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-      const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
-        requestOptions: { timeout: 1 }
-      });
-      await assertThrowsAbortError(async () => {
-        await iter.next();
-      });
-    });
+  it("list 0 versions of a non-existing key", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    let totalVersions = 0;
+    for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+      assert.equal(
+        version.name,
+        keyName,
+        "Unexpected key name in result from listPropertiesOfKeyVersions()."
+      );
+      totalVersions += 1;
+    }
+    assert.equal(totalVersions, 0, `Unexpected total versions for key ${keyName}`);
+  });
 
-    it("can get the versions of a key (paged)", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      await client.createKey(keyName, "RSA");
-      let totalVersions = 0;
-      for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
-        for (const version of page) {
-          assert.equal(
-            version.name,
-            keyName,
-            "Unexpected key name in result from listPropertiesOfKeyVersions()."
-          );
-          totalVersions += 1;
-        }
-      }
-      assert.equal(totalVersions, 1, `Unexpected total versions for key ${keyName}`);
-      await testClient.flushKey(keyName);
-    });
-
-    it("list 0 versions of a non-existing key", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      let totalVersions = 0;
-      for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+  it("list 0 versions of a non-existing key (paged)", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    let totalVersions = 0;
+    for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
+      for (const version of page) {
         assert.equal(
           version.name,
           keyName,
@@ -115,138 +127,122 @@ versionsToTest(serviceApiVersions, {}, (serviceVersion, onVersions) => {
         );
         totalVersions += 1;
       }
-      assert.equal(totalVersions, 0, `Unexpected total versions for key ${keyName}`);
+    }
+    assert.equal(totalVersions, 0, `Unexpected total versions for key ${keyName}`);
+  });
+
+  it("can get several inserted keys", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    const keyNames = [`${keyName}-0`, `${keyName}-1`];
+    for (const name of keyNames) {
+      await client.createKey(name, "RSA");
+    }
+
+    let found = 0;
+    for await (const properties of client.listPropertiesOfKeys()) {
+      // The vault might contain more keys than the ones we inserted.
+      if (!keyNames.includes(properties.name)) continue;
+      found += 1;
+    }
+
+    assert.equal(found, 2, "Unexpected number of keys found by getKeys.");
+
+    for (const name of keyNames) {
+      await testClient.flushKey(name);
+    }
+  });
+
+  // On playback mode, the tests happen too fast for the timeout to work
+  it("can get several inserted keys with requestOptions timeout", async function() {
+    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+    const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
+
+    await assertThrowsAbortError(async () => {
+      await iter.next();
     });
+  });
 
-    it("list 0 versions of a non-existing key (paged)", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      let totalVersions = 0;
-      for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
-        for (const version of page) {
-          assert.equal(
-            version.name,
-            keyName,
-            "Unexpected key name in result from listPropertiesOfKeyVersions()."
-          );
-          totalVersions += 1;
-        }
-      }
-      assert.equal(totalVersions, 0, `Unexpected total versions for key ${keyName}`);
-    });
+  it("can get several inserted keys (paged)", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    const keyNames = [`${keyName}-0`, `${keyName}-1`];
+    for (const name of keyNames) {
+      await client.createKey(name, "RSA");
+    }
 
-    it("can get several inserted keys", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const keyNames = [`${keyName}-0`, `${keyName}-1`];
-      for (const name of keyNames) {
-        await client.createKey(name, "RSA");
-      }
-
-      let found = 0;
-      for await (const properties of client.listPropertiesOfKeys()) {
+    let found = 0;
+    for await (const page of client.listPropertiesOfKeys().byPage()) {
+      for (const properties of page) {
         // The vault might contain more keys than the ones we inserted.
         if (!keyNames.includes(properties.name)) continue;
         found += 1;
       }
+    }
 
-      assert.equal(found, 2, "Unexpected number of keys found by getKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by getKeys.");
 
-      for (const name of keyNames) {
-        await testClient.flushKey(name);
-      }
+    for (const name of keyNames) {
+      await testClient.flushKey(name);
+    }
+  });
+
+  it("list deleted keys", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    const keyNames = [`${keyName}-0`, `${keyName}-1`];
+    for (const name of keyNames) {
+      await client.createKey(name, "RSA");
+    }
+    for (const name of keyNames) {
+      const poller = await client.beginDeleteKey(name, testPollerProperties);
+      await poller.pollUntilDone();
+    }
+
+    let found = 0;
+    for await (const deletedKey of client.listDeletedKeys()) {
+      // The vault might contain more keys than the ones we inserted.
+      if (!keyNames.includes(deletedKey.name)) continue;
+      found += 1;
+    }
+
+    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
+
+    for (const name of keyNames) {
+      await testClient.purgeKey(name);
+    }
+  });
+
+  // On playback mode, the tests happen too fast for the timeout to work
+  it("list deleted keys with requestOptions timeout", async function() {
+    recorder.skip(undefined, "Timeout tests don't work on playback mode.");
+    const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
+    await assertThrowsAbortError(async () => {
+      await iter.next();
     });
+  });
 
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can get several inserted keys with requestOptions timeout", async function() {
-      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-      const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
+  it("list deleted keys (paged)", async function(this: Context) {
+    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+    const keyNames = [`${keyName}-0`, `${keyName}-1`];
+    for (const name of keyNames) {
+      await client.createKey(name, "RSA");
+    }
+    for (const name of keyNames) {
+      const poller = await client.beginDeleteKey(name, testPollerProperties);
+      await poller.pollUntilDone();
+    }
 
-      await assertThrowsAbortError(async () => {
-        await iter.next();
-      });
-    });
-
-    it("can get several inserted keys (paged)", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const keyNames = [`${keyName}-0`, `${keyName}-1`];
-      for (const name of keyNames) {
-        await client.createKey(name, "RSA");
-      }
-
-      let found = 0;
-      for await (const page of client.listPropertiesOfKeys().byPage()) {
-        for (const properties of page) {
-          // The vault might contain more keys than the ones we inserted.
-          if (!keyNames.includes(properties.name)) continue;
-          found += 1;
-        }
-      }
-
-      assert.equal(found, 2, "Unexpected number of keys found by getKeys.");
-
-      for (const name of keyNames) {
-        await testClient.flushKey(name);
-      }
-    });
-
-    it("list deleted keys", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const keyNames = [`${keyName}-0`, `${keyName}-1`];
-      for (const name of keyNames) {
-        await client.createKey(name, "RSA");
-      }
-      for (const name of keyNames) {
-        const poller = await client.beginDeleteKey(name, testPollerProperties);
-        await poller.pollUntilDone();
-      }
-
-      let found = 0;
-      for await (const deletedKey of client.listDeletedKeys()) {
+    let found = 0;
+    for await (const page of client.listDeletedKeys().byPage()) {
+      for (const deletedKey of page) {
         // The vault might contain more keys than the ones we inserted.
         if (!keyNames.includes(deletedKey.name)) continue;
         found += 1;
       }
+    }
 
-      assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
 
-      for (const name of keyNames) {
-        await testClient.purgeKey(name);
-      }
-    });
-
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("list deleted keys with requestOptions timeout", async function() {
-      recorder.skip(undefined, "Timeout tests don't work on playback mode.");
-      const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
-      await assertThrowsAbortError(async () => {
-        await iter.next();
-      });
-    });
-
-    it("list deleted keys (paged)", async function(this: Context) {
-      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-      const keyNames = [`${keyName}-0`, `${keyName}-1`];
-      for (const name of keyNames) {
-        await client.createKey(name, "RSA");
-      }
-      for (const name of keyNames) {
-        const poller = await client.beginDeleteKey(name, testPollerProperties);
-        await poller.pollUntilDone();
-      }
-
-      let found = 0;
-      for await (const page of client.listDeletedKeys().byPage()) {
-        for (const deletedKey of page) {
-          // The vault might contain more keys than the ones we inserted.
-          if (!keyNames.includes(deletedKey.name)) continue;
-          found += 1;
-        }
-      }
-
-      assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
-
-      for (const name of keyNames) {
-        await testClient.purgeKey(name);
-      }
-    });
+    for (const name of keyNames) {
+      await testClient.purgeKey(name);
+    }
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -19,6 +19,7 @@ import TestClient from "../utils/testClient";
 import { Recorder, env } from "@azure/test-utils-recorder";
 import { ClientSecretCredential } from "@azure/identity";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
+import { getServiceVersion } from "../utils/utils.common";
 const { assert } = chai;
 
 describe("Local cryptography public tests", () => {
@@ -35,7 +36,7 @@ describe("Local cryptography public tests", () => {
   }
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     client = authentication.client;
     recorder = authentication.recorder;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.delete.spec.ts
@@ -10,6 +10,7 @@ import { KeyClient, DeletedKey } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { getServiceVersion } from "../utils/utils.common";
 
 describe("Keys client - Long Running Operations - delete", () => {
   const keyPrefix = `lroDelete${env.CERTIFICATE_NAME || "KeyName"}`;
@@ -19,7 +20,7 @@ describe("Keys client - Long Running Operations - delete", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     keySuffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
@@ -7,7 +7,7 @@ import { env, Recorder } from "@azure/test-utils-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { KeyClient, DeletedKey } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
@@ -20,7 +20,7 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     keySuffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/public/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/recoverBackupRestore.spec.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import { Context } from "mocha";
 import { isNode } from "@azure/core-http";
 import { KeyClient } from "../../src";
-import { assertThrowsAbortError } from "../utils/utils.common";
+import { assertThrowsAbortError, getServiceVersion } from "../utils/utils.common";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { env, Recorder, isRecordMode, isPlaybackMode } from "@azure/test-utils-recorder";
 import { authenticate } from "../utils/testAuthentication";
@@ -19,7 +19,7 @@ describe("Keys client - restore keys and recover backups", () => {
   let recorder: Recorder;
 
   beforeEach(async function(this: Context) {
-    const authentication = await authenticate(this);
+    const authentication = await authenticate(this, getServiceVersion());
     keySuffix = authentication.keySuffix;
     client = authentication.client;
     testClient = authentication.testClient;

--- a/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testAuthentication.ts
@@ -8,10 +8,7 @@ import { uniqueString } from "./recorderUtils";
 import TestClient from "./testClient";
 import { Context } from "mocha";
 
-// Adding this to the source would change the public API.
-type ApiVersions = "7.0" | "7.1" | "7.2";
-
-export async function authenticate(that: Context, version?: string): Promise<any> {
+export async function authenticate(that: Context, version: string): Promise<any> {
   const keySuffix = uniqueString();
   const recorderEnvSetup: RecorderEnvironmentSetup = {
     replaceableVariables: {
@@ -41,7 +38,7 @@ export async function authenticate(that: Context, version?: string): Promise<any
   }
 
   const client = new KeyClient(keyVaultUrl, credential, {
-    serviceVersion: version as ApiVersions
+    serviceVersion: version
   });
   const testClient = new TestClient(client);
 

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -38,6 +38,7 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
 }
 
 export function getServiceVersion(): string {
+  console.log("env.SERVICE_VERSION", env.SERVICE_VERSION);
   if (!env.SERVICE_VERSION || env.SERVICE_VERSION === "latest") {
     return LATEST_API_VERSION;
   }

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -54,8 +54,8 @@ export const serviceVersions = ["7.0", "7.1", "7.2"] as const;
 /**
  * A convenience wrapper allowing us to limit service versions without using the `versionsToTest` wrapper.
  *
- * @param supportedVersions - The {@see SupportedVersions} to limit this test against.
- * @param serviceVersion - The service version we want to test support for. If omitted we will default to the version return {@see getServiceVersion}
+ * @param supportedVersions - The {@link SupportedVersions} to limit this test against.
+ * @param serviceVersion - The service version we want to test support for. If omitted we will default to the version returned from {@link getServiceVersion}.
  * @returns A Mocha Wrapper which will skip or execute the chained tests depending the currently tested service version and the supported versions.
  */
 export function onVersions(

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { SupportedVersions, supports } from "@azure/test-utils-multi-version";
 import { env } from "@azure/test-utils-recorder";
 import * as assert from "assert";
+import { LATEST_API_VERSION } from "../../src/keysModels";
 
 // Async iterator's polyfill for Node 8
 if (!Symbol || !(Symbol as any).asyncIterator) {
@@ -34,3 +36,17 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
     throw new Error("Expected cb to throw an AbortError");
   }
 }
+
+export function getServiceVersion(): string {
+  if (!env.SERVICE_VERSION || env.SERVICE_VERSION === "latest") {
+    return LATEST_API_VERSION;
+  }
+
+  return env.SERVICE_VERSION;
+}
+
+export function onVersions(supportedVersions: SupportedVersions) {
+  return supports(getServiceVersion(), supportedVersions, supportedServiceVersions);
+}
+
+export const supportedServiceVersions = ["7.0", "7.1", "7.2"] as const;

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -43,6 +43,7 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
  * @returns - The service version to test
  */
 export function getServiceVersion(): string {
+  console.log("env.SERVICE_VERSION", env.SERVICE_VERSION);
   return env.SERVICE_VERSION || LATEST_API_VERSION;
 }
 

--- a/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/utils.common.ts
@@ -43,7 +43,6 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
  * @returns - The service version to test
  */
 export function getServiceVersion(): string {
-  console.log("env.SERVICE_VERSION", env.SERVICE_VERSION);
   return env.SERVICE_VERSION || LATEST_API_VERSION;
 }
 


### PR DESCRIPTION
## What

- Adds support for live testing multiple service versions
- Adds the matrix config and plumbing to pass service version as an environment variable
- Adds a helper method to support skipping tests when the service version isn't supported

## Why

KeyVault currently supports three service versions: 7.0, 7.1, and 7.2. Being able to ensure our
live tests run against previous service versions is a way to future proof ourselves and allow us
to ensure continued support.

After a bit of discussion we agreed that it would be worthwhile to add the indirection of passing
the service version as an environment variable and avoid having to run all service versions tests
in sequence.