### PR TITLE
Fix d.ts filename for web-pubsub-express

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/api-extractor.json
+++ b/sdk/web-pubsub/web-pubsub-express/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/index.d.ts"
+    "publicTrimmedFilePath": "./types/web-pubsub-express.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {


### PR DESCRIPTION
It was emitting `index.d.ts` and therefore not getting packed into the package.