### PR TITLE
[service-bus] Add support for sending AmqpAnnotatedMessage (and control destination section of body)

### DIFF
--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -28,6 +28,7 @@ export interface AmqpAnnotatedMessage {
         [key: string]: any;
     };
     body: any;
+    bodyType?: "data" | "sequence" | "value";
     deliveryAnnotations?: {
         [key: string]: any;
     };

--- a/sdk/core/core-amqp/src/amqpAnnotatedMessage.ts
+++ b/sdk/core/core-amqp/src/amqpAnnotatedMessage.ts
@@ -38,6 +38,10 @@ export interface AmqpAnnotatedMessage {
    * The message body.
    */
   body: any;
+  /**
+   * The AMQP section where the data was decoded from.
+   */
+  bodyType?: "data" | "sequence" | "value";
 }
 
 /**

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.1.0-beta.1 (Unreleased)
 
+### New Features
+
+- Enable encoding the body of a message to the 'value' or 'sequence' sections (via AmqpAnnotatedMessage.bodyType). Using this encoding is not required but does allow you to take advantage of native AMQP serialization for supported primitives or sequences.
 - Adds support for passing `NamedKeyCredential` as the credential type to `ServiceBusClient` and `ServiceBusAdminstrationClient`. Also adds support for passing `SASCredential` to `ServiceBusClient`.
   These credential types support rotation via their `update` methods and are an alternative to using the `SharedAccessKeyName/SharedAccessKey` or `SharedAccessSignature` properties in a connection string.
   Resolves [#11891](https://github.com/Azure/azure-sdk-for-js/issues/11891).

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.1.0-beta.1 (Unreleased)
+## 7.1.0-beta.1 (2021-04-07)
 
 ### New Features
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -400,7 +400,7 @@ export interface ServiceBusMessageBatch {
     // @internal
     readonly _messageSpanContexts: SpanContext[];
     readonly sizeInBytes: number;
-    tryAddMessage(message: ServiceBusMessage, options?: TryAddOptions): boolean;
+    tryAddMessage(message: ServiceBusMessage | AmqpAnnotatedMessage, options?: TryAddOptions): boolean;
 }
 
 // @public
@@ -459,7 +459,7 @@ export interface ServiceBusSender {
     entityPath: string;
     isClosed: boolean;
     scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long[]>;
-    sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch, options?: OperationOptionsBase): Promise<void>;
+    sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -5,7 +5,6 @@ import { message } from "rhea-promise";
 import isBuffer from "is-buffer";
 import { Buffer } from "buffer";
 import { logErrorStackTrace, logger } from "./log";
-import { isObjectWithProperties } from "./util/typeGuards";
 
 /**
  * The default data transformer that will be used by the Azure SDK.
@@ -23,9 +22,15 @@ export const defaultDataTransformer = {
    * - content: The given AMQP message body as a Buffer.
    * - multiple: true | undefined.
    */
-  encode(body: unknown): any {
+  encode(body: unknown, bodyType: "data" | "value" | "sequence"): any {
     let result: any;
-    if (isBuffer(body)) {
+    if (bodyType === "value") {
+      // TODO: Expose value_section from `rhea` similar to the data_section and sequence_section. Right now there isn't a way to create a value section officially.
+      result = message.data_section(body);
+      result.typecode = valueSectionTypeCode;
+    } else if (bodyType === "sequence") {
+      result = message.sequence_section(body);
+    } else if (isBuffer(body)) {
       result = message.data_section(body);
     } else {
       // string, undefined, null, boolean, array, object, number should end up here
@@ -47,6 +52,72 @@ export const defaultDataTransformer = {
     }
     return result;
   },
+  /**
+   * A function that takes the body property from an AMQP message
+   * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
+   * If it cannot decode the body then it returns the body
+   * as-is.
+   *
+   * NOTE: Use this to decode a message body when you know that the entire contents are _only_ contained
+   * in the 'data' section of the message (for instance, messages from the $mgmt link). Otherwise
+   * use 'defaultDataTransformer.decodeWithType', which can handle data coming from separate sections
+   * of the AMQP mesage.
+   *
+   * @param body - The AMQP message body
+   * @return decoded body or the given body as-is.
+   */
+  decode(body: any): any {
+    let actualContent = body;
+
+    if (isRheaAmqpSection(body)) {
+      actualContent = body.content;
+    }
+
+    return tryToJsonDecode(actualContent);
+  },
+  /**
+   * A function that takes the body property from an AMQP message, which can come from either
+   * the 'data', 'value' or 'sequence' sections of an AMQP message.
+   *
+   * If the body is not a JSON string the the raw contents will be returned, along with the bodyType
+   * indicating which part of the AMQP message the body was decoded from.
+   *
+   * @param body - The AMQP message body as received from rhea.
+   * @return The decoded/raw body and the body type.
+   */
+  decodeWithType(
+    body: any | RheaAmqpSection
+  ): { body: any; bodyType: "data" | "sequence" | "value" } {
+    try {
+      if (isRheaAmqpSection(body)) {
+        switch (body.typecode) {
+          case dataSectionTypeCode:
+            return { body: tryToJsonDecode(body.content), bodyType: "data" };
+          case sequenceSectionTypeCode:
+            // typecode:
+            // handle sequences
+            return { body: body.content, bodyType: "sequence" };
+          case valueSectionTypeCode:
+            // value
+            return { body: body.content, bodyType: "value" };
+        }
+      } else {
+        // not sure - we have to try to infer the proper bodyType and content
+        if (isBuffer(body)) {
+          // This indicates that we are getting the AMQP described type. Let us try decoding it.
+          return { body: tryToJsonDecode(body), bodyType: "data" };
+        } else {
+          return { body: body, bodyType: "value" };
+        }
+      }
+    } catch (err) {
+      logger.verbose(
+        "[decode] An error occurred while decoding the received message body. The error is: %O",
+        err
+      );
+      throw err;
+    }
+  }
 
   /**
    * A function that takes the body property from an AMQP message
@@ -56,31 +127,84 @@ export const defaultDataTransformer = {
    * @param body - The AMQP message body
    * @returns decoded body or the given body as-is.
    */
-  decode(body: unknown): any {
-    let processedBody: any = body;
-    try {
-      if (isObjectWithProperties(body, ["content"]) && isBuffer(body.content)) {
-        // This indicates that we are getting the AMQP described type. Let us try decoding it.
-        processedBody = body.content;
-      }
-      try {
-        // Trying to stringify and JSON.parse() anything else will fail flat and we shall return
-        // the original type back
-        const bodyStr: string = processedBody.toString("utf8");
-        processedBody = JSON.parse(bodyStr);
-      } catch (err) {
-        logger.verbose(
-          "[decode] An error occurred while trying JSON.parse() on the received body. " +
-            "The error is %O",
-          err
-        );
-      }
-    } catch (err) {
-      logger.verbose(
-        "[decode] An error occurred while decoding the received message body. The error is: %O",
-        err
-      );
-    }
-    return processedBody;
-  }
+  // decode(body: unknown): any {
+  //   let processedBody: any = body;
+  //   try {
+  //     if (isObjectWithProperties(body, ["content"]) && isBuffer(body.content)) {
+  //       // This indicates that we are getting the AMQP described type. Let us try decoding it.
+  //       processedBody = body.content;
+  //     }
+  //     try {
+  //       // Trying to stringify and JSON.parse() anything else will fail flat and we shall return
+  //       // the original type back
+  //       const bodyStr: string = processedBody.toString("utf8");
+  //       processedBody = JSON.parse(bodyStr);
+  //     } catch (err) {
+  //       logger.verbose(
+  //         "[decode] An error occurred while trying JSON.parse() on the received body. " +
+  //           "The error is %O",
+  //         err
+  //       );
+  //     }
+  //   } catch (err) {
+  //     logger.verbose(
+  //       "[decode] An error occurred while decoding the received message body. The error is: %O",
+  //       err
+  //     );
+  //   }
+  //   return processedBody;
+  // }
 };
+
+/** @internal */
+export function isRheaAmqpSection(
+  possibleSection: any | RheaAmqpSection
+): possibleSection is RheaAmqpSection {
+  return possibleSection != null && typeof possibleSection.typecode === "number";
+}
+
+/**
+ * Attempts to decode 'body' as a JSON string. If it fails it returns body
+ * verbatim.
+ *
+ * @param body An AMQP message body.
+ * @returns A JSON decoded object, or body if body was not a JSON string.
+ *
+ * @internal
+ */
+export function tryToJsonDecode(body: any): any {
+  let processedBody = body;
+  try {
+    // Trying to stringify and JSON.parse() anything else will fail flat and we shall return
+    // the original type back
+    const bodyStr: string = processedBody.toString("utf8");
+    processedBody = JSON.parse(bodyStr);
+  } catch (err) {
+    logger.verbose(
+      "[decode] An error occurred while trying JSON.parse() on the received body. " +
+        "The error is %O",
+      err
+    );
+  }
+  return processedBody;
+}
+
+/** @internal */
+export const dataSectionTypeCode: 0x75 = 0x75;
+/** @internal */
+export const sequenceSectionTypeCode: 0x76 = 0x76;
+/** @internal */
+export const valueSectionTypeCode: 0x77 = 0x77;
+
+/**
+ * Mirror of the internal Section interface in rhea.
+ *
+ * @internal
+ */
+export interface RheaAmqpSection {
+  typecode:
+    | typeof dataSectionTypeCode
+    | typeof sequenceSectionTypeCode
+    | typeof valueSectionTypeCode;
+  content: any;
+}

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -5,6 +5,7 @@ import { message } from "rhea-promise";
 import isBuffer from "is-buffer";
 import { Buffer } from "buffer";
 import { logErrorStackTrace, logger } from "./log";
+import { isDefined } from "./util/typeGuards";
 
 /**
  * The default data transformer that will be used by the Azure SDK.
@@ -124,7 +125,11 @@ export const defaultDataTransformer = {
 export function isRheaAmqpSection(
   possibleSection: any | RheaAmqpSection
 ): possibleSection is RheaAmqpSection {
-  return possibleSection != null && typeof possibleSection.typecode === "number";
+  return (
+    possibleSection != null &&
+    typeof possibleSection.typecode === "number" &&
+    isDefined(possibleSection.content)
+  );
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -5,7 +5,6 @@ import { message } from "rhea-promise";
 import isBuffer from "is-buffer";
 import { Buffer } from "buffer";
 import { logErrorStackTrace, logger } from "./log";
-import { isDefined } from "./util/typeGuards";
 
 /**
  * The default data transformer that will be used by the Azure SDK.
@@ -125,11 +124,7 @@ export const defaultDataTransformer = {
 export function isRheaAmqpSection(
   possibleSection: any | RheaAmqpSection
 ): possibleSection is RheaAmqpSection {
-  return (
-    possibleSection != null &&
-    typeof possibleSection.typecode === "number" &&
-    isDefined(possibleSection.content)
-  );
+  return possibleSection != null && typeof possibleSection.typecode === "number";
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -124,7 +124,13 @@ export const defaultDataTransformer = {
 export function isRheaAmqpSection(
   possibleSection: any | RheaAmqpSection
 ): possibleSection is RheaAmqpSection {
-  return possibleSection != null && typeof possibleSection.typecode === "number";
+  return (
+    possibleSection != null &&
+    typeof possibleSection.typecode === "number" &&
+    (possibleSection.typecode === dataSectionTypeCode ||
+      possibleSection.typecode === valueSectionTypeCode ||
+      possibleSection.typecode === sequenceSectionTypeCode)
+  );
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -66,7 +66,7 @@ export const defaultDataTransformer = {
    * @param body - The AMQP message body
    * @return decoded body or the given body as-is.
    */
-  decode(body: any): any {
+  decode(body: unknown): unknown {
     let actualContent = body;
 
     if (isRheaAmqpSection(body)) {
@@ -86,8 +86,8 @@ export const defaultDataTransformer = {
    * @return The decoded/raw body and the body type.
    */
   decodeWithType(
-    body: any | RheaAmqpSection
-  ): { body: any; bodyType: "data" | "sequence" | "value" } {
+    body: unknown | RheaAmqpSection
+  ): { body: unknown; bodyType: "data" | "sequence" | "value" } {
     try {
       if (isRheaAmqpSection(body)) {
         switch (body.typecode) {
@@ -118,42 +118,6 @@ export const defaultDataTransformer = {
       throw err;
     }
   }
-
-  /**
-   * A function that takes the body property from an AMQP message
-   * (an AMQP Data type (data section in rhea terms)) and returns the decoded message body.
-   * If it cannot decode the body then it returns the body
-   * as-is.
-   * @param body - The AMQP message body
-   * @returns decoded body or the given body as-is.
-   */
-  // decode(body: unknown): any {
-  //   let processedBody: any = body;
-  //   try {
-  //     if (isObjectWithProperties(body, ["content"]) && isBuffer(body.content)) {
-  //       // This indicates that we are getting the AMQP described type. Let us try decoding it.
-  //       processedBody = body.content;
-  //     }
-  //     try {
-  //       // Trying to stringify and JSON.parse() anything else will fail flat and we shall return
-  //       // the original type back
-  //       const bodyStr: string = processedBody.toString("utf8");
-  //       processedBody = JSON.parse(bodyStr);
-  //     } catch (err) {
-  //       logger.verbose(
-  //         "[decode] An error occurred while trying JSON.parse() on the received body. " +
-  //           "The error is %O",
-  //         err
-  //       );
-  //     }
-  //   } catch (err) {
-  //     logger.verbose(
-  //       "[decode] An error occurred while decoding the received message body. The error is: %O",
-  //       err
-  //     );
-  //   }
-  //   return processedBody;
-  // }
 };
 
 /** @internal */

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -6,6 +6,7 @@ import { MessageSender } from "./core/messageSender";
 import { ServiceBusMessage } from "./serviceBusMessage";
 import { ConnectionContext } from "./connectionContext";
 import {
+  errorInvalidMessageTypeSingleOrArray,
   getSenderClosedErrorMsg,
   throwErrorIfConnectionClosed,
   throwIfNotValidServiceBusMessage,
@@ -14,7 +15,13 @@ import {
 } from "./util/errors";
 import { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
 import { CreateMessageBatchOptions } from "./models";
-import { RetryConfig, RetryOperationType, RetryOptions, retry } from "@azure/core-amqp";
+import {
+  RetryConfig,
+  RetryOperationType,
+  RetryOptions,
+  retry,
+  AmqpAnnotatedMessage
+} from "@azure/core-amqp";
 import { OperationOptionsBase } from "./modelsToBeSharedWithEventHubs";
 import { SpanStatusCode, Link, SpanKind } from "@azure/core-tracing";
 import { senderLogger as logger } from "./log";
@@ -44,7 +51,12 @@ export interface ServiceBusSender {
    * @throws `ServiceBusError` if the service returns an error while sending messages to the service.
    */
   sendMessages(
-    messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch,
+    messages:
+      | ServiceBusMessage
+      | ServiceBusMessage[]
+      | ServiceBusMessageBatch
+      | AmqpAnnotatedMessage
+      | AmqpAnnotatedMessage[],
     options?: OperationOptionsBase
   ): Promise<void>;
 
@@ -166,13 +178,16 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
   }
 
   async sendMessages(
-    messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch,
+    messages:
+      | ServiceBusMessage
+      | ServiceBusMessage[]
+      | ServiceBusMessageBatch
+      | AmqpAnnotatedMessage
+      | AmqpAnnotatedMessage[],
     options?: OperationOptionsBase
   ): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(this._context.connectionId, "messages", messages);
-    const invalidTypeErrMsg =
-      "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
 
     let batch: ServiceBusMessageBatch;
     if (isServiceBusMessageBatch(messages)) {
@@ -183,7 +198,7 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
       }
       batch = await this.createMessageBatch(options);
       for (const message of messages) {
-        throwIfNotValidServiceBusMessage(message, invalidTypeErrMsg);
+        throwIfNotValidServiceBusMessage(message, errorInvalidMessageTypeSingleOrArray);
         if (!batch.tryAddMessage(message, options)) {
           // this is too big - throw an error
           throw new ServiceBusError(
@@ -246,10 +261,7 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
     const messagesToSchedule = Array.isArray(messages) ? messages : [messages];
 
     for (const message of messagesToSchedule) {
-      throwIfNotValidServiceBusMessage(
-        message,
-        "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage."
-      );
+      throwIfNotValidServiceBusMessage(message, errorInvalidMessageTypeSingleOrArray);
     }
 
     const scheduleMessageOperationPromise = async (): Promise<Long[]> => {

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -582,7 +582,7 @@ export function fromRheaMessage(
   rawMessage.bodyType = bodyType;
 
   const rcvdsbmsg: ServiceBusReceivedMessage = {
-    _rawAmqpMessage: AmqpAnnotatedMessage.fromRheaMessage(msg),
+    _rawAmqpMessage: rawMessage,
     _delivery: delivery,
     deliveryCount: msg.delivery_count,
     lockToken:

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -618,12 +618,9 @@ export function isServiceBusMessage(possible: unknown): possible is ServiceBusMe
  * @internal
  * @ignore
  */
-export function isAmqpAnnotatedMessage(possible: any): possible is AmqpAnnotatedMessage {
+export function isAmqpAnnotatedMessage(possible: unknown): possible is AmqpAnnotatedMessage {
   return (
-    possible != null &&
-    typeof possible === "object" &&
-    "body" in possible &&
-    "bodyType" in possible &&
+    isObjectWithProperties(possible, ["body", "bodyType"]) &&
     possible.constructor.name !== ServiceBusMessageImpl.name
   );
 }

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -274,11 +274,56 @@ export function getMessagePropertyTypeMismatchError(msg: ServiceBusMessage): Err
  * @internal
  * Converts given ServiceBusMessage to RheaMessage
  */
-export function toRheaMessage(msg: ServiceBusMessage): RheaMessage {
+export function toRheaMessage(
+  msg: ServiceBusMessage | ServiceBusReceivedMessage | AmqpAnnotatedMessage,
+  encoder: Pick<typeof defaultDataTransformer, "encode">
+): RheaMessage {
+  if (isAmqpAnnotatedMessage(msg)) {
+    const amqpMsg: RheaMessage = {
+      body: encoder.encode(msg.body, msg.bodyType ?? "data"),
+      message_annotations: {}
+    };
+
+    if (msg.applicationProperties != null) {
+      amqpMsg.application_properties = msg.applicationProperties;
+    }
+
+    if (msg.messageAnnotations != null) {
+      amqpMsg.message_annotations = msg.messageAnnotations;
+    }
+
+    if (msg.deliveryAnnotations != null) {
+      amqpMsg.delivery_annotations = msg.deliveryAnnotations;
+    }
+
+    return amqpMsg;
+  }
+
+  let bodyType: "data" | "sequence" | "value" = "data";
+
+  if (isServiceBusReceivedMessage(msg)) {
+    /*
+     * TODO: this is a bit complicated.
+     *
+     * It seems reasonable to expect to be able to round-trip a message (ie,
+     * receive a message, and then send it again, possibly to another queue / topic).
+     * If the user does that we need to make sure to respect their original AMQP
+     * type so when the message is re - encoded we don't put 'body' into the wrong spot.
+     *
+     * The complication is that we need to decide if we're okay with respecting a field
+     * from the rawAmqpMessage, which up until now we've treated as just vestigial
+     * information on send. My hope is that the use case of "alter the sb message in some
+     * incompatible way with the underying _rawAmqpMessage.bodyType" is not common
+     * enough for us to try to do anything more than what I'm doing here.
+     */
+    bodyType = msg._rawAmqpMessage.bodyType ?? "data";
+  }
+
   const amqpMsg: RheaMessage = {
-    body: msg.body,
+    body: encoder.encode(msg.body, bodyType),
     message_annotations: {}
   };
+
   if (msg.applicationProperties != null) {
     amqpMsg.application_properties = msg.applicationProperties;
   }
@@ -291,6 +336,7 @@ export function toRheaMessage(msg: ServiceBusMessage): RheaMessage {
         "Length of 'sessionId' property on the message cannot be greater than 128 characters."
       );
     }
+
     amqpMsg.group_id = msg.sessionId;
   }
   if (msg.replyTo != null) {
@@ -451,8 +497,11 @@ export function fromRheaMessage(
       body: undefined
     };
   }
+
+  const { body, bodyType } = defaultDataTransformer.decodeWithType(msg.body);
+
   const sbmsg: ServiceBusMessage = {
-    body: msg.body
+    body: body
   };
 
   if (msg.application_properties != null) {
@@ -529,6 +578,9 @@ export function fromRheaMessage(
     props.expiresAtUtc = new Date(props.enqueuedTimeUtc.getTime() + msg.ttl!);
   }
 
+  const rawMessage = AmqpAnnotatedMessage.fromRheaMessage(msg);
+  rawMessage.bodyType = bodyType;
+
   const rcvdsbmsg: ServiceBusReceivedMessage = {
     _rawAmqpMessage: AmqpAnnotatedMessage.fromRheaMessage(msg),
     _delivery: delivery,
@@ -560,6 +612,29 @@ export function fromRheaMessage(
  */
 export function isServiceBusMessage(possible: unknown): possible is ServiceBusMessage {
   return isObjectWithProperties(possible, ["body"]);
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+export function isAmqpAnnotatedMessage(possible: any): possible is AmqpAnnotatedMessage {
+  return (
+    possible != null &&
+    typeof possible === "object" &&
+    "body" in possible &&
+    "bodyType" in possible &&
+    possible.constructor.name !== ServiceBusMessageImpl.name
+  );
+}
+
+/**
+ * @internal
+ */
+export function isServiceBusReceivedMessage(
+  possible: unknown
+): possible is ServiceBusReceivedMessage {
+  return isServiceBusMessage(possible) && "_rawAmqpMessage" in possible;
 }
 
 /**
@@ -766,11 +841,24 @@ export class ServiceBusMessageImpl implements ServiceBusReceivedMessage {
     if (receiveMode === "receiveAndDelete") {
       this.lockToken = undefined;
     }
+
+    let actualBodyType:
+      | ReturnType<typeof defaultDataTransformer["decodeWithType"]>["bodyType"]
+      | undefined = undefined;
+
     if (msg.body) {
-      this.body = defaultDataTransformer.decode(msg.body);
+      try {
+        const result = defaultDataTransformer.decodeWithType(msg.body);
+
+        this.body = result.body;
+        actualBodyType = result.bodyType;
+      } catch (err) {
+        this.body = undefined;
+      }
     }
     // TODO: _rawAmqpMessage is already being populated in fromRheaMessage(), no need to do it twice
     this._rawAmqpMessage = AmqpAnnotatedMessage.fromRheaMessage(msg);
+    this._rawAmqpMessage.bodyType = actualBodyType;
     this.delivery = delivery;
   }
 

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -71,7 +71,7 @@ export interface ServiceBusMessageBatch {
    * **NOTE**: Always remember to check the return value of this method, before calling it again
    * for the next event.
    *
-   * @param message - An individual service bus message.
+   * @param message - The message to add to the batch.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
   tryAddMessage(

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -6,7 +6,11 @@ import {
   toRheaMessage,
   getMessagePropertyTypeMismatchError
 } from "./serviceBusMessage";
-import { throwIfNotValidServiceBusMessage, throwTypeErrorIfParameterMissing } from "./util/errors";
+import {
+  errorInvalidMessageTypeSingle,
+  throwIfNotValidServiceBusMessage,
+  throwTypeErrorIfParameterMissing
+} from "./util/errors";
 import { ConnectionContext } from "./connectionContext";
 import {
   MessageAnnotations,
@@ -17,6 +21,7 @@ import {
 import { SpanContext } from "@azure/core-tracing";
 import { convertTryAddOptionsForCompatibility, instrumentMessage } from "./diagnostics/tracing";
 import { TryAddOptions } from "./modelsToBeSharedWithEventHubs";
+import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { defaultDataTransformer } from "./dataTransformer";
 
 /**
@@ -69,7 +74,10 @@ export interface ServiceBusMessageBatch {
    * @param message - An individual service bus message.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
-  tryAddMessage(message: ServiceBusMessage, options?: TryAddOptions): boolean;
+  tryAddMessage(
+    message: ServiceBusMessage | AmqpAnnotatedMessage,
+    options?: TryAddOptions
+  ): boolean;
 
   /**
    * The AMQP message containing encoded events that were added to the batch.
@@ -229,12 +237,12 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * @param originalMessage - An individual service bus message.
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
-  public tryAddMessage(originalMessage: ServiceBusMessage, options: TryAddOptions = {}): boolean {
+  public tryAddMessage(
+    originalMessage: ServiceBusMessage | AmqpAnnotatedMessage,
+    options: TryAddOptions = {}
+  ): boolean {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "message", originalMessage);
-    throwIfNotValidServiceBusMessage(
-      originalMessage,
-      "Provided value for 'message' must be of type ServiceBusMessage."
-    );
+    throwIfNotValidServiceBusMessage(originalMessage, errorInvalidMessageTypeSingle);
 
     options = convertTryAddOptionsForCompatibility(options);
 
@@ -246,8 +254,7 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
     );
 
     // Convert ServiceBusMessage to AmqpMessage.
-    const amqpMessage = toRheaMessage(message);
-    amqpMessage.body = defaultDataTransformer.encode(message.body);
+    const amqpMessage = toRheaMessage(message, defaultDataTransformer);
 
     let encodedMessage: Buffer;
     try {

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -270,7 +270,7 @@ export function throwIfNotValidServiceBusMessage(
 
 /** @internal */
 export const errorInvalidMessageTypeSingleOrArray =
-  "Provided value for 'messages' must be of type: ServiceBusMessage, AmqpAnnotatedMessage or an array of type ServiceBusMessage or AmqpAnnotatedMessage.";
+  "Provided value for 'messages' must be of type: ServiceBusMessage, AmqpAnnotatedMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage or AmqpAnnotatedMessage.";
 
 /** @internal */
 export const errorInvalidMessageTypeSingle =

--- a/sdk/servicebus/service-bus/test/internal/amqp.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/amqp.spec.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import { ServiceBusReceiver, ServiceBusSender } from "../../src";
+import {
+  createServiceBusClientForTests,
+  ServiceBusClientForTests
+} from "../public/utils/testutils2";
+import { TestClientType } from "../public/utils/testUtils";
+const assert = chai.assert;
+
+describe("AMQP message encoding", () => {
+  // Messaging format (describes the three types of encodable entities - 'data', 'sequence' or 'value')
+  // http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-messaging-v1.0-csprd01.html#type-data
+
+  // Primitive types
+  // http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-types-v1.0-csprd01.html#toc
+
+  describe("amqp encoding/decoding", () => {
+    let client: ServiceBusClientForTests;
+    let sender: ServiceBusSender;
+    let receiver: ServiceBusReceiver;
+
+    before(() => {
+      client = createServiceBusClientForTests();
+    });
+
+    beforeEach(async () => {
+      const testEntities = await client.test.createTestEntities(TestClientType.UnpartitionedQueue);
+      sender = await client.test.createSender(testEntities);
+      receiver = await client.test.createReceiveAndDeleteReceiver(testEntities);
+    });
+
+    afterEach(() => client.test.afterEach());
+    after(() => client.test.after());
+
+    it("values", async () => {
+      const valueTypes = [[1, 2, 3], 1, 1.5, "hello", { hello: "world" }];
+
+      for (const valueType of valueTypes) {
+        await sender.sendMessages({
+          body: valueType,
+          bodyType: "value"
+        });
+
+        const messages = await receiver.receiveMessages(1);
+        const message = messages[0];
+
+        assert.deepEqual(
+          message._rawAmqpMessage.bodyType,
+          "value",
+          `Should be identified as a value: ${valueType.toString()}`
+        );
+        assert.deepEqual(
+          message.body,
+          valueType,
+          `Deserialized body should be equal: : ${valueType.toString()}`
+        );
+      }
+    });
+
+    it("sequences", async () => {
+      const sequenceTypes = [
+        [[1], [2], [3]],
+        [1, 2, 3]
+      ];
+
+      for (const sequenceType of sequenceTypes) {
+        await sender.sendMessages({
+          body: sequenceType,
+          bodyType: "sequence"
+        });
+
+        const messages = await receiver.receiveMessages(1);
+        const message = messages[0];
+
+        assert.deepEqual(
+          message._rawAmqpMessage.bodyType,
+          "sequence",
+          `Should be identified as sequence: ${sequenceType.toString()}`
+        );
+        assert.deepEqual(
+          message.body,
+          sequenceType,
+          `Deserialized body should be equal: : ${sequenceType.toString()}`
+        );
+      }
+    });
+
+    it("data", async () => {
+      const buff = Buffer.from("hello", "utf8");
+
+      const dataTypes = [1, 1.5, "hello", { hello: "world" }, buff, [1, 2, 3]];
+
+      for (const dataType of dataTypes) {
+        await sender.sendMessages({
+          body: dataType,
+          bodyType: "data"
+        });
+
+        const messages = await receiver.receiveMessages(1);
+        const message = messages[0];
+
+        assert.deepEqual(
+          message._rawAmqpMessage.bodyType,
+          "data",
+          `Should be identified as data: ${dataType.toString()}`
+        );
+        assert.deepEqual(
+          message.body,
+          dataType,
+          `Deserialized body should be equal: : ${dataType.toString()}`
+        );
+      }
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  isAmqpAnnotatedMessage,
+  isServiceBusMessage,
+  ServiceBusMessage,
+  ServiceBusMessageImpl,
+  ServiceBusReceivedMessage,
+  toRheaMessage
+} from "../../../src/serviceBusMessage";
+import * as chai from "chai";
+import { Delivery, Message } from "rhea-promise";
+import { AmqpAnnotatedMessage, Constants } from "@azure/core-amqp";
+import {
+  dataSectionTypeCode,
+  defaultDataTransformer,
+  isRheaAmqpSection,
+  valueSectionTypeCode
+} from "../../../src/dataTransformer";
+const assert = chai.assert;
+
+describe("AMQP message encoding", () => {
+  const exampleReceivedMessage: () => ServiceBusReceivedMessage = () =>
+    new ServiceBusMessageImpl(
+      ({
+        message_annotations: {
+          [Constants.enqueuedTime]: Date.now()
+        }
+      } as any) as Message,
+      {} as Delivery,
+      false,
+      "receiveAndDelete"
+    );
+
+  it("isAmqpAnnotatedMessage", () => {
+    assert.isFalse(isAmqpAnnotatedMessage({}));
+    assert.isFalse(isAmqpAnnotatedMessage({ body: "hello world" }));
+    assert.isFalse(isAmqpAnnotatedMessage(exampleReceivedMessage()));
+
+    assert.isTrue(
+      isAmqpAnnotatedMessage({
+        body: "hello world",
+        bodyType: "sequence"
+      })
+    );
+    assert.isTrue(
+      isAmqpAnnotatedMessage({
+        body: "hello world",
+        bodyType: "value"
+      })
+    );
+    assert.isTrue(
+      isAmqpAnnotatedMessage({
+        body: "hello world",
+        bodyType: "data"
+      })
+    );
+
+    assert.isTrue(
+      isAmqpAnnotatedMessage({
+        body: "hello world",
+        bodyType: undefined // the property _must_ exist, but undefined is fine. We'll default to 'data'
+      })
+    );
+  });
+
+  it("isServiceBusMessage", () => {
+    assert.isTrue(
+      isServiceBusMessage({ body: undefined }),
+      "object with undefined 'body' should be a ServiceBusMessage"
+    ); // no field is really required for a Service Bus message.
+    assert.isTrue(isServiceBusMessage({ body: "hello world" }), "object has a 'body' field"); // no field is really required for a Service Bus message.
+    assert.isTrue(
+      isServiceBusMessage(exampleReceivedMessage()),
+      "a ServiceBusReceivedMessage is also a sendable ServiceBusMessage"
+    );
+  });
+
+  describe("toRheaMessage", () => {
+    it("AmqpAnnotatedMessage (explicit type)", () => {
+      const amqpAnnotatedMessage: AmqpAnnotatedMessage = {
+        body: "hello",
+        bodyType: "value"
+      };
+
+      const rheaMessage = toRheaMessage(amqpAnnotatedMessage, defaultDataTransformer);
+
+      if (!isRheaAmqpSection(rheaMessage.body)) {
+        throw new Error("rheaMessage.body was not a rhea section");
+      }
+
+      assert.equal(rheaMessage.body.typecode, valueSectionTypeCode);
+    });
+
+    it("AmqpAnnotatedMessage (implicit type)", () => {
+      const amqpAnnotatedMessage: AmqpAnnotatedMessage = {
+        body: "hello",
+        bodyType: undefined
+      };
+
+      const rheaMessage = toRheaMessage(amqpAnnotatedMessage, defaultDataTransformer);
+
+      if (!isRheaAmqpSection(rheaMessage.body)) {
+        throw new Error("rheaMessage.body was not a rhea section");
+      }
+
+      assert.equal(rheaMessage.body.typecode, dataSectionTypeCode);
+    });
+
+    it("ServiceBusMessage", () => {
+      const serviceBusMessage: ServiceBusMessage = {
+        body: "hello"
+      };
+
+      const rheaMessage = toRheaMessage(serviceBusMessage, defaultDataTransformer);
+
+      if (!isRheaAmqpSection(rheaMessage.body)) {
+        throw new Error("rheaMessage.body was not a rhea section");
+      }
+
+      assert.equal(rheaMessage.body.typecode, dataSectionTypeCode);
+    });
+
+    it("ServiceBusReceivedMessage", () => {
+      const serviceBusReceivedMessage = exampleReceivedMessage();
+
+      (serviceBusReceivedMessage as Record<keyof ServiceBusReceivedMessage, any>)[
+        "_rawAmqpMessage"
+      ] = {
+        bodyType: "data"
+      };
+
+      const rheaMessage = toRheaMessage(serviceBusReceivedMessage, defaultDataTransformer);
+
+      if (!isRheaAmqpSection(rheaMessage.body)) {
+        throw new Error("rheaMessage.body was not a rhea section");
+      }
+
+      assert.equal(rheaMessage.body.typecode, dataSectionTypeCode);
+    });
+
+    it("ServiceBusReceivedMessage (but was decoded from 'value')", () => {
+      const serviceBusReceivedMessage = exampleReceivedMessage();
+
+      (serviceBusReceivedMessage as Record<keyof ServiceBusReceivedMessage, any>)[
+        "_rawAmqpMessage"
+      ] = {
+        bodyType: "value"
+      };
+
+      const rheaMessage = toRheaMessage(serviceBusReceivedMessage, defaultDataTransformer);
+
+      if (!isRheaAmqpSection(rheaMessage.body)) {
+        throw new Error("rheaMessage.body was not a rhea section");
+      }
+
+      assert.equal(rheaMessage.body.typecode, valueSectionTypeCode);
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -703,7 +703,6 @@ describe("BatchingReceiver unit tests", () => {
         maxWaitTimeInMs: 5000
       })
       .then((messages) => {
-        console.log(`===> then running, messages: ${messages.map((m) => m.body).join(", ")}`);
         return [...messages];
       });
 

--- a/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
@@ -42,7 +42,7 @@ describe("DataTransformer", function() {
   const transformer = defaultDataTransformer;
 
   it("should correctly encode/decode a string message body", function(done) {
-    const encoded: any = transformer.encode(stringBody);
+    const encoded: any = transformer.encode(stringBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -51,7 +51,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode a number message body", function(done) {
-    const encoded: any = transformer.encode(numberBody);
+    const encoded: any = transformer.encode(numberBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -60,7 +60,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode a boolean message body", function(done) {
-    const encoded: any = transformer.encode(booleanBody);
+    const encoded: any = transformer.encode(booleanBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -69,7 +69,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode a null message body", function(done) {
-    const encoded: any = transformer.encode(nullBody);
+    const encoded: any = transformer.encode(nullBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -78,7 +78,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode an undefined message body", function(done) {
-    const encoded: any = transformer.encode(undefinedBody);
+    const encoded: any = transformer.encode(undefinedBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -87,7 +87,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode an empty string message body", function(done) {
-    const encoded: any = transformer.encode(emptyStringBody);
+    const encoded: any = transformer.encode(emptyStringBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -96,7 +96,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode an array message body", function(done) {
-    const encoded: any = transformer.encode(arrayBody);
+    const encoded: any = transformer.encode(arrayBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -105,7 +105,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode an object message body", function(done) {
-    const encoded: any = transformer.encode(objectBody);
+    const encoded: any = transformer.encode(objectBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -114,7 +114,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode a buffer message body", function(done) {
-    const encoded: any = transformer.encode(bufferBody);
+    const encoded: any = transformer.encode(bufferBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);
@@ -123,7 +123,7 @@ describe("DataTransformer", function() {
   });
 
   it("should correctly encode/decode a hex buffer message body", function(done) {
-    const encoded: any = transformer.encode(hexBufferBody);
+    const encoded: any = transformer.encode(hexBufferBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded);

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -7,7 +7,11 @@ import { ConnectionContext } from "../../../src/connectionContext";
 import { ServiceBusMessage } from "../../../src";
 import { isServiceBusMessageBatch, ServiceBusSenderImpl } from "../../../src/sender";
 import { createConnectionContextForTests } from "./unittestUtils";
-import { PartitionKeySessionIdMismatchError } from "../../../src/util/errors";
+import {
+  errorInvalidMessageTypeSingleOrArray,
+  errorInvalidMessageTypeSingle,
+  PartitionKeySessionIdMismatchError
+} from "../../../src/util/errors";
 
 const assert = chai.assert;
 
@@ -47,8 +51,7 @@ describe("sender unit tests", () => {
 
   badMessages.forEach((invalidValue) => {
     it(`don't allow Sender.sendMessages(${invalidValue})`, async () => {
-      let expectedErrorMsg =
-        "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
+      let expectedErrorMsg = errorInvalidMessageTypeSingleOrArray;
       if (invalidValue === null || invalidValue === undefined) {
         expectedErrorMsg = `Missing parameter "messages"`;
       }
@@ -72,7 +75,7 @@ describe("sender unit tests", () => {
   badMessages.forEach((invalidValue) => {
     it(`don't allow tryAdd(${invalidValue})`, async () => {
       const batch = await sender.createMessageBatch();
-      let expectedErrorMsg = "Provided value for 'message' must be of type ServiceBusMessage.";
+      let expectedErrorMsg = errorInvalidMessageTypeSingle;
       if (invalidValue === null || invalidValue === undefined) {
         expectedErrorMsg = `Missing parameter "message"`;
       }
@@ -95,8 +98,7 @@ describe("sender unit tests", () => {
 
   badMessages.forEach((invalidValue) => {
     it(`don't allow Sender.scheduleMessages(${invalidValue})`, async () => {
-      let expectedErrorMsg =
-        "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage.";
+      let expectedErrorMsg = errorInvalidMessageTypeSingleOrArray;
       if (invalidValue === null || invalidValue === undefined) {
         expectedErrorMsg = `Missing parameter "messages"`;
       }


### PR DESCRIPTION
Adding in support to send AmqpAnnotatedMessage and also to control where the body is encoded in the sent message (via the `bodyType`) field.