### PR TITLE
[core-tracing] The rollup commonjs plugin needs extra "hinting" to handle opentelemetry/api versions

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -39,19 +39,26 @@ export function openTelemetryCommonJs(): Record<string, string[]> {
     ];
   }
 
-  namedExports[
-    // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
-    "../../../common/temp/node_modules/.pnpm/@opentelemetry/api@0.10.2/node_modules/@opentelemetry/api/build/src/index.js"
-  ] = [
-    "SpanKind",
-    "TraceFlags",
-    "getSpan",
-    "setSpan",
-    "StatusCode",
-    "CanonicalCode",
-    "getSpanContext",
-    "setSpanContext"
+  const releasedOpenTelemetryVersions = [
+    "0.10.2",
+    "1.0.0-rc.0"
   ];
+
+  for (const version of releasedOpenTelemetryVersions) {
+    namedExports[
+      // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
+      `../../../common/temp/node_modules/.pnpm/@opentelemetry/api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
+    ] = [
+        "SpanKind",
+        "TraceFlags",
+        "getSpan",
+        "setSpan",
+        "StatusCode",
+        "CanonicalCode",
+        "getSpanContext",
+        "setSpanContext"
+      ];
+  }
 
   return namedExports;
 }


### PR DESCRIPTION
The rollup commonJS plugin associates our manually namedExports to an ID, which typically is a package ID.

Due to the fact that the opentelemetry/api project can enter into the node_modules from multiple locations (either from an older dependency, like identity prior to our centralization, or a release version of core-tracing) we have to explicitly _name_ the path to the package, not just the package name.