### PR TITLE
[Service Bus] This internal type setTimeoutArgs is showing up in the (Typedoc) docs - removing

### DIFF
--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -519,6 +519,9 @@ export type EntityAvailabilityStatus =
   | "Restoring"
   | "Unknown";
 
+/**
+ * @internal
+ */
 type setTimeoutArgs = (callback: (...args: any[]) => void, ms: number, ...args: any[]) => any;
 
 /**


### PR DESCRIPTION
setTimeoutArgs is only used internally.