### PR TITLE
[service-bus] Converting `parallel receive` live tests to unit tests

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusReceiverUnitTests.spec.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BatchingReceiver } from "../../../src/core/batchingReceiver";
+import { ServiceBusReceiverImpl } from "../../../src/receivers/receiver";
+import { assertThrows } from "../../public/utils/testUtils";
+import { createConnectionContextForTests, getPromiseResolverForTest } from "./unittestUtils";
+import chai from "chai";
+import { InternalMessageHandlers } from "../../../src/models";
+const assert = chai.assert;
+
+describe("ServiceBusReceiver unit tests", () => {
+  let receiver: ServiceBusReceiverImpl;
+
+  beforeEach(() => {
+    receiver = new ServiceBusReceiverImpl(
+      createConnectionContextForTests(),
+      "entityPath",
+      "peekLock",
+      0
+    );
+  });
+
+  afterEach(() => receiver.close());
+
+  const expectedError: Record<string, any> = {
+    name: "Error",
+    message: 'The receiver for "entityPath" is already receiving messages.'
+  };
+
+  it("isAlreadyReceiving (batching first, then streaming)", async () => {
+    assert.isFalse(receiver["_isReceivingMessages"](), "Nothing should be receiving messages");
+
+    receiver["_batchingReceiver"] = {
+      isOpen: () => true,
+      isReceivingMessages: true,
+      close: async () => {}
+    } as BatchingReceiver;
+
+    assert.isTrue(receiver["_isReceivingMessages"](), "Batching receiver is receiving messages");
+
+    const subscribeFn = async () => {
+      receiver.subscribe({
+        processError: async (_errArgs) => {},
+        processMessage: async (_msg) => {}
+      });
+    };
+
+    await assertThrows(
+      subscribeFn,
+      expectedError,
+      "Trying to receive a separate way, in parallel, should throw"
+    );
+  });
+
+  it("isAlreadyReceiving (streaming first, then batching)", async () => {
+    assert.isFalse(receiver["_isReceivingMessages"](), "Nothing should be receiving messages");
+
+    const { promise: subscriberInitializedPromise, resolve } = getPromiseResolverForTest();
+
+    receiver.subscribe({
+      processInitialize: async () => {
+        resolve();
+      },
+      processError: async (_errArgs) => {},
+      processMessage: async (_msg) => {}
+    } as InternalMessageHandlers);
+
+    await subscriberInitializedPromise;
+
+    assert.isTrue(receiver["_isReceivingMessages"](), "Streaming receiver is receiving messages");
+
+    await assertThrows(
+      () => receiver.receiveMessages(1),
+      expectedError,
+      "Trying to receive a separate way, in parallel, should throw"
+    );
+  });
+});

--- a/sdk/servicebus/service-bus/test/public/utils/testUtils.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/testUtils.ts
@@ -210,7 +210,8 @@ export enum EntityNames {
  */
 export async function assertThrows<T>(
   fn: () => Promise<T>,
-  expectedErr: Record<string, any>
+  expectedErr: Record<string, any>,
+  assertMessage?: string
 ): Promise<Error> {
   try {
     await fn();
@@ -225,5 +226,5 @@ export async function assertThrows<T>(
     return err;
   }
 
-  throw new Error("assert failure: error was expected, but none was thrown");
+  throw new Error(`assert failure, an error was expected, but none was thrown: ${assertMessage}`);
 }


### PR DESCRIPTION
There were two live tests that were basically exercising a small segment of validation code to make sure you can't try to receiveMessages() and subscribe() at the same time. These tests have been flaky in the past, and were really only testing logic so I just migrated them to unit tests instead.