### PR TITLE
Support multiple subscription configuration options

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -69,12 +69,17 @@ jobs:
           AgentImage: $(OSVmImage)
 
       - ${{ if ne(parameters.ServiceDirectory, '') }}:
+        - template: /eng/common/TestResources/build-test-resource-config.yml
+          parameters:
+            SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
+            SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
+
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             ${{ if or(parameters.Location, parameters.CloudConfig.Location) }}:
               Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-            SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
+            SubscriptionConfiguration: $(SubscriptionConfiguration)
             ArmTemplateParameters: $(ArmTemplateParameters)
 
       - script: |
@@ -160,7 +165,7 @@ jobs:
         - template: /eng/common/TestResources/remove-test-resources.yml
           parameters:
             ServiceDirectory: "${{ parameters.ServiceDirectory }}"
-            SubscriptionConfiguration: '${{ parameters.CloudConfig.SubscriptionConfiguration }}'
+            SubscriptionConfiguration: $(SubscriptionConfiguration)
 
       - task: PublishCodeCoverageResults@1
         displayName: "Publish NodeJs Code Coverage to DevOps"


### PR DESCRIPTION
This PR enables live tests to use multiple subscription configurations per cloud instead of one. Currently there are some services that need to manage their own cloud-specific values in a keyvault they control (e.g. acs, storage), but also need to use some shared values that only Azure SDK engineering systems can have access to, like service principal credentials.

This change takes advantage of a [recent update](https://github.com/Azure/azure-sdk-tools/pull/1560) to enable merging multiple subscription configurations together before passing the value to the ARM template deployment job.