### PR TITLE
[Document Translator] Fix typedef file name

### DIFF
--- a/sdk/documenttranslator/ai-document-translator-rest/.eslintrc.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/.eslintrc.json
@@ -2,6 +2,8 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-modules-only-named": "warn"
+    "@azure/azure-sdk/ts-modules-only-named": "warn",
+    "@azure/azure-sdk/ts-apiextractor-json-types": "warn",
+    "@azure/azure-sdk/ts-package-json-types": "warn"
   }
 }

--- a/sdk/documenttranslator/ai-document-translator-rest/api-extractor.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/ai-document-translator-rest.d.ts"
+    "publicTrimmedFilePath": "./types/ai-document-translator.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
-  "types": "./types/ai-document-translator-rest.d.ts",
+  "types": "./types/ai-document-translator.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/documenttranslator/ai-document-translator/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "bugs": {


### PR DESCRIPTION
During pre-release validation I realized that there was a miss match in the typings file name between package.files and api-extractor config. This causes the package to not include any type definitions file.

 