### PR TITLE
Remove duplicate calls to bypass-local-dns.yml

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -64,10 +64,6 @@ jobs:
     steps:
       - template: ../steps/common.yml
 
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-        parameters:
-          AgentImage: $(OSVmImage)
-
       - ${{ if ne(parameters.ServiceDirectory, '') }}:
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -107,10 +107,6 @@ jobs:
         value: "@{ storageEndpointSuffix = 'core.chinacloudapi.cn'; cognitiveServicesEndpointSuffix = 'cognitiveservices.azure.cn'; searchSku = 'basic' }"
 
     steps:
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-        parameters:
-          AgentImage: $(OSVmImage)
-
       - template: /eng/pipelines/templates/steps/common.yml
 
       - template: /eng/pipelines/templates/steps/use-node-version.yml

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -1,5 +1,7 @@
 steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+    parameters:
+      AgentImage: $(OSVmImage)
 
   - task: UsePythonVersion@0
     displayName: "Use Python 3.6"

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -1,5 +1,5 @@
 steps:
-  - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml
+  - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - task: UsePythonVersion@0
     displayName: "Use Python 3.6"


### PR DESCRIPTION
- common.yml should call verify-agent-os.yml, to verify OS in any pipeline using common.yml
- bypass-local-dns.yml is now called from verify-agent-os.yml
- Removed duplicate calls to verify-agent-os.yml in pipelines already calling common.yml
