### PR TITLE
Kick off all CI jobs in parallel instead of waiting on build

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -44,7 +44,6 @@ jobs:
           TestPipeline: ${{ parameters.TestPipeline }}
 
   - job: "Analyze"
-    dependsOn: "Build"
     variables:
       - template: ../variables/globals.yml
 
@@ -65,8 +64,6 @@ jobs:
     - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
       parameters:
         JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-        DependsOn:
-          - 'Build'
         MatrixConfigs: ${{ parameters.MatrixConfigs }}
         MatrixFilters: ${{ parameters.MatrixFilters }}
         MatrixReplace: ${{ parameters.MatrixReplace }}


### PR DESCRIPTION
There is nothing currently in the build job that is a pre-requisite for the Analyze and Test jobs in our CI pipelines. The only reasoning I can think of for why we would want to make these jobs sequential is to save agent time when the build or analyze step fails, but digging through the data this is not a common scenario (looking at the last week of failure analysis, I think ALL the failures are from the unit test jobs, not the build/analyze jobs).

Removing `DependsOn` here will allow PR authors to get signal on test failures anywhere from 5-20 minutes faster, which I think will significantly improve the dev loop in cases where test signal from CI is necessary (e.g. for cross-OS tests the dev can't run locally).