### PR TITLE
[KeyVault] - remote calls in hybrid mode if local crypto errors

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0-beta.3 (2021-04-05)
+## 4.0.0-beta.3 (2021-04-06)
 
 - Updated the Latest service version to 7.2.
 - Long Running Operations will now use the `status` field to determine whether the operation failed.

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.0-beta.3 (2021-04-05)
+## 4.2.0-beta.3 (2021-04-06)
 
 - Updated the Latest service version to 7.2.
 - Added a sample demonstrating how to import PFX / PEM certificates.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.2.0-beta.6 (Unreleased)
+
+- Updated `CryptographyClient` to ensure that any local cryptography error is properly handled. We will now try to perform the operation locally where we can but fallback to KeyVault if the local operation fails.
+
 ## 4.2.0-beta.5 (2021-04-05)
 
 - Added local cryptography support for encryption / decryption for `A128CBCPAD`, `A192CBCPAD`, and `A256CBCPAD`.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 4.2.0-beta.6 (Unreleased)
-
-- Updated `CryptographyClient` to ensure that any local cryptography error is properly handled. We will now try to perform the operation locally where we can but fallback to KeyVault if the local operation fails.
-
-## 4.2.0-beta.5 (2021-04-05)
+## 4.2.0-beta.5 (2021-04-06)
 
 - Added local cryptography support for encryption / decryption for `A128CBCPAD`, `A192CBCPAD`, and `A256CBCPAD`.
 - For AES-CBC encryption we will now generate an IV if the user did not pass it in, making `iv` optional for those parameters.
@@ -14,6 +10,7 @@
   - Finally, naming conventions have been standardized across the KeyVault libraries taking the format of `Azure.KeyVault.<PACKAGE NAME>.<CLIENT NAME>`.
 - Fixed an issue where retrying a failed initial Key Vault request may result in an empty body.
 - [Breaking] Removed the now unused `LocalCryptographyAlgorithmName` type (Added in 4.2.0-beta.1 to support `LocalCryptographyClient` and unused since 4.2.0-beta.4)
+- Updated `CryptographyClient` to ensure that any local cryptography error is properly handled. We will now try to perform the operation locally where we can but fallback to KeyVault if the local operation fails.
 
 ## 4.2.0-beta.4 (2021-03-09)
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -33,7 +33,7 @@ import {
   AesCbcEncryptionAlgorithm
 } from "./cryptographyClientModels";
 import { RemoteCryptographyProvider } from "./cryptography/remoteCryptographyProvider";
-import { createHash, randomBytes } from "./cryptography/crypto";
+import { randomBytes } from "./cryptography/crypto";
 import { CryptographyProvider, CryptographyProviderOperation } from "./cryptography/models";
 import { RsaCryptographyProvider } from "./cryptography/rsaCryptographyProvider";
 import { AesCryptographyProvider } from "./cryptography/aesCryptographyProvider";
@@ -187,7 +187,7 @@ export class CryptographyClient {
     plaintext: Uint8Array,
     options?: EncryptOptions
   ): Promise<EncryptResult>;
-  public async encrypt(
+  public encrypt(
     ...args:
       | [EncryptParameters, EncryptOptions?]
       | [EncryptionAlgorithm, Uint8Array, EncryptOptions?]
@@ -198,7 +198,14 @@ export class CryptographyClient {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Encrypt);
       this.initializeIV(parameters);
       const provider = await this.getProvider("encrypt", parameters.algorithm);
-      return provider.encrypt(parameters, updatedOptions);
+      try {
+        return provider.encrypt(parameters, updatedOptions);
+      } catch (error) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.encrypt(parameters, updatedOptions);
+        }
+        throw error;
+      }
     });
   }
 
@@ -284,7 +291,7 @@ export class CryptographyClient {
     ciphertext: Uint8Array,
     options?: DecryptOptions
   ): Promise<DecryptResult>;
-  public async decrypt(
+  public decrypt(
     ...args:
       | [DecryptParameters, DecryptOptions?]
       | [EncryptionAlgorithm, Uint8Array, DecryptOptions?]
@@ -294,8 +301,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.decrypt`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Decrypt);
       const provider = await this.getProvider("decrypt", parameters.algorithm);
-      const result = await provider.decrypt(parameters, updatedOptions);
-      return result;
+      try {
+        return provider.decrypt(parameters, updatedOptions);
+      } catch (error) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.decrypt(parameters, updatedOptions);
+        }
+        throw error;
+      }
     });
   }
 
@@ -341,7 +354,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.wrapKey`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.WrapKey);
       const provider = await this.getProvider("wrapKey", algorithm);
-      return provider.wrapKey(algorithm, key, updatedOptions);
+      try {
+        return provider.wrapKey(algorithm, key, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.wrapKey(algorithm, key, options);
+        }
+        throw err;
+      }
     });
   }
 
@@ -365,7 +385,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.unwrapKey`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.UnwrapKey);
       const provider = await this.getProvider("unwrapKey", algorithm);
-      return provider.unwrapKey(algorithm, encryptedKey, updatedOptions);
+      try {
+        return provider.unwrapKey(algorithm, encryptedKey, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.unwrapKey(algorithm, encryptedKey, options);
+        }
+        throw err;
+      }
     });
   }
 
@@ -389,7 +416,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.sign`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Sign);
       const provider = await this.getProvider("sign", algorithm);
-      return provider.sign(algorithm, digest, updatedOptions);
+      try {
+        return provider.sign(algorithm, digest, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.sign(algorithm, digest, updatedOptions);
+        }
+        throw err;
+      }
     });
   }
 
@@ -415,7 +449,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.verify`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Verify);
       const provider = await this.getProvider("verify", algorithm);
-      return provider.verify(algorithm, digest, signature, updatedOptions);
+      try {
+        return provider.verify(algorithm, digest, signature, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.verify(algorithm, digest, signature, updatedOptions);
+        }
+        throw err;
+      }
     });
   }
 
@@ -439,8 +480,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.signData`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Sign);
       const provider = await this.getProvider("signData", algorithm);
-      const digest = await createHash(algorithm, data);
-      return provider.sign(algorithm, digest, updatedOptions);
+      try {
+        return provider.signData(algorithm, data, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.signData(algorithm, data, options);
+        }
+        throw err;
+      }
     });
   }
 
@@ -466,7 +513,14 @@ export class CryptographyClient {
     return withTrace(`CryptographyClient.verifyData`, options, async (updatedOptions) => {
       this.ensureValid(await this.fetchKey(), KnownKeyOperations.Verify);
       const provider = await this.getProvider("verifyData", algorithm);
-      return provider.verifyData(algorithm, data, signature, updatedOptions);
+      try {
+        return provider.verifyData(algorithm, data, signature, updatedOptions);
+      } catch (err) {
+        if (this.remoteProvider) {
+          return this.remoteProvider.verifyData(algorithm, data, signature, updatedOptions);
+        }
+        throw err;
+      }
     });
   }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -165,7 +165,7 @@ export class CryptographyClient {
    * @param encryptParameters - The encryption parameters, keyed on the encryption algorithm chosen.
    * @param options - Additional options.
    */
-  public async encrypt(
+  public encrypt(
     encryptParameters: EncryptParameters,
     options?: EncryptOptions
   ): Promise<EncryptResult>;

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -290,7 +290,7 @@ export class KeyClient {
         }
       };
     }
-    return withTrace("KeyClient.createKey", unflattenedOptions, async (updatedOptions) => {
+    return withTrace("createKey", unflattenedOptions, async (updatedOptions) => {
       const response = await this.client.createKey(this.vaultUrl, name, keyType, updatedOptions);
       return getKeyFromKeyBundle(response);
     });
@@ -396,7 +396,7 @@ export class KeyClient {
       };
     }
 
-    return withTrace(`KeyClient.importKey`, unflattenedOptions, async (updatedOptions) => {
+    return withTrace(`importKey`, unflattenedOptions, async (updatedOptions) => {
       const response = await this.client.importKey(this.vaultUrl, name, key, updatedOptions);
       return getKeyFromKeyBundle(response);
     });
@@ -470,7 +470,7 @@ export class KeyClient {
     keyVersion: string,
     options: UpdateKeyPropertiesOptions = {}
   ): Promise<KeyVaultKey> {
-    return withTrace(`KeyClient.updateKeyProperties`, options, async (updatedOptions) => {
+    return withTrace(`updateKeyProperties`, options, async (updatedOptions) => {
       const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = updatedOptions;
       const unflattenedOptions = {
         ...remainingOptions,
@@ -504,7 +504,7 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public getKey(name: string, options: GetKeyOptions = {}): Promise<KeyVaultKey> {
-    return withTrace(`KeyClient.getKey`, options, async (updatedOptions) => {
+    return withTrace(`getKey`, options, async (updatedOptions) => {
       const response = await this.client.getKey(
         this.vaultUrl,
         name,
@@ -529,7 +529,7 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public getDeletedKey(name: string, options: GetDeletedKeyOptions = {}): Promise<DeletedKey> {
-    return withTrace(`KeyClient.getDeletedKey`, options, async (updatedOptions) => {
+    return withTrace(`getDeletedKey`, options, async (updatedOptions) => {
       const response = await this.client.getDeletedKey(this.vaultUrl, name, updatedOptions);
       return getKeyFromKeyBundle(response);
     });
@@ -552,7 +552,7 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public purgeDeletedKey(name: string, options: PurgeDeletedKeyOptions = {}): Promise<void> {
-    return withTrace(`KeyClient.purgeDeletedKey`, options, async (updatedOptions) => {
+    return withTrace(`purgeDeletedKey`, options, async (updatedOptions) => {
       await this.client.purgeDeletedKey(this.vaultUrl, name, updatedOptions);
     });
   }
@@ -617,7 +617,7 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public backupKey(name: string, options: BackupKeyOptions = {}): Promise<Uint8Array | undefined> {
-    return withTrace(`KeyClient.backupKey`, options, async (updatedOptions) => {
+    return withTrace(`backupKey`, options, async (updatedOptions) => {
       const response = await this.client.backupKey(this.vaultUrl, name, updatedOptions);
       return response.value;
     });
@@ -642,7 +642,7 @@ export class KeyClient {
     backup: Uint8Array,
     options: RestoreKeyBackupOptions = {}
   ): Promise<KeyVaultKey> {
-    return withTrace(`KeyClient.restoreKeyBackup`, options, async (updatedOptions) => {
+    return withTrace(`restoreKeyBackup`, options, async (updatedOptions) => {
       const response = await this.client.restoreKey(this.vaultUrl, backup, updatedOptions);
       return getKeyFromKeyBundle(response);
     });
@@ -667,7 +667,7 @@ export class KeyClient {
         ...options
       };
       const currentSetResponse = await withTrace(
-        "KeyClient.listPropertiesOfKeyVersionsPage",
+        "listPropertiesOfKeyVersionsPage",
         optionsComplete,
         async (updatedOptions) => this.client.getKeyVersions(this.vaultUrl, name, updatedOptions)
       );
@@ -679,7 +679,7 @@ export class KeyClient {
     }
     while (continuationState.continuationToken) {
       const currentSetResponse = await withTrace(
-        "KeyClient.listPropertiesOfKeyVersionsPage",
+        "listPropertiesOfKeyVersionsPage",
         options || {},
         async (updatedOptions) =>
           this.client.getKeyVersions(continuationState.continuationToken!, name, updatedOptions)
@@ -763,7 +763,7 @@ export class KeyClient {
         ...options
       };
       const currentSetResponse = await withTrace(
-        "KeyClient.listPropertiesOfKeysPage",
+        "listPropertiesOfKeysPage",
         optionsComplete,
         async (updatedOptions) => this.client.getKeys(this.vaultUrl, updatedOptions)
       );
@@ -855,7 +855,7 @@ export class KeyClient {
         ...options
       };
       const currentSetResponse = await withTrace(
-        "KeyClient.listDeletedKeysPage",
+        "listDeletedKeysPage",
         optionsComplete,
         async (updatedOptions) => this.client.getDeletedKeys(this.vaultUrl, updatedOptions)
       );
@@ -866,7 +866,7 @@ export class KeyClient {
     }
     while (continuationState.continuationToken) {
       const currentSetResponse = await withTrace(
-        "KeyClient.listDeletedKeysPage",
+        "listDeletedKeysPage",
         options || {},
         async (updatedOptions) =>
           this.client.getDeletedKeys(continuationState.continuationToken!, updatedOptions)

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -287,7 +287,7 @@ describe("internal crypto tests", () => {
 
           const parameters: EncryptParameters = {
             algorithm: "RSA-OAEP",
-            plaintext: Buffer.from("text")
+            plaintext: stringToUint8Array("text")
           };
 
           await cryptoClient.encrypt(parameters);
@@ -299,7 +299,7 @@ describe("internal crypto tests", () => {
 
           const parameters: DecryptParameters = {
             algorithm: "RSA-OAEP",
-            ciphertext: Buffer.from("text")
+            ciphertext: stringToUint8Array("text")
           };
           await cryptoClient.decrypt(parameters);
           assert.isTrue(remoteStub.calledOnceWith(parameters));
@@ -308,7 +308,7 @@ describe("internal crypto tests", () => {
         it("remotes the wrapKey operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "wrapKey");
 
-          const keyToWrap = Buffer.from("myKey");
+          const keyToWrap = stringToUint8Array("myKey");
           await cryptoClient.wrapKey("RSA-OAEP", keyToWrap);
           assert.isTrue(remoteStub.calledOnceWith("RSA-OAEP", keyToWrap));
         });
@@ -316,7 +316,7 @@ describe("internal crypto tests", () => {
         it("remotes the unwrapKey operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "unwrapKey");
 
-          const wrappedKey = Buffer.from("myKey");
+          const wrappedKey = stringToUint8Array("myKey");
           await cryptoClient.unwrapKey("RSA-OAEP", wrappedKey);
           assert.isTrue(remoteStub.calledOnceWith("RSA-OAEP", wrappedKey));
         });
@@ -324,7 +324,7 @@ describe("internal crypto tests", () => {
         it("remotes the sign operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "sign");
 
-          const data = Buffer.from("myKey");
+          const data = stringToUint8Array("myKey");
           await cryptoClient.sign("PS256", data);
           assert.isTrue(remoteStub.calledOnceWith("PS256", data));
         });
@@ -332,7 +332,7 @@ describe("internal crypto tests", () => {
         it("remotes the signData operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "signData");
 
-          const data = Buffer.from("myKey");
+          const data = stringToUint8Array("myKey");
           await cryptoClient.signData("PS256", data);
           assert.isTrue(remoteStub.calledOnceWith("PS256", data));
         });
@@ -340,8 +340,8 @@ describe("internal crypto tests", () => {
         it("remotes the verify operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "verify");
 
-          const data = Buffer.from("myKey");
-          const sig = Buffer.from("sig");
+          const data = stringToUint8Array("myKey");
+          const sig = stringToUint8Array("sig");
           await cryptoClient.verify("PS256", data, sig);
           assert.isTrue(remoteStub.calledOnceWith("PS256", data, sig));
         });
@@ -349,8 +349,8 @@ describe("internal crypto tests", () => {
         it("remotes the verifyData operation", async function() {
           const remoteStub = sinon.stub(remoteProvider, "verifyData");
 
-          const data = Buffer.from("myKey");
-          const sig = Buffer.from("sig");
+          const data = stringToUint8Array("myKey");
+          const sig = stringToUint8Array("sig");
           await cryptoClient.verifyData("PS256", data, sig);
           assert.isTrue(remoteStub.calledOnceWith("PS256", data, sig));
         });
@@ -358,9 +358,6 @@ describe("internal crypto tests", () => {
     });
 
     describe("local only mode", function() {
-      let cryptoClient: CryptographyClient;
-      let localProvider: RsaCryptographyProvider;
-
       beforeEach(() => {
         const jwk: JsonWebKey = {};
         localProvider = new RsaCryptographyProvider(jwk);
@@ -375,37 +372,37 @@ describe("internal crypto tests", () => {
       describe("when a local provider errors", function() {
         it("throws the original encrypt exception", async function() {
           await assert.isRejected(
-            cryptoClient.encrypt({ algorithm: "RSA-OAEP", plaintext: Buffer.from("text") })
+            cryptoClient.encrypt({ algorithm: "RSA-OAEP", plaintext: stringToUint8Array("text") })
           );
         });
 
         it("throws the original decrypt exception", async function() {
           await assert.isRejected(
-            cryptoClient.decrypt({ algorithm: "RSA-OAEP", ciphertext: Buffer.from("text") })
+            cryptoClient.decrypt({ algorithm: "RSA-OAEP", ciphertext: stringToUint8Array("text") })
           );
         });
 
         it("throws the original wrapKey exception", async function() {
-          await assert.isRejected(cryptoClient.wrapKey("RSA-OAEP", Buffer.from("myKey")));
+          await assert.isRejected(cryptoClient.wrapKey("RSA-OAEP", stringToUint8Array("myKey")));
         });
 
         it("throws the original unwrapKey exception", async function() {
-          await assert.isRejected(cryptoClient.unwrapKey("RSA-OAEP", Buffer.from("myKey")));
+          await assert.isRejected(cryptoClient.unwrapKey("RSA-OAEP", stringToUint8Array("myKey")));
         });
         it("throws the original sign exception", async function() {
-          await assert.isRejected(cryptoClient.sign("PS256", Buffer.from("data")));
+          await assert.isRejected(cryptoClient.sign("PS256", stringToUint8Array("data")));
         });
         it("throws the original signData exception", async function() {
-          await assert.isRejected(cryptoClient.signData("PS256", Buffer.from("data")));
+          await assert.isRejected(cryptoClient.signData("PS256", stringToUint8Array("data")));
         });
         it("throws the original verify exception", async function() {
           await assert.isRejected(
-            cryptoClient.verify("PS256", Buffer.from("data"), Buffer.from("sig"))
+            cryptoClient.verify("PS256", stringToUint8Array("data"), stringToUint8Array("sig"))
           );
         });
         it("throws the original verifyData exception", async function() {
           await assert.isRejected(
-            cryptoClient.verifyData("PS256", Buffer.from("data"), Buffer.from("sig"))
+            cryptoClient.verifyData("PS256", stringToUint8Array("data"), stringToUint8Array("sig"))
           );
         });
       });

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.0-beta.4 (2021-04-05)
+## 4.2.0-beta.4 (2021-04-06)
 
 - Improved tracing across the various KeyVault libraries. By switching to a consistent naming convention, ensuring spans are always closed appropriately, and setting the correct status when an operation errors developers can expect an improved experience when enabling distributed tracing.
   - We now ensure tracing spans are properly closed with an appropriate status when an operation throws an exception.

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -83,7 +83,7 @@ export {
   logger
 };
 
-const withTrace = createTraceFunction("Azure.KeyVault.Certificates.SecretClient");
+const withTrace = createTraceFunction("Azure.KeyVault.Secrets.SecretClient");
 
 /**
  * The SecretClient provides methods to manage {@link KeyVaultSecret} in

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
@@ -9,7 +9,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 /**
  * @internal
  */
-export const withTrace = createTraceFunction("Azure.KeyVault.Certificates.DeleteSecretPoller");
+export const withTrace = createTraceFunction("Azure.KeyVault.Secrets.DeleteSecretPoller");
 
 /**
  * Class that creates a poller that waits until a secret finishes being deleted.

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
@@ -12,9 +12,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 /**
  * @internal
  */
-export const withTrace = createTraceFunction(
-  "Azure.KeyVault.Certificates.RecoverDeletedSecretPoller"
-);
+export const withTrace = createTraceFunction("Azure.KeyVault.Secrets.RecoverDeletedSecretPoller");
 
 /**
  * Class that deletes a poller that waits until a secret finishes being deleted


### PR DESCRIPTION
## What

- If we can remote, and a local crypto operation fails, then we remote the call.

## Why

- In hybrid mode we want to be able to continue supporting crypto operations even if for unknown reasons the local provider fails. This ensures that we can defer to the remote provider if possible. 
- In local-only mode, we surface the original error to be handled by user code.

Resolves #14713