### PR TITLE
[core-tracing] Updating surface to be clean of constructs that won't work in TS 3.1

### DIFF
--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -4,24 +4,9 @@
 
 ```ts
 
-import { context } from '@opentelemetry/api';
-import { Exception } from '@opentelemetry/api';
-import { getSpan } from '@opentelemetry/api';
-import { getSpanContext } from '@opentelemetry/api';
 import { Span as OpenCensusSpan } from '@opencensus/web-types';
 import { Tracer as OpenCensusTracer } from '@opencensus/web-types';
-import { SpanContext as OTSpanContext } from '@opentelemetry/api';
-import { SpanOptions as OTSpanOptions } from '@opentelemetry/api';
-import { setSpan } from '@opentelemetry/api';
-import { setSpanContext } from '@opentelemetry/api';
-import { SpanAttributes as SpanAttributes_2 } from '@opentelemetry/api';
-import { SpanAttributeValue as SpanAttributeValue_2 } from '@opentelemetry/api';
-import { SpanKind } from '@opentelemetry/api';
-import { SpanStatus } from '@opentelemetry/api';
-import { TimeInput } from '@opentelemetry/api';
-import { Tracer } from '@opentelemetry/api';
 import { TracerBase } from '@opencensus/web-types';
-import { TraceState } from '@opentelemetry/api';
 
 // @public
 export interface Context {
@@ -30,7 +15,13 @@ export interface Context {
     setValue(key: symbol, value: unknown): Context;
 }
 
-export { context }
+// @public
+export const context: ContextAPI;
+
+// @public
+export interface ContextAPI {
+    active(): Context;
+}
 
 // @public
 export function createSpanFunction(args: CreateSpanFunctionArgs): <T extends {
@@ -46,20 +37,50 @@ export interface CreateSpanFunctionArgs {
     packagePrefix: string;
 }
 
-export { Exception }
+// @public
+export type Exception = ExceptionWithCode | ExceptionWithMessage | ExceptionWithName | string;
+
+// @public
+export interface ExceptionWithCode {
+    code: string | number;
+    message?: string;
+    name?: string;
+    stack?: string;
+}
+
+// @public
+export interface ExceptionWithMessage {
+    code?: string | number;
+    message: string;
+    name?: string;
+    stack?: string;
+}
+
+// @public
+export interface ExceptionWithName {
+    code?: string | number;
+    message?: string;
+    name: string;
+    stack?: string;
+}
 
 // @public
 export function extractSpanContextFromTraceParentHeader(traceParentHeader: string): SpanContext | undefined;
 
-export { getSpan }
+// @public
+export function getSpan(context: Context): Span | undefined;
 
-export { getSpanContext }
+// @public
+export function getSpanContext(context: Context): SpanContext | undefined;
 
 // @public
 export function getTraceParentHeader(spanContext: SpanContext): string | undefined;
 
 // @public
 export function getTracer(): Tracer;
+
+// @public
+export type HrTime = [number, number];
 
 // @public
 export interface Link {
@@ -130,13 +151,11 @@ export interface OperationTracingOptions {
     tracingContext?: Context;
 }
 
-export { OTSpanContext }
+// @public
+export function setSpan(context: Context, span: Span): Context;
 
-export { OTSpanOptions }
-
-export { setSpan }
-
-export { setSpanContext }
+// @public
+export function setSpanContext(context: Context, spanContext: SpanContext): Context;
 
 // @public
 export function setTracer(tracer: Tracer): void;
@@ -181,7 +200,14 @@ export interface SpanGraphNode {
     name: string;
 }
 
-export { SpanKind }
+// @public
+export enum SpanKind {
+    CLIENT = 2,
+    CONSUMER = 4,
+    INTERNAL = 0,
+    PRODUCER = 3,
+    SERVER = 1
+}
 
 // @public
 export interface SpanOptions {
@@ -191,7 +217,11 @@ export interface SpanOptions {
     startTime?: TimeInput;
 }
 
-export { SpanStatus }
+// @public
+export interface SpanStatus {
+    code: SpanStatusCode;
+    message?: string;
+}
 
 // @public
 export enum SpanStatusCode {
@@ -202,17 +232,17 @@ export enum SpanStatusCode {
 
 // @public
 export class TestSpan extends NoOpSpan {
-    constructor(parentTracer: Tracer, name: string, context: OTSpanContext, kind: SpanKind, parentSpanId?: string, startTime?: TimeInput);
-    readonly attributes: SpanAttributes_2;
-    context(): OTSpanContext;
+    constructor(parentTracer: Tracer, name: string, context: SpanContext, kind: SpanKind, parentSpanId?: string, startTime?: TimeInput);
+    readonly attributes: SpanAttributes;
+    context(): SpanContext;
     end(_endTime?: number): void;
     endCalled: boolean;
     isRecording(): boolean;
     kind: SpanKind;
     name: string;
     readonly parentSpanId?: string;
-    setAttribute(key: string, value: SpanAttributeValue_2): this;
-    setAttributes(attributes: SpanAttributes_2): this;
+    setAttribute(key: string, value: SpanAttributeValue): this;
+    setAttributes(attributes: SpanAttributes): this;
     setStatus(status: SpanStatus): this;
     readonly startTime: TimeInput;
     status: SpanStatus;
@@ -228,7 +258,8 @@ export class TestTracer extends NoOpTracer {
     startSpan(name: string, options?: SpanOptions, context?: Context): TestSpan;
     }
 
-export { TimeInput }
+// @public
+export type TimeInput = HrTime | number | Date;
 
 // @public
 export const enum TraceFlags {
@@ -236,7 +267,18 @@ export const enum TraceFlags {
     SAMPLED = 1
 }
 
-export { TraceState }
+// @public
+export interface Tracer {
+    startSpan(name: string, options?: SpanOptions, context?: Context): Span;
+}
+
+// @public
+export interface TraceState {
+    get(key: string): string | undefined;
+    serialize(): string;
+    set(key: string, value: string): TraceState;
+    unset(key: string): TraceState;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -16,11 +16,17 @@ export { createSpanFunction, CreateSpanFunctionArgs } from "./createSpan";
 export {
   context,
   Context,
+  ContextAPI,
   Exception,
+  ExceptionWithCode,
+  ExceptionWithMessage,
+  ExceptionWithName,
   getSpan,
   getSpanContext,
+  HrTime,
   Link,
   LinkContext,
+  OperationTracingOptions,
   setSpan,
   setSpanContext,
   Span,
@@ -33,11 +39,9 @@ export {
   SpanStatusCode,
   TimeInput,
   TraceFlags,
+  Tracer,
   TraceState
 } from "./interfaces";
-
-// OT interfaces
-export { SpanContext as OTSpanContext, SpanOptions as OTSpanOptions } from "@opentelemetry/api";
 
 // Utilities
 export {
@@ -47,5 +51,3 @@ export {
 
 // OpenCensus Interfaces
 export { Tracer as OpenCensusTracer, Span as OpenCensusSpan } from "@opencensus/web-types";
-
-export { OperationTracingOptions } from "./interfaces";

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -2,30 +2,227 @@
 // Licensed under the MIT license.
 
 import {
-  context,
-  Exception,
-  getSpan,
-  getSpanContext,
-  setSpan,
-  setSpanContext,
-  SpanKind,
-  SpanStatus,
-  TimeInput,
-  TraceState
+  context as otContext,
+  getSpan as otGetSpan,
+  getSpanContext as otGetSpanContext,
+  setSpan as otSetSpan,
+  setSpanContext as otSetSpanContext
 } from "@opentelemetry/api";
 
-export {
-  context,
-  getSpan,
-  getSpanContext,
-  setSpan,
-  setSpanContext,
-  SpanKind,
-  SpanStatus,
-  TimeInput,
-  TraceState,
-  Exception
-};
+/**
+ * A Tracer.
+ */
+export interface Tracer {
+  /**
+   * Starts a new {@link Span}. Start the span without setting it on context.
+   *
+   * This method does NOT modify the current Context.
+   *
+   * @param name The name of the span
+   * @param [options] SpanOptions used for span creation
+   * @param [context] Context to use to extract parent
+   * @returns Span The newly created span
+   * @example
+   *     const span = tracer.startSpan('op');
+   *     span.setAttribute('key', 'value');
+   *     span.end();
+   */
+  startSpan(name: string, options?: SpanOptions, context?: Context): Span;
+}
+
+/**
+ * TraceState.
+ */
+export interface TraceState {
+  /**
+   * Create a new TraceState which inherits from this TraceState and has the
+   * given key set.
+   * The new entry will always be added in the front of the list of states.
+   *
+   * @param key key of the TraceState entry.
+   * @param value value of the TraceState entry.
+   */
+  set(key: string, value: string): TraceState;
+  /**
+   * Return a new TraceState which inherits from this TraceState but does not
+   * contain the given key.
+   *
+   * @param key the key for the TraceState entry to be removed.
+   */
+  unset(key: string): TraceState;
+  /**
+   * Returns the value to which the specified key is mapped, or `undefined` if
+   * this map contains no mapping for the key.
+   *
+   * @param key with which the specified value is to be associated.
+   * @returns the value to which the specified key is mapped, or `undefined` if
+   *     this map contains no mapping for the key.
+   */
+  get(key: string): string | undefined;
+  /**
+   * Serializes the TraceState to a `list` as defined below. The `list` is a
+   * series of `list-members` separated by commas `,`, and a list-member is a
+   * key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
+   * surrounding `list-members` are ignored. There can be a maximum of 32
+   * `list-members` in a `list`.
+   *
+   * @returns the serialized string.
+   */
+  serialize(): string;
+}
+
+/**
+ * Represents high resolution time.
+ */
+export declare type HrTime = [number, number];
+
+/**
+ * Used to represent a Time.
+ */
+export type TimeInput = HrTime | number | Date;
+
+/**
+ * The status for a span.
+ */
+export interface SpanStatus {
+  /** The status code of this message. */
+  code: SpanStatusCode;
+  /** A developer-facing error message. */
+  message?: string;
+}
+
+/**
+ * The kind of span.
+ */
+export enum SpanKind {
+  /** Default value. Indicates that the span is used internally. */
+  INTERNAL = 0,
+  /**
+   * Indicates that the span covers server-side handling of an RPC or other
+   * remote request.
+   */
+  SERVER = 1,
+  /**
+   * Indicates that the span covers the client-side wrapper around an RPC or
+   * other remote request.
+   */
+  CLIENT = 2,
+  /**
+   * Indicates that the span describes producer sending a message to a
+   * broker. Unlike client and server, there is no direct critical path latency
+   * relationship between producer and consumer spans.
+   */
+  PRODUCER = 3,
+  /**
+   * Indicates that the span describes consumer receiving a message from a
+   * broker. Unlike client and server, there is no direct critical path latency
+   * relationship between producer and consumer spans.
+   */
+  CONSUMER = 4
+}
+
+/**
+ * An Exception for a Span.
+ */
+export declare type Exception =
+  | ExceptionWithCode
+  | ExceptionWithMessage
+  | ExceptionWithName
+  | string;
+
+/**
+ * An Exception with a code.
+ */
+export interface ExceptionWithCode {
+  /** The code. */
+  code: string | number;
+  /** The name. */
+  name?: string;
+  /** The message. */
+  message?: string;
+  /** The stack. */
+  stack?: string;
+}
+
+/**
+ * An Exception with a message.
+ */
+export interface ExceptionWithMessage {
+  /** The code. */
+  code?: string | number;
+  /** The message. */
+  message: string;
+  /** The name. */
+  name?: string;
+  /** The stack. */
+  stack?: string;
+}
+
+/**
+ * An Exception with a name.
+ */
+export interface ExceptionWithName {
+  /** The code. */
+  code?: string | number;
+  /** The message. */
+  message?: string;
+  /** The name. */
+  name: string;
+  /** The stack. */
+  stack?: string;
+}
+
+/**
+ * Return the span if one exists
+ *
+ * @param context context to get span from
+ */
+export function getSpan(context: Context): Span | undefined {
+  return otGetSpan(context);
+}
+
+/**
+ * Set the span on a context
+ *
+ * @param context context to use as parent
+ * @param span span to set active
+ */
+export function setSpan(context: Context, span: Span): Context {
+  return otSetSpan(context, span);
+}
+
+/**
+ * Wrap span context in a NoopSpan and set as span in a new
+ * context
+ *
+ * @param context context to set active span on
+ * @param spanContext span context to be wrapped
+ */
+export function setSpanContext(context: Context, spanContext: SpanContext): Context {
+  return otSetSpanContext(context, spanContext);
+}
+
+/**
+ * Get the span context of the span if it exists.
+ *
+ * @param context context to get values from
+ */
+export function getSpanContext(context: Context): SpanContext | undefined {
+  return otGetSpanContext(context);
+}
+
+/**
+ * Singleton object which represents the entry point to the OpenTelemetry Context API
+ */
+export interface ContextAPI {
+  /**
+   * Get the currently active context
+   */
+  active(): Context;
+}
+
+/** Entrypoint for context API */
+export const context: ContextAPI = otContext;
 
 /** SpanStatusCode */
 export enum SpanStatusCode {

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -18,10 +18,10 @@ export interface Tracer {
    *
    * This method does NOT modify the current Context.
    *
-   * @param name The name of the span
-   * @param [options] SpanOptions used for span creation
-   * @param [context] Context to use to extract parent
-   * @returns Span The newly created span
+   * @param name - The name of the span
+   * @param options - SpanOptions used for span creation
+   * @param context - Context to use to extract parent
+   * @returns The newly created span
    * @example
    *     const span = tracer.startSpan('op');
    *     span.setAttribute('key', 'value');
@@ -39,22 +39,22 @@ export interface TraceState {
    * given key set.
    * The new entry will always be added in the front of the list of states.
    *
-   * @param key key of the TraceState entry.
-   * @param value value of the TraceState entry.
+   * @param key - key of the TraceState entry.
+   * @param value - value of the TraceState entry.
    */
   set(key: string, value: string): TraceState;
   /**
    * Return a new TraceState which inherits from this TraceState but does not
    * contain the given key.
    *
-   * @param key the key for the TraceState entry to be removed.
+   * @param key - the key for the TraceState entry to be removed.
    */
   unset(key: string): TraceState;
   /**
    * Returns the value to which the specified key is mapped, or `undefined` if
    * this map contains no mapping for the key.
    *
-   * @param key with which the specified value is to be associated.
+   * @param key - with which the specified value is to be associated.
    * @returns the value to which the specified key is mapped, or `undefined` if
    *     this map contains no mapping for the key.
    */
@@ -175,7 +175,7 @@ export interface ExceptionWithName {
 /**
  * Return the span if one exists
  *
- * @param context context to get span from
+ * @param context - context to get span from
  */
 export function getSpan(context: Context): Span | undefined {
   return otGetSpan(context);
@@ -184,8 +184,8 @@ export function getSpan(context: Context): Span | undefined {
 /**
  * Set the span on a context
  *
- * @param context context to use as parent
- * @param span span to set active
+ * @param context - context to use as parent
+ * @param span - span to set active
  */
 export function setSpan(context: Context, span: Span): Context {
   return otSetSpan(context, span);
@@ -195,8 +195,8 @@ export function setSpan(context: Context, span: Span): Context {
  * Wrap span context in a NoopSpan and set as span in a new
  * context
  *
- * @param context context to set active span on
- * @param spanContext span context to be wrapped
+ * @param context - context to set active span on
+ * @param spanContext - span context to be wrapped
  */
 export function setSpanContext(context: Context, spanContext: SpanContext): Context {
   return otSetSpanContext(context, spanContext);
@@ -205,7 +205,7 @@ export function setSpanContext(context: Context, spanContext: SpanContext): Cont
 /**
  * Get the span context of the span if it exists.
  *
- * @param context context to get values from
+ * @param context - context to get values from
  */
 export function getSpanContext(context: Context): SpanContext | undefined {
   return otGetSpanContext(context);

--- a/sdk/core/core-tracing/src/tracerProxy.ts
+++ b/sdk/core/core-tracing/src/tracerProxy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { NoOpTracer } from "./tracers/noop/noOpTracer";
-import { Tracer } from "@opentelemetry/api";
+import { Tracer } from "./interfaces";
 import { getCache } from "./utils/cache";
 
 let defaultTracer: Tracer;

--- a/sdk/core/core-tracing/src/tracers/noop/noOpTracer.ts
+++ b/sdk/core/core-tracing/src/tracers/noop/noOpTracer.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 import { NoOpSpan } from "./noOpSpan";
-import { Span, SpanOptions } from "../../interfaces";
-import { Tracer } from "@opentelemetry/api";
+import { Span, SpanOptions, Tracer } from "../../interfaces";
 
 /**
  * A no-op implementation of Tracer that can be used when tracing

--- a/sdk/core/core-tracing/src/tracers/opencensus/openCensusTracerWrapper.ts
+++ b/sdk/core/core-tracing/src/tracers/opencensus/openCensusTracerWrapper.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Tracer } from "@opentelemetry/api";
+import { Tracer } from "../../interfaces";
 import { OpenCensusSpanWrapper } from "./openCensusSpanWrapper";
 import { TracerBase as OpenCensusTracer } from "@opencensus/web-types";
 import { Span, SpanOptions } from "../../interfaces";

--- a/sdk/core/core-tracing/src/tracers/test/testSpan.ts
+++ b/sdk/core/core-tracing/src/tracers/test/testSpan.ts
@@ -10,7 +10,7 @@ import {
   SpanAttributes,
   SpanStatusCode,
   SpanAttributeValue
-} from "@opentelemetry/api";
+} from "../../interfaces";
 import { NoOpSpan } from "../noop/noOpSpan";
 
 /**

--- a/sdk/core/core-tracing/src/utils/cache.ts
+++ b/sdk/core/core-tracing/src/utils/cache.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Tracer } from "@opentelemetry/api";
+import { Tracer } from "../interfaces";
 import { getGlobalObject } from "./global";
 
 // V1 = OpenTelemetry 0.1


### PR DESCRIPTION
Some of the types for the core-tracing API were just being re-exported from opentelemetry/api (directly, not copied). `@opentelemetry/api` uses some constructs that aren't available in TypeScript 3.1, which causes problems for consumers of core-tracing.

This PR fixes that by duplicating the types, which should cut off any compiling/importing of the opentelemetry types by consumers of core-tracing.