### PR TITLE
[Identity] Getting rid of instanceof

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.0.0-beta.2 (Unreleased)
 
-- Bug fix: Replaced cases where `instanceof` was used to compare errors with comparisons on the error names. Uneven updates on our dependencies would cause `instanceof` to mismatch our error comparisons. Comparing by error name makes sure dependency changes won't alter our logic.
 - Added `clientId` to the `AuthenticationRecord` type.
 - `AuthenticationRecord` no longer has a `serialize` method. This method is now called `serializeAuthenticationRecord` and is a function exported at the top level of the Identity library, similar to `deserializeAuthenticationRecord`.
 - `serializeAuthenticationRecord` now serializes into a JSON string with camel case properties. This makes it re-usable across languages.

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0-beta.2 (Unreleased)
 
+- Bug fix: Replaced cases where `instanceof` was used to compare errors with comparisons on the error names. Uneven updates on our dependencies would cause `instanceof` to mismatch our error comparisons. Comparing by error name makes sure dependency changes won't alter our logic.
 - Added `clientId` to the `AuthenticationRecord` type.
 - `AuthenticationRecord` no longer has a `serialize` method. This method is now called `serializeAuthenticationRecord` and is a function exported at the top level of the Identity library, similar to `deserializeAuthenticationRecord`.
 - `serializeAuthenticationRecord` now serializes into a JSON string with camel case properties. This makes it re-usable across languages.

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -149,8 +149,9 @@ export class MsalBaseUtilities {
    * Handles MSAL errors.
    */
   protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    if (error instanceof msalCommon.AuthError) {
-      switch (error.errorCode) {
+    if (error.name === "AuthError" || error.name === "ClientAuthError") {
+      const msalError = error as msalCommon.AuthError;
+      switch (msalError.errorCode) {
         case "endpoints_resolution_error":
           this.logger.info(formatError(scopes, error.message));
           return new CredentialUnavailable(error.message);
@@ -158,7 +159,7 @@ export class MsalBaseUtilities {
         case "interaction_required":
         case "login_required":
           this.logger.info(
-            formatError(scopes, `Authentication returned errorCode ${error.errorCode}`)
+            formatError(scopes, `Authentication returned errorCode ${msalError.errorCode}`)
           );
           break;
         default:
@@ -166,7 +167,7 @@ export class MsalBaseUtilities {
           break;
       }
     }
-    if (error instanceof msalCommon.ClientConfigurationError) {
+    if (error.name === "ClientConfigurationError") {
       return error;
     }
     if (error.name === "AbortError") {

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -149,7 +149,11 @@ export class MsalBaseUtilities {
    * Handles MSAL errors.
    */
   protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    if (error.name === "AuthError" || error.name === "ClientAuthError") {
+    if (
+      error.name === "AuthError" ||
+      error.name === "ClientAuthError" ||
+      error.name === "BrowserAuthError"
+    ) {
       const msalError = error as msalCommon.AuthError;
       switch (msalError.errorCode) {
         case "endpoints_resolution_error":
@@ -167,10 +171,11 @@ export class MsalBaseUtilities {
           break;
       }
     }
-    if (error.name === "ClientConfigurationError") {
-      return error;
-    }
-    if (error.name === "AbortError") {
+    if (
+      error.name === "ClientConfigurationError" ||
+      error.name === "BrowserConfigurationAuthError" ||
+      error.name === "AbortError"
+    ) {
       return error;
     }
     return new AuthenticationRequired(scopes, getTokenOptions, error.message);


### PR DESCRIPTION
I had some instances of `instanceof`, which is causing issues once @azure/msal-common gets updated, since @azure/msal-node hasn't been released with the latest version of @azure/msal-common.

For background: instanceof will not match for two different class definitions with the same name loaded on runtime. They can look similar, but if they're not the same exact class definition, instanceof won't match. This dependency mismatch causes instanceof to fail, since both versions of a same dependency are being loaded, causing the runtime to have two classes with the same name.

I know that checking for `error.name` is the way to go, but I had forgotten to remove these before.

After this, there are no further instances of `instanceof` in Identity's code.

This will fix the `rush update --full` PRs.