### PR TITLE
Regenerated Computer Vision SDK 3.2

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-computervision/LICENSE.txt
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Microsoft
+Copyright (c) 2021 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cognitiveservices/cognitiveservices-computervision/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-computervision",
   "author": "Microsoft Corporation",
   "description": "ComputerVisionClient Library with typescript type definitions for node.js and browser.",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
@@ -102,7 +102,7 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DetectObjectsResponse>
    */
-  detectObjects(url: string, options?: msRest.RequestOptionsBase): Promise<Models.DetectObjectsResponse>;
+  detectObjects(url: string, options?: Models.ComputerVisionClientDetectObjectsOptionalParams): Promise<Models.DetectObjectsResponse>;
   /**
    * @param url Publicly reachable URL of an image.
    * @param callback The callback
@@ -113,8 +113,8 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  detectObjects(url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DetectResult>): void;
-  detectObjects(url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DetectResult>, callback?: msRest.ServiceCallback<Models.DetectResult>): Promise<Models.DetectObjectsResponse> {
+  detectObjects(url: string, options: Models.ComputerVisionClientDetectObjectsOptionalParams, callback: msRest.ServiceCallback<Models.DetectResult>): void;
+  detectObjects(url: string, options?: Models.ComputerVisionClientDetectObjectsOptionalParams | msRest.ServiceCallback<Models.DetectResult>, callback?: msRest.ServiceCallback<Models.DetectResult>): Promise<Models.DetectObjectsResponse> {
     return this.sendOperationRequest(
       {
         url,
@@ -331,7 +331,7 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetAreaOfInterestResponse>
    */
-  getAreaOfInterest(url: string, options?: msRest.RequestOptionsBase): Promise<Models.GetAreaOfInterestResponse>;
+  getAreaOfInterest(url: string, options?: Models.ComputerVisionClientGetAreaOfInterestOptionalParams): Promise<Models.GetAreaOfInterestResponse>;
   /**
    * @param url Publicly reachable URL of an image.
    * @param callback The callback
@@ -342,8 +342,8 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAreaOfInterest(url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AreaOfInterestResult>): void;
-  getAreaOfInterest(url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AreaOfInterestResult>, callback?: msRest.ServiceCallback<Models.AreaOfInterestResult>): Promise<Models.GetAreaOfInterestResponse> {
+  getAreaOfInterest(url: string, options: Models.ComputerVisionClientGetAreaOfInterestOptionalParams, callback: msRest.ServiceCallback<Models.AreaOfInterestResult>): void;
+  getAreaOfInterest(url: string, options?: Models.ComputerVisionClientGetAreaOfInterestOptionalParams | msRest.ServiceCallback<Models.AreaOfInterestResult>, callback?: msRest.ServiceCallback<Models.AreaOfInterestResult>): Promise<Models.GetAreaOfInterestResponse> {
     return this.sendOperationRequest(
       {
         url,
@@ -458,7 +458,7 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetAreaOfInterestInStreamResponse>
    */
-  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase): Promise<Models.GetAreaOfInterestInStreamResponse>;
+  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientGetAreaOfInterestInStreamOptionalParams): Promise<Models.GetAreaOfInterestInStreamResponse>;
   /**
    * @param image An image stream.
    * @param callback The callback
@@ -469,8 +469,8 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AreaOfInterestResult>): void;
-  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AreaOfInterestResult>, callback?: msRest.ServiceCallback<Models.AreaOfInterestResult>): Promise<Models.GetAreaOfInterestInStreamResponse> {
+  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options: Models.ComputerVisionClientGetAreaOfInterestInStreamOptionalParams, callback: msRest.ServiceCallback<Models.AreaOfInterestResult>): void;
+  getAreaOfInterestInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientGetAreaOfInterestInStreamOptionalParams | msRest.ServiceCallback<Models.AreaOfInterestResult>, callback?: msRest.ServiceCallback<Models.AreaOfInterestResult>): Promise<Models.GetAreaOfInterestInStreamResponse> {
     return this.sendOperationRequest(
       {
         image,
@@ -524,7 +524,7 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DetectObjectsInStreamResponse>
    */
-  detectObjectsInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase): Promise<Models.DetectObjectsInStreamResponse>;
+  detectObjectsInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientDetectObjectsInStreamOptionalParams): Promise<Models.DetectObjectsInStreamResponse>;
   /**
    * @param image An image stream.
    * @param callback The callback
@@ -535,8 +535,8 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  detectObjectsInStream(image: msRest.HttpRequestBody, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DetectResult>): void;
-  detectObjectsInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DetectResult>, callback?: msRest.ServiceCallback<Models.DetectResult>): Promise<Models.DetectObjectsInStreamResponse> {
+  detectObjectsInStream(image: msRest.HttpRequestBody, options: Models.ComputerVisionClientDetectObjectsInStreamOptionalParams, callback: msRest.ServiceCallback<Models.DetectResult>): void;
+  detectObjectsInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientDetectObjectsInStreamOptionalParams | msRest.ServiceCallback<Models.DetectResult>, callback?: msRest.ServiceCallback<Models.DetectResult>): Promise<Models.DetectObjectsInStreamResponse> {
     return this.sendOperationRequest(
       {
         image,
@@ -759,7 +759,8 @@ const analyzeImageOperationSpec: msRest.OperationSpec = {
     Parameters.visualFeatures,
     Parameters.details,
     Parameters.language0,
-    Parameters.descriptionExclude
+    Parameters.descriptionExclude,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -775,7 +776,7 @@ const analyzeImageOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ImageAnalysis
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -790,7 +791,8 @@ const describeImageOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.maxCandidates,
     Parameters.language0,
-    Parameters.descriptionExclude
+    Parameters.descriptionExclude,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -806,7 +808,7 @@ const describeImageOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ImageDescription
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -817,6 +819,9 @@ const detectObjectsOperationSpec: msRest.OperationSpec = {
   path: "detect",
   urlParameters: [
     Parameters.endpoint
+  ],
+  queryParameters: [
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -832,7 +837,7 @@ const detectObjectsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.DetectResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -849,7 +854,7 @@ const listModelsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ListModelsResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -863,7 +868,8 @@ const analyzeImageByDomainOperationSpec: msRest.OperationSpec = {
     Parameters.model
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language0,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -879,7 +885,7 @@ const analyzeImageByDomainOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.DomainModelResults
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -893,7 +899,8 @@ const recognizePrintedTextOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.detectOrientation,
-    Parameters.language1
+    Parameters.language1,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -909,7 +916,7 @@ const recognizePrintedTextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.OcrResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -922,7 +929,8 @@ const tagImageOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language0,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -938,7 +946,7 @@ const tagImageOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.TagResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -953,7 +961,8 @@ const generateThumbnailOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.width,
     Parameters.height,
-    Parameters.smartCropping
+    Parameters.smartCropping,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -984,6 +993,9 @@ const getAreaOfInterestOperationSpec: msRest.OperationSpec = {
   urlParameters: [
     Parameters.endpoint
   ],
+  queryParameters: [
+    Parameters.modelVersion
+  ],
   requestBody: {
     parameterPath: {
       url: "url"
@@ -998,7 +1010,7 @@ const getAreaOfInterestOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.AreaOfInterestResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1011,7 +1023,9 @@ const readOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language2,
+    Parameters.pages,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: {
@@ -1027,7 +1041,7 @@ const readOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ReadHeaders
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError,
+      bodyMapper: Mappers.ComputerVisionOcrError,
       headersMapper: Mappers.ReadHeaders
     }
   },
@@ -1046,7 +1060,7 @@ const getReadResultOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ReadOperationResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionOcrError
     }
   },
   serializer
@@ -1062,7 +1076,8 @@ const analyzeImageInStreamOperationSpec: msRest.OperationSpec = {
     Parameters.visualFeatures,
     Parameters.details,
     Parameters.language0,
-    Parameters.descriptionExclude
+    Parameters.descriptionExclude,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1080,7 +1095,7 @@ const analyzeImageInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ImageAnalysis
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1091,6 +1106,9 @@ const getAreaOfInterestInStreamOperationSpec: msRest.OperationSpec = {
   path: "areaOfInterest",
   urlParameters: [
     Parameters.endpoint
+  ],
+  queryParameters: [
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1108,7 +1126,7 @@ const getAreaOfInterestInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.AreaOfInterestResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1123,7 +1141,8 @@ const describeImageInStreamOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.maxCandidates,
     Parameters.language0,
-    Parameters.descriptionExclude
+    Parameters.descriptionExclude,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1141,7 +1160,7 @@ const describeImageInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ImageDescription
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1152,6 +1171,9 @@ const detectObjectsInStreamOperationSpec: msRest.OperationSpec = {
   path: "detect",
   urlParameters: [
     Parameters.endpoint
+  ],
+  queryParameters: [
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1169,7 +1191,7 @@ const detectObjectsInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.DetectResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1184,7 +1206,8 @@ const generateThumbnailInStreamOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.width,
     Parameters.height,
-    Parameters.smartCropping
+    Parameters.smartCropping,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1219,7 +1242,8 @@ const analyzeImageByDomainInStreamOperationSpec: msRest.OperationSpec = {
     Parameters.model
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language0,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1237,7 +1261,7 @@ const analyzeImageByDomainInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.DomainModelResults
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1251,7 +1275,8 @@ const recognizePrintedTextInStreamOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.detectOrientation,
-    Parameters.language1
+    Parameters.language1,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1269,7 +1294,7 @@ const recognizePrintedTextInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.OcrResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1282,7 +1307,8 @@ const tagImageInStreamOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language0,
+    Parameters.modelVersion
   ],
   requestBody: {
     parameterPath: "image",
@@ -1300,7 +1326,7 @@ const tagImageInStreamOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.TagResult
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionErrorResponse
     }
   },
   serializer
@@ -1313,7 +1339,8 @@ const readInStreamOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.language0
+    Parameters.language2,
+    Parameters.pages
   ],
   requestBody: {
     parameterPath: "image",
@@ -1331,7 +1358,7 @@ const readInStreamOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ReadInStreamHeaders
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError,
+      bodyMapper: Mappers.ComputerVisionOcrError,
       headersMapper: Mappers.ReadInStreamHeaders
     }
   },

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-computervision";
-const packageVersion = "7.1.0";
+const packageVersion = "8.0.0";
 
 export class ComputerVisionClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -42,7 +42,7 @@ export class ComputerVisionClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/vision/v3.1";
+    this.baseUri = "{Endpoint}/vision/v3.2";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
     this.credentials = credentials;

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
@@ -383,6 +383,7 @@ export interface ImageAnalysis {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -403,6 +404,7 @@ export interface ImageDescription {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -419,6 +421,7 @@ export interface DetectResult {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -459,6 +462,7 @@ export interface DomainModelResults {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -546,6 +550,7 @@ export interface OcrResult {
    * An array of objects, where each object represents a region of recognized text.
    */
   regions?: OcrRegion[];
+  modelVersion?: string;
 }
 
 /**
@@ -561,6 +566,7 @@ export interface TagResult {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -577,6 +583,7 @@ export interface AreaOfInterestResult {
    */
   requestId?: string;
   metadata?: ImageMetadata;
+  modelVersion?: string;
 }
 
 /**
@@ -592,49 +599,74 @@ export interface ImageUrl {
 /**
  * Details about the API request error.
  */
+export interface ComputerVisionInnerError {
+  /**
+   * The error code. Possible values include: 'InvalidImageFormat', 'UnsupportedMediaType',
+   * 'InvalidImageUrl', 'NotSupportedFeature', 'NotSupportedImage', 'Timeout',
+   * 'InternalServerError', 'InvalidImageSize', 'BadArgument', 'DetectFaceError',
+   * 'NotSupportedLanguage', 'InvalidThumbnailSize', 'InvalidDetails', 'InvalidModel',
+   * 'CancelledRequest', 'NotSupportedVisualFeature', 'FailedToProcess', 'Unspecified',
+   * 'StorageException'
+   */
+  code: ComputerVisionInnerErrorCodeValue;
+  /**
+   * Error message.
+   */
+  message: string;
+}
+
+/**
+ * The API request error.
+ */
 export interface ComputerVisionError {
   /**
-   * The error code.
+   * The error code. Possible values include: 'InvalidRequest', 'InvalidArgument',
+   * 'InternalServerError', 'ServiceUnavailable'
    */
-  code: any;
+  code: ComputerVisionErrorCodes;
   /**
    * A message explaining the error reported by the service.
    */
   message: string;
   /**
-   * A unique request identifier.
+   * Inner error contains more specific information.
    */
-  requestId?: string;
+  innererror?: ComputerVisionInnerError;
 }
 
 /**
- * Result of domain-specific classifications for the domain of landmarks.
+ * The API error response.
  */
-export interface LandmarkResults {
+export interface ComputerVisionErrorResponse {
   /**
-   * List of landmarks recognized in the image.
+   * Error contents.
    */
-  landmarks?: LandmarksModel[];
-  /**
-   * Id of the REST API request.
-   */
-  requestId?: string;
-  metadata?: ImageMetadata;
+  error: ComputerVisionError;
 }
 
 /**
- * Result of domain-specific classifications for the domain of celebrities.
+ * An object representing the style of the text line.
  */
-export interface CelebrityResults {
+export interface Style {
   /**
-   * List of celebrities recognized in the image.
+   * The text line style name, including handwriting and other. Possible values include: 'other',
+   * 'handwriting'
    */
-  celebrities?: CelebritiesModel[];
+  name: TextStyle;
   /**
-   * Id of the REST API request.
+   * The confidence of text line style.
    */
-  requestId?: string;
-  metadata?: ImageMetadata;
+  confidence: number;
+}
+
+/**
+ * An object representing the appearance of the text line.
+ */
+export interface Appearance {
+  /**
+   * An object representing the style of the text line.
+   */
+  style: Style;
 }
 
 /**
@@ -668,6 +700,10 @@ export interface Line {
    * Bounding box of a recognized line.
    */
   boundingBox: number[];
+  /**
+   * Appearance of the text line.
+   */
+  appearance?: Appearance;
   /**
    * The text content of the line.
    */
@@ -722,6 +758,10 @@ export interface AnalyzeResults {
    */
   version: string;
   /**
+   * Version of the OCR model used for text extraction.
+   */
+  modelVersion: string;
+  /**
    * Text extracted from the input.
    */
   readResults: ReadResult[];
@@ -748,6 +788,24 @@ export interface ReadOperationResult {
    * Analyze batch operation result.
    */
   analyzeResult?: AnalyzeResults;
+}
+
+/**
+ * Details about the API request error.
+ */
+export interface ComputerVisionOcrError {
+  /**
+   * The error code.
+   */
+  code: any;
+  /**
+   * A message explaining the error reported by the service.
+   */
+  message: string;
+  /**
+   * A unique request identifier.
+   */
+  requestId?: string;
 }
 
 /**
@@ -787,6 +845,11 @@ export interface ComputerVisionClientAnalyzeImageOptionalParams extends msRest.R
    * Turn off specified domain models when generating the description.
    */
   descriptionExclude?: DescriptionExclude[];
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -808,6 +871,22 @@ export interface ComputerVisionClientDescribeImageOptionalParams extends msRest.
    * Turn off specified domain models when generating the description.
    */
   descriptionExclude?: DescriptionExclude[];
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface ComputerVisionClientDetectObjectsOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -821,6 +900,11 @@ export interface ComputerVisionClientAnalyzeImageByDomainOptionalParams extends 
    * 'pt', 'zh'. Default value: 'en'.
    */
   language?: Language2;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -834,6 +918,11 @@ export interface ComputerVisionClientRecognizePrintedTextOptionalParams extends 
    * 'sr-Cyrl', 'sr-Latn', 'sk'. Default value: 'unk'.
    */
   language?: OcrLanguages;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -847,6 +936,11 @@ export interface ComputerVisionClientTagImageOptionalParams extends msRest.Reque
    * 'pt', 'zh'. Default value: 'en'.
    */
   language?: Language3;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -857,6 +951,22 @@ export interface ComputerVisionClientGenerateThumbnailOptionalParams extends msR
    * Boolean flag for enabling smart cropping. Default value: false.
    */
   smartCropping?: boolean;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface ComputerVisionClientGetAreaOfInterestOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -864,14 +974,29 @@ export interface ComputerVisionClientGenerateThumbnailOptionalParams extends msR
  */
 export interface ComputerVisionClientReadOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The BCP-47 language code of the text in the document. Currently, only English ('en'), Dutch
-   * (‘nl’), French (‘fr’), German (‘de’), Italian (‘it’), Portuguese (‘pt), and Spanish ('es') are
-   * supported. Read supports auto language identification and multi-language documents, so only
-   * provide a language code if you would like to force the documented to be processed as that
-   * specific language. Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'. Default
-   * value: 'en'.
+   * The BCP-47 language code of the text in the document. Read supports auto language
+   * identification and multi-language documents, so only provide a language code if you would like
+   * to force the document to be processed in that specific language. See
+   * https://aka.ms/ocr-languages for list of supported languages. Possible values include: 'af',
+   * 'ast', 'bi', 'br', 'ca', 'ceb', 'ch', 'co', 'crh', 'cs', 'csb', 'da', 'de', 'en', 'es', 'et',
+   * 'eu', 'fi', 'fil', 'fj', 'fr', 'fur', 'fy', 'ga', 'gd', 'gil', 'gl', 'gv', 'hni', 'hsb', 'ht',
+   * 'hu', 'ia', 'id', 'it', 'iu', 'ja', 'jv', 'kaa', 'kac', 'kea', 'kha', 'kl', 'ko', 'ku', 'kw',
+   * 'lb', 'ms', 'mww', 'nap', 'nl', 'no', 'oc', 'pl', 'pt', 'quc', 'rm', 'sco', 'sl', 'sq', 'sv',
+   * 'sw', 'tet', 'tr', 'tt', 'uz', 'vo', 'wae', 'yua', 'za', 'zh-Hans', 'zh-Hant', 'zu'
    */
   language?: OcrDetectionLanguage;
+  /**
+   * Custom page numbers for multi-page documents(PDF/TIFF), input the number of the pages you want
+   * to get OCR result. For a range of pages, use a hyphen. Separate each page or range with a
+   * comma.
+   */
+  pages?: string[];
+  /**
+   * Optional parameter to specify the version of the OCR model used for text extraction. Accepted
+   * values are: "latest", "latest-preview", "2021-04-12". Defaults to "latest". Default value:
+   * 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -911,6 +1036,22 @@ export interface ComputerVisionClientAnalyzeImageInStreamOptionalParams extends 
    * Turn off specified domain models when generating the description.
    */
   descriptionExclude?: DescriptionExclude[];
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface ComputerVisionClientGetAreaOfInterestInStreamOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -932,6 +1073,22 @@ export interface ComputerVisionClientDescribeImageInStreamOptionalParams extends
    * Turn off specified domain models when generating the description.
    */
   descriptionExclude?: DescriptionExclude[];
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface ComputerVisionClientDetectObjectsInStreamOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -942,6 +1099,11 @@ export interface ComputerVisionClientGenerateThumbnailInStreamOptionalParams ext
    * Boolean flag for enabling smart cropping. Default value: false.
    */
   smartCropping?: boolean;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -955,6 +1117,11 @@ export interface ComputerVisionClientAnalyzeImageByDomainInStreamOptionalParams 
    * 'pt', 'zh'. Default value: 'en'.
    */
   language?: Language6;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -968,6 +1135,11 @@ export interface ComputerVisionClientRecognizePrintedTextInStreamOptionalParams 
    * 'sr-Cyrl', 'sr-Latn', 'sk'. Default value: 'unk'.
    */
   language?: OcrLanguages;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -981,6 +1153,11 @@ export interface ComputerVisionClientTagImageInStreamOptionalParams extends msRe
    * 'pt', 'zh'. Default value: 'en'.
    */
   language?: Language7;
+  /**
+   * Optional parameter to specify the version of the AI model. Accepted values are: "latest",
+   * "2021-04-01". Defaults to "latest". Default value: 'latest'.
+   */
+  modelVersion?: string;
 }
 
 /**
@@ -988,14 +1165,23 @@ export interface ComputerVisionClientTagImageInStreamOptionalParams extends msRe
  */
 export interface ComputerVisionClientReadInStreamOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The BCP-47 language code of the text in the document. Currently, only English ('en'), Dutch
-   * (‘nl’), French (‘fr’), German (‘de’), Italian (‘it’), Portuguese (‘pt), and Spanish ('es') are
-   * supported. Read supports auto language identification and multi-language documents, so only
-   * provide a language code if you would like to force the documented to be processed as that
-   * specific language. Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'. Default
-   * value: 'en'.
+   * The BCP-47 language code of the text in the document. Read supports auto language
+   * identification and multi-language documents, so only provide a language code if you would like
+   * to force the document to be processed in that specific language. See
+   * https://aka.ms/ocr-languages for list of supported languages. Possible values include: 'af',
+   * 'ast', 'bi', 'br', 'ca', 'ceb', 'ch', 'co', 'crh', 'cs', 'csb', 'da', 'de', 'en', 'es', 'et',
+   * 'eu', 'fi', 'fil', 'fj', 'fr', 'fur', 'fy', 'ga', 'gd', 'gil', 'gl', 'gv', 'hni', 'hsb', 'ht',
+   * 'hu', 'ia', 'id', 'it', 'iu', 'ja', 'jv', 'kaa', 'kac', 'kea', 'kha', 'kl', 'ko', 'ku', 'kw',
+   * 'lb', 'ms', 'mww', 'nap', 'nl', 'no', 'oc', 'pl', 'pt', 'quc', 'rm', 'sco', 'sl', 'sq', 'sv',
+   * 'sw', 'tet', 'tr', 'tt', 'uz', 'vo', 'wae', 'yua', 'za', 'zh-Hans', 'zh-Hant', 'zu'
    */
   language?: OcrDetectionLanguage;
+  /**
+   * Custom page numbers for multi-page documents(PDF/TIFF), input the number of the pages you want
+   * to get OCR result. For a range of pages, use a hyphen. Separate each page or range with a
+   * comma.
+   */
+  pages?: string[];
 }
 
 /**
@@ -1027,6 +1213,27 @@ export interface ReadInStreamHeaders {
 export type Gender = 'Male' | 'Female';
 
 /**
+ * Defines values for ComputerVisionErrorCodes.
+ * Possible values include: 'InvalidRequest', 'InvalidArgument', 'InternalServerError',
+ * 'ServiceUnavailable'
+ * @readonly
+ * @enum {string}
+ */
+export type ComputerVisionErrorCodes = 'InvalidRequest' | 'InvalidArgument' | 'InternalServerError' | 'ServiceUnavailable';
+
+/**
+ * Defines values for ComputerVisionInnerErrorCodeValue.
+ * Possible values include: 'InvalidImageFormat', 'UnsupportedMediaType', 'InvalidImageUrl',
+ * 'NotSupportedFeature', 'NotSupportedImage', 'Timeout', 'InternalServerError',
+ * 'InvalidImageSize', 'BadArgument', 'DetectFaceError', 'NotSupportedLanguage',
+ * 'InvalidThumbnailSize', 'InvalidDetails', 'InvalidModel', 'CancelledRequest',
+ * 'NotSupportedVisualFeature', 'FailedToProcess', 'Unspecified', 'StorageException'
+ * @readonly
+ * @enum {string}
+ */
+export type ComputerVisionInnerErrorCodeValue = 'InvalidImageFormat' | 'UnsupportedMediaType' | 'InvalidImageUrl' | 'NotSupportedFeature' | 'NotSupportedImage' | 'Timeout' | 'InternalServerError' | 'InvalidImageSize' | 'BadArgument' | 'DetectFaceError' | 'NotSupportedLanguage' | 'InvalidThumbnailSize' | 'InvalidDetails' | 'InvalidModel' | 'CancelledRequest' | 'NotSupportedVisualFeature' | 'FailedToProcess' | 'Unspecified' | 'StorageException';
+
+/**
  * Defines values for OperationStatusCodes.
  * Possible values include: 'notStarted', 'running', 'failed', 'succeeded'
  * @readonly
@@ -1041,6 +1248,14 @@ export type OperationStatusCodes = 'notStarted' | 'running' | 'failed' | 'succee
  * @enum {string}
  */
 export type TextRecognitionResultDimensionUnit = 'pixel' | 'inch';
+
+/**
+ * Defines values for TextStyle.
+ * Possible values include: 'other', 'handwriting'
+ * @readonly
+ * @enum {string}
+ */
+export type TextStyle = 'other' | 'handwriting';
 
 /**
  * Defines values for DescriptionExclude.
@@ -1071,11 +1286,16 @@ export type VisualFeatureTypes = 'ImageType' | 'Faces' | 'Adult' | 'Categories' 
 
 /**
  * Defines values for OcrDetectionLanguage.
- * Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'
+ * Possible values include: 'af', 'ast', 'bi', 'br', 'ca', 'ceb', 'ch', 'co', 'crh', 'cs', 'csb',
+ * 'da', 'de', 'en', 'es', 'et', 'eu', 'fi', 'fil', 'fj', 'fr', 'fur', 'fy', 'ga', 'gd', 'gil',
+ * 'gl', 'gv', 'hni', 'hsb', 'ht', 'hu', 'ia', 'id', 'it', 'iu', 'ja', 'jv', 'kaa', 'kac', 'kea',
+ * 'kha', 'kl', 'ko', 'ku', 'kw', 'lb', 'ms', 'mww', 'nap', 'nl', 'no', 'oc', 'pl', 'pt', 'quc',
+ * 'rm', 'sco', 'sl', 'sq', 'sv', 'sw', 'tet', 'tr', 'tt', 'uz', 'vo', 'wae', 'yua', 'za',
+ * 'zh-Hans', 'zh-Hant', 'zu'
  * @readonly
  * @enum {string}
  */
-export type OcrDetectionLanguage = 'en' | 'es' | 'fr' | 'de' | 'it' | 'nl' | 'pt';
+export type OcrDetectionLanguage = 'af' | 'ast' | 'bi' | 'br' | 'ca' | 'ceb' | 'ch' | 'co' | 'crh' | 'cs' | 'csb' | 'da' | 'de' | 'en' | 'es' | 'et' | 'eu' | 'fi' | 'fil' | 'fj' | 'fr' | 'fur' | 'fy' | 'ga' | 'gd' | 'gil' | 'gl' | 'gv' | 'hni' | 'hsb' | 'ht' | 'hu' | 'ia' | 'id' | 'it' | 'iu' | 'ja' | 'jv' | 'kaa' | 'kac' | 'kea' | 'kha' | 'kl' | 'ko' | 'ku' | 'kw' | 'lb' | 'ms' | 'mww' | 'nap' | 'nl' | 'no' | 'oc' | 'pl' | 'pt' | 'quc' | 'rm' | 'sco' | 'sl' | 'sq' | 'sv' | 'sw' | 'tet' | 'tr' | 'tt' | 'uz' | 'vo' | 'wae' | 'yua' | 'za' | 'zh-Hans' | 'zh-Hant' | 'zu';
 
 /**
  * Defines values for Details.

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/mappers.ts
@@ -705,6 +705,12 @@ export const ImageAnalysis: msRest.CompositeMapper = {
           name: "Composite",
           className: "ImageMetadata"
         }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -754,6 +760,12 @@ export const ImageDescription: msRest.CompositeMapper = {
           name: "Composite",
           className: "ImageMetadata"
         }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -791,6 +803,12 @@ export const DetectResult: msRest.CompositeMapper = {
         type: {
           name: "Composite",
           className: "ImageMetadata"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
         }
       }
     }
@@ -874,6 +892,12 @@ export const DomainModelResults: msRest.CompositeMapper = {
         type: {
           name: "Composite",
           className: "ImageMetadata"
+        }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
         }
       }
     }
@@ -1003,6 +1027,12 @@ export const OcrResult: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -1040,6 +1070,12 @@ export const TagResult: msRest.CompositeMapper = {
           name: "Composite",
           className: "ImageMetadata"
         }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -1072,6 +1108,12 @@ export const AreaOfInterestResult: msRest.CompositeMapper = {
           name: "Composite",
           className: "ImageMetadata"
         }
+      },
+      modelVersion: {
+        serializedName: "modelVersion",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -1094,6 +1136,30 @@ export const ImageUrl: msRest.CompositeMapper = {
   }
 };
 
+export const ComputerVisionInnerError: msRest.CompositeMapper = {
+  serializedName: "ComputerVisionInnerError",
+  type: {
+    name: "Composite",
+    className: "ComputerVisionInnerError",
+    modelProperties: {
+      code: {
+        required: true,
+        serializedName: "code",
+        type: {
+          name: "String"
+        }
+      },
+      message: {
+        required: true,
+        serializedName: "message",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const ComputerVisionError: msRest.CompositeMapper = {
   serializedName: "ComputerVisionError",
   type: {
@@ -1104,7 +1170,7 @@ export const ComputerVisionError: msRest.CompositeMapper = {
         required: true,
         serializedName: "code",
         type: {
-          name: "Object"
+          name: "String"
         }
       },
       message: {
@@ -1114,84 +1180,71 @@ export const ComputerVisionError: msRest.CompositeMapper = {
           name: "String"
         }
       },
-      requestId: {
-        serializedName: "requestId",
+      innererror: {
+        serializedName: "innererror",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "ComputerVisionInnerError"
         }
       }
     }
   }
 };
 
-export const LandmarkResults: msRest.CompositeMapper = {
-  serializedName: "LandmarkResults",
+export const ComputerVisionErrorResponse: msRest.CompositeMapper = {
+  serializedName: "ComputerVisionErrorResponse",
   type: {
     name: "Composite",
-    className: "LandmarkResults",
+    className: "ComputerVisionErrorResponse",
     modelProperties: {
-      landmarks: {
-        nullable: true,
-        serializedName: "landmarks",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "LandmarksModel"
-            }
-          }
-        }
-      },
-      requestId: {
-        nullable: true,
-        serializedName: "requestId",
-        type: {
-          name: "String"
-        }
-      },
-      metadata: {
-        serializedName: "metadata",
+      error: {
+        required: true,
+        serializedName: "error",
         type: {
           name: "Composite",
-          className: "ImageMetadata"
+          className: "ComputerVisionError"
         }
       }
     }
   }
 };
 
-export const CelebrityResults: msRest.CompositeMapper = {
-  serializedName: "CelebrityResults",
+export const Style: msRest.CompositeMapper = {
+  serializedName: "Style",
   type: {
     name: "Composite",
-    className: "CelebrityResults",
+    className: "Style",
     modelProperties: {
-      celebrities: {
-        nullable: true,
-        serializedName: "celebrities",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "CelebritiesModel"
-            }
-          }
-        }
-      },
-      requestId: {
-        nullable: true,
-        serializedName: "requestId",
+      name: {
+        required: true,
+        serializedName: "name",
         type: {
           name: "String"
         }
       },
-      metadata: {
-        serializedName: "metadata",
+      confidence: {
+        required: true,
+        serializedName: "confidence",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const Appearance: msRest.CompositeMapper = {
+  serializedName: "Appearance",
+  type: {
+    name: "Composite",
+    className: "Appearance",
+    modelProperties: {
+      style: {
+        required: true,
+        serializedName: "style",
         type: {
           name: "Composite",
-          className: "ImageMetadata"
+          className: "Style"
         }
       }
     }
@@ -1256,6 +1309,13 @@ export const Line: msRest.CompositeMapper = {
               name: "Number"
             }
           }
+        }
+      },
+      appearance: {
+        serializedName: "appearance",
+        type: {
+          name: "Composite",
+          className: "Appearance"
         }
       },
       text: {
@@ -1364,6 +1424,16 @@ export const AnalyzeResults: msRest.CompositeMapper = {
           name: "String"
         }
       },
+      modelVersion: {
+        required: true,
+        serializedName: "modelVersion",
+        constraints: {
+          Pattern: /^(latest|\d{4}-\d{2}-\d{2})(-preview)?$/
+        },
+        type: {
+          name: "String"
+        }
+      },
       readResults: {
         required: true,
         serializedName: "readResults",
@@ -1419,6 +1489,36 @@ export const ReadOperationResult: msRest.CompositeMapper = {
         type: {
           name: "Composite",
           className: "AnalyzeResults"
+        }
+      }
+    }
+  }
+};
+
+export const ComputerVisionOcrError: msRest.CompositeMapper = {
+  serializedName: "ComputerVisionOcrError",
+  type: {
+    name: "Composite",
+    className: "ComputerVisionOcrError",
+    modelProperties: {
+      code: {
+        required: true,
+        serializedName: "code",
+        type: {
+          name: "Object"
+        }
+      },
+      message: {
+        required: true,
+        serializedName: "message",
+        type: {
+          name: "String"
+        }
+      },
+      requestId: {
+        serializedName: "requestId",
+        type: {
+          name: "String"
         }
       }
     }

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/parameters.ts
@@ -146,6 +146,18 @@ export const language1: msRest.OperationQueryParameter = {
     }
   }
 };
+export const language2: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "language"
+  ],
+  mapper: {
+    serializedName: "language",
+    type: {
+      name: "String"
+    }
+  }
+};
 export const maxCandidates: msRest.OperationQueryParameter = {
   parameterPath: [
     "options",
@@ -169,6 +181,22 @@ export const model: msRest.OperationURLParameter = {
     }
   }
 };
+export const modelVersion: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "modelVersion"
+  ],
+  mapper: {
+    serializedName: "model-version",
+    defaultValue: 'latest',
+    constraints: {
+      Pattern: /^(latest|\d{4}-\d{2}-\d{2})(-preview)?$/
+    },
+    type: {
+      name: "String"
+    }
+  }
+};
 export const operationId: msRest.OperationURLParameter = {
   parameterPath: "operationId",
   mapper: {
@@ -178,6 +206,24 @@ export const operationId: msRest.OperationURLParameter = {
       name: "Uuid"
     }
   }
+};
+export const pages: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "pages"
+  ],
+  mapper: {
+    serializedName: "pages",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: msRest.QueryCollectionFormat.Csv
 };
 export const smartCropping: msRest.OperationQueryParameter = {
   parameterPath: [


### PR DESCRIPTION
This PR is to regenerate and release Cognitive Services Computer Vision 3.2 JS SDK. 

**Command Used**

```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=C:\Users\sarajama\Projects\azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=8.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/ComputerVision/readme.md
AutoRest code generation utility [cli version: 3.0.6339; node: v14.15.4, max-memory: 4096 MB]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest

There is a new version of AutoRest available (3.1.4).
 > You can install the newer version with with npm install -g autorest@latest

NOTE: AutoRest core version selected from configuration: ~2.0.4413.
   Loading AutoRest core      'C:\Users\sarajama\.autorest\@microsoft.azure_autorest-core@2.0.4419\node_modules\@microsoft.azure\autorest-core\dist' (2.0.4419)
   Loading AutoRest extension '@microsoft.azure/autorest.typescript' (4.2.4->4.2.4)
   Loading AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.51->2.3.51)
```

As you can see, there are breaking changes with this version of SDK. So, I have updated the version from 7.1.0 -> 8.0.0.

@ramya-rao-a Please review and approve. 