### PR TITLE
Update readme.md to use @azure/identity for authentication

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/README.md
+++ b/sdk/digitaltwins/digital-twins-core/README.md
@@ -9,118 +9,80 @@ This package contains an isomorphic SDK for Azure Digital Twins API to provide a
 - Node.js version 6.x.x or higher
 - Browser JavaScript
 
-### How to Install
+### Prerequisites
+
+- An [Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance-portal).
+
+### Install the `@azure/digital-twins-core` package
+
+Install the Digital Twins Core client library for JavaScript with `npm`:
 
 ```bash
 npm install @azure/digital-twins-core
 ```
 
-### How to use
+### Browser support
 
-#### nodejs - Authentication, client creation and list digitalTwinModels as an example written in TypeScript.
+#### JavaScript Bundle
 
-##### Install @azure/ms-rest-nodeauth
+To use this client library in the browser, first you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
-```bash
-npm install @azure/ms-rest-nodeauth
-```
+#### CORS
 
-##### Sample code
-
-```typescript
-import * as coreHttp from "@azure/core-http";
-import * as coreArm from "@azure/core-arm";
-import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
-import {
-  AzureDigitalTwinsAPI,
-  AzureDigitalTwinsAPIModels,
-  AzureDigitalTwinsAPIMappers
-} from "@azure/digital-twins-core";
-const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
-msRestNodeAuth
-  .interactiveLogin()
-  .then((creds) => {
-    const client = new AzureDigitalTwinsAPI(creds, subscriptionId);
-    const dependenciesFor = ["testdependenciesFor"];
-    const includeModelDefinition = true;
-    const maxItemCount = 1;
-    client.digitalTwinModels
-      .list(dependenciesFor, includeModelDefinition, maxItemCount)
-      .then((result) => {
-        console.log("The result is:");
-        console.log(result);
-      });
-  }
-  .catch((err) => {
-    console.error(err);
-  })
-```
-
-#### browser - Authentication, client creation and list digitalTwinModels as an example written in JavaScript.
-
-##### Install @azure/ms-rest-browserauth
-
-```bash
-npm install @azure/ms-rest-browserauth
-```
-
-##### Sample code
-
-See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to Azure in the browser.
-
-- index.html
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>@azure/digital-twins-core sample</title>
-    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
-    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
-    <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
-    <script src="node_modules/@azure/digital-twins-core/dist/digital-twins-core.js"></script>
-    <script type="text/javascript">
-      const subscriptionId = "<Subscription_Id>";
-      const authManager = new msAuth.AuthManager({
-        clientId: "<client id for your Azure AD app>",
-        tenant: "<optional tenant for your organization>"
-      });
-      authManager.finalizeLogin().then((res) => {
-        if (!res.isLoggedIn) {
-          // may cause redirects
-          authManager.login();
-        }
-        const client = new Azure.Digitaltwins.AzureDigitalTwinsAPI(res.creds, subscriptionId);
-        const dependenciesFor = ["testdependenciesFor"];
-        const includeModelDefinition = true;
-        const maxItemCount = 1;
-        client.digitalTwinModels
-          .list(dependenciesFor, includeModelDefinition, maxItemCount)
-          .then((result) => {
-            console.log("The result is:");
-            console.log(result);
-          })
-          .catch((err) => {
-            console.log("An error occurred:");
-            console.error(err);
-          });
-      });
-    </script>
-  </head>
-  <body></body>
-</html
-```
+Azure Digital Twins doesn't currently support Cross-Origin Resource Sharing (CORS). As a result, this library cannot be used to make direct calls to the template service from a browser. Please refer to [this document](https://github.com/Azure/azure-sdk-for-js/blob/master/samples/cors/ts/README.md) for guidance.
 
 ## Key concepts
 
-Azure Digital Twins Preview is an Azure IoT service that creates comprehensive models of the physical environment. It can create spatial intelligence graphs to model the relationships and interactions between people, spaces, and devices.
+### Azure Digital Twins
+
+Azure Digital Twins is an Azure IoT service that creates comprehensive models of the physical environment. It can create spatial intelligence graphs to model the relationships and interactions between people, spaces, and devices.
 You can learn more about Azure Digital Twins by visiting [Azure Digital Twins Documentation](https://docs.microsoft.com/azure/digital-twins/)
+
+### `DigitalTwinsClient`
+
+`DigitalTwinsClient` is the client object that users of this library use to manage their Azure Digital Twins instance.
 
 ## Examples
 
-Please take a look at the Readme file in
+### TypeScript example for authentication, client creation and listing models in an Azure Digital Twins instance.
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { DigitalTwinsClient } from "@azure/digital-twins-core";
+import { inspect } from "util";
+
+async function main() {
+  const url = "<URL to Azure Digital Twins instance>";
+
+  // DefaultAzureCredential is provided by @azure/identity. It supports
+  // different authentication mechanisms and determines the appropriate
+  // credential type based of the environment it is executing in. See
+  // https://www.npmjs.com/package/@azure/identity for more information on
+  // authenticating with DefaultAzureCredential or other implementations of
+  // TokenCredential.
+  const credential = new DefaultAzureCredential();
+  const serviceClient = new DigitalTwinsClient(url, credential);
+
+  // List models
+  const models = serviceClient.listModels();
+  for await (const model of models) {
+    console.log(`Model:`);
+    console.log(inspect(model));
+  }
+}
+
+main().catch((err) => {
+  console.log("error code: ", err.code);
+  console.log("error message: ", err.message);
+  console.log("error stack: ", err.stack);
+});
+```
+
+### Additional Examples
+
+Please take a look at the
 [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/samples)
-directory for detailed examples on how to use this library.
+directory for additional examples on how to use this library.
 
 ## Troubleshooting
 
@@ -136,12 +98,6 @@ setLogLevel("info");
 
 For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger).
 
-## Next steps
-
-Please take a look at the
-[samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/samples)
-directory for detailed examples on how to use this library.
-
 ## Contributing
 
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
@@ -149,4 +105,3 @@ If you'd like to contribute to this library, please read the [contributing guide
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-  ![Impressions](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/README.md)

--- a/sdk/digitaltwins/digital-twins-core/README.md
+++ b/sdk/digitaltwins/digital-twins-core/README.md
@@ -178,9 +178,8 @@ main().catch((err) => {
 
 ### Additional Examples
 
-Please take a look at the
-[samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/samples)
-directory for additional examples on how to use this library.
+Additional examples can be found in the
+[samples directory](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/samples).
 
 ## Troubleshooting
 
@@ -195,6 +194,10 @@ setLogLevel("info");
 ```
 
 For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger).
+
+## Next steps
+
+Please take a look at the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/digitaltwins/digital-twins-core/samples) directory for detailed examples that demonstrate how to use the client libraries.
 
 ## Contributing
 

--- a/sdk/digitaltwins/digital-twins-core/README.md
+++ b/sdk/digitaltwins/digital-twins-core/README.md
@@ -51,10 +51,9 @@ You can learn more about Azure Digital Twins by visiting [Azure Digital Twins Do
 ### Create the DigitalTwinsClient
 
 To create a new `DigitalTwinsClient`, you need the endpoint to an Azure Digital Twins instance and credentials.
-Here, we use `DefaultAzureCredential` for credentials.
-DefaultAzureCredential is provided by [`@azure/identity`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity).
+Here, we use `DefaultAzureCredential` for credentials from the package `@azure/identity`.
 It supports different authentication mechanisms and determines the appropriate credential type based of the environment it is executing in.
-See `@azure/identity` in [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) for more information on authenticating with DefaultAzureCredential or other implementations of TokenCredential.
+See the [readme for @azure/identity](https://www.npmjs.com/package/@azure/identity) for more information on the different authentication options you can use.
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");

--- a/sdk/digitaltwins/digital-twins-core/README.md
+++ b/sdk/digitaltwins/digital-twins-core/README.md
@@ -250,7 +250,7 @@ for await (const incomingRelationship of incomingRelationships) {
 #### Create event route
 
 To create an event route, provide an ID of an event route (in this case, "myEventRouteId") and event route data containing the endpoint and optional filter like the example shown below.
-For more information on filtering events, see [this documentation](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-routes-apis-cli#filter-events).
+For more information on filtering events, see [this documentation](https://docs.microsoft.com/azure/digital-twins/how-to-manage-routes-apis-cli#filter-events).
 
 ```javascript
 const eventHubEndpointName = "myEventHubEndpointName";


### PR DESCRIPTION
close #13295 

Updated README to use `@azure/identity` for authentication rather than `@azure/ms-rest-nodeauth` and `@azure/ms-rest-browserauth`. Made some other miscellaneous tweaks as well to match more closely to the template README.