### PR TITLE
[samples] Fix issues identitfied by docs team

### DIFF
--- a/sdk/deviceupdate/iot-device-update/samples/javascript/README.md
+++ b/sdk/deviceupdate/iot-device-update/samples/javascript/README.md
@@ -4,7 +4,8 @@ languages:
   - javascript
 products:
   - azure
-  - azure-iot-device-update
+  - azure-iot
+  - azure-iot-hub
 urlFragment: azure-iot-device-update-javascript
 ---
 

--- a/sdk/deviceupdate/iot-device-update/samples/typescript/README.md
+++ b/sdk/deviceupdate/iot-device-update/samples/typescript/README.md
@@ -4,7 +4,8 @@ languages:
   - typescript
 products:
   - azure
-  - azure-iot-device-update
+  - azure-iot
+  - azure-iot-hub
 urlFragment: azure-iot-device-update-typescript
 ---
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/javascript/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/javascript/README.md
@@ -1,14 +1,3 @@
-<!-- Commented out due to conflict with real storage samples
----
-page_type: sample
-languages:
-  - javascript
-products:
-  - azure
-  - azure-storage
-urlFragment: storage-blob-javascript
---->
-
 # Azure Storage Blob client library samples for JavaScript
 
 These sample programs show how to use the JavaScript client libraries for Azure Storage Blobs in some common scenarios.

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/javascript/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/javascript/README.md
@@ -1,3 +1,4 @@
+<!-- Commented out due to conflict with real storage samples
 ---
 page_type: sample
 languages:
@@ -6,7 +7,7 @@ products:
   - azure
   - azure-storage
 urlFragment: storage-blob-javascript
----
+--->
 
 # Azure Storage Blob client library samples for JavaScript
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/typescript/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/typescript/README.md
@@ -1,3 +1,4 @@
+<!-- Commented out due to conflict with real storage samples
 ---
 page_type: sample
 languages:
@@ -6,7 +7,7 @@ products:
   - azure
   - azure-storage
 urlFragment: storage-blob-typescript
----
+--->
 
 # Azure Storage Blob client library samples for TypeScript
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/typescript/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/@azure/storage-blob/typescript/README.md
@@ -1,14 +1,3 @@
-<!-- Commented out due to conflict with real storage samples
----
-page_type: sample
-languages:
-  - typescript
-products:
-  - azure
-  - azure-storage
-urlFragment: storage-blob-typescript
---->
-
 # Azure Storage Blob client library samples for TypeScript
 
 These sample programs show how to use the TypeScript client libraries for Azure Storage Blobs in some common scenarios.


### PR DESCRIPTION
There are a couple of problems with the samples that are apparently blocking publication across our repo.

- monitor-opentelemetry-exporter has some samples that have the same `urlFragment` as the real storage samples, so I've commented them out for now
- deviceupdate has an invalid product