### PR TITLE
Revert "Revise stage condition. (#14851)"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -229,7 +229,7 @@ stages:
     - job: PublishPackages
       # Run Integration job only if SetDevVersion is set to true or ( SetDevVersion is empty and job is a scheduled CI run)
       # If SetDevVersion is set to false then we should skip integration job even for scheduled runs.
-      condition: and(eq(variables['SetDevVersion'], 'true'), eq(variables['System.TeamProject'], 'internal'))
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['SetDevVersion'], ''), eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
       displayName: Publish package to daily feed
       pool:
         name: azsdk-pool-mms-ubuntu-1804-general


### PR DESCRIPTION
This reverts commit 64668dca74f22a4e5cb817bce8a753f18710a1aa. Unfortunately the SetDevVersion variable was never working correctly, so removing the duplicated conditions in the expressions broke nightly package publishing. To get nightly publishing unblocked for the JS repo I've reverted the commit for now. A subsequent commit will tidy up the expression after I've got the variable plumbed across.