### PR TITLE
[dev-tool] Allow relative-path imports in sample files.

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -102,6 +102,28 @@ function createPackageJson(info: SampleGenerationInfo, outputKind: OutputKind): 
   };
 }
 
+/**
+ * Determines whether a module specifier is a package dependency.
+ *
+ * A dependency is a module specifier that does not refer to a node builtin and
+ * is not a relative path.
+ *
+ * Absolute path imports are not supported in samples (because the package base
+ * is not fixed relative to the source file).
+ *
+ * @param moduleSpecifier - the string given to `import` or `require`
+ * @returns - true if `moduleSpecifier` should be considered a reference to a
+ * node module dependency
+ */
+function isDependency(moduleSpecifier: string): boolean {
+  if (nodeBuiltins.includes(moduleSpecifier)) return false;
+
+  // This seems like a reasonable test for "is a relative path" as long as
+  // absolute path imports are forbidden.
+  const isRelativePath = /^\.\.?\//.test(moduleSpecifier);
+  return !isRelativePath;
+}
+
 async function processSources(
   projectInfo: ProjectInfo,
   sources: string[],
@@ -217,7 +239,7 @@ async function processSources(
         }
       }),
       summary: summary ?? fail(`${relativeSourcePath} does not include an @summary tag.`),
-      importedModules: importedModules.filter((name) => !nodeBuiltins.includes(name)),
+      importedModules: importedModules.filter(isDependency),
       usedEnvironmentVariables,
       azSdkTags
     };
@@ -328,10 +350,10 @@ async function makeSampleGenerationInfo(
                 packageJson.dependencies[dependency];
               if (dependencyVersion === undefined) {
                 log.error(
-                  `Dependency "${dependency}", imported by ${source.filePath}, has an unknown version.`
+                  `Dependency "${dependency}", imported by ${source.filePath}, has an unknown version. (Are you missing "./" for a relative path?)`
                 );
                 log.error(
-                  "Specify a version for it by including it in the package's `devDependencies`."
+                  `Specify a version for "${dependency}" by including it in the package's "devDependencies".`
                 );
               }
 

--- a/common/tools/dev-tool/src/util/sampleGenerationInfo.ts
+++ b/common/tools/dev-tool/src/util/sampleGenerationInfo.ts
@@ -18,7 +18,9 @@ export const DEFAULT_TYPESCRIPT_CONFIG = {
   compilerOptions: {
     target: "ES2018",
     module: "commonjs",
+
     moduleResolution: "node",
+    resolveJsonModule: true,
 
     esModuleInterop: true,
     allowSyntheticDefaultImports: true,


### PR DESCRIPTION
This is a little oversight when analyzing the sample files' imports. Relative path imports need to be filtered out when considering dependencies. We were already filtering node builtin modules, so I abstracted the logic to a helper function `isDependency`.

It's difficult to support _absolute_ path imports in the samples without doing a lot more work involving simulating node module resolution and adding a lot more logic to the output structure for TS and JS. Plus, I'm not convinced that absolute path imports make a lot of sense within the sample code anyway. So, relative path imports need to start with one or two dots and a forward slash, i.e. the regexp `/^\.\.?\//`.

I also made the dependency diagnostic error refer to the possibility that "./" is missing for relative imports.

We found this because @vishnureddy17 is importing JSON files as modules in the samples for digital-twins-core, and he was seeing messages such as:

```
[publish] Dependency "./dtdl/digitalTwins/buildingTwin.json", imported by dt_digitaltwins_lifecycle.ts, has an unknown version.
```

And this should be a well-supported use-case. Since I don't think there's any harm in doing it, I also added `resolveJsonModules: true` by default in the sample tsconfig.