### PR TITLE
[KeyVault] - Remove KeyOperationsOptions from public API

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -118,7 +118,7 @@ export interface CryptographyOptions extends coreHttp.OperationOptions {
 }
 
 // @public
-export interface DecryptOptions extends KeyOperationsOptions {
+export interface DecryptOptions extends CryptographyOptions {
 }
 
 // @public
@@ -152,7 +152,7 @@ export type DeletionRecoveryLevel = string;
 export type EncryptionAlgorithm = string;
 
 // @public
-export interface EncryptOptions extends KeyOperationsOptions {
+export interface EncryptOptions extends CryptographyOptions {
 }
 
 // @public
@@ -240,10 +240,6 @@ export type KeyCurveName = string;
 
 // @public
 export type KeyOperation = string;
-
-// @public
-export interface KeyOperationsOptions extends CryptographyOptions {
-}
 
 // @public
 export interface KeyPollerOptions extends coreHttp.OperationOptions {
@@ -431,7 +427,7 @@ export interface SignResult {
 }
 
 // @public
-export interface UnwrapKeyOptions extends KeyOperationsOptions {
+export interface UnwrapKeyOptions extends CryptographyOptions {
 }
 
 // @public
@@ -467,7 +463,7 @@ export interface VerifyResult {
 }
 
 // @public
-export interface WrapKeyOptions extends KeyOperationsOptions {
+export interface WrapKeyOptions extends CryptographyOptions {
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -149,19 +149,14 @@ export interface VerifyResult {
 }
 
 /**
- * Common optional properties for encrypt, decrypt, wrap and unwrap.
- */
-export interface KeyOperationsOptions extends CryptographyOptions {}
-
-/**
  * Options for {@link encrypt}.
  */
-export interface EncryptOptions extends KeyOperationsOptions {}
+export interface EncryptOptions extends CryptographyOptions {}
 
 /**
  * Options for {@link decrypt}.
  */
-export interface DecryptOptions extends KeyOperationsOptions {}
+export interface DecryptOptions extends CryptographyOptions {}
 
 /**
  * Options for {@link sign}.
@@ -181,12 +176,12 @@ export interface VerifyDataOptions extends CryptographyOptions {}
 /**
  * Options for {@link wrapKey}.
  */
-export interface WrapKeyOptions extends KeyOperationsOptions {}
+export interface WrapKeyOptions extends CryptographyOptions {}
 
 /**
  * Options for {@link unwrapKey}.
  */
-export interface UnwrapKeyOptions extends KeyOperationsOptions {}
+export interface UnwrapKeyOptions extends CryptographyOptions {}
 
 /**
  * A union type representing all supported RSA encryption algorithms.

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -78,7 +78,6 @@ import {
   UnwrapResult,
   VerifyResult,
   WrapResult,
-  KeyOperationsOptions,
   EncryptResult,
   DecryptOptions,
   EncryptOptions,
@@ -106,7 +105,6 @@ import { createTraceFunction } from "../../keyvault-common/src";
 
 export {
   CryptographyClientOptions,
-  KeyOperationsOptions,
   KeyClientOptions,
   BackupKeyOptions,
   CreateEcKeyOptions,


### PR DESCRIPTION
## What

- Remove `KeyOperationOptions` from cryptography API and use `CryptographyOptions` everywhere

## Why

`KeyOperationsOptions` was used as a common placeholder for `iv`, `additionalAuthenticatedData`, and `authenticationTag` up until very recently:  https://github.com/Azure/azure-sdk-for-js/pull/13889/files#diff-7e7a216d0920c250e6742ecece9de13be1712657c97776fbfbfec386896cab13L141-L155

Because we moved to using `EncryptParameters` and `DecryptParameters` we no longer need a common type for a subset of cryptography operations. This PR just cleans up the public API a bit before we GA. 