### PR TITLE
[service-bus] AdminClient: ForwardTo wasn't applying on update due to bad property ordering in XML

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -6,6 +6,10 @@
   These credential types support rotation via their `update` methods and are an alternative to using the `SharedAccessKeyName/SharedAccessKey` or `SharedAccessSignature` properties in a connection string.
   Resolves [#11891](https://github.com/Azure/azure-sdk-for-js/issues/11891).
 
+### Bug fixes
+
+- Some of the queue properties such as "forwardTo" and "autoDeleteOnIdle" were not being set as requested through the `ServiceBusAdministrationClient.createQueue` method because of a bug w.r.t the ordering of XML properties. The issue has been fixed in [#14692](https://github.com/Azure/azure-sdk-for-js/pull/14692).
+
 ## 7.0.4 (2021-03-31)
 
 ### Bug fixes

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -55,10 +55,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     Status: getStringOrUndefined(queue.status),
     ForwardTo: getStringOrUndefined(queue.forwardTo),
     UserMetadata: getStringOrUndefined(queue.userMetadata),
-
-    // TODO: found while syncing the ordering. This property is in .net, but not in ours?
-    // SupportOrdering: true,
-    
     AutoDeleteOnIdle: getStringOrUndefined(queue.autoDeleteOnIdle),
     EnablePartitioning: getStringOrUndefined(queue.enablePartitioning),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(queue.forwardDeadLetteredMessagesTo),

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -55,7 +55,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     EnablePartitioning: getStringOrUndefined(queue.enablePartitioning),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(queue.forwardDeadLetteredMessagesTo),
 
-    // TODO: can't find this in the .net ATOM library.
     EntityAvailabilityStatus: getStringOrUndefined(queue.availabilityStatus),
     EnableExpress: getStringOrUndefined(queue.enableExpress)
   };

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -54,7 +54,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     AutoDeleteOnIdle: getStringOrUndefined(queue.autoDeleteOnIdle),
     EnablePartitioning: getStringOrUndefined(queue.enablePartitioning),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(queue.forwardDeadLetteredMessagesTo),
-
     EntityAvailabilityStatus: getStringOrUndefined(queue.availabilityStatus),
     EnableExpress: getStringOrUndefined(queue.enableExpress)
   };

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -36,7 +36,7 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     // not picking up on it.
     //
     // The authority on this ordering is here:
-    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueuePropertiesExtensions.cs#L20
+    // https://github.com/Azure/azure-sdk-for-net/blob/8af2dfc32c96ef3e340f9d20013bf588d97ea756/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueuePropertiesExtensions.cs#L20
 
     LockDuration: queue.lockDuration,
     MaxSizeInMegabytes: getStringOrUndefined(queue.maxSizeInMegabytes),

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -31,6 +31,13 @@ import {
  */
 export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptions {
   return {
+    // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
+    // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
+    // not picking up on it. 
+    // 
+    // The authority on this ordering is here:
+    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueuePropertiesExtensions.cs#L20
+
     LockDuration: queue.lockDuration,
     MaxSizeInMegabytes: getStringOrUndefined(queue.maxSizeInMegabytes),
     RequiresDuplicateDetection: getStringOrUndefined(queue.requiresDuplicateDetection),
@@ -40,15 +47,25 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     DuplicateDetectionHistoryTimeWindow: queue.duplicateDetectionHistoryTimeWindow,
     MaxDeliveryCount: getStringOrUndefined(queue.maxDeliveryCount),
     EnableBatchedOperations: getStringOrUndefined(queue.enableBatchedOperations),
-    AuthorizationRules: getRawAuthorizationRules(queue.authorizationRules),
+    
+    // TODO: found while syncing the ordering. This property is in .net, but not in ours?
+    //IsAnonymousAccessible: false,
+
+    AuthorizationRules: getRawAuthorizationRules(queue.authorizationRules),    
     Status: getStringOrUndefined(queue.status),
+    ForwardTo: getStringOrUndefined(queue.forwardTo),
+    UserMetadata: getStringOrUndefined(queue.userMetadata),
+
+    // TODO: found while syncing the ordering. This property is in .net, but not in ours?
+    // SupportOrdering: true,
+    
     AutoDeleteOnIdle: getStringOrUndefined(queue.autoDeleteOnIdle),
     EnablePartitioning: getStringOrUndefined(queue.enablePartitioning),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(queue.forwardDeadLetteredMessagesTo),
-    ForwardTo: getStringOrUndefined(queue.forwardTo),
-    UserMetadata: getStringOrUndefined(queue.userMetadata),
+
+    // TODO: can't find this in the .net ATOM library.
     EntityAvailabilityStatus: getStringOrUndefined(queue.availabilityStatus),
-    EnableExpress: getStringOrUndefined(queue.enableExpress)
+    EnableExpress: getStringOrUndefined(queue.enableExpress),
   };
 }
 

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -47,10 +47,6 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     DuplicateDetectionHistoryTimeWindow: queue.duplicateDetectionHistoryTimeWindow,
     MaxDeliveryCount: getStringOrUndefined(queue.maxDeliveryCount),
     EnableBatchedOperations: getStringOrUndefined(queue.enableBatchedOperations),
-    
-    // TODO: found while syncing the ordering. This property is in .net, but not in ours?
-    //IsAnonymousAccessible: false,
-
     AuthorizationRules: getRawAuthorizationRules(queue.authorizationRules),    
     Status: getStringOrUndefined(queue.status),
     ForwardTo: getStringOrUndefined(queue.forwardTo),

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -33,8 +33,8 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
   return {
     // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
     // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
-    // not picking up on it. 
-    // 
+    // not picking up on it.
+    //
     // The authority on this ordering is here:
     // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueuePropertiesExtensions.cs#L20
 
@@ -47,7 +47,7 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
     DuplicateDetectionHistoryTimeWindow: queue.duplicateDetectionHistoryTimeWindow,
     MaxDeliveryCount: getStringOrUndefined(queue.maxDeliveryCount),
     EnableBatchedOperations: getStringOrUndefined(queue.enableBatchedOperations),
-    AuthorizationRules: getRawAuthorizationRules(queue.authorizationRules),    
+    AuthorizationRules: getRawAuthorizationRules(queue.authorizationRules),
     Status: getStringOrUndefined(queue.status),
     ForwardTo: getStringOrUndefined(queue.forwardTo),
     UserMetadata: getStringOrUndefined(queue.userMetadata),
@@ -57,7 +57,7 @@ export function buildQueueOptions(queue: CreateQueueOptions): InternalQueueOptio
 
     // TODO: can't find this in the .net ATOM library.
     EntityAvailabilityStatus: getStringOrUndefined(queue.availabilityStatus),
-    EnableExpress: getStringOrUndefined(queue.enableExpress),
+    EnableExpress: getStringOrUndefined(queue.enableExpress)
   };
 }
 

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -41,7 +41,7 @@ export function buildSubscriptionOptions(
     // not picking up on it.
     //
     // The authority on this ordering is here:
-    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionPropertiesExtensions.cs#L191
+    // https://github.com/Azure/azure-sdk-for-net/blob/8af2dfc32c96ef3e340f9d20013bf588d97ea756/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionPropertiesExtensions.cs#L191
     LockDuration: subscription.lockDuration,
     RequiresSession: getStringOrUndefined(subscription.requiresSession),
     DefaultMessageTimeToLive: getStringOrUndefined(subscription.defaultMessageTimeToLive),

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -38,8 +38,8 @@ export function buildSubscriptionOptions(
   return {
     // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
     // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
-    // not picking up on it. 
-    // 
+    // not picking up on it.
+    //
     // The authority on this ordering is here:
     // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionPropertiesExtensions.cs#L191
     LockDuration: subscription.lockDuration,

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -36,6 +36,12 @@ export function buildSubscriptionOptions(
   subscription: CreateSubscriptionOptions
 ): InternalSubscriptionOptions {
   return {
+    // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
+    // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
+    // not picking up on it. 
+    // 
+    // The authority on this ordering is here:
+    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/SubscriptionPropertiesExtensions.cs#L191
     LockDuration: subscription.lockDuration,
     RequiresSession: getStringOrUndefined(subscription.requiresSession),
     DefaultMessageTimeToLive: getStringOrUndefined(subscription.defaultMessageTimeToLive),
@@ -55,6 +61,7 @@ export function buildSubscriptionOptions(
     UserMetadata: getStringOrUndefined(subscription.userMetadata),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(subscription.forwardDeadLetteredMessagesTo),
     AutoDeleteOnIdle: getStringOrUndefined(subscription.autoDeleteOnIdle),
+    // TODO: EntityAvailabilityStatus does not exist in .net
     EntityAvailabilityStatus: getStringOrUndefined(subscription.availabilityStatus)
   };
 }

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -61,7 +61,6 @@ export function buildSubscriptionOptions(
     UserMetadata: getStringOrUndefined(subscription.userMetadata),
     ForwardDeadLetteredMessagesTo: getStringOrUndefined(subscription.forwardDeadLetteredMessagesTo),
     AutoDeleteOnIdle: getStringOrUndefined(subscription.autoDeleteOnIdle),
-    // TODO: EntityAvailabilityStatus does not exist in .net
     EntityAvailabilityStatus: getStringOrUndefined(subscription.availabilityStatus)
   };
 }

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -31,17 +31,28 @@ import {
  */
 export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptions {
   return {
+    // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
+    // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
+    // not picking up on it. 
+    // 
+    // The authority on this ordering is here:
+    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicPropertiesExtensions.cs#L175
+
     DefaultMessageTimeToLive: topic.defaultMessageTimeToLive,
     MaxSizeInMegabytes: getStringOrUndefined(topic.maxSizeInMegabytes),
     RequiresDuplicateDetection: getStringOrUndefined(topic.requiresDuplicateDetection),
     DuplicateDetectionHistoryTimeWindow: topic.duplicateDetectionHistoryTimeWindow,
     EnableBatchedOperations: getStringOrUndefined(topic.enableBatchedOperations),
+    // TODO: in .net, but not in here: FilteringMessagesBeforePublishing
+    // TODO: in .net, but not in here: IsAnonymousAccessible
     AuthorizationRules: getRawAuthorizationRules(topic.authorizationRules),
     Status: getStringOrUndefined(topic.status),
+    // TODO: in .net, but not in here: ForwardTo
     UserMetadata: getStringOrUndefined(topic.userMetadata),
     SupportOrdering: getStringOrUndefined(topic.supportOrdering),
     AutoDeleteOnIdle: getStringOrUndefined(topic.autoDeleteOnIdle),
     EnablePartitioning: getStringOrUndefined(topic.enablePartitioning),
+    // TODO: in .net, but not in here: EnableSubscriptionPartitioning
     EntityAvailabilityStatus: getStringOrUndefined(topic.availabilityStatus),
     EnableExpress: getStringOrUndefined(topic.enableExpress)
   };

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -33,8 +33,8 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
   return {
     // NOTE: this ordering is extremely important. As an example, misordering of the ForwardTo property
     // resulted in a customer bug where the Forwarding attributes appeared to be set but the portal was
-    // not picking up on it. 
-    // 
+    // not picking up on it.
+    //
     // The authority on this ordering is here:
     // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicPropertiesExtensions.cs#L175
 

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -46,7 +46,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
     // TODO: in .net, but not in here: FilteringMessagesBeforePublishing
     AuthorizationRules: getRawAuthorizationRules(topic.authorizationRules),
     Status: getStringOrUndefined(topic.status),
-    // TODO: in .net, but not in here: ForwardTo
     UserMetadata: getStringOrUndefined(topic.userMetadata),
     SupportOrdering: getStringOrUndefined(topic.supportOrdering),
     AutoDeleteOnIdle: getStringOrUndefined(topic.autoDeleteOnIdle),

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -50,7 +50,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
     SupportOrdering: getStringOrUndefined(topic.supportOrdering),
     AutoDeleteOnIdle: getStringOrUndefined(topic.autoDeleteOnIdle),
     EnablePartitioning: getStringOrUndefined(topic.enablePartitioning),
-    // TODO: in .net, but not in here: EnableSubscriptionPartitioning
     EntityAvailabilityStatus: getStringOrUndefined(topic.availabilityStatus),
     EnableExpress: getStringOrUndefined(topic.enableExpress)
   };

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -36,7 +36,7 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
     // not picking up on it.
     //
     // The authority on this ordering is here:
-    // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicPropertiesExtensions.cs#L175
+    // https://github.com/Azure/azure-sdk-for-net/blob/8af2dfc32c96ef3e340f9d20013bf588d97ea756/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicPropertiesExtensions.cs#L175
 
     DefaultMessageTimeToLive: topic.defaultMessageTimeToLive,
     MaxSizeInMegabytes: getStringOrUndefined(topic.maxSizeInMegabytes),

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -43,7 +43,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
     RequiresDuplicateDetection: getStringOrUndefined(topic.requiresDuplicateDetection),
     DuplicateDetectionHistoryTimeWindow: topic.duplicateDetectionHistoryTimeWindow,
     EnableBatchedOperations: getStringOrUndefined(topic.enableBatchedOperations),
-    // TODO: in .net, but not in here: FilteringMessagesBeforePublishing
     AuthorizationRules: getRawAuthorizationRules(topic.authorizationRules),
     Status: getStringOrUndefined(topic.status),
     UserMetadata: getStringOrUndefined(topic.userMetadata),

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -44,7 +44,6 @@ export function buildTopicOptions(topic: CreateTopicOptions): InternalTopicOptio
     DuplicateDetectionHistoryTimeWindow: topic.duplicateDetectionHistoryTimeWindow,
     EnableBatchedOperations: getStringOrUndefined(topic.enableBatchedOperations),
     // TODO: in .net, but not in here: FilteringMessagesBeforePublishing
-    // TODO: in .net, but not in here: IsAnonymousAccessible
     AuthorizationRules: getRawAuthorizationRules(topic.authorizationRules),
     Status: getStringOrUndefined(topic.status),
     // TODO: in .net, but not in here: ForwardTo

--- a/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
@@ -81,8 +81,12 @@ describe("Atom management - forwarding", () => {
   });
 
   it("queue: forwarding", async () => {
-    const willForward = await serviceBusClient.test.createTestEntities(TestClientType.PartitionedQueue);
-    const willBeForwardedTo = await serviceBusClient.test.createTestEntities(TestClientType.UnpartitionedQueue);
+    const willForward = await serviceBusClient.test.createTestEntities(
+      TestClientType.PartitionedQueue
+    );
+    const willBeForwardedTo = await serviceBusClient.test.createTestEntities(
+      TestClientType.UnpartitionedQueue
+    );
 
     // make it so all messages from `willForward` are forwarded to `willBeForwardedTo`
     const queueProperties = await serviceBusAtomManagementClient.getQueue(willForward.queue!);
@@ -90,35 +94,48 @@ describe("Atom management - forwarding", () => {
     await serviceBusAtomManagementClient.updateQueue(queueProperties);
 
     const receiver = await serviceBusClient.test.createReceiveAndDeleteReceiver(willBeForwardedTo);
-    const sender = await serviceBusClient.test.createSender(willForward);    
-    
+    const sender = await serviceBusClient.test.createSender(willForward);
+
     await sender.sendMessages({
       body: "forwarded message with queues!"
     });
 
     const messages = await receiver.receiveMessages(1);
-    assert.deepEqual([{ body: "forwarded message with queues!" }], messages.map(m => ({ body: m.body })));
-  }); 
+    assert.deepEqual(
+      [{ body: "forwarded message with queues!" }],
+      messages.map((m) => ({ body: m.body }))
+    );
+  });
 
   it("subscription: forwarding", async () => {
-    const willForward = await serviceBusClient.test.createTestEntities(TestClientType.PartitionedSubscription);
-    const willBeForwardedTo = await serviceBusClient.test.createTestEntities(TestClientType.UnpartitionedQueue);
+    const willForward = await serviceBusClient.test.createTestEntities(
+      TestClientType.PartitionedSubscription
+    );
+    const willBeForwardedTo = await serviceBusClient.test.createTestEntities(
+      TestClientType.UnpartitionedQueue
+    );
 
     // make it so all messages from `willForward` are forwarded to `willBeForwardedTo`
-    const subscriptionProperties = await serviceBusAtomManagementClient.getSubscription(willForward.topic!, willForward.subscription!);
+    const subscriptionProperties = await serviceBusAtomManagementClient.getSubscription(
+      willForward.topic!,
+      willForward.subscription!
+    );
     subscriptionProperties.forwardTo = willBeForwardedTo.queue!;
     await serviceBusAtomManagementClient.updateSubscription(subscriptionProperties);
 
     const receiver = await serviceBusClient.test.createReceiveAndDeleteReceiver(willBeForwardedTo);
-    const sender = await serviceBusClient.test.createSender(willForward);    
-    
+    const sender = await serviceBusClient.test.createSender(willForward);
+
     await sender.sendMessages({
       body: "forwarded message with subscriptions!"
     });
 
     const messages = await receiver.receiveMessages(1);
-    assert.deepEqual([{ body: "forwarded message with subscriptions!" }], messages.map(m => ({ body: m.body })));
-  }); 
+    assert.deepEqual(
+      [{ body: "forwarded message with subscriptions!" }],
+      messages.map((m) => ({ body: m.body }))
+    );
+  });
 });
 
 describe("Atom management - Namespace", function(): void {


### PR DESCRIPTION
The ordering of properties in the XML requests to the Service Bus ATOM API is significant and changing it can have side effects.

In this instance, the ordering issues caused us to appear to have setup forwarding properly for a queue but forwarding was NOT actually enabled. Our previous testing missed this because this data actually round-trips properly through the API but it doesn't trigger whatever actual setting needs to happen to cause forwarding to happen.

This PR reconciles our queue, topic and subscription entities ordering against the .net layer, which acts as the de-facto authority.

Fixes #14539