### PR TITLE
[Recorder] Mask access_token from browser recordings - relaxing for non json parsable content

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.0 (Unreleased)
 
+## 2021-04-07
+
+- Relaxing `maskAccessTokenInBrowserRecording` method to ignore the access_token replacement if the response is not JSON parsable.
+  [#14793](https://github.com/Azure/azure-sdk-for-js/pull/14793)
+
 ## 2021-03-17
 
 - Adds an internal helper method to mask "access_token" in the recorder rather than expecting users to provide it through the custom config `customizationsOnRecordings` from `RecorderEnvironmentSetup`. [#12759](https://github.com/Azure/azure-sdk-for-js/pull/12759)

--- a/sdk/test-utils/recorder/src/utils/index.ts
+++ b/sdk/test-utils/recorder/src/utils/index.ts
@@ -505,10 +505,14 @@ export function maskAccessTokenInBrowserRecording(fixtures: string): string {
     // Replaces only if the content-type is json
     if (isContentTypeInBrowserRecording(fixtures[i], jsonContentTypes)) {
       if ((fixtures[i] as any).response) {
-        const parsedResponse = JSON.parse((fixtures[i] as any).response);
-        if (parsedResponse["access_token"]) {
-          parsedResponse["access_token"] = "access_token";
-          (fixtures[i] as any).response = JSON.stringify(parsedResponse);
+        try {
+          const parsedResponse = JSON.parse((fixtures[i] as any).response);
+          if (parsedResponse["access_token"]) {
+            parsedResponse["access_token"] = "access_token";
+            (fixtures[i] as any).response = JSON.stringify(parsedResponse);
+          }
+        } catch (_) {
+          // Skip for non-JSON parsable content
         }
       }
     }

--- a/sdk/test-utils/recorder/test/browser/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/utils.spec.ts
@@ -227,6 +227,40 @@ describe("Browser utils", () => {
             responseHeaders: {}
           }
         ]
+      },
+      {
+        name: `no impact on the recording with json content type but no json response`,
+        input: [
+          {
+            method: "GET",
+            url: "https://managed_hsm.azure.net/keys/cryptography-client-test1e909341f12eab0",
+            query: { "api-version": "7.2" },
+            requestBody: "",
+            status: 401,
+            response: "OK",
+            responseHeaders: {
+              "content-security-policy": "default-src 'self'",
+              "content-type": "application/json; charset=utf-8",
+              "strict-transport-security": "max-age=31536000; includeSubDomains",
+              "x-ms-server-latency": "0"
+            }
+          }
+        ],
+        output: [
+          {
+            method: "GET",
+            url: "https://managed_hsm.azure.net/keys/cryptography-client-test1e909341f12eab0",
+            query: { "api-version": "7.2" },
+            requestBody: "",
+            status: 401,
+            response: "OK",
+            responseHeaders: {
+              "content-security-policy": "default-src 'self'",
+              "content-type": "application/json; charset=utf-8",
+              "strict-transport-security": "max-age=31536000; includeSubDomains"
+            }
+          }
+        ]
       }
     ].forEach((test) => {
       it(test.name, () => {

--- a/sdk/test-utils/recorder/test/browser/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/browser/utils.spec.ts
@@ -241,8 +241,7 @@ describe("Browser utils", () => {
             responseHeaders: {
               "content-security-policy": "default-src 'self'",
               "content-type": "application/json; charset=utf-8",
-              "strict-transport-security": "max-age=31536000; includeSubDomains",
-              "x-ms-server-latency": "0"
+              "strict-transport-security": "max-age=31536000; includeSubDomains"
             }
           }
         ],


### PR DESCRIPTION
@maorleger came up with a case where `maskAccessTokenInBrowserRecording` was throwing an error because the response wasn't JSON though the content type is "application/json; charset=utf-8".

Example
```js
          {
            method: "GET",
            url: "https://managed_hsm.azure.net/keys/cryptography-client-test1e909341f12eab0",
            query: { "api-version": "7.2" },
            requestBody: "",
            status: 401,
            response: "OK",
            responseHeaders: {
              "content-security-policy": "default-src 'self'",
              "content-type": "application/json; charset=utf-8",
              "strict-transport-security": "max-age=31536000; includeSubDomains",
              "x-ms-server-latency": "0"
            }
          }
```

This PR attempts to fix such cases by not doing anything when the response is not JSON parsable.