### PR TITLE
[ai-form-recognizer] Enable tests in sovereign clouds.

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/tests.yml
+++ b/sdk/formrecognizer/ai-form-recognizer/tests.yml
@@ -3,10 +3,10 @@
 # tests pipeline. This is useful for when we want to test in different
 # environments: Prod, Canary, etc.
 parameters:
-- name: Location
-  displayName: Location
-  type: string
-  default: canadacentral
+  - name: Location
+    displayName: Location
+    type: string
+    default: canadacentral
 
 trigger: none
 
@@ -20,3 +20,17 @@ stages:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: "canadacentral"
+        Canary:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          Location: "centraluseuap"
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources-test)
+          Location: "usgovvirginia"
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          Location: "chinaeast2"
+      SupportedClouds: "Public,Canary,UsGov,China"

--- a/sdk/formrecognizer/test-resources.json
+++ b/sdk/formrecognizer/test-resources.json
@@ -36,7 +36,7 @@
     },
     "blobResourceId": {
       "type": "string",
-      "defaultValue": "[resourceId('2cd617ea-1866-46b1-90e3-fffb087ebf9b', 'TrainingData', 'Microsoft.Storage/storageAccounts', parameters('blobStorageAccount'))]"
+      "defaultValue": "[resourceId('TrainingData', 'Microsoft.Storage/storageAccounts', parameters('blobStorageAccount'))]"
     },
     "trainingDataSasProperties": {
       "type": "object",
@@ -68,6 +68,10 @@
         "signedPermission": "rl",
         "signedResource": "c"
       }
+    },
+    "cognitiveServicesEndpointSuffix": {
+      "type": "string",
+      "defaultValue": ".cognitiveservices.azure.com/"
     }
   },
   "variables": {
@@ -101,7 +105,7 @@
   "outputs": {
     "FORM_RECOGNIZER_ENDPOINT": {
       "type": "string",
-      "value": "[concat('https://', parameters('baseName'), '.cognitiveservices.azure.com/')]"
+      "value": "[concat('https://', parameters('baseName'), parameters('cognitiveServicesEndpointSuffix'))]"
     },
     "FORM_RECOGNIZER_API_KEY": {
       "type": "string",


### PR DESCRIPTION
WIP.

This PR is experimenting with adding support to Form Recognizer for running our tests in multiple clouds, including sovereign clouds:

- Canada Central (preferred prod region)
- Canary (centraluseuap)
- US Gov
- China

Closes #10086