### PR TITLE
Code changes to add muli api support

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -109,6 +109,12 @@ export interface BaseLexicalAnalyzer {
 }
 
 // @public
+export interface BaseLexicalNormalizer {
+    name: string;
+    odatatype: "#Microsoft.Azure.Search.CustomNormalizer";
+}
+
+// @public
 export interface BaseLexicalTokenizer {
     name: string;
     odatatype: "#Microsoft.Azure.Search.ClassicTokenizer" | "#Microsoft.Azure.Search.EdgeNGramTokenizer" | "#Microsoft.Azure.Search.KeywordTokenizer" | "#Microsoft.Azure.Search.KeywordTokenizerV2" | "#Microsoft.Azure.Search.MicrosoftLanguageTokenizer" | "#Microsoft.Azure.Search.MicrosoftLanguageStemmingTokenizer" | "#Microsoft.Azure.Search.NGramTokenizer" | "#Microsoft.Azure.Search.PathHierarchyTokenizerV2" | "#Microsoft.Azure.Search.PatternTokenizer" | "#Microsoft.Azure.Search.StandardTokenizer" | "#Microsoft.Azure.Search.StandardTokenizerV2" | "#Microsoft.Azure.Search.UaxUrlEmailTokenizer";
@@ -314,7 +320,8 @@ export type CustomEntityLookupSkill = BaseSearchIndexerSkill & {
 export type CustomEntityLookupSkillLanguage = string;
 
 // @public
-export type CustomNormalizer = LexicalNormalizer & {
+export type CustomNormalizer = BaseLexicalNormalizer & {
+    odatatype: "#Microsoft.Azure.Search.CustomNormalizer";
     tokenFilters?: TokenFilterName[];
     charFilters?: CharFilterName[];
 };
@@ -1289,10 +1296,7 @@ export type LexicalAnalyzer = CustomAnalyzer | PatternAnalyzer | LuceneStandardA
 export type LexicalAnalyzerName = string;
 
 // @public
-export interface LexicalNormalizer {
-    name: string;
-    odatatype: string;
-}
+export type LexicalNormalizer = CustomNormalizer;
 
 // @public
 export type LexicalNormalizerName = string;
@@ -1530,7 +1534,7 @@ export type ScoringStatistics = "local" | "global";
 
 // @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
-    constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
+    constructor(endpoint: string, indexName: string, credential: KeyCredential, apiVersion?: string, options?: SearchClientOptions);
     readonly apiVersion: string;
     autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options?: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: T[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
@@ -1596,7 +1600,7 @@ export interface SearchIndex {
 
 // @public
 export class SearchIndexClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexClientOptions);
+    constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options?: SearchIndexClientOptions);
     analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
     readonly apiVersion: string;
     createIndex(index: SearchIndex, options?: CreateIndexOptions): Promise<SearchIndex>;
@@ -1608,7 +1612,7 @@ export class SearchIndexClient {
     readonly endpoint: string;
     getIndex(indexName: string, options?: GetIndexOptions): Promise<SearchIndex>;
     getIndexStatistics(indexName: string, options?: GetIndexStatisticsOptions): Promise<SearchIndexStatistics>;
-    getSearchClient<T>(indexName: string, options?: SearchClientOptions): SearchClient<T>;
+    getSearchClient<T>(indexName: string, apiVersion?: string, options?: SearchClientOptions): SearchClient<T>;
     getServiceStatistics(options?: GetServiceStatisticsOptions): Promise<SearchServiceStatistics>;
     getSynonymMap(synonymMapName: string, options?: GetSynonymMapsOptions): Promise<SynonymMap>;
     listIndexes(options?: ListIndexesOptions): IndexIterator;
@@ -1638,7 +1642,7 @@ export interface SearchIndexer {
 
 // @public
 export class SearchIndexerClient {
-    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexerClientOptions);
+    constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options?: SearchIndexerClientOptions);
     readonly apiVersion: string;
     createDataSourceConnection(dataSourceConnection: SearchIndexerDataSourceConnection, options?: CreateDataSourceConnectionOptions): Promise<SearchIndexerDataSourceConnection>;
     createIndexer(indexer: SearchIndexer, options?: CreateIndexerOptions): Promise<SearchIndexer>;

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1534,7 +1534,7 @@ export type ScoringStatistics = "local" | "global";
 
 // @public
 export class SearchClient<T> implements IndexDocumentsClient<T> {
-    constructor(endpoint: string, indexName: string, credential: KeyCredential, apiVersion?: string, options?: SearchClientOptions);
+    constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
     autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options?: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: T[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
@@ -1552,7 +1552,9 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 }
 
 // @public
-export type SearchClientOptions = PipelineOptions;
+export interface SearchClientOptions extends PipelineOptions {
+    apiVersion?: string;
+}
 
 // @public
 export interface SearchDocumentsPageResult<T> extends SearchDocumentsResultBase {
@@ -1600,7 +1602,7 @@ export interface SearchIndex {
 
 // @public
 export class SearchIndexClient {
-    constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options?: SearchIndexClientOptions);
+    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexClientOptions);
     analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
     readonly apiVersion: string;
     createIndex(index: SearchIndex, options?: CreateIndexOptions): Promise<SearchIndex>;
@@ -1612,7 +1614,7 @@ export class SearchIndexClient {
     readonly endpoint: string;
     getIndex(indexName: string, options?: GetIndexOptions): Promise<SearchIndex>;
     getIndexStatistics(indexName: string, options?: GetIndexStatisticsOptions): Promise<SearchIndexStatistics>;
-    getSearchClient<T>(indexName: string, apiVersion?: string, options?: SearchClientOptions): SearchClient<T>;
+    getSearchClient<T>(indexName: string, options?: SearchClientOptions): SearchClient<T>;
     getServiceStatistics(options?: GetServiceStatisticsOptions): Promise<SearchServiceStatistics>;
     getSynonymMap(synonymMapName: string, options?: GetSynonymMapsOptions): Promise<SynonymMap>;
     listIndexes(options?: ListIndexesOptions): IndexIterator;
@@ -1622,7 +1624,9 @@ export class SearchIndexClient {
     }
 
 // @public
-export type SearchIndexClientOptions = PipelineOptions;
+export interface SearchIndexClientOptions extends PipelineOptions {
+    apiVersion?: string;
+}
 
 // @public
 export interface SearchIndexer {
@@ -1642,7 +1646,7 @@ export interface SearchIndexer {
 
 // @public
 export class SearchIndexerClient {
-    constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options?: SearchIndexerClientOptions);
+    constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexerClientOptions);
     readonly apiVersion: string;
     createDataSourceConnection(dataSourceConnection: SearchIndexerDataSourceConnection, options?: CreateDataSourceConnectionOptions): Promise<SearchIndexerDataSourceConnection>;
     createIndexer(indexer: SearchIndexer, options?: CreateIndexerOptions): Promise<SearchIndexer>;
@@ -1669,7 +1673,9 @@ export class SearchIndexerClient {
 }
 
 // @public
-export type SearchIndexerClientOptions = PipelineOptions;
+export interface SearchIndexerClientOptions extends PipelineOptions {
+    apiVersion?: string;
+}
 
 // @public
 export interface SearchIndexerDataContainer {

--- a/sdk/search/search-documents/src/generated/service/models/index.ts
+++ b/sdk/search/search-documents/src/generated/service/models/index.ts
@@ -92,6 +92,7 @@ export type CharFilterUnion =
   | CharFilter
   | MappingCharFilter
   | PatternReplaceCharFilter;
+export type LexicalNormalizerUnion = LexicalNormalizer | CustomNormalizer;
 export type SimilarityUnion = Similarity | ClassicSimilarity | BM25Similarity;
 
 /** Represents a datasource definition, which can be used to configure an indexer. */
@@ -595,7 +596,7 @@ export interface SearchIndex {
   /** The character filters for the index. */
   charFilters?: CharFilterUnion[];
   /** The normalizers for the index. */
-  normalizers?: LexicalNormalizer[];
+  normalizers?: LexicalNormalizerUnion[];
   /** A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019. */
   encryptionKey?: SearchResourceEncryptionKey | null;
   /** The type of similarity algorithm to be used when scoring and ranking the documents matching a search query. The similarity algorithm can only be defined at index creation time and cannot be modified on existing indexes. If null, the ClassicSimilarity algorithm is used. */
@@ -761,8 +762,8 @@ export interface CharFilter {
 
 /** Base type for normalizers. */
 export interface LexicalNormalizer {
-  /** Identifies the concrete type of the normalizer. */
-  odatatype: string;
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  odatatype: "#Microsoft.Azure.Search.CustomNormalizer";
   /** The name of the normalizer. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. It cannot end in '.microsoft' nor '.lucene', nor be named 'asciifolding', 'standard', 'lowercase', 'uppercase', or 'elision'. */
   name: string;
 }
@@ -1654,6 +1655,8 @@ export type PatternReplaceCharFilter = CharFilter & {
 
 /** Allows you to configure normalization for filterable, sortable, and facetable fields, which by default operate with strict matching. This is a user-defined configuration consisting of at least one or more filters, which modify the token that is stored. */
 export type CustomNormalizer = LexicalNormalizer & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  odatatype: "#Microsoft.Azure.Search.CustomNormalizer";
   /** A list of token filters used to filter out or modify the input token. For example, you can specify a lowercase filter that converts all characters to lowercase. The filters are run in the order in which they are listed. */
   tokenFilters?: TokenFilterName[];
   /** A list of character filters used to prepare input text before it is processed. For instance, they can replace certain characters or symbols. The filters are run in the order in which they are listed. */

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -1737,6 +1737,11 @@ export const LexicalNormalizer: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "LexicalNormalizer",
+    uberParent: "LexicalNormalizer",
+    polymorphicDiscriminator: {
+      serializedName: "@odata\\.type",
+      clientName: "@odata\\.type"
+    },
     modelProperties: {
       odatatype: {
         serializedName: "@odata\\.type",
@@ -4578,6 +4583,8 @@ export const CustomNormalizer: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "CustomNormalizer",
+    uberParent: "LexicalNormalizer",
+    polymorphicDiscriminator: LexicalNormalizer.type.polymorphicDiscriminator,
     modelProperties: {
       ...LexicalNormalizer.type.modelProperties,
       tokenFilters: {
@@ -4656,6 +4663,7 @@ export let discriminators = {
   LexicalTokenizer: LexicalTokenizer,
   TokenFilter: TokenFilter,
   CharFilter: CharFilter,
+  LexicalNormalizer: LexicalNormalizer,
   Similarity: Similarity,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy": HighWaterMarkChangeDetectionPolicy,
   "DataChangeDetectionPolicy.#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy": SqlIntegratedChangeTrackingPolicy,
@@ -4723,6 +4731,7 @@ export let discriminators = {
   "TokenFilter.#Microsoft.Azure.Search.WordDelimiterTokenFilter": WordDelimiterTokenFilter,
   "CharFilter.#Microsoft.Azure.Search.MappingCharFilter": MappingCharFilter,
   "CharFilter.#Microsoft.Azure.Search.PatternReplaceCharFilter": PatternReplaceCharFilter,
+  "LexicalNormalizer.#Microsoft.Azure.Search.CustomNormalizer": CustomNormalizer,
   "Similarity.#Microsoft.Azure.Search.ClassicSimilarity": ClassicSimilarity,
   "Similarity.#Microsoft.Azure.Search.BM25Similarity": BM25Similarity
 };

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -110,7 +110,8 @@ export {
   SearchResourceEncryptionKey,
   SearchIndexStatistics,
   SearchServiceStatistics,
-  SearchIndexer
+  SearchIndexer,
+  LexicalNormalizer
 } from "./serviceModels";
 export { default as GeographyPoint } from "./geographyPoint";
 export { odata } from "./odata";
@@ -275,13 +276,13 @@ export {
   LexicalAnalyzer as BaseLexicalAnalyzer,
   CharFilter as BaseCharFilter,
   DataDeletionDetectionPolicy as BaseDataDeletionDetectionPolicy,
-  LexicalNormalizer,
   LexicalNormalizerName,
   KnownLexicalNormalizerName,
   CustomNormalizer,
   TokenFilterName,
   KnownTokenFilterName,
   CharFilterName,
-  KnownCharFilterName
+  KnownCharFilterName,
+  LexicalNormalizer as BaseLexicalNormalizer
 } from "./generated/service/models";
 export { AzureKeyCredential } from "@azure/core-auth";

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -151,7 +151,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       apiVersion = this.apiVersion;
     } else {
       if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`)
+        throw new Error(`Invalid Api Version: ${apiVersion}`);
       }
     }
 

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -149,6 +149,10 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
 
     if (!apiVersion) {
       apiVersion = this.apiVersion;
+    } else {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
+        throw new Error(`Invalid Api Version: ${apiVersion}`)
+      }
     }
 
     this.client = new GeneratedClient(this.endpoint, this.indexName, apiVersion, pipeline);

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -106,6 +106,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     endpoint: string,
     indexName: string,
     credential: KeyCredential,
+    apiVersion?: string,
     options: SearchClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -146,7 +147,11 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
 
-    this.client = new GeneratedClient(this.endpoint, this.indexName, this.apiVersion, pipeline);
+    if(!apiVersion) {
+      apiVersion = this.apiVersion;
+    }
+
+    this.client = new GeneratedClient(this.endpoint, this.indexName, apiVersion, pipeline);
   }
 
   /**

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -51,7 +51,12 @@ import { IndexDocumentsClient } from "./searchIndexingBufferedSender";
 /**
  * Client options used to configure Cognitive Search API requests.
  */
-export type SearchClientOptions = PipelineOptions;
+export interface SearchClientOptions extends PipelineOptions {
+  /**
+   * The API version to use when communicating with the service.
+   */
+  apiVersion?: string;
+}
 
 /**
  * Class used to perform operations against a search index,
@@ -106,7 +111,6 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
     endpoint: string,
     indexName: string,
     credential: KeyCredential,
-    apiVersion?: string,
     options: SearchClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -147,12 +151,13 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
 
-    if (!apiVersion) {
-      apiVersion = this.apiVersion;
-    } else {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`);
+    let apiVersion = this.apiVersion;
+
+    if (options.apiVersion) {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
+      apiVersion = options.apiVersion;
     }
 
     this.client = new GeneratedClient(this.endpoint, this.indexName, apiVersion, pipeline);

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -147,7 +147,7 @@ export class SearchClient<T> implements IndexDocumentsClient<T> {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
 
-    if(!apiVersion) {
+    if (!apiVersion) {
       apiVersion = this.apiVersion;
     }
 

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -96,7 +96,12 @@ export class SearchIndexClient {
    * @param credential - Used to authenticate requests to the service.
    * @param options - Used to configure the Search Index client.
    */
-  constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options: SearchIndexClientOptions = {}) {
+  constructor(
+    endpoint: string,
+    credential: KeyCredential,
+    apiVersion?: string,
+    options: SearchIndexClientOptions = {}
+  ) {
     this.endpoint = endpoint;
     this.credential = credential;
     this.options = options;
@@ -137,7 +142,7 @@ export class SearchIndexClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    if(!apiVersion) {
+    if (!apiVersion) {
       apiVersion = this.apiVersion;
     }
 
@@ -615,7 +620,17 @@ export class SearchIndexClient {
    * @param indexName - Name of the index
    * @param options - SearchClient Options
    */
-  public getSearchClient<T>(indexName: string, apiVersion?: string, options?: GetSearchClientOptions): SearchClient<T> {
-    return new SearchClient<T>(this.endpoint, indexName, this.credential, apiVersion, options || this.options);
+  public getSearchClient<T>(
+    indexName: string,
+    apiVersion?: string,
+    options?: GetSearchClientOptions
+  ): SearchClient<T> {
+    return new SearchClient<T>(
+      this.endpoint,
+      indexName,
+      this.credential,
+      apiVersion,
+      options || this.options
+    );
   }
 }

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -146,7 +146,7 @@ export class SearchIndexClient {
       apiVersion = this.apiVersion;
     } else {
       if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`)
+        throw new Error(`Invalid Api Version: ${apiVersion}`);
       }
     }
 

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -96,7 +96,7 @@ export class SearchIndexClient {
    * @param credential - Used to authenticate requests to the service.
    * @param options - Used to configure the Search Index client.
    */
-  constructor(endpoint: string, credential: KeyCredential, options: SearchIndexClientOptions = {}) {
+  constructor(endpoint: string, credential: KeyCredential, apiVersion?: string, options: SearchIndexClientOptions = {}) {
     this.endpoint = endpoint;
     this.credential = credential;
     this.options = options;
@@ -137,7 +137,11 @@ export class SearchIndexClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    this.client = new GeneratedClient(this.endpoint, this.apiVersion, pipeline);
+    if(!apiVersion) {
+      apiVersion = this.apiVersion;
+    }
+
+    this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);
   }
 
   private async *listIndexesPage(
@@ -611,7 +615,7 @@ export class SearchIndexClient {
    * @param indexName - Name of the index
    * @param options - SearchClient Options
    */
-  public getSearchClient<T>(indexName: string, options?: GetSearchClientOptions): SearchClient<T> {
-    return new SearchClient<T>(this.endpoint, indexName, this.credential, options || this.options);
+  public getSearchClient<T>(indexName: string, apiVersion?: string, options?: GetSearchClientOptions): SearchClient<T> {
+    return new SearchClient<T>(this.endpoint, indexName, this.credential, apiVersion, options || this.options);
   }
 }

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -144,6 +144,10 @@ export class SearchIndexClient {
 
     if (!apiVersion) {
       apiVersion = this.apiVersion;
+    } else {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
+        throw new Error(`Invalid Api Version: ${apiVersion}`)
+      }
     }
 
     this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -45,7 +45,12 @@ import { SearchClient, SearchClientOptions as GetSearchClientOptions } from "./s
 /**
  * Client options used to configure Cognitive Search API requests.
  */
-export type SearchIndexClientOptions = PipelineOptions;
+export interface SearchIndexClientOptions extends PipelineOptions {
+  /**
+   * The API version to use when communicating with the service.
+   */
+  apiVersion?: string;
+}
 
 /**
  * Class to perform operations to manage
@@ -96,12 +101,7 @@ export class SearchIndexClient {
    * @param credential - Used to authenticate requests to the service.
    * @param options - Used to configure the Search Index client.
    */
-  constructor(
-    endpoint: string,
-    credential: KeyCredential,
-    apiVersion?: string,
-    options: SearchIndexClientOptions = {}
-  ) {
+  constructor(endpoint: string, credential: KeyCredential, options: SearchIndexClientOptions = {}) {
     this.endpoint = endpoint;
     this.credential = credential;
     this.options = options;
@@ -142,12 +142,13 @@ export class SearchIndexClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    if (!apiVersion) {
-      apiVersion = this.apiVersion;
-    } else {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`);
+    let apiVersion = this.apiVersion;
+
+    if (options.apiVersion) {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
+      apiVersion = options.apiVersion;
     }
 
     this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);
@@ -624,17 +625,7 @@ export class SearchIndexClient {
    * @param indexName - Name of the index
    * @param options - SearchClient Options
    */
-  public getSearchClient<T>(
-    indexName: string,
-    apiVersion?: string,
-    options?: GetSearchClientOptions
-  ): SearchClient<T> {
-    return new SearchClient<T>(
-      this.endpoint,
-      indexName,
-      this.credential,
-      apiVersion,
-      options || this.options
-    );
+  public getSearchClient<T>(indexName: string, options?: GetSearchClientOptions): SearchClient<T> {
+    return new SearchClient<T>(this.endpoint, indexName, this.credential, options || this.options);
   }
 }

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -44,7 +44,12 @@ import { odataMetadataPolicy } from "./odataMetadataPolicy";
 /**
  * Client options used to configure Cognitive Search API requests.
  */
-export type SearchIndexerClientOptions = PipelineOptions;
+export interface SearchIndexerClientOptions extends PipelineOptions {
+  /**
+   * The API version to use when communicating with the service.
+   */
+  apiVersion?: string;
+}
 
 /**
  * Class to perform operations to manage
@@ -88,7 +93,6 @@ export class SearchIndexerClient {
   constructor(
     endpoint: string,
     credential: KeyCredential,
-    apiVersion?: string,
     options: SearchIndexerClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -129,12 +133,13 @@ export class SearchIndexerClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    if (!apiVersion) {
-      apiVersion = this.apiVersion;
-    } else {
-      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`);
+    let apiVersion = this.apiVersion;
+
+    if (options.apiVersion) {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(options.apiVersion)) {
+        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
       }
+      apiVersion = options.apiVersion;
     }
 
     this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -131,6 +131,10 @@ export class SearchIndexerClient {
 
     if (!apiVersion) {
       apiVersion = this.apiVersion;
+    } else {
+      if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
+        throw new Error(`Invalid Api Version: ${apiVersion}`)
+      }
     }
 
     this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -133,7 +133,7 @@ export class SearchIndexerClient {
       apiVersion = this.apiVersion;
     } else {
       if (!["2020-06-30-Preview", "2020-06-30"].includes(apiVersion)) {
-        throw new Error(`Invalid Api Version: ${apiVersion}`)
+        throw new Error(`Invalid Api Version: ${apiVersion}`);
       }
     }
 

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -88,6 +88,7 @@ export class SearchIndexerClient {
   constructor(
     endpoint: string,
     credential: KeyCredential,
+    apiVersion?: string,
     options: SearchIndexerClientOptions = {}
   ) {
     this.endpoint = endpoint;
@@ -128,7 +129,11 @@ export class SearchIndexerClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    this.client = new GeneratedClient(this.endpoint, this.apiVersion, pipeline);
+    if(!apiVersion) {
+      apiVersion = this.apiVersion;
+    }
+
+    this.client = new GeneratedClient(this.endpoint, apiVersion, pipeline);
   }
 
   /**

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -129,7 +129,7 @@ export class SearchIndexerClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    if(!apiVersion) {
+    if (!apiVersion) {
       apiVersion = this.apiVersion;
     }
 

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -74,8 +74,8 @@ import {
   FieldMapping,
   IndexingParameters,
   IndexingSchedule,
-  LexicalNormalizer,
-  LexicalNormalizerName
+  LexicalNormalizerName,
+  CustomNormalizer
 } from "./generated/service/models";
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -659,6 +659,11 @@ export type TokenFilter =
  * Contains the possible cases for CharFilter.
  */
 export type CharFilter = MappingCharFilter | PatternReplaceCharFilter;
+
+/**
+ * Contains the possible cases for LexicalNormalizer.
+ */
+export type LexicalNormalizer = CustomNormalizer;
 
 /**
  * Contains the possible cases for ScoringFunction.

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -46,7 +46,6 @@ import {
   PatternAnalyzer as GeneratedPatternAnalyzer,
   CustomAnalyzer,
   PatternTokenizer,
-  LexicalNormalizer,
   LexicalNormalizerName
 } from "./generated/service/models";
 import {
@@ -70,7 +69,8 @@ import {
   DataDeletionDetectionPolicy,
   SimilarityAlgorithm,
   SearchResourceEncryptionKey,
-  PatternAnalyzer
+  PatternAnalyzer,
+  LexicalNormalizer
 } from "./serviceModels";
 import { SuggestDocumentsResult, SuggestResult, SearchResult } from "./indexModels";
 import {

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -278,3 +278,13 @@ directive:
     transform: >
       $["x-ms-client-name"] = "tokenizerName"
 ```
+
+### Add discriminator to LexicalNormalizer
+
+```yaml
+directive:
+  from: swagger-document
+  where: $.definitions.LexicalNormalizer
+  transform: >
+    $["discriminator"] = "@odata.type";
+```


### PR DESCRIPTION
Two new requests have come for search-documents SDK. 

1. There is a bug in the current swagger. This should be fixed before next release. In the meantime, we need to add a swagger transform and handle the bug. The issue is detailed [here](https://github.com/Azure/azure-sdk-for-net/pull/20078#discussion_r606518341)

2. This issue is regarding passing a different version to the search clients constructors. It has already been communicated to the customers that there might be additional fields coming up due to version changes and to the service team that there should not be any compatibility changes. This design will be dicussed in detail before next release. But for this release, we wanted to try this design of multi api support. 

@xirzec Please review this PR