### PR TITLE
Use 1es hosted pools for smoke tests

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -15,7 +15,8 @@ jobs:
       variables:
         - template: /eng/pipelines/templates/variables/globals.yml
       pool:
-        vmImage: $(OSVmImage)
+        name: "azsdk-pool-mms-ubuntu-1804-general"
+        vmImage: "MMSUbuntu18.04"
       displayName: Check Smoke Test Eligibility
       steps:
         - template: /eng/pipelines/templates/steps/use-node-version.yml
@@ -64,20 +65,20 @@ jobs:
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "10.x"
         Windows Node12 (AzureCloud):
-          Pool: Azure Pipelines
-          OSVmImage: "windows-2019"
+          Pool: "azsdk-pool-mms-win-2019-general"
+          OSVmImage: "MMS2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "12.x"
         Linux Node14 (AzureCloud):
-          Pool: Azure Pipelines
-          OSVmImage: "ubuntu-18.04"
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "14.x"
         Linux Node16 (AzureCloud):
-          Pool: Azure Pipelines
-          OSVmImage: "ubuntu-18.04"
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "16.x"


### PR DESCRIPTION
This PR switches the smoke test jobs and utility jobs to use the 1es hosted agents for windows and ubuntu runs.