### PR TITLE
[identity] Update to latest core-tracing library

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -81,7 +81,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-http": "^1.2.4",
-    "@azure/core-tracing": "1.0.0-preview.11",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@azure/logger": "^1.0.0",
     "@azure/msal-node": "1.0.0-beta.6",
     "@types/stoppable": "^1.1.0",


### PR DESCRIPTION
There is a PR out [link](#14699) to update core-tracing to use an earlier version of opentelemetry/api. When that PR has completed and core-tracing has been released we should apply this and release with that version of core-tracing for identity/1.3.0