### PR TITLE
Revert "Make tag as optional (#14427)"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -85,7 +85,7 @@ stages:
                         inputs:
                           targetType: filePath
                           filePath: "eng/tools/publish-to-npm.ps1"
-                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $env:Tag -additionalTag $env:AdditionalTag -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
+                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $(Tag) -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
 
           - ${{if ne(artifact.skipPublishDocMs, 'true')}}:

--- a/eng/tools/publish-to-npm.ps1
+++ b/eng/tools/publish-to-npm.ps1
@@ -1,7 +1,7 @@
 param (
   $pathToArtifacts,
   $accessLevel,
-  $tag="",
+  $tag,
   $additionalTag="",
   $registry,
   $npmToken,
@@ -125,17 +125,8 @@ try {
 
     foreach ($p in $packageList) {
         if($p.Publish) {
-            if ($tag)
-            {
-              Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag"
-              npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag
-            }
-            else
-            {
-              Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true"
-              npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true
-            }
-
+            Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag"
+            npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag
             if ($LastExitCode -ne 0) {
                 Write-Host "npm publish failed with exit code $LastExitCode"
                 exit 1


### PR DESCRIPTION
- This change appears to cause all packages to be published with no tags
- This reverts commit 74a61620d00e35001bc722cc809e0de02d4cbb9f.

## Verification Builds
Publish template with current master: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=828494&view=results
Publish template with #14427 reverted: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=828505&view=results