### PR TITLE
[Communication] communication-identity test separation for min/max testing

### DIFF
--- a/sdk/communication/communication-identity/.vscode/launch.json
+++ b/sdk/communication/communication-identity/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--timeout",
         "999999",
         "--colors",
-        "${workspaceFolder}/test/*.spec.ts"
+        "${workspaceFolder}/test/**/*.spec.ts"
       ],
       "env": {
         "TS_NODE_COMPILER_OPTIONS": "{\"module\": \"commonjs\"}",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -23,7 +23,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 300000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace -t 300000  dist-esm/test/public/*.spec.js dist-esm/test/public/node/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",

--- a/sdk/communication/communication-identity/rollup.base.config.js
+++ b/sdk/communication/communication-identity/rollup.base.config.js
@@ -41,7 +41,7 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // Entry points - test files under the `test` folder(common for both browser and node), node specific test files
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
+    baseConfig.input = ["dist-esm/test/public/*.spec.js", "dist-esm/test/public/node/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
@@ -109,7 +109,7 @@ export function browserConfig(test = false) {
 
   if (test) {
     // Entry points - test files under the `test` folder(common for both browser and node), browser specific test files
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/browser/*.spec.js"];
+    baseConfig.input = ["dist-esm/test/public/*.spec.js", "dist-esm/test/public/browser/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "dist-test/index.browser.js";
 

--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "@azure/communication-common";
 import { assert } from "chai";
 import sinon from "sinon";
-import { CommunicationIdentityClient } from "../src";
+import { CommunicationIdentityClient } from "../../src";
 import { TestCommunicationIdentityClient } from "./utils/testCommunicationIdentityClient";
 import { getTokenHttpClient } from "./utils/mockHttpClients";
 

--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@azure/communication-common";
 import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
-import { CommunicationIdentityClient } from "../src";
+import { CommunicationIdentityClient } from "../../src";
 import { createRecordedCommunicationIdentityClient } from "./utils/recordedClient";
 import { Context } from "mocha";
 

--- a/sdk/communication/communication-identity/test/public/communicationIdentityClientWithToken.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClientWithToken.spec.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
-import { CommunicationIdentityClient } from "../src";
+import { CommunicationIdentityClient } from "../../src";
 import { createRecordedCommunicationIdentityClientWithToken } from "./utils/recordedClient";
 import { Context } from "mocha";
 

--- a/sdk/communication/communication-identity/test/public/utils/mockHttpClients.ts
+++ b/sdk/communication/communication-identity/test/public/utils/mockHttpClients.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { HttpClient, WebResourceLike, HttpOperationResponse, HttpHeaders } from "@azure/core-http";
-import { CommunicationAccessToken } from "../../src";
-import { CommunicationIdentityAccessTokenResult } from "../../src/generated/src/models";
+import { CommunicationAccessToken } from "../../../src";
+import { CommunicationIdentityAccessTokenResult } from "../../../src/generated/src/models";
 
 export const createMockHttpClient = <T = Record<string, unknown>>(
   status: number = 200,

--- a/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
@@ -12,7 +12,7 @@ import {
   isPlaybackMode
 } from "@azure/test-utils-recorder";
 import { isNode, TokenCredential } from "@azure/core-http";
-import { CommunicationIdentityClient } from "../../src";
+import { CommunicationIdentityClient } from "../../../src";
 import { DefaultAzureCredential } from "@azure/identity";
 import { parseConnectionString } from "@azure/communication-common";
 

--- a/sdk/communication/communication-identity/test/public/utils/testCommunicationIdentityClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/testCommunicationIdentityClient.ts
@@ -6,6 +6,7 @@ import { CommunicationUserIdentifier } from "@azure/communication-common";
 import {
   CommunicationAccessToken,
   CommunicationIdentityClient,
+  CommunicationIdentityClientOptions,
   CommunicationUserToken,
   TokenScope
 } from "../../../src";
@@ -24,38 +25,42 @@ export class TestCommunicationIdentityClient {
     scopes: TokenScope[],
     options: OperationOptions = {}
   ): Promise<CommunicationAccessToken> {
+    // casting is a workaround to enable min-max testing
     const client = new CommunicationIdentityClient(this.connectionString, {
       httpClient: getTokenHttpClient
-    });
-    return client.getToken(user, scopes, options);
+    } as CommunicationIdentityClientOptions);
+    return client.getToken(user, scopes, options as any);
   }
 
   public async revokeTokensTest(
     user: CommunicationUserIdentifier,
     options: OperationOptions = {}
   ): Promise<void> {
+    // casting is a workaround to enable min-max testing
     const client = new CommunicationIdentityClient(this.connectionString, {
       httpClient: revokeTokensHttpClient
-    });
-    return client.revokeTokens(user, options);
+    } as CommunicationIdentityClientOptions);
+    return client.revokeTokens(user, options as any);
   }
 
   public async createUserTest(
     options: OperationOptions = {}
   ): Promise<CommunicationUserIdentifier> {
+    // casting is a workaround to enable min-max testing
     const client = new CommunicationIdentityClient(this.connectionString, {
       httpClient: createUserHttpClient
-    });
-    return client.createUser(options);
+    } as CommunicationIdentityClientOptions);
+    return client.createUser(options as any);
   }
 
   public async createUserAndTokenTest(
     scopes: TokenScope[],
     options: OperationOptions = {}
   ): Promise<CommunicationUserToken> {
+    // casting is a workaround to enable min-max testing
     const client = new CommunicationIdentityClient(this.connectionString, {
       httpClient: createUserAndTokenHttpClient
-    });
-    return client.createUserAndToken(scopes, options);
+    } as CommunicationIdentityClientOptions);
+    return client.createUserAndToken(scopes, options as any);
   }
 }

--- a/sdk/communication/communication-identity/test/public/utils/testCommunicationIdentityClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/testCommunicationIdentityClient.ts
@@ -8,7 +8,7 @@ import {
   CommunicationIdentityClient,
   CommunicationUserToken,
   TokenScope
-} from "../../src";
+} from "../../../src";
 import {
   getTokenHttpClient,
   createUserHttpClient,


### PR DESCRIPTION
This addresses [this github issue](https://github.com/Azure/azure-sdk-for-js/issues/13816) for the communication identity package.

There's also a workaround that's been added due to an issue with module resolution for min-max testing. It's being investigated