### PR TITLE
[core-tracing] Downgrade to "^0.18.0" of opentelemetry/api for compatibility

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -805,6 +805,12 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-Rr5NklomjXd7BqfGRs8lD78MvDM+tPeUdHNXilyRIgsUu3gKEKpl3ZgJMiI7gx5r94OqvNc5MukkwKK6xjWYfA==
+  /@opentelemetry/api/0.18.1:
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==
   /@opentelemetry/api/1.0.0-rc.0:
     dev: false
     engines:
@@ -7920,7 +7926,7 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-qsu+JHz4BNdJcYWXsew7OlaHsB9LFmHpkASL0SoN6xjOXJR5Ei2y0brIebwknhxi7AZGrMmVDZrOIWHFqLGPeA==
+      integrity: sha512-iItMzob++ct7sGjHGLQKISCJK+oW9NwDIucpCrPpEMt2MH2TyBaSHv4DOuDa2Y/jBtO9W4Hj0Fbt/aKXewREYw==
       tarball: file:projects/app-configuration.tgz
     version: 0.0.0
   file:projects/attestation.tgz:
@@ -8687,7 +8693,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.11
       '@opencensus/web-types': 0.0.7
-      '@opentelemetry/api': 1.0.0-rc.0
+      '@opentelemetry/api': 0.18.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
@@ -8716,7 +8722,7 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-Tc2a/MYDRNdd0WnJm+5KhRblSFh/WyKj1V7LrK63PCNzSAgUfzjo2TFHV/2NB/Nvm3fy2UUbNldipZCo0Hdqbw==
+      integrity: sha512-G0+jWB2z/Kev0dFhn2LC/v6j78NZDke1TROXxTnq7Wcak15TACsH0+YE/fiv3dspba27B0xLXLr99TNBt976Cw==
       tarball: file:projects/core-tracing.tgz
     version: 0.0.0
   file:projects/core-util.tgz:
@@ -9787,13 +9793,14 @@ packages:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
       '@types/node': 8.10.66
       dotenv: 8.2.0
+      eslint: 7.22.0
       ts-node: 9.1.1_typescript@4.2.3
       tslib: 2.1.0
       typescript: 4.2.3
     dev: false
     name: '@rush-temp/perf-ai-metrics-advisor'
     resolution:
-      integrity: sha512-DXAe5wGj5oid/Sd2BBkW83MfFjax/XSsMs+tMOCz2nf0CIa6HCTetCCOvHLEfTHdToIO7ntJ2D79Qlyu8jgByQ==
+      integrity: sha512-E4lOFEzezusJDqX2TP0TnCUsLxdHPoISaWlUb9seeTlTO17B8azbdw5W8+p5ql/YAj0pnYNCJPyPoVvme756/g==
       tarball: file:projects/perf-ai-metrics-advisor.tgz
     version: 0.0.0
   file:projects/perf-ai-text-analytics.tgz:
@@ -9913,7 +9920,7 @@ packages:
     dev: false
     name: '@rush-temp/perf-search-documents'
     resolution:
-      integrity: sha512-Iseqa3A93xYgTFoPYJTDTjOYobeSSaS3I4s+HDcVvaTzrgr4D17oUvGxIX4/2DE2003I7JgzFO1kNjwbC6+3lg==
+      integrity: sha512-UEZdA+EPRblJfIP8D38K716j/lO/TVT3FrYzEP96rZKMWFRuOt0BDvP1FerYtWE9hieotwR69wm7v5bPPpjuyg==
       tarball: file:projects/perf-search-documents.tgz
     version: 0.0.0
   file:projects/perf-storage-blob.tgz:

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -39,25 +39,22 @@ export function openTelemetryCommonJs(): Record<string, string[]> {
     ];
   }
 
-  const releasedOpenTelemetryVersions = [
-    "0.10.2",
-    "1.0.0-rc.0"
-  ];
+  const releasedOpenTelemetryVersions = ["0.10.2", "1.0.0-rc.0", "0.18.0", "0.18.1", "0.18.2"];
 
   for (const version of releasedOpenTelemetryVersions) {
     namedExports[
       // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
       `../../../common/temp/node_modules/.pnpm/@opentelemetry/api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
     ] = [
-        "SpanKind",
-        "TraceFlags",
-        "getSpan",
-        "setSpan",
-        "StatusCode",
-        "CanonicalCode",
-        "getSpanContext",
-        "setSpanContext"
-      ];
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "StatusCode",
+      "CanonicalCode",
+      "getSpanContext",
+      "setSpanContext"
+    ];
   }
 
   return namedExports;

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -66,7 +66,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11"
+    "@azure/core-tracing": "1.0.0-preview.12"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -89,7 +89,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -71,7 +71,7 @@
     "@azure/communication-signaling": "1.0.0-beta.3",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -66,7 +66,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "jwt-decode": "~2.2.0",
     "tslib": "^2.0.0"

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -70,7 +70,7 @@
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/logger": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -69,7 +69,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -71,7 +71,7 @@
     "@azure/communication-common": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -76,7 +76,7 @@
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.0.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -80,7 +80,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -131,7 +131,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.1",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "form-data": "^3.0.0",
     "tslib": "^2.0.0",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "dependencies": {
     "@opencensus/web-types": "0.0.7",
-    "@opentelemetry/api": "1.0.0-rc.0",
+    "@opentelemetry/api": "^0.18.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/core/core-tracing/src/utils/cache.ts
+++ b/sdk/core/core-tracing/src/utils/cache.ts
@@ -8,7 +8,8 @@ import { getGlobalObject } from "./global";
 // V2 = OpenTelemetry 0.2
 // V3 = OpenTelemetry 0.6.1
 // V4 = OpenTelemetry 1.0.0-rc.0
-const GLOBAL_TRACER_VERSION = 4;
+// V5 = OpenTelemetry ^0.18.0
+const GLOBAL_TRACER_VERSION = 5;
 // preview5 shipped with @azure/core-tracing.tracerCache
 // and didn't have smart detection for collisions
 const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache3");

--- a/sdk/deviceupdate/iot-device-update/package.json
+++ b/sdk/deviceupdate/iot-device-update/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -92,7 +92,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0",
     "uuid": "^8.3.0"

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -93,7 +93,7 @@
     "@azure/core-amqp": "^2.2.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "buffer": "^5.2.1",
     "is-buffer": "^2.0.3",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -82,7 +82,7 @@
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -82,7 +82,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/msal-common": "~4.0.1",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -80,7 +80,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -96,7 +96,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "tslib": "^2.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11"
+    "@azure/core-tracing": "1.0.0-preview.12"
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -90,7 +90,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -95,7 +95,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -81,7 +81,7 @@
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@azure/schema-registry": "1.0.0-beta.2",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "avsc": "^5.5.1",
     "tslib": "^2.0.0",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -87,7 +87,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -78,7 +78,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0",
     "events": "^3.0.0"

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -99,7 +99,7 @@
     "@azure/core-amqp": "^2.2.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-auth": "^1.3.0",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -99,7 +99,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -122,7 +122,7 @@
     "@azure/core-http": "^1.2.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -101,7 +101,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@azure/storage-blob": "^12.5.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -113,7 +113,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
     "tslib": "^2.0.0"

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -108,7 +108,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -10,7 +10,7 @@
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@azure/core-paging": "^1.1.1",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0-beta.3",
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0"
   },
   "keywords": [

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -72,7 +72,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-xml": "1.0.0-beta.1",
     "@azure/logger": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "tslib": "^2.0.0",
     "uuid": "^8.3.0"
   },

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -64,7 +64,7 @@
   "private": true,
   "dependencies": {
     "@azure/core-http": "^1.2.0",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "fs-extra": "^8.1.0",
     "nise": "^4.0.3",
     "nock": "^12.0.3",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -96,7 +96,7 @@
     "@azure/core-rest-pipeline": "^1.0.0",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
It appears moving to 1.0.0-rc.0 was premature as the remainder of the opentelemetry ecosystem have not yet moved to it. It looks like it's prepped to happen at any time, but relying on that timing means we can't get a consistent set of tracing packages within our own stack, which isn't a good idea.

There is an version matrix [here](https://github.com/open-telemetry/opentelemetry-js#compatibility-matrix) - 0.18.x is the most modern version that is listed as compatible with the latest core-version. So we're a bit ahead and should go back.

As they sort out some versioning/compatibility issues between 1.0-rc.0 and the rest of the opentelemetry stack we will:
- Downgrade core-tracing's opentelemetry/api to ^0.18.0 (from 1.0.0-rc.0)
- Upgrade everyone to core-tracing-preview.12 (which only needs that downgrade, no code changes required)
- Update centralized rollup config to accommodate the version range.
- Bump cache version to 5 (for now).

NOTE: @xirzec, I am fairly certain we're going to run into the "Two incompatible versions of @azure/core-tracing have been loaded." - this happened last time in the samples and I erroneously bumped `GLOBAL_TRACER_SYMBOL` up in addition to GLOBAL_TRACER_VERSION` to fix it. This happened last time because various packages were pulling stuff in a combination from either npm or from the local tree and thus getting two different core-tracing versions. 

I believe the only way to fix this is time the releases of the packages so we get 1) core-tracing, then 2) core* and 3) identity out. Then no matter where the packages are pulling their dependencies from they'll get the same core-tracing package.

So:
1. Release core-tracing
2. Release core-http, core-rest-pipeline and core-client (I believe)
3. Release identity hotfix since all packages are using the GA identity and not the in-tree version of identity. We have this branch: https://github.com/azure/azure-sdk-for-js/tree/hotfix/identity_1.3.0. It's not yet released, but @sadasant will be working on that this week. @sadasant, we'll need to update _that_ branch to refer to core-tracing@1.0.0-preview.12 after step #1 above.
4. Update the entire tree to core-tracing@preview.12.