### PR TITLE
[Identity] InteractiveBrowserCredential should handle open() throws

### DIFF
--- a/sdk/identity/identity/recordings/node/interactivebrowsercredential_internal/recording_throws_an_expected_error_if_no_browser_is_available.js
+++ b/sdk/identity/identity/recordings/node/interactivebrowsercredential_internal/recording_throws_an_expected_error_if_no_browser_is_available.js
@@ -1,0 +1,76 @@
+let nock = require('nock');
+
+module.exports.hash = "ca8a7c0c51461e95fe57ba420278e3aa";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '9a0ebf02-d46a-4a0c-8153-a768757ecf00',
+  'x-ms-ests-server',
+  '2.1.11562.10 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=fpc;; expires=Thu, 29-Apr-2021 20:27:26 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=esctx; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 30 Mar 2021 20:27:25 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"NA","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Length',
+  '1651',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '1f54ec47-8006-40cf-b0ad-29ce16e80200',
+  'x-ms-ests-server',
+  '2.1.11562.10 - WUS2 ProdSlices',
+  'Set-Cookie',
+  'fpc=fpc;; expires=Thu, 29-Apr-2021 20:27:26 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=esctx; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 30 Mar 2021 20:27:26 GMT'
+]);

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -44,6 +44,7 @@ describe("InteractiveBrowserCredential (internal)", function() {
       error = e;
     }
 
+    assert.equal(error?.name, "CredentialUnavailable");
     assert.equal(error?.message, `Could not open a browser window. Error: ${testErrorMessage}`);
   });
 });

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+
+import Sinon from "sinon";
+import assert from "assert";
+import { Context } from "mocha";
+import { env } from "@azure/test-utils-recorder";
+import { InteractiveBrowserCredential } from "../../../src";
+import { MsalTestCleanup, msalNodeTestSetup } from "../../msalTestUtils";
+import { interactiveBrowserMockable } from "../../../src/msal/nodeFlows/msalOpenBrowser";
+
+describe("InteractiveBrowserCredential (internal)", function() {
+  let cleanup: MsalTestCleanup;
+  let sandbox: Sinon.SinonSandbox;
+
+  beforeEach(function(this: Context) {
+    const setup = msalNodeTestSetup(this);
+    sandbox = setup.sandbox;
+    cleanup = setup.cleanup;
+  });
+  afterEach(async function() {
+    await cleanup();
+  });
+
+  const scope = "https://vault.azure.net/.default";
+
+  it("Throws an expected error if no browser is available", async function() {
+    // The SinonStub type does not include this second parameter to throws().
+    const testErrorMessage = "No browsers available on this test.";
+    (sandbox.stub(interactiveBrowserMockable, "open") as any).throws("TestError", testErrorMessage);
+
+    const credential = new InteractiveBrowserCredential({
+      redirectUri: "http://localhost:8081",
+      tenantId: env.AZURE_TENANT_ID,
+      clientId: env.AZURE_CLIENT_ID
+    });
+
+    let error: Error | undefined;
+    try {
+      await credential.getToken(scope);
+    } catch (e) {
+      error = e;
+    }
+
+    assert.equal(error?.message, `Could not open a browser window. Error: ${testErrorMessage}`);
+  });
+});

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -29,7 +29,7 @@ describe("InteractiveBrowserCredential (internal)", function() {
 
   it("Throws an expected error if no browser is available", async function() {
     // On Node 8, URL is not defined. We use URL on the msalOpenBrowser.ts file.
-    if (!isNode8) {
+    if (isNode8) {
       this.skip();
     }
 

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -10,6 +10,7 @@ import { env } from "@azure/test-utils-recorder";
 import { InteractiveBrowserCredential } from "../../../src";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../msalTestUtils";
 import { interactiveBrowserMockable } from "../../../src/msal/nodeFlows/msalOpenBrowser";
+import { isNode8 } from "../../../src/tokenCache/nodeVersion";
 
 describe("InteractiveBrowserCredential (internal)", function() {
   let cleanup: MsalTestCleanup;
@@ -27,6 +28,11 @@ describe("InteractiveBrowserCredential (internal)", function() {
   const scope = "https://vault.azure.net/.default";
 
   it("Throws an expected error if no browser is available", async function() {
+    // On Node 8, URL is not defined. We use URL on the msalOpenBrowser.ts file.
+    if (!isNode8) {
+      this.skip();
+    }
+
     // The SinonStub type does not include this second parameter to throws().
     const testErrorMessage = "No browsers available on this test.";
     (sandbox.stub(interactiveBrowserMockable, "open") as any).throws("TestError", testErrorMessage);

--- a/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -27,7 +27,7 @@ describe("InteractiveBrowserCredential (internal)", function() {
 
   const scope = "https://vault.azure.net/.default";
 
-  it("Throws an expected error if no browser is available", async function() {
+  it("Throws an expected error if no browser is available", async function(this: Context) {
     // On Node 8, URL is not defined. We use URL on the msalOpenBrowser.ts file.
     if (isNode8) {
       this.skip();


### PR DESCRIPTION
This PR adds a way to handle throws coming form the `open` dependency. One way this dependency will throw is if the are no browsers available. One quick way to test this is to install `open` in a Linux VM and to run this Node code: 

```js
const open = require("open");

(async () => open("http://sadasant.com/", { wait: true }))()
  .then(console.log)
  .catch(e => console.log("open() error", { message: e.message }));
```

Which will cause this error:

```
open() error { message: 'spawn xdg-open ENOENT' }
```

This effectively means that InteractiveBrowserCredential  will throw if there are no browsers available. This could be useful if we ever want to provide a backup to DeviceCode on those cases.

Though this issue is not blocking the release, introducing InteractiveBrowserCredential tests to our CI will help us catch anything we haven't noticed yet.

Fixes #14616