### PR TITLE
[core-auth] [Identity] Added an optional property correlationId to the GetTokenOptions

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.1 (Unreleased)
 
+- Adds an optional property `correlationId` to the `GetTokenOptions`.
 
 ## 1.3.0 (2021-03-30)
 

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -44,6 +44,7 @@ export interface Context {
 // @public
 export interface GetTokenOptions {
     abortSignal?: AbortSignalLike;
+    correlationId?: string;
     requestOptions?: {
         timeout?: number;
     };

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -26,6 +26,10 @@ export interface TokenCredential {
  */
 export interface GetTokenOptions {
   /**
+   * A correlation Id can be send through the `getToken` calls, so that underlying requests can be better associated and traced through the HTTP logs.
+   */
+  correlationId?: string;
+  /**
    * The signal which can be used to abort requests.
    */
   abortSignal?: AbortSignalLike;


### PR DESCRIPTION
The new Identity gives users the ability to configure getTokenOptions, however that wasn't exposed since the credentials rely on this type from core-auth.

Though we could add this on Identity as a separate type, I believe we should add this property to core-auth.