### PR TITLE
[EventGrid] Document Distributed Tracing extension

### DIFF
--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -170,6 +170,10 @@ Compared with using `JSON.parse` directly, `EventGridDeserializer` does some add
 
 When creating an instance of `EventGridDeserializer` you may supply custom deserializers that are used to further convert the `data` object.
 
+### Distributed Tracing and Cloud Events
+
+This library supports distributed tracing using [`@azure/core-tracing`][azure-core-tracing-github]. When using distributed tracing, this library will create a span during a `send` operation. In addition, when sending events using the Cloud Events 1.0 schema, the SDK will add distributed tracing metadata to the events using the [Distributed Tracing extension][cloud-events-distributed-tracing-spec]. The values for the `traceparent` and `tracestate` extension properties correspond to the `traceparent` and `tracestate` headers from the HTTP request which sends the events. If an event already has a `traceparent` extension property it is not updated.
+
 ## Examples
 
 ### Publish a Custom Event to an Event Grid Topic using the Event Grid Schema
@@ -298,3 +302,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 [azure_sub]: https://azure.microsoft.com/free/
 [event_grid]: https://docs.microsoft.com/azure/event-grid
 [azure_portal]: https://portal.azure.com
+[azure-core-tracing-github]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/core-tracing
+[cloud-events-distributed-tracing-spec]: https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md


### PR DESCRIPTION
When events are sent using the Cloud Event schema, and distributed
tracing is used (so `traceparent` and `tracestate` are added as
headers on an http request) the SDK automatically ads this information
to the events as they are sent, using the distributed tracing
extension properties, as documented by the CNCF, if they are not
already present.

Add a small note about this to the README.md

Fixes #12036