### PR TITLE
Fix clean task for keyvault-common

### DIFF
--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -33,7 +33,7 @@
     "build:test": "echo skipped",
     "build": "npm run extract-api && npm run build:es6 && npm run build:nodebrowser",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "clean": "rimraf dist-esm dist-test typings *.tgz *.log samples/typescript/dist",
+    "clean": "rimraf dist-esm dist-test types *.tgz *.log samples/typescript/dist",
     "execute:js-samples": "echo skipped",
     "execute:ts-samples": "echo skipped",
     "execute:samples": "npm run build:samples && npm run execute:js-samples && npm run execute:ts-samples",


### PR DESCRIPTION
The directory name was wrong in the clean task, so stale types files weren't getting cleaned up.