### PR TITLE
[communication] SMS enable aad browser tests

### DIFF
--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -117,7 +117,7 @@ module.exports = function(config) {
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
+        flags: ["--no-sandbox", "--disable-web-security"]
       }
     },
 

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:47 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - NCUS ProdSlices",
+    "x-ms-request-id": "e33014af-9dad-4056-8ba6-b24d3d98b800"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":false}}",
+   "status": 202,
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104240152484c16fcc5-8d2e-4679-9c55-e68d203ddbc5_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:47 GMT",
+    "ms-cv": "v4kML53nKkeuhYk80qlShw.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "073mDYAAAAAAr7Hgs498KQo9ZAKH1ok28WVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "827ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "6d39c9c57e9160d4a3a0e376be58c39d"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:50 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - NCUS ProdSlices",
+    "x-ms-request-id": "e33014af-9dad-4056-8ba6-b24d8398b800"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"},{\"to\":\"+1425555012345\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":false}}",
+   "status": 202,
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210424015250b2016fad-f6b7-4ef6-93e8-62bde6db873a_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true},{\"to\":\"+1425555012345\",\"httpStatusCode\":400,\"errorMessage\":\"Invalid To phone number format.\",\"successful\":false}]}",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:50 GMT",
+    "ms-cv": "MewgLNj13EaZPJnFlHG5YQ.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "08nmDYAAAAAA8x2Gl1Or1QaP5u0MSr8k4WVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "350ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "2eb6de647e1107f39688ece93bdde8b3"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:48 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - EUS ProdSlices",
+    "x-ms-request-id": "d52cb074-655d-4ef3-a84a-12a396b6b700"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
+   "status": 202,
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104240152496a9beb86-16eb-47ef-a380-ad66ce47c6d8_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:48 GMT",
+    "ms-cv": "Nwa3QrCapkaf09WX6m8ehQ.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "08HmDYAAAAAA8rLZrpGWvQIDlUdHqferTWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "417ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "513763af6208d96eebc5802f066cb6e5"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
@@ -1,0 +1,73 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:49 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - WUS2 ProdSlices",
+    "x-ms-request-id": "d3fef585-0b9f-4eb0-8ad4-2fab1e1d4401"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
+   "status": 202,
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104240152499df8edd3-776b-492a-a90d-3788e931996b_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:49 GMT",
+    "ms-cv": "44l10md4CUqVv9Sjdu2jNA.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "08XmDYAAAAAB5ePE5vXihQIy79lU/YoDnWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "334ms"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
+   "status": 202,
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104240152502ffa4357-dcc4-4249-8a3c-0fee3270b1ee_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:49 GMT",
+    "ms-cv": "45EsapimCUS/aFzFYqSGAQ.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "08XmDYAAAAAAUcVSVgpk7RKCcu0qoJLU9WVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "330ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "79dd2ab18eaa39469f724e185887a994"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:50 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - SCUS ProdSlices",
+    "x-ms-request-id": "e109dde3-b008-4052-b217-5ee8721f9f00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
+   "status": 401,
+   "response": "",
+   "responseHeaders": {
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-length": "0",
+    "date": "Sat, 24 Apr 2021 01:52:50 GMT",
+    "ms-cv": "boiA5R7BFki3nen6/+J/Ow.0",
+    "request-context": "appId=",
+    "status": "401",
+    "x-azure-ref": "08nmDYAAAAADvLcMh63CnSZoZC/ydVEQFWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "280ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "2843d7b2d8c43380ba09ed5cf0644f0a"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
@@ -1,0 +1,52 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:51 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+est\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.16 - NCUS ProdSlices",
+    "x-ms-request-id": "e33014af-9dad-4056-8ba6-b24d9b98b800"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/sms",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"from\":\"+1425555012345\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
+   "status": 400,
+   "response": "{\"From\":[\"Invalid From phone number format\"]}",
+   "responseHeaders": {
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:50 GMT",
+    "ms-cv": "X+OCs/jlBUW9EcpqcGq4bw.0",
+    "request-context": "appId=",
+    "status": "400",
+    "x-azure-ref": "083mDYAAAAACzVXI78LLkT7XTqy9f9SuLWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "12ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "f90fd00200508634c1acae0fd4a9d9c7"
+}

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message.json
@@ -8,9 +8,16 @@
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":false}}",
    "status": 202,
-   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210414013839f4346fa3-6c8a-477e-9250-a3310beeda10_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210424015251c05b9140-7557-4913-a30c-23c8ed2d2f2a_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:51 GMT",
+    "ms-cv": "GZmfpT+VGk+fm00Kb6s/vw.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "083mDYAAAAACcyAjrCafIRZ03l9iuawYZWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "351ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
@@ -8,9 +8,16 @@
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"},{\"to\":\"+1425555012345\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":false}}",
    "status": 202,
-   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104140138416967b3d9-f24e-4663-acf9-de9c7a869d35_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true},{\"to\":\"+1425555012345\",\"httpStatusCode\":400,\"errorMessage\":\"Invalid To phone number format.\",\"successful\":false}]}",
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210424015253e635a2eb-13ad-4ef0-9967-b59e15538de6_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true},{\"to\":\"+1425555012345\",\"httpStatusCode\":400,\"errorMessage\":\"Invalid To phone number format.\",\"successful\":false}]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:53 GMT",
+    "ms-cv": "Lk5VfjPmPEOAl+AhEkWfpA.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "09XmDYAAAAACzKfXGsiYpT6GWIplAsb/PWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "395ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
@@ -8,9 +8,16 @@
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
    "status": 202,
-   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104140138394666b848-7b0a-4bd7-8f48-d27be58acaee_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210424015252995ea4c1-b445-4573-abd8-dfe422c5ea4a_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:51 GMT",
+    "ms-cv": "ymMZpmMnsUKaY5GdOU2XWQ.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "083mDYAAAAABwOiRcWR+fQokiumdcrengWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "386ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
@@ -8,9 +8,16 @@
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
    "status": 202,
-   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_2021041401384093c29530-dfd2-4ff3-9bcd-c784b7cd5e52_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_202104240152528ec5c4ad-e3c4-4961-b7be-4cf45cec3905_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:52 GMT",
+    "ms-cv": "QwJfO72hc0mBzIY+CakQLg.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "09HmDYAAAAABTKE2XhR6/Rb81k9ewYLVjWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "392ms"
    }
   },
   {
@@ -21,9 +28,16 @@
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
    "status": 202,
-   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_20210414013840c5e242ce-d8c0-4799-aefe-0ec6da11d7f9_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
+   "response": "{\"value\":[{\"to\":\"+14255550123\",\"messageId\":\"Outgoing_2021042401525343fbb265-a944-4690-8f02-74deb17f5924_noam\",\"httpStatusCode\":202,\"repeatabilityResult\":\"accepted\",\"successful\":true}]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:52 GMT",
+    "ms-cv": "kwki6TxoLESl3X2+PViHOg.0",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "09HmDYAAAAACDwFVlR96wSbRUMpKm2oV+WVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "474ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
@@ -7,10 +7,17 @@
     "api-version": "2021-03-07"
    },
    "requestBody": "{\"from\":\"+14255550123\",\"smsRecipients\":[{\"to\":\"+14255550123\",\"repeatabilityRequestId\":\"sanitized\",\"repeatabilityFirstSent\":\"Thu, 01 Jan 1970 00:00:00 GMT\"}],\"message\":\"test message\",\"smsSendOptions\":{\"enableDeliveryReport\":true,\"tag\":\"SMS_LIVE_TEST\"}}",
-   "status": 404,
+   "status": 401,
    "response": "",
    "responseHeaders": {
-    "content-length": "0"
+    "api-supported-versions": "2020-07-20-preview1, 2020-08-20-preview, 2021-03-07",
+    "content-length": "0",
+    "date": "Sat, 24 Apr 2021 01:52:53 GMT",
+    "ms-cv": "y+3Yvbaic0C7ZqJfdqp0YA.0",
+    "request-context": "appId=",
+    "status": "401",
+    "x-azure-ref": "09XmDYAAAAAB16lq36mMsSorud4RPhNHKWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "332ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
@@ -10,7 +10,13 @@
    "status": 400,
    "response": "{\"From\":[\"Invalid From phone number format\"]}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "content-type": "application/json; charset=utf-8",
+    "date": "Sat, 24 Apr 2021 01:52:53 GMT",
+    "ms-cv": "rD6ustT2CkSDMUR116HyDA.0",
+    "request-context": "appId=",
+    "status": "400",
+    "x-azure-ref": "09nmDYAAAAAD7F6OU/oGkRYIC1qwVN6wQWVZSMzBFREdFMDMxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "13ms"
    }
   }
  ],

--- a/sdk/communication/communication-sms/test/internal/smsClient.internal.spec.ts
+++ b/sdk/communication/communication-sms/test/internal/smsClient.internal.spec.ts
@@ -14,7 +14,6 @@ import * as dotenv from "dotenv";
 import * as sinon from "sinon";
 import { Uuid } from "../../src/utils/uuid";
 import {
-  createCredential,
   createSmsClient,
   createSmsClientWithToken,
   recorderConfiguration
@@ -42,8 +41,7 @@ matrix([[true, false]], async function(useAad) {
       }
 
       if (useAad) {
-        const token = createCredential() || this.skip();
-        this.smsClient = createSmsClientWithToken(token);
+        this.smsClient = createSmsClientWithToken();
       } else {
         this.smsClient = createSmsClient();
       }

--- a/sdk/communication/communication-sms/test/public/smsClient.spec.ts
+++ b/sdk/communication/communication-sms/test/public/smsClient.spec.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ *  These tests only run in Live Mode because Http Requests with Randomized UUIDs do not play well with the recorder
+ *  They are duplicated in an internal test which contains workaround logic to record/playback the tests
+ */
+
 import { record, Recorder } from "@azure/test-utils-recorder";
 import { isNode } from "@azure/core-http";
 import * as dotenv from "dotenv";
 import {
-  createCredential,
   createSmsClient,
   createSmsClientWithToken,
   recorderConfiguration
@@ -30,8 +34,7 @@ matrix([[true, false]], async function(useAad) {
       );
 
       if (useAad) {
-        const token = createCredential() || this.skip();
-        this.smsClient = createSmsClientWithToken(token);
+        this.smsClient = createSmsClientWithToken();
       } else {
         this.smsClient = createSmsClient();
       }

--- a/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
@@ -9,7 +9,7 @@ import {
   isNode,
   WebResourceLike
 } from "@azure/core-http";
-import { DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { ClientSecretCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
 import { env, isPlaybackMode, RecorderEnvironmentSetup } from "@azure/test-utils-recorder";
 import { SmsClient, SmsClientOptions } from "../../../src";
 
@@ -39,18 +39,22 @@ export const recorderConfiguration: RecorderEnvironmentSetup = {
   queryParametersToSkip: []
 };
 
-export function createCredential(): TokenCredential | undefined {
-  if (isPlaybackMode() && isNode) {
+function createCredential(): TokenCredential {
+  if (isPlaybackMode()) {
     return {
       getToken: async (_scopes) => {
         return { token: "testToken", expiresOnTimestamp: 11111 };
       }
     };
   } else {
-    try {
+    if (isNode) {
       return new DefaultAzureCredential();
-    } catch {
-      return undefined;
+    } else {
+      return new ClientSecretCredential(
+        env.AZURE_TENANT_ID,
+        env.AZURE_CLIENT_ID,
+        env.AZURE_CLIENT_SECRET
+      );
     }
   }
 }
@@ -62,9 +66,9 @@ export function createSmsClient(): SmsClient {
   } as SmsClientOptions);
 }
 
-export function createSmsClientWithToken(credential: TokenCredential): SmsClient {
+export function createSmsClientWithToken(): SmsClient {
   const { endpoint } = parseConnectionString(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING);
-
+  const credential: TokenCredential = createCredential();
   // workaround: casting because min testing has issues with httpClient newer versions having extra optional fields
   return new SmsClient(endpoint, credential, {
     httpClient: createTestHttpClient()


### PR DESCRIPTION
Using the ClientSecretCredential enables us to run these live tests in the browser so we no longer have to skip them :)
This is a companion to the same changes for the communication-identity package