### PR TITLE
[Identity] - Remove `await` from README

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -140,9 +140,6 @@ const credential = new DefaultAzureCredential();
 
 // Create authenticated client
 const client = new KeyClient(vaultUrl, credential);
-
-// Use service from authenticated client
-const getResult = await client.getKey("MyKeyName");
 ```
 
 ### Specifying a user assigned managed identity with the `DefaultAzureCredential`


### PR DESCRIPTION
This small PR just removes an `await` call that doesn't make sense outside of async functions. Using a client is also not necessary to demonstrate how to create one.

Resolves #14002