### PR TITLE
[event-hubs] fixes sendBatch race condition causing TypeError to be thrown

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.5.1 (Unreleased)
 
+- Fixes issue [#14606](https://github.com/Azure/azure-sdk-for-js/issues/14606) where the `EventHubConsumerClient` could call subscribe's `processError` callback with a "Too much pending tasks" error. This could occur if the consumer was unable to connect to the service for an extended period of time.
+
 - Fixes issue [#15002](https://github.com/Azure/azure-sdk-for-js/issues/15002) where in rare cases an unexpected `TypeError` could be thrown from `EventHubProducerClient.sendBatch` when the connection was disconnected while sending events was in progress.
 
 ## 5.5.0 (2021-04-06)

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.5.1 (Unreleased)
 
+- Fixes issue [#15002](https://github.com/Azure/azure-sdk-for-js/issues/15002) where in rare cases an unexpected `TypeError` could be thrown from `EventHubProducerClient.sendBatch` when the connection was disconnected while sending events was in progress.
 
 ## 5.5.0 (2021-04-06)
 

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -586,7 +586,7 @@ export class EventHubReceiver extends LinkEntity {
         // store the underlying link in a cache
         this._context.receivers[this.name] = this;
 
-        await this._ensureTokenRenewal();
+        this._ensureTokenRenewal();
       } else {
         logger.verbose(
           "[%s] The receiver '%s' with address '%s' is open -> %s and is connecting " +

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -217,7 +217,6 @@ export class EventHubSender extends LinkEntity {
     } = {}
   ): Promise<number> {
     const sender = await this._getLink(options);
-    this._sender = sender;
 
     return sender.maxMessageSize;
   }
@@ -343,7 +342,6 @@ export class EventHubSender extends LinkEntity {
     const sendEventPromise = async (): Promise<void> => {
       const initStartTime = Date.now();
       const sender = await this._getLink(options);
-      this._sender = sender;
       const timeTakenByInit = Date.now() - initStartTime;
       logger.verbose(
         "[%s] Sender '%s', credit: %d available: %d",
@@ -526,6 +524,7 @@ export class EventHubSender extends LinkEntity {
         );
 
         const sender = await this._context.connection.createAwaitableSender(options);
+        this._sender = sender;
         logger.verbose(
           "[%s] Sender '%s' created with sender options: %O",
           this._context.connectionId,

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -215,7 +215,7 @@ export class LinkEntity {
    * Ensures that the token is renewed within the predefined renewal margin.
    * @hidden
    */
-  protected async _ensureTokenRenewal(): Promise<void> {
+  protected _ensureTokenRenewal(): void {
     if (!this._tokenTimeoutInMs) {
       return;
     }

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -37,8 +37,8 @@ describe("disconnected", function() {
       const context = createConnectionContext(service.connectionString, service.path);
       const sender = EventHubSender.create(context);
 
-      // Create the sender link so we can check when 'send' is about to be called on it.
-      await sender["_createLinkIfNotOpen"]();
+      // Create the sender link via getMaxMessageSize() so we can check when 'send' is about to be called on it.
+      await sender.getMaxMessageSize();
       should.equal(sender.isOpen(), true, "Expected sender to be open.");
 
       // Here we stub out the 'send' call on the AwaitableSender.

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+const should = chai.should();
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+import { EnvVarKeys, getEnvVars } from "../../public/utils/testUtils";
+import { EventHubSender } from "../../../src/eventHubSender";
+import { createConnectionContext } from "../../../src/connectionContext";
+import { stub } from "sinon";
+import { MessagingError } from "@azure/core-amqp";
+const env = getEnvVars();
+
+describe("disconnected", function() {
+  const service = {
+    connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+    path: env[EnvVarKeys.EVENTHUB_NAME]
+  };
+  before("validate environment", function(): void {
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_NAME],
+      "define EVENTHUB_NAME in your environment before running integration tests."
+    );
+  });
+
+  describe("EventHubSender", function() {
+    /**
+     * Test added for issue https://github.com/Azure/azure-sdk-for-js/issues/15002
+     * Prior to fixing this issue, a TypeError would be thrown when this test was ran.
+     */
+    it("send works after disconnect", async () => {
+      const context = createConnectionContext(service.connectionString, service.path);
+      const sender = EventHubSender.create(context);
+
+      // Create the sender link so we can check when 'send' is about to be called on it.
+      await sender["_createLinkIfNotOpen"]();
+      should.equal(sender.isOpen(), true, "Expected sender to be open.");
+
+      // Here we stub out the 'send' call on the AwaitableSender.
+      // We do 2 things:
+      // 1. Call `idle()` on the underlying rhea connection so that a disconnect is triggered.
+      // 2. Reject with a MessagingError.
+      // The MessagingError is thrown so that the send operation will be retried.
+      // The disconnect that's triggered will cause the existing AwaitableSender to be closed.
+
+      // If everything works as expected, then a new AwaitableSender should be created on the next
+      // retry attempt and the event should be successfully sent.
+      const senderLink = sender["_sender"]!;
+      const sendStub = stub(senderLink, "send");
+      sendStub.callsFake(async () => {
+        context.connection["_connection"].idle();
+        throw new MessagingError("Fake rejection!");
+      });
+
+      await sender.send([{ body: "foo" }]);
+
+      await context.close();
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/15002

## Background

`@azure/event-hubs` 5.5.0 introduced a bug where a `TypeError` could be thrown from `EventHubProducerClient.sendBatch` if the connection was disconnected between the points where the sender link was initialized and the events were sent to the service.

This was because the logic to initialize the sender link and the logic to actually send events across the link were separated into separate retriable operations. When a connection `disconnected` event is encountered after the link is initialized, the existing link is closed. However, the sending of events can be retried. Since the link was closed, we'd get our version of a null pointer error when trying to interact with the link.

## Changes

This PR does 2 things to fix the issue and prevent future 'null pointer' exceptions.

1. We recombine the link initialization and sending of events into the same retriable operation. This way, if the disconnected event occurs and the link has been closed, we'll recreate the link before trying to send the events again.
2. The `EventHubSender._trySendBatch` method has been updated to remove all of our TypeScript non-null assertions. `) `_createLinkIfNotOpen` has been updated to return the sender link that's created directly so we can be sure it exists before we try to use it.

## What about Service Bus?

I looked at the Service Bus code and it already keeps the link initialization and sending of events in the same retriable operation. It currently does use a non-null type assertion on the sender link, though because the link initialization and sending of events are currently combined, this should be safe _for now_.