### PR TITLE
[communication] re-enable skipped phone number search test

### DIFF
--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -27,10 +27,6 @@ matrix([[true, false]], async function(useAad) {
     };
 
     before(function(this: Context) {
-      // SKIPPING BECAUSE TOLL-FREE ACQUISITION IS DISABLED
-      // STOP SKIPPING WHEN SERVICE ENABLES ACQUISITION
-      this.skip();
-
       if (useAad && !canCreateRecordedClientWithToken()) {
         this.skip();
       }


### PR DESCRIPTION
removed skip after PSTN team re-enabled toll free search