### PR TITLE
[core] - Ensure Tracing Spans have the correct status

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.2.5 (Unreleased)
 
+### Fixed
+
 - Delay loading of NO_PROXY environment variable until when request pipeline is being created. This fixes [issue 14873](https://github.com/Azure/azure-sdk-for-js/issues/14873)
 - Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.2.5 (Unreleased)
 
-- Delay loading of NO_PROXY environment variable until  when request pipeline is being created. This fixes [issue 14873](https://github.com/Azure/azure-sdk-for-js/issues/14873)
+- Delay loading of NO_PROXY environment variable until when request pipeline is being created. This fixes [issue 14873](https://github.com/Azure/azure-sdk-for-js/issues/14873)
+- Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 
 ## 1.2.4 (2021-03-30)
 

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getTraceParentHeader, createSpanFunction, SpanKind } from "@azure/core-tracing";
+import {
+  getTraceParentHeader,
+  createSpanFunction,
+  SpanKind,
+  SpanStatusCode
+} from "@azure/core-tracing";
 import {
   RequestPolicyFactory,
   RequestPolicy,
@@ -88,11 +93,19 @@ export class TracingPolicy extends BaseRequestPolicy {
       if (serviceRequestId) {
         span.setAttribute("serviceRequestId", serviceRequestId);
       }
-      span.end();
+      span.setStatus({
+        code: SpanStatusCode.OK
+      });
       return response;
     } catch (err) {
-      span.end();
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err.message
+      });
+      span.setAttribute("http.status_code", err.statusCode);
       throw err;
+    } finally {
+      span.end();
     }
   }
 }

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0-beta.2 (Unreleased)
 
+- Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 
 ## 1.1.0-beta.1 (2021-05-06)
 
@@ -15,7 +16,6 @@
 
 - Rewrote `bearerTokenAuthenticationPolicy` to use a new backend that refreshes tokens only when they're about to expire and not multiple times before. This is based on a similar fix implemented on `@azure/core-http@1.2.4` ([PR with the changes](https://github.com/Azure/azure-sdk-for-js/pull/14223)). This fixes the issue: [13369](https://github.com/Azure/azure-sdk-for-js/issues/13369).
 - Delay loading of NO_PROXY environment variable until when request pipeline is being created. This fixes [issue 14873](https://github.com/Azure/azure-sdk-for-js/issues/14873)
-- Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 
 ## 1.0.3 (2021-03-30)
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0-beta.2 (Unreleased)
 
+### Fixed
+
 - Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 
 ## 1.1.0-beta.1 (2021-05-06)

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Rewrote `bearerTokenAuthenticationPolicy` to use a new backend that refreshes tokens only when they're about to expire and not multiple times before. This is based on a similar fix implemented on `@azure/core-http@1.2.4` ([PR with the changes](https://github.com/Azure/azure-sdk-for-js/pull/14223)). This fixes the issue: [13369](https://github.com/Azure/azure-sdk-for-js/issues/13369).
 - Delay loading of NO_PROXY environment variable until when request pipeline is being created. This fixes [issue 14873](https://github.com/Azure/azure-sdk-for-js/issues/14873)
+- Fixed an issue where tracing spans were not setting a status correctly (on success or error) which results in the span status being `UNSET`. In addition, we will now capture the HTTP status code when a request fails in the tracing span. [PR 15061](https://github.com/Azure/azure-sdk-for-js/pull/15061)
 
 ## 1.0.3 (2021-03-30)
 

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -4,7 +4,8 @@
 import {
   getTraceParentHeader,
   OperationTracingOptions,
-  createSpanFunction
+  createSpanFunction,
+  SpanStatusCode
 } from "@azure/core-tracing";
 import { SpanKind } from "@azure/core-tracing";
 import { PipelineResponse, PipelineRequest, SendRequest } from "../interfaces";
@@ -93,11 +94,19 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
         if (serviceRequestId) {
           span.setAttribute("serviceRequestId", serviceRequestId);
         }
-        span.end();
+        span.setStatus({
+          code: SpanStatusCode.OK
+        });
         return response;
       } catch (err) {
-        span.end();
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err.message
+        });
+        span.setAttribute("http.status_code", err.statusCode);
         throw err;
+      } finally {
+        span.end();
       }
     }
   };


### PR DESCRIPTION
## What

- Call `span.setStatus` in both the happy path and the error path
- When handling an error, add the message and the http error code

## Why

I noticed in passing that the core http spans had a status of UNSET which is a recent change in OpenTel. As a fix, added
code to ensure we set the status correctly. 

I debated whether a 400-ish status code is an error or not, since we technically did make a successful HTTP call, but my 
reasoning for setting all errors as trace errors is that as a developer if I _only_ had this data (without any convenience layer
spans) I would want to see where this error originated. 

This is a smallish change, but one that will help add consistency in our tracing data.

Resolves #15045 

![image](https://user-images.githubusercontent.com/753570/116484544-22c97980-a83e-11eb-9d86-cdb1c21a22aa.png)
