### PR TITLE
[communication] address lint errors

### DIFF
--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -25,7 +25,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 300000  \"dist-esm/test/*.spec.js\" \"dist-esm/test/node/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o communication-chat-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/communication/communication-chat/src/models/mappers.ts
+++ b/sdk/communication/communication-chat/src/models/mappers.ts
@@ -58,6 +58,22 @@ export const mapToAddChatParticipantsRequestRestModel = (
 
 /**
  * @internal
+ * Mapping chat participant REST model to chat participant SDK model
+ */
+export const mapToChatParticipantSdkModel = (
+  chatParticipant: RestModel.ChatParticipant
+): ChatParticipant => {
+  const { communicationIdentifier, ...rest } = chatParticipant;
+  return {
+    ...rest,
+    id: deserializeCommunicationIdentifier(
+      communicationIdentifier as SerializedCommunicationIdentifier
+    )
+  };
+};
+
+/**
+ * @internal
  */
 export const mapToChatContentSdkModel = (
   content: RestModel.ChatMessageContent
@@ -109,23 +125,7 @@ export const mapToChatMessageSdkModel = (chatMessage: RestModel.ChatMessage): Ch
 export const mapToChatMessagesSdkModelArray = (
   chatMessagesCollection: RestModel.ChatMessagesCollection
 ): ChatMessage[] => {
-  return chatMessagesCollection.value?.map((chatMessage) => mapToChatMessageSdkModel(chatMessage))!;
-};
-
-/**
- * @internal
- * Mapping chat participant REST model to chat participant SDK model
- */
-export const mapToChatParticipantSdkModel = (
-  chatParticipant: RestModel.ChatParticipant
-): ChatParticipant => {
-  const { communicationIdentifier, ...rest } = chatParticipant;
-  return {
-    ...rest,
-    id: deserializeCommunicationIdentifier(
-      communicationIdentifier as SerializedCommunicationIdentifier
-    )
-  };
+  return chatMessagesCollection.value?.map((chatMessage) => mapToChatMessageSdkModel(chatMessage));
 };
 
 /**

--- a/sdk/communication/communication-chat/test/chatClient.spec.ts
+++ b/sdk/communication/communication-chat/test/chatClient.spec.ts
@@ -11,7 +11,7 @@ import { CommunicationIdentifier } from "@azure/communication-common";
 import { Context } from "mocha";
 
 describe("ChatClient", function() {
-  let threadId: string;
+  let threadId: string | undefined;
   let recorder: Recorder;
   let chatClient: ChatClient;
   let chatThreadClient: ChatThreadClient;
@@ -61,13 +61,13 @@ describe("ChatClient", function() {
     }).timeout(8000);
 
     it("successfully retrieves a thread client", async function() {
-      chatThreadClient = await chatClient.getChatThreadClient(threadId);
+      chatThreadClient = await chatClient.getChatThreadClient(threadId!);
       assert.isNotNull(chatThreadClient);
       assert.equal(chatThreadClient.threadId, threadId);
     });
 
     it("successfully deletes a thread", async function() {
-      await chatClient.deleteChatThread(threadId);
+      await chatClient.deleteChatThread(threadId!);
     });
   });
 
@@ -84,10 +84,10 @@ describe("ChatClient", function() {
         participants: [{ id: testUser }]
       };
       const chatThreadResult = await chatClient.createChatThread(request);
-      threadId = chatThreadResult.chatThread?.id!;
+      threadId = chatThreadResult.chatThread?.id;
 
       // Create ChatThreadClient
-      chatThreadClient = chatClient.getChatThreadClient(threadId);
+      chatThreadClient = chatClient.getChatThreadClient(threadId!);
     });
 
     beforeEach(async function() {
@@ -143,11 +143,14 @@ describe("ChatClient", function() {
 
       // Edit message
       const message = { content: "content" };
-      chatThreadClient.sendMessage(message).then((result) => {
-        chatThreadClient.updateMessage(result.id, {
-          content: "new content"
-        });
-      });
+      chatThreadClient
+        .sendMessage(message)
+        .then((result) => {
+          return chatThreadClient.updateMessage(result.id, {
+            content: "new content"
+          });
+        })
+        .catch((error) => console.error(error));
     }).timeout(8000);
 
     it("successfully listens to chatMessageReceivedEvents", function(done) {
@@ -171,9 +174,12 @@ describe("ChatClient", function() {
 
       // Delete message
       const message = { content: `content` };
-      chatThreadClient.sendMessage(message).then((result) => {
-        chatThreadClient.deleteMessage(result.id);
-      });
+      chatThreadClient
+        .sendMessage(message)
+        .then((result) => {
+          return chatThreadClient.deleteMessage(result.id);
+        })
+        .catch((error) => console.error(error));
     }).timeout(8000);
 
     it("successfully listens to chatThreadCreatedEvents", function(done) {
@@ -203,9 +209,12 @@ describe("ChatClient", function() {
         topic: "test delete thread event",
         participants: [{ id: testUser }]
       };
-      chatClient.createChatThread(request).then((result) => {
-        chatClient.deleteChatThread(result.chatThread?.id!);
-      });
+      chatClient
+        .createChatThread(request)
+        .then((result) => {
+          return chatClient.deleteChatThread(result.chatThread?.id as string);
+        })
+        .catch((error) => console.error(error));
     }).timeout(8000);
 
     it("successfully listens to chatThreadPropertiesUpdatedEvents", function(done) {
@@ -255,11 +264,14 @@ describe("ChatClient", function() {
 
       // Send read receipt
       const message = { content: "content" };
-      chatThreadClient.sendMessage(message).then((result) => {
-        chatThreadClient.sendReadReceipt({
-          chatMessageId: result.id
-        });
-      });
+      chatThreadClient
+        .sendMessage(message)
+        .then((result) => {
+          return chatThreadClient.sendReadReceipt({
+            chatMessageId: result.id
+          });
+        })
+        .catch((error) => console.error(error));
     }).timeout(8000);
   });
 });

--- a/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.mocked.spec.ts
@@ -93,7 +93,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     const spy = sinon.spy(mockHttpClient, "sendRequest");
 
     const sendRequest: SendMessageRequest = {
-      content: mockMessage.content?.message!
+      content: mockMessage.content?.message as string
     };
 
     const sendOptions: SendMessageOptions = {

--- a/sdk/communication/communication-chat/test/chatThreadClient.spec.ts
+++ b/sdk/communication/communication-chat/test/chatThreadClient.spec.ts
@@ -47,7 +47,7 @@ describe("ChatThreadClient", function() {
     };
 
     const chatThreadResult = await chatClient.createChatThread(request, options);
-    threadId = chatThreadResult.chatThread?.id!;
+    threadId = chatThreadResult.chatThread?.id as string;
 
     // Create ChatThreadClient
     chatThreadClient = await chatClient.getChatThreadClient(threadId);

--- a/sdk/communication/communication-chat/test/utils/mockClient.ts
+++ b/sdk/communication/communication-chat/test/utils/mockClient.ts
@@ -20,7 +20,7 @@ export const mockParticipant: RestModel.ChatParticipant = {
 
 export const mockSdkModelParticipant: ChatParticipant = {
   id: {
-    communicationUserId: mockParticipant.communicationIdentifier.communicationUser?.id!
+    communicationUserId: mockParticipant.communicationIdentifier.communicationUser?.id as string
   },
   displayName: mockParticipant.displayName,
   shareHistoryTime: mockParticipant.shareHistoryTime

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -26,7 +26,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 300000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o communication-identity-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/communication/communication-identity/test/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/communicationIdentityClient.mocked.spec.ts
@@ -70,10 +70,10 @@ describe("CommunicationIdentityClient [Mocked]", () => {
 
   it("[createUser] excludes _response from results", async () => {
     const client = new TestCommunicationIdentityClient();
-    const user = await client.createUserTest();
+    const newUser = await client.createUserTest();
 
-    assert.isTrue(isCommunicationUserIdentifier(user));
-    assert.equal(user.communicationUserId, "identity");
-    assert.isFalse("_response" in user);
+    assert.isTrue(isCommunicationUserIdentifier(newUser));
+    assert.equal(newUser.communicationUserId, "identity");
+    assert.isFalse("_response" in newUser);
   });
 });

--- a/sdk/communication/communication-identity/test/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-identity/test/utils/mockHttpClients.ts
@@ -5,7 +5,10 @@ import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from 
 import { CommunicationAccessToken } from "../../src";
 import { CommunicationIdentityAccessTokenResult } from "../../src/generated/src/models";
 
-export const createMockHttpClient = <T = Record<string, unknown>>(status: number = 200, parsedBody?: T): HttpClient => {
+export const createMockHttpClient = <T = Record<string, unknown>>(
+  status: number = 200,
+  parsedBody?: T
+): HttpClient => {
   return {
     async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
       return {

--- a/sdk/communication/communication-identity/test/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-identity/test/utils/mockHttpClients.ts
@@ -5,7 +5,7 @@ import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from 
 import { CommunicationAccessToken } from "../../src";
 import { CommunicationIdentityAccessTokenResult } from "../../src/generated/src/models";
 
-export const createMockHttpClient = <T = {}>(status: number = 200, parsedBody?: T): HttpClient => {
+export const createMockHttpClient = <T = Record<string, unknown>>(status: number = 200, parsedBody?: T): HttpClient => {
   return {
     async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
       return {


### PR DESCRIPTION
This PR addresses the final lint errors in the `communication-chat` and `communication-identity` libraries. Also updates the `lint` script in each package as per #13723.

@ramya-rao-a there are still a few warnings related to unused variables (all when destructuring objects), will these cause build breaks?