### PR TITLE
[Communication] - TESTS - removing unused value in test.yml 

### DIFF
--- a/sdk/communication/communication-phone-numbers/tests.yml
+++ b/sdk/communication/communication-phone-numbers/tests.yml
@@ -6,7 +6,6 @@ stages:
       PackageName: "@azure/communication-phone-numbers"
       ServiceDirectory: communication
       EnvVars:
-        AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
         AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: $(communication-livetest-connection-string)
         AZURE_PHONE_NUMBER: $(communication-livetest-phone-number)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/communication/communication-sms/tests.yml
+++ b/sdk/communication/communication-sms/tests.yml
@@ -6,7 +6,6 @@ stages:
       PackageName: "@azure/communication-sms"
       ServiceDirectory: communication
       EnvVars:
-        AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
         AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: $(communication-livetest-connection-string)
         AZURE_PHONE_NUMBER: $(communication-livetest-phone-number)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
While working through documentation for live testing we found this env var `AZURE_SUBSCRIPTION_ID` that didn't seem to be in use. 
