### PR TITLE
[Identity] Reducing DeviceCodeCredential intervals

### DIFF
--- a/sdk/identity/identity/recordings/node/devicecodecredential/recording_allows_setting_disableautomaticauthentication.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential/recording_allows_setting_disableautomaticauthentication.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval":5,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
+  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval":0.1,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
   'Cache-Control',
   'no-store, no-cache',
   'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_and_allows_the_customization_of_the_prompt_callback.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_and_allows_the_customization_of_the_prompt_callback.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=azure_client_id")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_with_default_values.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_with_default_values.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_with_provided_values.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential/recording_authenticates_with_provided_values.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=azure_client_id")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential/recording_supports_tracing.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential/recording_supports_tracing.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=azure_client_id")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential_internal/recording_authenticates_silently_after_the_initial_request.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential_internal/recording_authenticates_silently_after_the_initial_request.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=azure_client_id")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_accepts_tokencachepersistenceoptions.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_accepts_tokencachepersistenceoptions.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_allows_passing_an_authenticationrecord_to_avoid_further_manual_authentications.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_allows_passing_an_authenticationrecord_to_avoid_further_manual_authentications.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval":5,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
+  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval": 0.1,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
   'Cache-Control',
   'no-store, no-cache',
   'Pragma',
@@ -290,7 +290,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval":5,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
+  .reply(200, {"user_code":"USER_CODE","device_code":"DEVICE_CODE","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval": 0.1,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate."}, [
   'Cache-Control',
   'no-store, no-cache',
   'Pragma',

--- a/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_authenticates_silently_with_tokencachepersistenceoptions.js
+++ b/sdk/identity/identity/recordings/node/devicecodecredential_internal_persistent_tests/recording_authenticates_silently_with_tokencachepersistenceoptions.js
@@ -77,7 +77,7 @@ nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
 
 nock('https://login.microsoftonline.com:443', { "encodedQueryParams": true })
   .post('/organizations/oauth2/v2.0/devicecode', "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46")
-  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 5, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
+  .reply(200, { "user_code": "USER_CODE", "device_code": "DEVICE_CODE", "verification_uri": "https://microsoft.com/devicelogin", "expires_in": 900, "interval": 0.1, "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code USER_CODE to authenticate." }, [
     'Cache-Control',
     'no-store, no-cache',
     'Pragma',

--- a/sdk/identity/identity/test/msalTestUtils.ts
+++ b/sdk/identity/identity/test/msalTestUtils.ts
@@ -71,6 +71,7 @@ export function msalNodeTestSetup(
         recording.replace(/device_code":"[^"]*/g, `device_code":"DEVICE_CODE`),
       (recording: string): string =>
         recording.replace(/device_code=[^&]*/g, `device_code=DEVICE_CODE`),
+      (recording: string): string => recording.replace(/"interval": *[0-9]*/g, `"interval": 0.1`),
       // This last part is a JWT token that comes from the service, that has three parts joined by a dot.
       // Our fake id_token has the following parts encoded in base64 and joined by a dot:
       // - {"typ":"JWT","alg":"RS256","kid":"kid"}


### PR DESCRIPTION
This PR fixes the recordings (and the recorder settings) to reduce the DeviceCodeCredential intervals from 5 seconds to 0.1 seconds (I tried 0 seconds, but that didn't work).

Fixes #14375
Fixes #14267