### PR TITLE
[KeyVault] - Ensure we restore the request body correctly

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -8,6 +8,7 @@
   - We now ensure tracing spans are properly closed with an appropriate status when an operation throws an exception.
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
+- Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
 
 ## 4.0.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -9,6 +9,7 @@
   - We now ensure tracing spans are properly closed with an appropriate status when an operation throws an exception.
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
+- Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
 
 ## 4.2.0-beta.2 (2021-02-09)
 

--- a/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/challengeBasedAuthenticationPolicy.spec.ts
@@ -9,12 +9,15 @@ import { env, Recorder } from "@azure/test-utils-recorder";
 import {
   AuthenticationChallengeCache,
   AuthenticationChallenge,
-  parseWWWAuthenticate
+  parseWWWAuthenticate,
+  challengeBasedAuthenticationPolicy
 } from "../../../keyvault-common/src";
 import { CertificateClient } from "../../src";
 import { testPollerProperties } from "../utils/recorderUtils";
 import { authenticate } from "../utils/testAuthentication";
 import TestClient from "../utils/testClient";
+import { WebResource } from "@azure/core-http";
+import { ClientSecretCredential } from "@azure/identity";
 
 // Following the philosophy of not testing the insides if we can test the outsides...
 // I present you with this "Get Out of Jail Free" card (in reference to Monopoly).
@@ -155,5 +158,35 @@ describe("Challenge based authentication tests", () => {
         c: "c"
       });
     });
+  });
+});
+
+describe("Local Challenge based authentication tests", () => {
+  it("should recover gracefully when a downstream policy fails", async () => {
+    // The simplest possible policy with a _nextPolicy that throws an error.
+    const credential = new ClientSecretCredential(
+      env.AZURE_TENANT_ID!,
+      env.AZURE_CLIENT_ID!,
+      env.AZURE_CLIENT_SECRET!
+    );
+
+    const policy = challengeBasedAuthenticationPolicy(credential).create(
+      {
+        sendRequest: () => {
+          throw new Error("Boom");
+        }
+      },
+      { log: () => null, shouldLog: () => false }
+    );
+
+    const request = new WebResource("https://portal.azure.com", "GET", "request body");
+
+    try {
+      await policy.sendRequest(request);
+    } catch (err) {
+      // the next policy throws
+    }
+
+    assert.equal(request.body, "request body");
   });
 });

--- a/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-common/src/challengeBasedAuthenticationPolicy.ts
@@ -218,8 +218,11 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       // If there's no challenge in cache, a blank body will start the challenge.
       const originalBody = webResource.body;
       webResource.body = "";
-      response = await this._nextPolicy.sendRequest(webResource);
-      webResource.body = originalBody;
+      try {
+        response = await this._nextPolicy.sendRequest(webResource);
+      } finally {
+        webResource.body = originalBody;
+      }
     } else {
       // If we did have a challenge in memory,
       // we attempt to load the token from the cache into the request before we try to send the request.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -8,6 +8,7 @@
   - We now ensure tracing spans are properly closed with an appropriate status when an operation throws an exception.
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
+- Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
 
 ## 4.2.0-beta.4 (2021-03-09)
 

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -6,6 +6,7 @@
   - We now ensure tracing spans are properly closed with an appropriate status when an operation throws an exception.
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
+- Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
 
 ## 4.2.0-beta.3 (2021-03-09)
 

--- a/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
@@ -41,5 +41,5 @@ export async function authenticate(that: Context): Promise<any> {
   const client = new SecretClient(keyVaultUrl, credential);
   const testClient = new TestClient(client);
 
-  return { recorder, client, testClient, secretSuffix };
+  return { recorder, client, testClient, secretSuffix, credential };
 }


### PR DESCRIPTION
This PR fixes an issue where the original request body is not restored in the event a downstream policy throws and we retry.

It's a small change, and I don't _love_ having the test duplicated in three places, but we currently do that for the other challenge based authentication tests and I didn't think this was the time to refactor that, especially given we will be moving to core-auth in the near future.

Fixes #14590