### PR TITLE
[Identity] AuthenticationRequired API alignment

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0-beta.2 (Unreleased)
 
+- Added properties `scopes` and `getTokenOptions` to the `AuthenticationRequired` error.
 - Added a new option to the constructor of `DefaultAzureCredential`, `includeInteractiveCredentials`, which enables `InteractiveBrowserCredential` as a last resource if no other credential is available.
 - `InteractiveBrowserCredential` no longer supports [Implicit Grant Flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-implicit-grant-flow) and will only support [Auth Code Flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) instead. Therefore the `flow` option introduced in `1.2.4-beta.1` has been removed. More information from the documentation on Implicit Grant Flow:
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -42,10 +42,10 @@ export interface AuthenticationRecord {
 
 // @public
 export class AuthenticationRequired extends CredentialUnavailable {
-    constructor(scopes: string[], getTokenOptions?: GetTokenOptions, message?: string);
-    // (undocumented)
+    constructor(
+    scopes: string[],
+    getTokenOptions?: GetTokenOptions, message?: string);
     getTokenOptions: GetTokenOptions;
-    // (undocumented)
     scopes: string[];
 }
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -42,7 +42,11 @@ export interface AuthenticationRecord {
 
 // @public
 export class AuthenticationRequired extends CredentialUnavailable {
-    constructor(message?: string);
+    constructor(scopes: string[], getTokenOptions?: GetTokenOptions, message?: string);
+    // (undocumented)
+    getTokenOptions: GetTokenOptions;
+    // (undocumented)
+    scopes: string[];
 }
 
 // @public

--- a/sdk/identity/identity/src/msal/browserFlows/browserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/browserCommon.ts
@@ -143,6 +143,8 @@ export abstract class MsalBrowser extends MsalBaseUtilities implements MsalBrows
       }
       if (options?.disableAutomaticAuthentication) {
         throw new AuthenticationRequired(
+          scopes,
+          options,
           "Automatic authentication has been disabled. You may call the authentication() method."
         );
       }

--- a/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
@@ -153,7 +153,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
   ): Promise<AccessToken> {
     const account = await this.getActiveAccount();
     if (!account) {
-      throw new AuthenticationRequired();
+      throw new AuthenticationRequired(scopes, options);
     }
 
     const parameters: msalBrowser.SilentRequest = {
@@ -169,7 +169,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       const response = await this.app.acquireTokenSilent(parameters);
       return this.handleResult(scopes, response);
     } catch (err) {
-      throw this.handleError(scopes, err);
+      throw this.handleError(scopes, err, options);
     }
   }
 
@@ -182,7 +182,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
   ): Promise<AccessToken> {
     const account = await this.getActiveAccount();
     if (!account) {
-      throw new AuthenticationRequired();
+      throw new AuthenticationRequired(scopes, options);
     }
 
     const parameters: msalBrowser.RedirectRequest = {

--- a/sdk/identity/identity/src/msal/errors.ts
+++ b/sdk/identity/identity/src/msal/errors.ts
@@ -9,7 +9,13 @@ import { CredentialUnavailable } from "../client/errors";
  */
 export class AuthenticationRequired extends CredentialUnavailable {
   constructor(
+    /**
+     * The list of scopes for which the token will have access.
+     */
     public scopes: string[],
+    /**
+     * The options used to configure the getToken request.
+     */
     public getTokenOptions: GetTokenOptions = {},
     message?: string
   ) {

--- a/sdk/identity/identity/src/msal/errors.ts
+++ b/sdk/identity/identity/src/msal/errors.ts
@@ -1,13 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { GetTokenOptions } from "@azure/core-http";
 import { CredentialUnavailable } from "../client/errors";
 
 /**
  * Error used to enforce authentication after trying to retrieve a token silently.
  */
 export class AuthenticationRequired extends CredentialUnavailable {
-  constructor(message?: string) {
+  constructor(
+    public scopes: string[],
+    public getTokenOptions: GetTokenOptions = {},
+    message?: string
+  ) {
     super(message);
     this.name = "AuthenticationRequired";
   }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
@@ -113,7 +113,7 @@ export class MsalClientCertificate extends MsalNode {
       // so each time getToken gets called, we will have to acquire a new token through the service.
       return this.handleResult(scopes, result || undefined);
     } catch (err) {
-      throw this.handleError(scopes, err);
+      throw this.handleError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
@@ -37,7 +37,7 @@ export class MsalClientSecret extends MsalNode {
       // so each time getToken gets called, we will have to acquire a new token through the service.
       return this.handleResult(scopes, result || undefined);
     } catch (err) {
-      throw this.handleError(scopes, err);
+      throw this.handleError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
@@ -46,7 +46,7 @@ export class MsalDeviceCode extends MsalNode {
       });
       return this.handleResult(scopes, deviceResponse || undefined);
     } catch (error) {
-      throw this.handleError(scopes, error);
+      throw this.handleError(scopes, error, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
@@ -43,7 +43,7 @@ export class MsalUsernamePassword extends MsalNode {
       const result = await this.publicApp!.acquireTokenByUsernamePassword(requestOptions);
       return this.handleResult(scopes, result || undefined);
     } catch (error) {
-      throw this.handleError(scopes, error);
+      throw this.handleError(scopes, error, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/nodeCommon.ts
@@ -196,7 +196,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
   ): Promise<AccessToken> {
     await this.getActiveAccount();
     if (!this.account) {
-      throw new AuthenticationRequired();
+      throw new AuthenticationRequired(scopes, options);
     }
 
     const silentRequest: msalNode.SilentFlowRequest = {
@@ -211,7 +211,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       const response = await this.publicApp!.acquireTokenSilent(silentRequest);
       return this.handleResult(scopes, response || undefined);
     } catch (err) {
-      throw this.handleError(scopes, err);
+      throw this.handleError(scopes, err, options);
     }
   }
 
@@ -236,6 +236,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       }
       if (options?.disableAutomaticAuthentication) {
         throw new AuthenticationRequired(
+          scopes,
+          options,
           "Automatic authentication has been disabled. You may call the authentication() method."
         );
       }


### PR DESCRIPTION
To align with other languages, this PR adds properties `scopes` and `getTokenOptions` to the AuthenticationRequired error. For that purpose, some other utility functions had to change to pass these values through.

Fixes #14585