### PR TITLE
[service-bus] Fixing some issues I introduced in an early merge

### DIFF
--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -498,7 +498,6 @@ describe("ServiceBusMessage validations", function(): void {
 
       await sender.sendMessages(testInput.message).catch((err) => {
         actualErrorMsg = err.message;
-        console.log(`=====> Caught error = `, err);
       });
 
       should.equal(actualErrorMsg, testInput.expectedErrorMessage, "Error not thrown as expected");

--- a/sdk/servicebus/service-bus/test/public/sessionsRequiredCleanEntityTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sessionsRequiredCleanEntityTests.spec.ts
@@ -50,8 +50,11 @@ describe("sessions tests -  requires completely clean entity for each test", () 
     // }
   }
 
-  afterEach(() => serviceBusClient.test.afterEach());
-  after(() => serviceBusClient.test.after());
+  afterEach(async () => {
+    await serviceBusClient.test.afterEach();
+    // each test recreates the client on start so we need to clean the entire thing up after each test.
+    await serviceBusClient.test.after();
+  });
 
   // These tests really do need to run against both queues and subscriptions as they seem
   // to behave differently on occasion when it runs against subscriptions.


### PR DESCRIPTION
One of my previous PRs merged earlier than the live test execution. Fixing some issues that were remaining:

- the ServiceBusClient in the test wasn't being closed after each test (sessionsRequiredCleanEntityTests.spec.ts is special in that it has to recreate new entities for each test). This is responsible for the current 3+ hour test executions happening in master for SB.
- Removed a stray console.log statement I left in the test.