### PR TITLE
[KeyVault] - Address various architecture feedback

### DIFF
--- a/sdk/keyvault/keyvault-admin/README.md
+++ b/sdk/keyvault/keyvault-admin/README.md
@@ -183,15 +183,15 @@ A Role Assignment is the association of a Role Definition to a service principal
 
 ### KeyVaultAccessControlClient
 
-A `KeyVaultAccessControlClient` provides both synchronous and asynchronous operations allowing for management of Role Definitions (instances of `KeyVaultRoleDefinition`) and Role Assignments (instances of `KeyVaultRoleAssignment`).
+A `KeyVaultAccessControlClient` provides operations allowing for management of Role Definitions (instances of `KeyVaultRoleDefinition`) and Role Assignments (instances of `KeyVaultRoleAssignment`).
 
 ### KeyVaultBackupClient
 
-A `KeyVaultBackupClient` provides both synchronous and asynchronous operations for performing full key backups, full key restores, and selective key restores.
+A `KeyVaultBackupClient` provides operations for performing full key backups, full key restores, and selective key restores.
 
 ### Long running operations
 
-The operations done by the `KeyVaultBackupClient` may take as much time as needed by the Azure resources, requiring a client layer to keep track, serialize and resume the operations through the lifecycle of the programs that wait for them to finish. This is done via a common abstraction through the package [@azure/core-lro][core-lro].
+The operations done by the `KeyVaultBackupClient` may take as much time as needed by the Azure resources, requiring a client layer to keep track, serialize, and resume the operations through the lifecycle of the programs that wait for them to finish. This is done via a common abstraction through the package [@azure/core-lro][core-lro].
 
 The `KeyVaultBackupClient` offers three methods that execute long running operations:
 

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -93,7 +93,7 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 
 // @public
 export class KeyVaultBackupClient {
-    constructor(vaultUrl: string, credential: TokenCredential, pipelineOptions?: BackupClientOptions);
+    constructor(vaultUrl: string, credential: TokenCredential, options?: BackupClientOptions);
     beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, BackupResult>>;
     beginRestore(blobStorageUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, RestoreResult>>;
     beginSelectiveRestore(blobStorageUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>>;

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -70,7 +70,7 @@ export class KeyVaultBackupClient {
    * ```
    * @param vaultUrl - the URL of the Key Vault. It should have this shape: `https://${your-key-vault-name}.vault.azure.net`
    * @param credential - An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the \@azure/identity package to create a credential that suits your needs.
-   * @param options - Pipeline options used to configure Key Vault API requests. Omit this parameter to use the default pipeline configuration.
+   * @param options - options used to configure Key Vault API requests.
    */
   constructor(vaultUrl: string, credential: TokenCredential, options: BackupClientOptions = {}) {
     this.vaultUrl = vaultUrl;

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -70,20 +70,16 @@ export class KeyVaultBackupClient {
    * ```
    * @param vaultUrl - the URL of the Key Vault. It should have this shape: `https://${your-key-vault-name}.vault.azure.net`
    * @param credential - An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the \@azure/identity package to create a credential that suits your needs.
-   * @param pipelineOptions - Pipeline options used to configure Key Vault API requests. Omit this parameter to use the default pipeline configuration.
+   * @param options - Pipeline options used to configure Key Vault API requests. Omit this parameter to use the default pipeline configuration.
    */
-  constructor(
-    vaultUrl: string,
-    credential: TokenCredential,
-    pipelineOptions: BackupClientOptions = {}
-  ) {
+  constructor(vaultUrl: string, credential: TokenCredential, options: BackupClientOptions = {}) {
     this.vaultUrl = vaultUrl;
 
     const libInfo = `azsdk-js-keyvault-admin/${SDK_VERSION}`;
 
-    const userAgentOptions = pipelineOptions.userAgentOptions;
+    const userAgentOptions = options.userAgentOptions;
 
-    pipelineOptions.userAgentOptions = {
+    options.userAgentOptions = {
       userAgentPrefix:
         userAgentOptions && userAgentOptions.userAgentPrefix
           ? `${userAgentOptions.userAgentPrefix} ${libInfo}`
@@ -95,7 +91,7 @@ export class KeyVaultBackupClient {
       : signingPolicy(credential);
 
     const internalPipelineOptions: InternalPipelineOptions = {
-      ...pipelineOptions,
+      ...options,
       loggingOptions: {
         logger: logger.info,
         allowedHeaderNames: [
@@ -110,7 +106,7 @@ export class KeyVaultBackupClient {
       internalPipelineOptions,
       authPolicy
     );
-    params.apiVersion = pipelineOptions.serviceVersion || LATEST_API_VERSION;
+    params.apiVersion = options.serviceVersion || LATEST_API_VERSION;
     this.client = new KeyVaultClient(params);
   }
 

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -97,7 +97,7 @@ export class CryptographyClient {
     encrypt(encryptParameters: EncryptParameters, options?: EncryptOptions): Promise<EncryptResult>;
     // @deprecated
     encrypt(algorithm: EncryptionAlgorithm, plaintext: Uint8Array, options?: EncryptOptions): Promise<EncryptResult>;
-    get keyId(): string | undefined;
+    get keyID(): string | undefined;
     sign(algorithm: SignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;
     signData(algorithm: SignatureAlgorithm, data: Uint8Array, options?: SignOptions): Promise<SignResult>;
     unwrapKey(algorithm: KeyWrapAlgorithm, encryptedKey: Uint8Array, options?: UnwrapKeyOptions): Promise<UnwrapResult>;

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -62,7 +62,6 @@ export interface BeginRecoverDeletedKeyOptions extends KeyPollerOptions {
 
 // @public
 export interface CreateEcKeyOptions extends CreateKeyOptions {
-    hsm?: boolean;
 }
 
 // @public
@@ -70,6 +69,7 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
     curve?: KeyCurveName;
     enabled?: boolean;
     readonly expiresOn?: Date;
+    hsm?: boolean;
     keyOps?: KeyOperation[];
     keySize?: number;
     notBefore?: Date;
@@ -80,12 +80,10 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
 
 // @public
 export interface CreateOctKeyOptions extends CreateKeyOptions {
-    hsm?: boolean;
 }
 
 // @public
 export interface CreateRsaKeyOptions extends CreateKeyOptions {
-    hsm?: boolean;
     publicExponent?: number;
 }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -142,7 +142,7 @@ export class CryptographyClient {
   /**
    * The ID of the key used to perform cryptographic operations for the client.
    */
-  get keyId(): string | undefined {
+  get keyID(): string | undefined {
     if (this.key.kind === "identifier") {
       return this.key.value;
     } else if (this.key.kind === "KeyVaultKey") {

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -300,6 +300,10 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
    * Possible values include: 'P-256', 'P-384', 'P-521', 'P-256K'
    */
   curve?: KeyCurveName;
+  /**
+   * Whether to import as a hardware key (HSM) or software key.
+   */
+  hsm?: boolean;
 }
 
 /**
@@ -333,23 +337,13 @@ export interface BeginRecoverDeletedKeyOptions extends KeyPollerOptions {}
  * An interface representing the optional parameters that can be
  * passed to {@link createEcKey}
  */
-export interface CreateEcKeyOptions extends CreateKeyOptions {
-  /**
-   * Whether to import as a hardware key (HSM) or software key.
-   */
-  hsm?: boolean;
-}
+export interface CreateEcKeyOptions extends CreateKeyOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link createRsaKey}
  */
 export interface CreateRsaKeyOptions extends CreateKeyOptions {
-  /**
-   * Whether to import as a hardware key (HSM) or software key.
-   */
-  hsm?: boolean;
-
   /** The public exponent for a RSA key. */
   publicExponent?: number;
 }
@@ -358,12 +352,7 @@ export interface CreateRsaKeyOptions extends CreateKeyOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link createOctKey}
  */
-export interface CreateOctKeyOptions extends CreateKeyOptions {
-  /**
-   * Whether to create a hardware-protected key in a hardware security module (HSM).
-   */
-  hsm?: boolean;
-}
+export interface CreateOctKeyOptions extends CreateKeyOptions {}
 
 /**
  * An interface representing the optional parameters that can be

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -55,7 +55,7 @@ describe("Local cryptography public tests", () => {
 
     it("the CryptographyClient can be created from a local JsonWebKey object", async function() {
       assert.isEmpty(cryptoClientFromKey.vaultUrl);
-      assert.equal(cryptoClientFromKey.keyId, customKeyVaultKey.id);
+      assert.equal(cryptoClientFromKey.keyID, customKeyVaultKey.id);
     });
 
     describe("when using an unsupported algorithm", function() {


### PR DESCRIPTION
## What

- KeyVaultBackupClient constructor: pipelineOptions -> options
- CryptographyClient: keyId -> keyID
- createKeyOptions: +hsm

## Why

As part of pre-GA architecture feedback with @chradek we discovered a few things that we would want to address
before we GA the KeyVault packages in May. This PR is meant to collect all the various items and keep track of what
was changed.