### PR TITLE
[Cosmos] Fixes MRW conflict worker because of uncaught 404s

### DIFF
--- a/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/ConflictWorker.ts
+++ b/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/ConflictWorker.ts
@@ -466,7 +466,11 @@ export class ConflictWorker {
     if (hasDeleteConflict) {
       do {
         try {
-          await container.item(items[0].id, undefined).read();
+          const response = await container.item(items[0].id, undefined).read();
+          if (response.statusCode === StatusCodes.NotFound) {
+            console.log(`Delete conflict won @ ${regionName}`);
+            return;
+          }
         } catch (err) {
           if (err.code === StatusCodes.NotFound) {
             console.log(`Delete conflict won @ ${regionName}`);
@@ -654,7 +658,11 @@ export class ConflictWorker {
     if (hasDeleteConflict) {
       do {
         try {
-          await container.item(items[0].id, undefined).read();
+          const response = await container.item(items[0].id, undefined).read();
+          if (response.statusCode === StatusCodes.NotFound) {
+            console.log(`Delete conflict won @ ${regionName}`);
+            return;
+          }
         } catch (err) {
           if (err.code === StatusCodes.NotFound) {
             console.log(`Delete conflict won @ ${regionName}`);

--- a/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/Worker.ts
+++ b/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/Worker.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { v4 as guid } from "uuid";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { Container } from "../../dist";
 
 export class Worker {


### PR DESCRIPTION
These 404s weren't uncaught errors, just successful responses with 404 status, so `try {} catch {}` failed. I left the catch in just for other error types, and in case that did work for a different type of backend or backend response.