### PR TITLE
[Core Lro] Release 1.0.5

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.0.5 (Unreleased)
+## 1.0.5 (2021-04-12)
 
+- Bug fix: Update compiled artifacts to use es6 instead of cjs modules.
 
 ## 1.0.4 (2021-03-30)
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.5 (2021-04-12)
 
-- Bug fix: Update compiled artifacts to use es6 instead of cjs modules.
+- No functionality changes from 1.0.4. This release is to correct an issue where 1.0.4 shipped with modules in the wrong format (cjs instead of es6.)
 
 ## 1.0.4 (2021-03-30)
 


### PR DESCRIPTION
v1.0.4 compiled artifacts use cjs modules and this release corrects this by switching to es6 modules instead.