### PR TITLE
Revert "Update CODEOWNERS (#13809)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 /sdk/batch/ @dpwatrous @paterasMSFT @zfengms @deyaaeldeen
 
 # PRLabel: %Communication
-/sdk/communication/ @acsdevx-msft
+/sdk/communication/ @DominikMe @0rland0Wats0n @ankitarorabit @Azure/azure-sdk-communication-code-reviewers
 
 # PRLabel: %Container Registry
 /sdk/containerregistry/ @jeremymeng


### PR DESCRIPTION
Owners were not pinged for "communication" at https://github.com/Azure/azure-sdk-for-js/pull/14792


As @ramya-rao-a suggested, reverting #13809 until the group alias is fixed. 

This reverts commit 67dc66b81db953927f75c7cbc653872bf70a290c.

/cc @meeraharidasa 