### PR TITLE
Add karma --no-sandbox config

### DIFF
--- a/sdk/communication/communication-common/karma.conf.js
+++ b/sdk/communication/communication-common/karma.conf.js
@@ -91,7 +91,7 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
     browsers: ["HeadlessChrome"],
-    
+
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",

--- a/sdk/communication/communication-common/karma.conf.js
+++ b/sdk/communication/communication-common/karma.conf.js
@@ -90,7 +90,14 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["HeadlessChrome"],
+    
+    customLaunchers: {
+      HeadlessChrome: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/communication/communication-identity/karma.conf.js
+++ b/sdk/communication/communication-identity/karma.conf.js
@@ -114,7 +114,7 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
     browsers: ["HeadlessChrome"],
-    
+
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",

--- a/sdk/communication/communication-identity/karma.conf.js
+++ b/sdk/communication/communication-identity/karma.conf.js
@@ -113,7 +113,14 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["HeadlessChrome"],
+    
+    customLaunchers: {
+      HeadlessChrome: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -112,7 +112,7 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
     browsers: ["HeadlessChrome"],
-    
+
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -111,7 +111,14 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["HeadlessChrome"],
+    
+    customLaunchers: {
+      HeadlessChrome: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -112,7 +112,14 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["HeadlessChrome"],
+    
+    customLaunchers: {
+      HeadlessChrome: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -113,7 +113,7 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
     browsers: ["HeadlessChrome"],
-    
+
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",


### PR DESCRIPTION
Running tests without this setting is causing issues in some machines.
Adding this configuration will also allow tests to work in container environments as well.


`communication-chat` package already uses this setting, so now all communication packages use the same configuration.