### PR TITLE
[Identity] - Add instructions for running Identity test in Azure Arc

### DIFF
--- a/sdk/identity/identity/test/manual-integration/AzureArc/INSTRUCTIONS.md
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/INSTRUCTIONS.md
@@ -1,0 +1,73 @@
+# Testing Identity in Azure Arc
+
+## Prerequisites
+
+- A non-Azure Windows or Linux VM.
+  - Must have NodeJS, NPM, and git installed.
+- Administrator privileges on the VM.
+- An Azure Key Vault.
+
+### Install Azure Arc on the VM
+
+> **Note:** You must be in your VM to install Azure Arc.
+
+1. Create an Azure Arc server resource on the [Azure Portal](https://portal.azure.com) (at the time of writing, the
+   resource is named "Azure Arc").
+2. Choose to add an existing server using an interactive script.
+3. When creating the resource, fill in your desired subscription, resource group, and region for the VM. Choose the
+   operating system of your existing VM.
+4. No other configuration is necessary. You can go to the "Download and run script" tab and download the script shown.
+5. Once the script has been downloaded, run the script on your machine with administrator privileges.
+6. If using a Linux VM, run the following commands (using your user name for `<user>`) to gain necessary privileges:
+
+```
+sudo usermod -a -G himds <user>
+sudo setfacl -m "g:himds:r-x" /var/opt/azcmagent/tokens/
+sudo setfacl -m "g::r-x" /var/opt/azcmagent/tokens/
+```
+
+7. Arc setup should now be complete. Restart your VM to finalize your environment setup.
+8. After restarting, check your environment by searching for environment variables named `IDENTITY_ENDPOINT` and
+   `IMDS_ENDPOINT`. If they are not present, or don't resemble `http://localhost:40342/metadata/identity/oauth2/token` and
+   `http://localhost:40342` respectively, you may need to wait a short while or try restarting the VM again.
+
+## Give the Azure Arc VM access to the key vault
+
+For the tests to pass, the VM will need secret management permissions in your key vault.
+
+1. Go to your key vault resource in the [Azure Portal](https://portal.azure.com).
+2. Go to the vault's "Access policies" page, and click "Add Access Policy".
+3. Using the secret management template, select your Arc VM resource as the principal.
+4. Click "Add".
+5. Don't forget to click "Save" at the top of the access policies page after the policy is added.
+
+## Run the azure-identity Tests on the Azure Arc VM
+
+> **Note:** The following steps are specific to JavaScript.
+
+In a terminal window, run:
+
+```bash
+git clone https://github.com/Azure/azure-sdk-for-js --single-branch --depth 1
+cd azure-sdk-for-js/sdk/identity/identity/test/manual-integration/AzureArc
+```
+
+Set the environment variable `KEYVAULT_URI` to the vault URI of your key vault.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Compile the test file using TypeScript:
+
+```bash
+npm run build
+```
+
+Run the test file:
+
+```bash
+node dist/index.js
+```

--- a/sdk/identity/identity/test/manual-integration/AzureArc/INSTRUCTIONS.md
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/INSTRUCTIONS.md
@@ -2,8 +2,7 @@
 
 ## Prerequisites
 
-- A non-Azure Windows or Linux VM.
-  - Must have NodeJS, NPM, and git installed.
+- A non-Azure Windows or Linux virtual machine with NodeJS, NPM, and git installed.
 - Administrator privileges on the VM.
 - An Azure Key Vault.
 
@@ -26,7 +25,7 @@ sudo setfacl -m "g:himds:r-x" /var/opt/azcmagent/tokens/
 sudo setfacl -m "g::r-x" /var/opt/azcmagent/tokens/
 ```
 
-7. Arc setup should now be complete. Restart your VM to finalize your environment setup.
+7. The Azure Arc setup should now be complete. Restart your VM to finalize your environment setup.
 8. After restarting, check your environment by searching for environment variables named `IDENTITY_ENDPOINT` and
    `IMDS_ENDPOINT`. If they are not present, or don't resemble `http://localhost:40342/metadata/identity/oauth2/token` and
    `http://localhost:40342` respectively, you may need to wait a short while or try restarting the VM again.

--- a/sdk/identity/identity/test/manual-integration/AzureArc/index.ts
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/index.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SecretClient } from "@azure/keyvault-secrets";
+import { ManagedIdentityCredential } from "@azure/identity";
+
+async function main(): Promise<void> {
+  // This will use the system managed identity
+  const credential = new ManagedIdentityCredential();
+
+  const vaultUri = process.env.KEYVAULT_URI;
+
+  if (!vaultUri) {
+    throw new Error("Missing KEYVAULT_URI environment variable.");
+  }
+  const client = new SecretClient(vaultUri, credential);
+
+  await client.setSecret("secret-name-system", "secret-value-system");
+
+  console.log("Successfully authenticated with Key Vault!");
+}
+
+main().catch((err) => {
+  console.log("error code: ", err.code);
+  console.log("error message: ", err.message);
+  console.log("error stack: ", err.stack);
+});

--- a/sdk/identity/identity/test/manual-integration/AzureArc/package.json
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "azurearctest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/identity": "^1.3.0",
+    "@azure/keyvault-secrets": "^4.1.0",
+    "typescript": "^4.2.4"
+  }
+}

--- a/sdk/identity/identity/test/manual-integration/AzureArc/tsconfig.json
+++ b/sdk/identity/identity/test/manual-integration/AzureArc/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "lib": ["DOM"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
+    "outDir": "dist",
+    "target": "es6"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
This commit adds instructions on how to setup and run an identity smoke test in Azure Arc using managed identity to our collection of manual-integration tests.

Tested manually using a Linux VM

Resolves #11724 