### PR TITLE
[Text Analytics] Auto-generated README.md

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -1,6 +1,6 @@
 # Azure Text Analytics Client library for JavaScript
 
-This package contains an isomorphic SDK for Azure Text Analytics Client.
+This package contains an isomorphic SDK (runs both in node.js and in browsers) for Azure Text Analytics Client.
 
 The Text Analytics API is a suite of natural language processing (NLP)  services built with best-in-class Microsoft machine learning algorithms.  The API can be used to analyze unstructured text for tasks such as sentiment analysis, key phrase extraction and language detection. Functionality for analysis of text specific to the healthcare domain and personal information are also available in the API. Further documentation can be found in <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview">https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview</a>
 
@@ -14,6 +14,7 @@ The Text Analytics API is a suite of natural language processing (NLP)  services
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
+- Browser Javascript
 
 ### Prerequisites
 
@@ -56,7 +57,7 @@ const client = new TextAnalyticsClient("<endpoint>", new DefaultAzureCredential(
 
 ### TextAnalyticsClient
 
-`TextAnalyticsClient` is the primary interface for developers using the Azure Text Analytics Client library. It provides asynchronous methods to access a specific use of Text Analytics.
+`TextAnalyticsClient` is the primary interface for developers using the Azure Text Analytics Client library. Explore the methods on this client object to understand the different features of the Text Analytics service that you can access.
 
 ## Troubleshooting
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -14,7 +14,7 @@ The Text Analytics API is a suite of natural language processing (NLP)  services
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser Javascript
+- Browser JavaScript
 
 ### Prerequisites
 
@@ -22,7 +22,7 @@ The Text Analytics API is a suite of natural language processing (NLP)  services
 
 ### Install the `@azure/ai-text-analytics` package
 
-Install the Azure Text Analytics Client library for Javascript with `npm`:
+Install the Azure Text Analytics Client library for JavaScript with `npm`:
 
 ```bash
 npm install @azure/ai-text-analytics
@@ -83,7 +83,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 
 ## Related projects
 
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+- [Microsoft Azure SDK for JavaScript](https://github.com/Azure/azure-sdk-for-js)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Ftextanalytics%2Fai-text-analytics%2FREADME.png)
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -1,30 +1,12 @@
-# Azure Text Analytics client library for JavaScript
+# Azure Text Analytics Client library for JavaScript
 
-[Azure TextAnalytics](https://azure.microsoft.com/services/cognitive-services/text-analytics/) is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:
+This package contains an isomorphic SDK for Azure Text Analytics Client.
 
-**Note:** This SDK targets Azure Text Analytics service API version 3.1.0-preview.3.
+The Text Analytics API is a suite of natural language processing (NLP)  services built with best-in-class Microsoft machine learning algorithms.  The API can be used to analyze unstructured text for tasks such as sentiment analysis, key phrase extraction and language detection. Functionality for analysis of text specific to the healthcare domain and personal information are also available in the API. Further documentation can be found in <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview">https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview</a>
 
-- Language Detection
-- Sentiment Analysis
-- Key Phrase Extraction
-- Named Entity Recognition
-- Recognition of Personally Identifiable Information
-- Linked Entity Recognition
-- Healthcare Analysis
-- Batch Processing
-
-Use the client library to:
-
-- Detect what language input text is written in.
-- Determine what customers think of your brand or topic by analyzing raw text for clues about positive or negative sentiment.
-- Automatically extract key phrases to quickly identify the main points.
-- Identify and categorize entities in your text as people, places, organizations, date/time, quantities, percentages, currencies, healthcare specific, and more.
-- Perform multiple of the above tasks at once.
-
-[Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/textanalytics/ai-text-analytics/) |
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-text-analytics) |
 [API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-text-analytics) |
-[Product documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples)
 
 ## Getting started
@@ -36,17 +18,10 @@ Use the client library to:
 ### Prerequisites
 
 - An [Azure subscription][azure_sub].
-- An existing [Cognitive Services][cognitive_resource] or Text Analytics resource. If you need to create the resource, you can use the [Azure Portal][azure_portal] or [Azure CLI][azure_cli].
-
-If you use the Azure CLI, replace `<your-resource-group-name>` and `<your-resource-name>` with your own unique names:
-
-```PowerShell
-az cognitiveservices account create --kind TextAnalytics --resource-group <your-resource-group-name> --name <your-resource-name> --sku <your-sku-name> --location <your-location>
-```
 
 ### Install the `@azure/ai-text-analytics` package
 
-Install the Azure Text Analytics client library for JavaScript with `npm`:
+Install the Azure Text Analytics Client library for Javascript with `npm`:
 
 ```bash
 npm install @azure/ai-text-analytics
@@ -54,46 +29,23 @@ npm install @azure/ai-text-analytics
 
 ### Create and authenticate a `TextAnalyticsClient`
 
-To create a client object to access the Text Analytics API, you will need the `endpoint` of your Text Analytics resource and a `credential`. The Text Analytics client can use either Azure Active Directory credentials or an API key credential to authenticate.
+To create a client object to access the Text Analytics API, you will need the `endpoint` of your Text Analytics resource and a `credential`. The Azure Text Analytics Client can use Azure Active Directory credentials to authenticate.
 
-You can find the endpoint for your text analytics resource either in the [Azure Portal][azure_portal] or by using the [Azure CLI][azure_cli] snippet below:
-
-```bash
-az cognitiveservices account show --name <your-resource-name> --resource-group <your-resource-group-name> --query "endpoint"
-```
-
-#### Using an API Key
-
-Use the [Azure Portal][azure_portal] to browse to your Text Analytics resource and retrieve an API key, or use the [Azure CLI][azure_cli] snippet below:
-
-**Note:** Sometimes the API key is referred to as a "subscription key" or "subscription API key."
-
-```PowerShell
-az cognitiveservices account keys list --resource-group <your-resource-group-name> --name <your-resource-name>
-```
-
-Once you have an API key and endpoint, you can use the `AzureKeyCredential` class to authenticate the client as follows:
-
-```js
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-```
+You can find the endpoint for your Text Analytics resource in the [Azure Portal][azure_portal].
 
 #### Using an Azure Active Directory Credential
 
-Client API key authentication is used in most of the examples, but you can also authenticate with Azure Active Directory using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below,
-or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
+Client API key authentication is used in most of the examples, but you can also authenticate with Azure Active Directory using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 
 ```bash
 npm install @azure/identity
 ```
 
-You will also need to [register a new AAD application][register_aad_app] and grant access to Text Analytics by assigning the `"Cognitive Services User"` role to your service principal (note: other roles such as `"Owner"` will not grant the necessary permissions, only `"Cognitive Services User"` will suffice to run the examples and the sample code).
+You will also need to register a new AAD application and grant access to Text Analytics by assigning the suitable role to your service principal (note: roles such as `"Owner"` will not grant the necessary permissions).
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 
-```js
+```javascript
 const { TextAnalyticsClient } = require("@azure/ai-text-analytics");
 const { DefaultAzureCredential } = require("@azure/identity");
 
@@ -104,404 +56,7 @@ const client = new TextAnalyticsClient("<endpoint>", new DefaultAzureCredential(
 
 ### TextAnalyticsClient
 
-`TextAnalyticsClient` is the primary interface for developers using the Text Analytics client library. It provides asynchronous methods to access a specific use of Text Analytics, such as language detection or key phrase extraction.
-
-### Input
-
-A **document** represents a single unit of input to be analyzed by the predictive models in the Text Analytics service. Operations on `TextAnalyticsClient` take a collection of inputs to be analyzed as a batch. The operation methods have overloads that allow the inputs to be represented as strings, or as objects with attached metadata.
-
-For example, each document can be passed as a string in an array, e.g.
-
-```typescript
-const documents = [
-  "I hated the movie. It was so slow!",
-  "The movie made it into my top ten favorites.",
-  "What a great movie!"
-];
-```
-
-or, if you wish to pass in a per-item document `id` or `language`/`countryHint`, they can be given as a list of `TextDocumentInput` or `DetectLanguageInput` depending on the operation;
-
-```javascript
-const textDocumentInputs = [
-  { id: "1", language: "en", text: "I hated the movie. It was so slow!" },
-  { id: "2", language: "en", text: "The movie made it into my top ten favorites." },
-  { id: "3", language: "en", text: "What a great movie!" }
-];
-```
-
-See [service limiations][data_limits] for the input, including document length limits, maximum batch size, and supported text encodings.
-
-### Return Value
-
-The return value corresponding to a single document is either a successful result or an error object. Each `TextAnalyticsClient` method returns a heterogeneous array of results and errors that correspond to the inputs by index. A text input and its result will have the same index in the input and result collections. The collection may also optionally include information about the input batch and how it was processed in the `statistics` field.
-
-An **result**, such as `AnalyzeSentimentResult`, is the result of a Text Analytics operation, containing a prediction or predictions about a single text input. An operation's result type also may optionally include information about the input document and how it was processed.
-
-The **error** object, `TextAnalyticsErrorResult`, indicates that the service encountered an error while processing the document and contains information about the error.
-
-### Document Error Handling
-
-In the collection returned by an operation, errors are distinguished from successful responses by the presence of the `error` property, which contains the inner `TextAnalyticsError` object if an error was encountered. For successful result objects, this property is _always_ `undefined`.
-
-For example, to filter out all errors, you could use the following `filter`:
-
-```javascript
-const results = await client.analyzeSentiment(documents);
-const onlySuccessful = results.filter((result) => result.error === undefined);
-```
-
-**Note**: TypeScript users can benefit from better type-checking of result and error objects if `compilerOptions.strictNullChecks` is set to `true` in the `tsconfig.json` configuration. For example:
-
-```typescript
-const [result] = await client.analyzeSentiment(["Hello world!"]);
-
-if (result.error !== undefined) {
-  // In this if block, TypeScript will be sure that the type of `result` is
-  // `TextAnalyticsError` if compilerOptions.strictNullChecks is enabled in
-  // the tsconfig.json
-
-  console.log(result.error);
-}
-```
-
-This capability was introduced in TypeScript 3.2, so users of TypeScript 3.1 must cast result values to their corresponding success variant as follows:
-
-```typescript
-const [result] = await client.detectLanguage(["Hello world!"]);
-
-if (result.error === undefined) {
-  const { primaryLanguage } = result as DetectLanguageSuccessResult;
-}
-```
-
-## Examples
-
-### Analyze Sentiment
-
-Analyze sentiment of text to determine if it is positive, negative, neutral, or mixed, including per-sentence sentiment analysis and confidence scores.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "I did not like the restaurant. The food was too spicy.",
-  "The restaurant was decorated beautifully. The atmosphere was unlike any other restaurant I've been to.",
-  "The food was yummy. :)"
-];
-
-async function main() {
-  const results = await client.analyzeSentiment(documents);
-
-  for (const result of results) {
-    if (result.error === undefined) {
-      console.log("Overall sentiment:", result.sentiment);
-      console.log("Scores:", result.confidenceScores);
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-
-main();
-```
-
-To get more granular information about the opinions related to aspects of a product/service, also known as Aspect-based Sentiment Analysis in Natural Language Processing (NLP), see a sample on sentiment analysis with opinion mining [here][analyze_sentiment_opinion_mining_sample].
-
-### Recognize Entities
-
-Recognize and categorize entities in text as people, places, organizations, dates/times, quantities, currencies, etc.
-
-The `language` parameter is optional. If it is not specified, the default English model will be used.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "Microsoft was founded by Bill Gates and Paul Allen.",
-  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
-  "Jeff bought three dozen eggs because there was a 50% discount."
-];
-
-async function main() {
-  const results = await client.recognizeEntities(documents, "en");
-
-  for (const result of results) {
-    if (result.error === undefined) {
-      console.log(" -- Recognized entities for input", result.id, "--");
-      for (const entity of result.entities) {
-        console.log(entity.text, ":", entity.category, "(Score:", entity.confidenceScore, ")");
-      }
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-
-main();
-```
-
-### Recognize PII Entities
-
-There is a separate endpoint and operation for recognizing Personally Identifiable Information (PII) in text such as Social Security Numbers, bank account information, credit card numbers, etc. Its usage is very similar to the standard entity recognition above:
-
-```javascript
-const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
-const client = new TextAnalyticsClient(
-  "<endpoint>",
-  new TextAnalyticsApiKeyCredential("<API key>")
-);
-const documents = [
-  "The employee's SSN is 555-55-5555.",
-  "The employee's phone number is (555) 555-5555."
-];
-async function main() {
-  const results = await client.recognizePiiEntities(documents, "en");
-  for (const result of results) {
-    if (result.error === undefined) {
-      console.log(" -- Recognized PII entities for input", result.id, "--");
-      for (const entity of result.entities) {
-        console.log(entity.text, ":", entity.category, "(Score:", entity.confidenceScore, ")");
-      }
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-main();
-```
-
-### Recognize Linked Entities
-
-A "Linked" entity is one that exists in a knowledge base (such as Wikipedia). The `recognizeLinkedEntities` operation can disambiguate entities by determining which entry in a knowledge base they likely refer to (for example, in a piece of text, does the word "Mars" refer to the planet, or to the Roman god of war). Linked entities contain associated URLs to the knowledge base that provides the definition of the entity.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "Microsoft was founded by Bill Gates and Paul Allen.",
-  "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia.",
-  "I use Azure Functions to develop my product."
-];
-
-async function main() {
-  const results = await client.recognizeLinkedEntities(documents, "en");
-
-  for (const result of results) {
-    if (result.error === undefined) {
-      console.log(" -- Recognized linked entities for input", result.id, "--");
-      for (const entity of result.entities) {
-        console.log(entity.name, "(URL:", entity.url, ", Source:", entity.dataSource, ")");
-        for (const match of entity.matches) {
-          console.log(
-            "  Occurrence:",
-            '"' + match.text + '"',
-            "(Score:",
-            match.confidenceScore,
-            ")"
-          );
-        }
-      }
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-
-main();
-```
-
-### Extract Key Phrases
-
-Key Phrase extraction identifies the main talking points in a document. For example, given input text "The food was delicious and there were wonderful staff", the service returns "food" and "wonderful staff".
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
-  "I need to take my cat to the veterinarian.",
-  "I will travel to South America in the summer."
-];
-
-async function main() {
-  const results = await client.extractKeyPhrases(documents, "en");
-
-  for (const result of results) {
-    if (result.error === undefined) {
-      console.log(" -- Extracted key phrases for input", result.id, "--");
-      console.log(result.keyPhrases);
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-
-main();
-```
-
-### Detect Language
-
-Determine the language of a piece of text.
-
-The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If provided, it should be set to an ISO-3166 Alpha-2 two-letter country code (such as "us" for the United States or "jp" for Japan) or to the value `"none"`. If the parameter is not provided, then the default `"us"` (United States) model will be used. If you do not know the country of origin of the document, then the parameter `"none"` should be used, and the Text Analytics service will apply a model that is tuned for an unknown country of origin.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "This is written in English.",
-  "Il documento scritto in italiano.",
-  "Dies ist in deutscher Sprache verfasst."
-];
-
-async function main() {
-  const results = await client.detectLanguage(documents, "none");
-
-  for (const result of results) {
-    if (result.error === undefined) {
-      const { primaryLanguage } = result;
-      console.log(
-        "Input #",
-        result.id,
-        "identified as",
-        primaryLanguage.name,
-        "( ISO6391:",
-        primaryLanguage.iso6391Name,
-        ", Score:",
-        primaryLanguage.confidenceScore,
-        ")"
-      );
-    } else {
-      console.error("Encountered an error:", result.error);
-    }
-  }
-}
-
-main();
-```
-
-### Analyze Healthcare Entities
-
-Healthcare analysis identifies healthcare entities. For example, given input text "Prescribed 100mg ibuprofen, taken twice daily", the service returns "100mg" categorized as Dosage, "ibuprofen" as MedicationName, and "twice daily" as Frequency.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "Prescribed 100mg ibuprofen, taken twice daily.",
-  "Patient does not suffer from high blood pressure."
-];
-
-async function main() {
-  const poller = await client.beginAnalyzeHealthcareEntities(documents);
-  const results = await poller.pollUntilDone();
-
-  for await (const result of results) {
-    console.log(`- Document ${result.id}`);
-    if (!result.error) {
-      console.log("\tRecognized Entities:");
-      for (const entity of result.entities) {
-        console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-      }
-    } else console.error("\tError:", result.error);
-  }
-}
-
-main();
-```
-
-### Analyze Batch Actions
-
-Analyze batch actions enables the application of multiple analyses (named actions) at once.
-
-```javascript
-const { TextAnalyticsClient, AzureKeyCredential } = require("@azure/ai-text-analytics");
-
-const client = new TextAnalyticsClient("<endpoint>", new AzureKeyCredential("<API key>"));
-
-const documents = [
-  "Microsoft was founded by Bill Gates and Paul Allen.",
-  "The employee's SSN is 555-55-5555.",
-  "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia.",
-  "I use Azure Functions to develop my product."
-];
-
-async function main() {
-  const actions = {
-    recognizeEntitiesActions: [{ modelVersion: "latest" }],
-    recognizePiiEntitiesActions: [{ modelVersion: "latest" }],
-    extractKeyPhrasesActions: [{ modelVersion: "latest" }]
-  };
-  const poller = await client.beginAnalyzeBatchActions(documents, actions);
-  const resultPages = await poller.pollUntilDone();
-  for await (const page of resultPages) {
-    const keyPhrasesAction = page.extractKeyPhrasesResults[0];
-    if (!keyPhrasesAction.error) {
-      for (const doc of keyPhrasesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tKey phrases:");
-          for (const phrase of doc.keyPhrases) {
-            console.log(`\t- ${phrase}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
-        }
-      }
-    }
-
-    const entitiesAction = page.recognizeEntitiesResults[0];
-    if (!entitiesAction.error) {
-      for (const doc of entitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tEntities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
-        }
-      }
-    }
-
-    const piiEntitiesAction = page.recognizePiiEntitiesResults[0];
-    if (!piiEntitiesAction.error) {
-      for (const doc of piiEntitiesAction.results) {
-        console.log(`- Document ${doc.id}`);
-        if (!doc.error) {
-          console.log("\tPii Entities:");
-          for (const entity of doc.entities) {
-            console.log(`\t- Entity ${entity.text} of type ${entity.category}`);
-          }
-        } else {
-          console.error("\tError:", doc.error);
-        }
-      }
-    }
-  }
-}
-
-main();
-```
-
-## Known Issues
-
-- `beginAnalyzeHealthcare` is still in gated preview and can not be used with AAD credentials. For more information, see (the Text Analytics for Health documentation)[https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/how-tos/text-analytics-for-health?tabs=ner#request-access-to-the-public-preview].
-- At time of this SDK release, the `modelVersion` option to `beginAnalyzeHealthcareEntities` is ignored by the service. The service always processes the operation using the "latest" model.
+`TextAnalyticsClient` is the primary interface for developers using the Azure Text Analytics Client library. It provides asynchronous methods to access a specific use of Text Analytics.
 
 ## Troubleshooting
 
@@ -519,9 +74,7 @@ For more detailed instructions on how to enable logs, you can look at the [@azur
 
 ## Next steps
 
-Please take a look at the
-[samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples)
-directory for detailed examples on how to use this library.
+Please take a look at the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples) directory for detailed examples on how to use this library.
 
 ## Contributing
 
@@ -535,11 +88,6 @@ If you'd like to contribute to this library, please read the [contributing guide
 
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/
-[cognitive_resource]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
 [azure_portal]: https://portal.azure.com
 [azure_identity]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity
-[cognitive_auth]: https://docs.microsoft.com/azure/cognitive-services/authentication
-[register_aad_app]: https://docs.microsoft.com/azure/cognitive-services/authentication#assign-a-role-to-a-service-principal
 [defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential
-[data_limits]: https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits
-[analyze_sentiment_opinion_mining_sample]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/analyzeSentimentWithOpinionMining.ts


### PR DESCRIPTION
By this work: https://github.com/Azure/autorest.typescript/pull/895. It does not have an `Examples` section which sets off the CI readme verification alarm.

Related issue: https://github.com/Azure/azure-sdk-for-js/issues/14449
[Swagger](https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d2982a8962885e8506b5ebc0b33cb8caf1dc7551/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json)