### PR TITLE
[attestation] upgrade `jsrsasign` to v10.2.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4379,10 +4379,10 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  /jsrsasign/10.1.13:
+  /jsrsasign/10.2.0:
     dev: false
     resolution:
-      integrity: sha512-EKifn2DocDxU2fWVqTJgFYjZUcL4fTUtfgN5OQP4t4i/WOioios8wq350E1aJFxCLmtdxGNqhLX3O0tdVqJoFg==
+      integrity: sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg==
   /jssha/2.4.2:
     deprecated: jsSHA versions < 3.0.0 will no longer receive feature updates
     dev: false
@@ -7920,7 +7920,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       dotenv: 8.2.0
       eslint: 7.23.0
-      jsrsasign: 10.1.13
+      jsrsasign: 10.2.0
       karma: 6.3.2
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -7950,7 +7950,7 @@ packages:
     dev: false
     name: '@rush-temp/attestation'
     resolution:
-      integrity: sha512-N5x401TVgKym6CeiIo+9X9gOZBUa5XozsIA09/92uwtF2VB6PPqVxWS6MRk1O/AcUmdrQoiFBi0ZxGKFVDra0Q==
+      integrity: sha512-308IFrOUbXclBJTqvF46pGIb+PckBwJ9PufzEE3dbB8mA9JIj+9838qEppUW8x9k2ENMx43+T6/FCh15qXsTgg==
       tarball: file:projects/attestation.tgz
     version: 0.0.0
   file:projects/communication-chat.tgz:

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -40,7 +40,7 @@
     "chai-as-promised": "^7.1.1",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
-    "jsrsasign": "^10.1.4",
+    "jsrsasign": "^10.2.0",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",


### PR DESCRIPTION
The new version addresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30246