### PR TITLE
Pass SubscriptionConfigurations parameter through to live test job

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -110,5 +110,6 @@ stages:
               - ${{ parameters.MatrixReplace }}
             CloudConfig:
               SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}
+              SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
               Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
               Cloud: ${{ cloud.key }}


### PR DESCRIPTION
I missed one place in https://github.com/Azure/azure-sdk-for-js/pull/14933 where we need to plumb the `SubscriptionConfigurations` parameter through to the live test config.