### PR TITLE
[communication-chat] add missing communication-identity dependency in JS sample

### DIFF
--- a/sdk/communication/communication-chat/samples/javascript/package.json
+++ b/sdk/communication/communication-chat/samples/javascript/package.json
@@ -26,6 +26,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/communication-chat": "latest",
+    "@azure/communication-identity": "latest",
     "@azure/identity": "^1.1.0",
     "dotenv": "^8.2.0"
   }


### PR DESCRIPTION
Fixes #14820 

For some reason this was missed, typescript sample has the dependency