### PR TITLE
[Identity] Decoupling CredentialUnavailableError from AuthenticationRequiredError

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## 2.0.0-beta.3 (Unreleased)
 
-- `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now doesn't extend `CredentialUnavailableError`.
-  - `AuthenticationRequiredError`, besides being useful to express when a manual authentication with `authenticate()` is required, it also shares a similarity with `CredentialUnavailableError` in which both were designed to tell `ChainedTokenCredential` to move ahead and try another credential.
-  - Because of how prone to errors is `instanceof`, we intentionally want to focus on asserting errors through the `error.name` property of each error.
+- `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now has the same impact on `ChainedTokenCredential` as the `CredentialUnavailableError` which is to allow the next credential in the chain to be tried.
 
 ## 2.0.0-beta.2 (2021-04-06)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -5,7 +5,6 @@
 - `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now doesn't extend `CredentialUnavailableError`.
   - `AuthenticationRequiredError`, besides being useful to express when a manual authentication with `authenticate()` is required, it also shares a similarity with `CredentialUnavailableError` in which both were designed to tell `ChainedTokenCredential` to move ahead and try another credential.
   - Because of how prone to errors is `instanceof`, we intentionally want to focus on asserting errors through the `error.name` property of each error.
-  - Since each error writes its own name, the proper way to check for both errors is to check for both error names, thus making inheritance unnecessary for that use case.
 
 ## 2.0.0-beta.2 (2021-04-06)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.0-beta.3 (Unreleased)
 
+- `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now doesn't extend `CredentialUnavailableError`.
+  - `AuthenticationRequiredError`, besides being useful to express when a manual authentication with `authenticate()` is required, it also shares a similarity with `CredentialUnavailableError` in which both were designed to tell `ChainedTokenCredential` to move ahead and try another credential.
+  - Because of how prone to errors is `instanceof`, we intentionally want to focus on asserting errors through the `error.name` property of each error.
+  - Since each error writes its own name, the proper way to check for both errors is to check for both error names, thus making inheritance unnecessary for that use case.
 
 ## 2.0.0-beta.2 (2021-04-06)
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -41,7 +41,7 @@ export interface AuthenticationRecord {
 }
 
 // @public
-export class AuthenticationRequiredError extends CredentialUnavailableError {
+export class AuthenticationRequiredError extends Error {
     constructor(
     scopes: string[],
     getTokenOptions?: GetTokenOptions, message?: string);

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -61,7 +61,10 @@ export class ChainedTokenCredential implements TokenCredential {
       try {
         token = await this._sources[i].getToken(scopes, updatedOptions);
       } catch (err) {
-        if (err.name === "CredentialUnavailableError") {
+        if (
+          err.name === "CredentialUnavailableError" ||
+          err.name === "AuthenticationRequiredError"
+        ) {
           errors.push(err);
         } else {
           logger.getToken.info(formatError(scopes, err));

--- a/sdk/identity/identity/src/msal/errors.ts
+++ b/sdk/identity/identity/src/msal/errors.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 import { GetTokenOptions } from "@azure/core-http";
-import { CredentialUnavailableError } from "../client/errors";
 
 /**
  * Error used to enforce authentication after trying to retrieve a token silently.
  */
-export class AuthenticationRequiredError extends CredentialUnavailableError {
+export class AuthenticationRequiredError extends Error {
   constructor(
     /**
      * The list of scopes for which the token will have access.

--- a/sdk/identity/identity/test/public/chainedTokenCredential.spec.ts
+++ b/sdk/identity/identity/test/public/chainedTokenCredential.spec.ts
@@ -8,7 +8,8 @@ import {
   TokenCredential,
   AccessToken,
   AggregateAuthenticationError,
-  CredentialUnavailableError
+  CredentialUnavailableError,
+  AuthenticationRequiredError
 } from "../../src";
 
 function mockCredential(returnPromise: Promise<AccessToken | null>): TokenCredential {
@@ -21,6 +22,15 @@ describe("ChainedTokenCredential", function() {
   it("returns the first token received from a credential", async () => {
     const chainedTokenCredential = new ChainedTokenCredential(
       mockCredential(Promise.reject(new CredentialUnavailableError("unavailable."))),
+      mockCredential(
+        Promise.reject(
+          new AuthenticationRequiredError(
+            ["https://vault.azure.net/.default"],
+            {},
+            "authentication-required."
+          )
+        )
+      ),
       mockCredential(Promise.resolve({ token: "firstToken", expiresOnTimestamp: 0 })),
       mockCredential(Promise.resolve({ token: "secondToken", expiresOnTimestamp: 0 }))
     );


### PR DESCRIPTION
`AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now doesn't extend `CredentialUnavailableError`.
  - `AuthenticationRequiredError`, besides being useful to express when a manual authentication with `authenticate()` is required, it also shares a similarity with `CredentialUnavailableError` in which both were designed to tell `ChainedTokenCredential` to move ahead and try another credential.
  - Because of how prone to errors is `instanceof`, we intentionally want to focus on asserting errors through the `error.name` property of each error.
  - Since each error writes its own name, the proper way to check for both errors is to check for both error names, thus making inheritance unnecessary for that use case.

Besides the code change, this PR also extends a current test with a simple case that showcases the underlying functionality.

Fixes #14751