### PR TITLE
[core-client] wrap response body for more mapper types

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.1 (Unreleased)
 
 - Expose `allowInsecureConnection` in `ServiceClientOptions` and `OperationRequestOptions` to allow operation requests to HTTP endpoints
+- Add back a missed condition when refactoring in #14387
 
 ## 1.1.0 (2021-03-30)
 

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.1 (Unreleased)
 
 - Expose `allowInsecureConnection` in `ServiceClientOptions` and `OperationRequestOptions` to allow operation requests to HTTP endpoints
-- Add back a missed condition when refactoring in #14387
+- Consider more mapper types as primitive thus requires wrapping
 
 ## 1.1.0 (2021-03-30)
 

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -176,6 +176,6 @@ export function flattenResponse(
     shouldWrapBody:
       expectedBodyTypeName !== "Composite" &&
       expectedBodyTypeName !== "Dictionary" &&
-      isPrimitiveBody(fullResponse.parsedBody)
+      (Boolean(bodyMapper) || isPrimitiveBody(fullResponse.parsedBody))
   });
 }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -7,7 +7,7 @@ import { CompositeMapper, FullOperationResponse, OperationResponseMap } from "./
  * The union of all possible types for a primitive response body.
  * @internal
  */
-export type BodyPrimitive = number | string | boolean | undefined | null;
+export type BodyPrimitive = number | string | boolean | Date | Uint8Array | undefined | null;
 
 /**
  * A type guard for a primitive response body.
@@ -15,11 +15,13 @@ export type BodyPrimitive = number | string | boolean | undefined | null;
  *
  * @internal
  */
-export function isPrimitiveBody(value: unknown): value is BodyPrimitive {
+export function isPrimitiveBody(value: unknown, mapperTypeName?: string): value is BodyPrimitive {
   return (
     typeof value === "string" ||
     typeof value === "number" ||
     typeof value === "boolean" ||
+    mapperTypeName?.match(/^(Date|DateTime|DateTimeRfc1123|UnixTime|ByteArray|Base64Url)$/i) !==
+      null ||
     value === undefined ||
     value === null
   );
@@ -176,6 +178,6 @@ export function flattenResponse(
     shouldWrapBody:
       expectedBodyTypeName !== "Composite" &&
       expectedBodyTypeName !== "Dictionary" &&
-      (Boolean(bodyMapper) || isPrimitiveBody(fullResponse.parsedBody))
+      isPrimitiveBody(fullResponse.parsedBody, expectedBodyTypeName)
   });
 }

--- a/sdk/core/core-client/src/utils.ts
+++ b/sdk/core/core-client/src/utils.ts
@@ -17,13 +17,15 @@ export type BodyPrimitive = number | string | boolean | Date | Uint8Array | unde
  */
 export function isPrimitiveBody(value: unknown, mapperTypeName?: string): value is BodyPrimitive {
   return (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean" ||
-    mapperTypeName?.match(/^(Date|DateTime|DateTimeRfc1123|UnixTime|ByteArray|Base64Url)$/i) !==
-      null ||
-    value === undefined ||
-    value === null
+    mapperTypeName !== "Composite" &&
+    mapperTypeName !== "Dictionary" &&
+    (typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      mapperTypeName?.match(/^(Date|DateTime|DateTimeRfc1123|UnixTime|ByteArray|Base64Url)$/i) !==
+        null ||
+      value === undefined ||
+      value === null)
   );
 }
 
@@ -175,9 +177,6 @@ export function flattenResponse(
     body: fullResponse.parsedBody,
     headers: parsedHeaders,
     hasNullableType: isNullable,
-    shouldWrapBody:
-      expectedBodyTypeName !== "Composite" &&
-      expectedBodyTypeName !== "Dictionary" &&
-      isPrimitiveBody(fullResponse.parsedBody, expectedBodyTypeName)
+    shouldWrapBody: isPrimitiveBody(fullResponse.parsedBody, expectedBodyTypeName)
   });
 }

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -1165,6 +1165,35 @@ describe("ServiceClient", function() {
       operationSpec
     );
   });
+
+  it("should wrap body when bodyWrapper is specified", async function() {
+    const operationSpec: OperationSpec = {
+      path: "/datetime/invalid",
+      httpMethod: "GET",
+      responses: {
+        200: {
+          bodyMapper: { type: { name: "DateTime" } }
+        }
+      },
+      baseUrl: "http://example.com",
+      serializer: createSerializer()
+    };
+
+    const client = new ServiceClient({
+      httpClient: {
+        sendRequest: (req) => {
+          return Promise.resolve({
+            request: req,
+            status: 200,
+            headers: createHttpHeaders(),
+            bodyAsText: `"201O-18-90D00:89:56.9AX"`
+          });
+        }
+      }
+    });
+    const response = await client.sendOperationRequest<{ body: Date }>({}, operationSpec);
+    assert.ok(response.body);
+  });
 });
 
 async function testSendOperationRequest(


### PR DESCRIPTION
This PR adds back a missing condition during the refactoring in #14387