### PR TITLE
[KeyVault] - Remove LocalSupportedAlgorithmName

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -9,6 +9,7 @@
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
 - Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
+- [Breaking] Removed the now unused `LocalCryptographyAlgorithmName` type.
 
 ## 4.2.0-beta.4 (2021-03-09)
 

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -9,7 +9,7 @@
   - If a traced operation throws an exception we will now properly record the exception message in the tracing span.
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
 - Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
-- [Breaking] Removed the now unused `LocalCryptographyAlgorithmName` type.
+- [Breaking] Removed the now unused `LocalCryptographyAlgorithmName` type (Added in 4.2.0-beta.1 to support `LocalCryptographyClient` and unused since 4.2.0-beta.4)
 
 ## 4.2.0-beta.4 (2021-03-09)
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -381,9 +381,6 @@ export interface ListPropertiesOfKeyVersionsOptions extends coreHttp.OperationOp
 }
 
 // @public
-export type LocalSupportedAlgorithmName = "RSA1_5" | "RSA-OAEP" | "PS256" | "RS256" | "PS384" | "RS384" | "PS512" | "RS512";
-
-// @public
 export const logger: import("@azure/logger").AzureLogger;
 
 export { PagedAsyncIterableIterator }

--- a/sdk/keyvault/keyvault-keys/src/cryptography/models.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/models.ts
@@ -21,19 +21,6 @@ import {
   WrapResult
 } from "..";
 
-/**
- * A union type representing the names of all of the locally supported algorithms.
- */
-export type LocalSupportedAlgorithmName =
-  | "RSA1_5"
-  | "RSA-OAEP"
-  | "PS256"
-  | "RS256"
-  | "PS384"
-  | "RS384"
-  | "PS512"
-  | "RS512";
-
 export class LocalCryptographyUnsupportedError extends Error {}
 
 /**

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -101,7 +101,6 @@ import {
 } from "./cryptographyClientModels";
 
 import { parseKeyVaultKeyId, KeyVaultKeyId } from "./identifier";
-import { LocalSupportedAlgorithmName } from "./cryptography/models";
 import { getKeyFromKeyBundle } from "./transformations";
 import { createTraceFunction } from "../../keyvault-common/src";
 
@@ -157,7 +156,6 @@ export {
   ListPropertiesOfKeysOptions,
   ListPropertiesOfKeyVersionsOptions,
   ListDeletedKeysOptions,
-  LocalSupportedAlgorithmName,
   PageSettings,
   PagedAsyncIterableIterator,
   KeyVaultKeyId,

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -2,13 +2,7 @@
 // Licensed under the MIT license.
 
 import { Context } from "mocha";
-import {
-  LocalSupportedAlgorithmName,
-  KeyClient,
-  CryptographyClient,
-  SignatureAlgorithm,
-  KeyVaultKey
-} from "../../src";
+import { KeyClient, CryptographyClient, SignatureAlgorithm, KeyVaultKey } from "../../src";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
@@ -213,7 +207,7 @@ describe("Local cryptography public tests", () => {
         // Local Cryptography Client part
         const localCryptoClient = new CryptographyClient(keyVaultKey.key!);
         const verifyResult = await localCryptoClient.verifyData(
-          localAlgorithmName as LocalSupportedAlgorithmName,
+          localAlgorithmName,
           digest,
           signature.result
         );


### PR DESCRIPTION
This PR removes LocalSupportedAlgorithmName. It is no longer used internally and not needed for customers, so this removes it from the public API and the codebase.