### PR TITLE
[test-recorder] mask more tokens

### DIFF
--- a/sdk/containerregistry/container-registry/test/public/utils.ts
+++ b/sdk/containerregistry/container-registry/test/public/utils.ts
@@ -32,14 +32,7 @@ export const recorderEnvSetup: RecorderEnvironmentSetup = {
   // variable or query parameter replacement.  The
   // `customizationsOnRecordings` field allows us to make arbitrary
   // replacements within recordings.
-  customizationsOnRecordings: [
-    (recording: string): string =>
-      recording.replace(/"refresh_token":"[^"]*"/g, `"refresh_token":"refresh_token"`),
-    (recording: string): string =>
-      recording.replace(/access_token=(.+?)(&|")/, `access_token=access_token$2`),
-    (recording: string): string =>
-      recording.replace(/refresh_token=(.+?)(&|")/, `refresh_token=refresh_token$2`)
-  ]
+  customizationsOnRecordings: []
 };
 
 export function createRegistryClient(): ContainerRegistryClient {

--- a/sdk/test-utils/recorder/src/utils/index.ts
+++ b/sdk/test-utils/recorder/src/utils/index.ts
@@ -474,12 +474,11 @@ export function maskAccessTokenInNockFixture(fixture: string): string {
   }
   // Replaces only if the content-type is json
   if (isContentTypeInNockFixture(fixture, jsonContentTypes)) {
-    // Matches the nock's reply from the fixture such as below
-    //   `.reply(200, {"token_type":"Bearer","expires_in":86399,"access_token":"e6z-9_g"}, [`
-    const matches = fixture.match(/\.reply\((.*), (.*), .*/);
-    if (matches && matches[2]) {
-      return fixture.replace(/"access_token"\s*:\s*"(.+?)"/, `"access_token":"access_token"`);
-    }
+    return fixture
+      .replace(/"access_token"\s*:\s*"(.+?)"/, `"access_token":"access_token"`)
+      .replace(/"refresh_token"\s*:\s*"[^"]*"/, `"refresh_token":"refresh_token"`)
+      .replace(/access_token=(.+?)(&|")/, `access_token=access_token$2`) // x-www-form-urlencoded request body
+      .replace(/refresh_token=(.+?)(&|")/, `refresh_token=refresh_token$2`); // x-www-form-urlencoded request body
   }
   return fixture;
 }


### PR DESCRIPTION
- Mask `access_token` and `refresh_token` that can appear either in `post(..)` or `reply(..)`.  Thus the `.reply()` checks is removed
- Remove the customization in ACR.