### PR TITLE
[event-hubs] fix race condition preventing connection recovery during connection disconnect

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.5.1 (Unreleased)
 
+- Fixes a race condition that would cause connection recovery to sometimes fail if a consumer or producer was closed at the same time a connection was disconnected.
+
 - Fixes issue [#14606](https://github.com/Azure/azure-sdk-for-js/issues/14606) where the `EventHubConsumerClient` could call subscribe's `processError` callback with a "Too much pending tasks" error. This could occur if the consumer was unable to connect to the service for an extended period of time.
 
 - Fixes issue [#15002](https://github.com/Azure/azure-sdk-for-js/issues/15002) where in rare cases an unexpected `TypeError` could be thrown from `EventHubProducerClient.sendBatch` when the connection was disconnected while sending events was in progress.

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { v4 as uuid } from "uuid";
 import { logErrorStackTrace, logger } from "./log";
 import {
   EventContext,
@@ -38,7 +37,6 @@ interface CreateReceiverOptions {
   onClose: OnAmqpEvent;
   onSessionError: OnAmqpEvent;
   onSessionClose: OnAmqpEvent;
-  newName?: boolean;
   eventPosition?: EventPosition;
 }
 
@@ -617,7 +615,6 @@ export class EventHubReceiver extends LinkEntity {
    * @hidden
    */
   private _createReceiverOptions(options: CreateReceiverOptions): RheaReceiverOptions {
-    if (options.newName) this.name = uuid();
     const rcvrOptions: RheaReceiverOptions = {
       name: this.name,
       autoaccept: true,
@@ -625,13 +622,11 @@ export class EventHubReceiver extends LinkEntity {
         address: this.address
       },
       credit_window: 0,
-      onMessage: options.onMessage || ((context: EventContext) => this._onAmqpMessage(context)),
-      onError: options.onError || ((context: EventContext) => this._onAmqpError(context)),
-      onClose: options.onClose || ((context: EventContext) => this._onAmqpClose(context)),
-      onSessionError:
-        options.onSessionError || ((context: EventContext) => this._onAmqpSessionError(context)),
-      onSessionClose:
-        options.onSessionClose || ((context: EventContext) => this._onAmqpSessionClose(context))
+      onMessage: options.onMessage,
+      onError: options.onError,
+      onClose: options.onClose,
+      onSessionError: options.onSessionError,
+      onSessionClose: options.onSessionClose
     };
 
     if (typeof this.ownerLevel === "number") {

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -10,9 +10,12 @@ import { EventHubSender } from "../../../src/eventHubSender";
 import { createConnectionContext } from "../../../src/connectionContext";
 import { stub } from "sinon";
 import { MessagingError } from "@azure/core-amqp";
+import { EventHubReceiver } from "../../../src/eventHubReceiver";
+import { EventHubConsumerClient, latestEventPosition } from "../../../src";
 const env = getEnvVars();
 
 describe("disconnected", function() {
+  let partitionIds: string[] = [];
   const service = {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
@@ -26,6 +29,16 @@ describe("disconnected", function() {
       env[EnvVarKeys.EVENTHUB_NAME],
       "define EVENTHUB_NAME in your environment before running integration tests."
     );
+  });
+
+  before("get partition ids", async function() {
+    const client = new EventHubConsumerClient(
+      EventHubConsumerClient.defaultConsumerGroupName,
+      service.connectionString,
+      service.path
+    );
+    partitionIds = await client.getPartitionIds();
+    return client.close();
   });
 
   describe("EventHubSender", function() {
@@ -60,6 +73,126 @@ describe("disconnected", function() {
       await sender.send([{ body: "foo" }]);
 
       await context.close();
+    });
+  });
+
+  describe("ConnectionContext", function() {
+    describe("onDisconnected", function() {
+      it("does not fail when entities are closed concurrently", async () => {
+        const context = createConnectionContext(service.connectionString, service.path);
+
+        // Add 2 receivers.
+        const receiver1 = new EventHubReceiver(
+          context,
+          EventHubConsumerClient.defaultConsumerGroupName,
+          partitionIds[0],
+          latestEventPosition
+        );
+        const receiver2 = new EventHubReceiver(
+          context,
+          EventHubConsumerClient.defaultConsumerGroupName,
+          partitionIds[1],
+          latestEventPosition
+        );
+
+        // Add 2 senders.
+        const sender1 = new EventHubSender(context);
+        const sender2 = new EventHubSender(context);
+
+        // Initialize sender links
+        await sender1["_getLink"]();
+        await sender2["_getLink"]();
+
+        // Initialize receiver links
+        await receiver1.initialize({
+          abortSignal: undefined,
+          timeoutInMs: 60000
+        });
+        await receiver2.initialize({
+          abortSignal: undefined,
+          timeoutInMs: 60000
+        });
+
+        // We are going to override sender1's close method so that it also invokes receiver2's close method.
+        const sender1Close = sender1.close.bind(sender1);
+        sender1.close = async function() {
+          sender2.close().catch(() => {
+            /* no-op */
+          });
+          return sender1Close();
+        };
+
+        // We are going to override receiver1's close method so that it also invokes receiver2's close method.
+        const receiver1Close = receiver1.close.bind(receiver1);
+        receiver1.close = async function() {
+          receiver2.close().catch(() => {
+            /* no-op */
+          });
+          return receiver1Close();
+        };
+
+        context.connection["_connection"].idle();
+        await context.readyToOpenLink();
+        console.log("open", context.connection.isOpen());
+        await context.close();
+      });
+    });
+
+    describe("close", function() {
+      it("does not fail when entities are closed concurrently", async () => {
+        const context = createConnectionContext(service.connectionString, service.path);
+
+        // Add 2 receivers.
+        const receiver1 = new EventHubReceiver(
+          context,
+          EventHubConsumerClient.defaultConsumerGroupName,
+          partitionIds[0],
+          latestEventPosition
+        );
+        const receiver2 = new EventHubReceiver(
+          context,
+          EventHubConsumerClient.defaultConsumerGroupName,
+          partitionIds[1],
+          latestEventPosition
+        );
+
+        // Add 2 senders.
+        const sender1 = new EventHubSender(context);
+        const sender2 = new EventHubSender(context);
+
+        // Initialize sender links
+        await sender1["_getLink"]();
+        await sender2["_getLink"]();
+
+        // Initialize receiver links
+        await receiver1.initialize({
+          abortSignal: undefined,
+          timeoutInMs: 60000
+        });
+        await receiver2.initialize({
+          abortSignal: undefined,
+          timeoutInMs: 60000
+        });
+
+        // We are going to override sender1's close method so that it also invokes receiver2's close method.
+        const sender1Close = sender1.close.bind(sender1);
+        sender1.close = async function() {
+          sender2.close().catch(() => {
+            /* no-op */
+          });
+          return sender1Close();
+        };
+
+        // We are going to override receiver1's close method so that it also invokes receiver2's close method.
+        const originalClose = receiver1.close.bind(receiver1);
+        receiver1.close = async function() {
+          receiver2.close().catch(() => {
+            /* no-op */
+          });
+          return originalClose();
+        };
+        await context.close();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

This PR fixes a race condition that can occur when the connection to the service is disconnected, or the connection is explicitly closed via `(EventHubConsumerClient|EventHubProducerClient).close()`. The race condition manifests as an UnhandledPromiseRejectionWarning when attempting to close senders or receivers in the `disconnected` event handler due to trying to close a resource that doesn't exist.

## Root cause analysis

Prior to this PR, the `disconnected` event handler grabbed the list of receiver/sender names from the `connectionContext`, then serially closed the receiver/senders.
https://github.com/Azure/azure-sdk-for-js/blob/13e6508b63d1b819d9d86392856e76b15e61c913/sdk/eventhub/event-hubs/src/connectionContext.ts#L333-L346

Whenever a sender/receiver is closed, it removes itself from the `connectionContext`. Closing is also an async (non-blocking) operation. Thus, it is possible for a sender/receiver to be closed and removed from `connectionContext` at the same time the SDK is iterating over the sender/receiver names.

In fact, the `connectionContext.close()` method has the same behavior and is one such place close could be called on senders/receivers, and there are other ways receivers/senders can be closed as well (e.g. receivers can be stopped by their PartitionPump.)

### UnhandledPromiseRejectionError

The UnhandledPromiseRejectionError occurs when this race condition is hit. As we iterate over the receivers by the cached list of receiverNames, if one of the receivers was closed after we got the list but before we were able to call close on it, the value of the receiver would be `undefined`. This causes an unhandled `TypeError` to be thrown as we try to call `close()` on `undefined`, and since we're in an async function, this triggers the UnhandledPromiseRejectionError.

It also stops execution of the function, so we never get to the point where we replace the old rhea connection with a new one.

### MessagingError timeouts

Under normal circumstances, the disconnected event handler will replace the underlying rhea connection object. However when this race condition happens the handler exits before the connection is replaced. This means we never get to execute the following:
https://github.com/Azure/azure-sdk-for-js/blob/13e6508b63d1b819d9d86392856e76b15e61c913/sdk/eventhub/event-hubs/src/connectionContext.ts#L348-L350

Since the disconnected function never completes, the `readyToOpenLink()` function that's part of link initialization will never yield:
https://github.com/Azure/azure-sdk-for-js/blob/13e6508b63d1b819d9d86392856e76b15e61c913/sdk/eventhub/event-hubs/src/managementClient.ts#L309-L319

This is why we end up seeing timeout errors after this race condition is hit...the SDK is hung up waiting for the disconnected event handler to complete but it never does. Note that this only impacts the connection that encountered the race condition, so other clients in the same process should be fine.

## Workaround in user code?

Since this race condition only impacts a single connection, one workaround a customer could implement is to instantiate a new EventHubConsumerClient or EventHubProducerClient if they start encountering multiple timeout MessagingErrors. Since timeouts can happen due to transient conditions, the customer can pick a threshold that makes sense for their system (e.g. N number of timeout errors over M period of time.)

## How does this PR fix the issue?

This PR does 2 things to protect against this race condition.
1. connectionContext.close() and the connectionContext disconnected event handler have been updated to close senders/receivers in parallel rather than serially. Since we gather all the senders/receivers in blocking code, we can be sure that another method running concurrently can't delete a sender/receiver before we call close on it.
2. Wraps the entire block of code that closes resources in a try/catch. This is just extra protection against the unexpected. We also ensure that the `waitForConnectionRefreshResolve` promise is always cleared at the end of disconnected even if an error is encountered, so that `readyToOpenLink` won't hang indefinitely if something similar happens again.