### PR TITLE
[Identity] Small fixes on the manual tests

### DIFF
--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "@azure/identity": "^1.1.0",
+    "@azure/identity": "^2.0.0-beta.1",
     "@azure/service-bus": "^7.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -24,6 +24,7 @@
     "@types/react-dom": "^16.8.5",
     "@types/webpack": "^4.4.13",
     "@types/webpack-dev-middleware": "^2.0.2",
+    "dotenv": "^8.2.0",
     "prettier": "^2.2.1",
     "ts-loader": "^5.3.1",
     "typescript": "~3.6.4",


### PR DESCRIPTION
Small tweaks on the manual folder. I use `dotenv` in some scripts in this folder, and a recent PR switched Identity back to 1.0.0, but this folder needs 2.0.0-beta.1 to work.