### PR TITLE
[KeyVault] - Fix broken sample links

### DIFF
--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -677,8 +677,8 @@ setLogLevel("info");
 
 You can find more code samples through the following links:
 
-- [KeyVault Certificates Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/samples/javascript)
-- [KeyVault Certificates Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/samples/typescript)
+- [KeyVault Certificates Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/samples/v4/javascript)
+- [KeyVault Certificates Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/samples/v4/typescript)
 - [KeyVault Certificates Test Cases](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/test/)
 
 ## Contributing

--- a/sdk/keyvault/keyvault-certificates/migration-guide.md
+++ b/sdk/keyvault/keyvault-certificates/migration-guide.md
@@ -6,15 +6,15 @@ Familiarity with the `azure-keyvault` package is assumed. For those new to the K
 
 ## Table of contents
 
-* [Migration benefits](#migration-benefits)
-* [Important changes](#important-changes)
-    - [Separate packages and clients](#separate-packages-and-clients)
-    - [Client constructors](#client-constructors)
-    - [Create a certificate](#create-a-certificate)
-    - [Retrieve a certificate](#retrieve-a-certificate)
-    - [List properties of certificates](#list-properties-of-certificates)
-    - [Delete a certificate](#delete-a-certificate)
-* [Additional samples](#additional-samples)
+- [Migration benefits](#migration-benefits)
+- [Important changes](#important-changes)
+  - [Separate packages and clients](#separate-packages-and-clients)
+  - [Client constructors](#client-constructors)
+  - [Create a certificate](#create-a-certificate)
+  - [Retrieve a certificate](#retrieve-a-certificate)
+  - [List properties of certificates](#list-properties-of-certificates)
+  - [Delete a certificate](#delete-a-certificate)
+- [Additional samples](#additional-samples)
 
 ## Migration benefits
 
@@ -27,6 +27,7 @@ To try and improve the development experience across Azure services, a set of un
 ### Cross Service SDK improvements
 
 The modern Key Vault client libraries also share some of the cross-service improvements made to the Azure development experience, such as:
+
 - Using the new `@azure/identity` library to share a single authentication approach between clients.
 - A unified logging and diagnostics pipeline that offers a common view of the activities across each of the client libraries.
 - The use of promises rather than callbacks for a simplified programming experience.
@@ -36,7 +37,7 @@ The modern Key Vault client libraries also share some of the cross-service impro
 
 ### Separate packages and clients
 
-In the interest of simplifying the API for working with Key Vault keys, secrets and certificates, the `azure-keyvault`  package is split into separate packages.
+In the interest of simplifying the API for working with Key Vault keys, secrets and certificates, the `azure-keyvault` package is split into separate packages.
 
 - [`@azure/keyvault-keys`][kvk-npm] contains `KeyClient` for working with Key Vault keys, and `CryptographyClient` for performing cryptographic operations.
 - [`@azure/keyvault-secrets`][kvs-npm] contains `SecretClient` for working with Key Vault secrets.
@@ -51,8 +52,8 @@ Across all of the new Azure client libraries, clients consistently take an endpo
 Previously in `azure-keyvault` you could create a `KeyVaultClient` by using credentials from `ms-rest-azure` (up to the version `^2.6.0`. Higher versions are not supported).
 
 ```js
-var KeyVault = require('azure-keyvault');
-var msRestAzure = require('ms-rest-azure');
+var KeyVault = require("azure-keyvault");
+var msRestAzure = require("ms-rest-azure");
 
 const clientId = "client id";
 const secret = "client secret";
@@ -60,11 +61,7 @@ const domain = "tenant id";
 const vaultUrl = `https://my-vault.vault.azure.net/`;
 
 async function main() {
-  const credentials = await msRestAzure.loginWithServicePrincipalSecret(
-    clientId,
-    secret,
-    domain
-  );
+  const credentials = await msRestAzure.loginWithServicePrincipalSecret(clientId, secret, domain);
   const client = new KeyVault.KeyVaultClient(credentials);
   const keyVaultCertificate = await client.getCertificate(vaultUrl, "MyCertificate", "");
   console.log(keyVaultCertificate);
@@ -81,7 +78,7 @@ You can install them by simply running the following command at the root of your
 npm install --save @azure/identity @azure/keyvault-certificates
 ```
 
-Below is a simple example using both `@azure/keyvault-certificates` and [`DefaultAzureCredential`][identity-readme-DAC]:
+Below is a simple example using both `@azure/keyvault-certificates` and [`DefaultAzureCredential`][identity-readme-dac]:
 
 ```ts
 // The default credential first checks environment variables for configuration as described above.
@@ -110,14 +107,16 @@ In `azure-keyvault` you could create a certificate by using `KeyVaultClient`'s `
 // Example of an old certificate policy
 let certificatePolicy = {
   issuerParameters: {
-    name: "Self",
+    name: "Self"
   },
   x509CertificateProperties: {
-    subject: "CN=CLIGetDefaultPolicy",
+    subject: "CN=CLIGetDefaultPolicy"
   }
 };
 
-let certificateOperation = await client.createCertificate(vaultUrl, "MyCertificate", { certificatePolicy: certificatePolicy });
+let certificateOperation = await client.createCertificate(vaultUrl, "MyCertificate", {
+  certificatePolicy: certificatePolicy
+});
 console.log(certificateOperation);
 ```
 
@@ -126,7 +125,7 @@ A similar approach exists now in `@azure/keyvault-certificates`. You can provide
 ```ts
 // Example of a new certificate policy
 const certificatePolicy = {
-  issuerName: 'Self',
+  issuerName: "Self",
   subject: "cn=MyCert"
 };
 
@@ -134,7 +133,6 @@ const poller = await client.beginCreateCertificate("MyCertificate", certificateP
 const keyVaultCertificate = poller.getResult();
 console.log(keyVaultCertificate);
 await poller.pollUntilDone();
-
 ```
 
 ### Retrieve a certificate
@@ -162,7 +160,9 @@ console.log(keyVaultCertificate.properties.version);
 
 for await (let versionProperties of client.listPropertiesOfCertificateVersions("MyCertificate")) {
   console.log("Name:", versionProperties.name, "Version:", versionProperties.version);
-  const keyVaultCertificate = await client.getCertificate(versionProperties.name, { version: versionProperties.version });
+  const keyVaultCertificate = await client.getCertificate(versionProperties.name, {
+    version: versionProperties.version
+  });
   console.log(keyVaultCertificate.properties.version);
 }
 ```
@@ -207,14 +207,14 @@ await client.purgeDeletedCertificate(deletedCertificate.name);
 
 ## Additional samples
 
-* [Key Vault Certificates samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples/javascript)
-* [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
-* [Key Vault Certificates samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples/typescript)
-* [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
+- [Key Vault Certificates samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples/v4/javascript)
+- [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
+- [Key Vault Certificates samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples/v4/typescript)
+- [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
 
 [kvk-npm]: https://www.npmjs.com/package/@azure/keyvault-keys
 [kvs-npm]: https://www.npmjs.com/package/@azure/keyvault-secrets
 [kvc-npm]: https://www.npmjs.com/package/@azure/keyvault-certificates
 [ts-guidelines]: https://azure.github.io/azure-sdk/typescript_introduction.html
 [identity-npm]: https://www.npmjs.com/package/@azure/identity
-[identity-readme-DAC]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential
+[identity-readme-dac]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -828,8 +828,8 @@ setLogLevel("info");
 
 You can find more code samples through the following links:
 
-- [KeyVault Keys Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/javascript)
-- [KeyVault Keys Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/typescript)
+- [KeyVault Keys Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/v4/javascript)
+- [KeyVault Keys Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/samples/v4/typescript)
 - [KeyVault Keys Test Cases](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/test/)
 
 ## Contributing

--- a/sdk/keyvault/keyvault-keys/migration-guide.md
+++ b/sdk/keyvault/keyvault-keys/migration-guide.md
@@ -6,16 +6,16 @@ Familiarity with the `azure-keyvault` package is assumed. For those new to the K
 
 ## Table of contents
 
-* [Migration benefits](#migration-benefits)
-* [Important changes](#important-changes)
-    - [Separate packages and clients](#separate-packages-and-clients)
-    - [Client constructors](#client-constructors)
-    - [Create a key](#create-a-key)
-    - [Retrieve a key](#retrieve-a-key)
-    - [List properties of keys](#list-properties-of-keys)
-    - [Delete a key](#delete-a-key)
-    - [Perform cryptographic operations](#perform-cryptographic-operations)
-* [Additional samples](#additional-samples)
+- [Migration benefits](#migration-benefits)
+- [Important changes](#important-changes)
+  - [Separate packages and clients](#separate-packages-and-clients)
+  - [Client constructors](#client-constructors)
+  - [Create a key](#create-a-key)
+  - [Retrieve a key](#retrieve-a-key)
+  - [List properties of keys](#list-properties-of-keys)
+  - [Delete a key](#delete-a-key)
+  - [Perform cryptographic operations](#perform-cryptographic-operations)
+- [Additional samples](#additional-samples)
 
 ## Migration benefits
 
@@ -28,6 +28,7 @@ To try and improve the development experience across Azure services, a set of un
 ### Cross Service SDK improvements
 
 The modern Key Vault client libraries also share some of the cross-service improvements made to the Azure development experience, such as:
+
 - Using the new `@azure/identity` library to share a single authentication approach between clients.
 - A unified logging and diagnostics pipeline that offers a common view of the activities across each of the client libraries.
 - The use of promises rather than callbacks for a simplified programming experience.
@@ -37,7 +38,7 @@ The modern Key Vault client libraries also share some of the cross-service impro
 
 ### Separate packages and clients
 
-In the interest of simplifying the API for working with Key Vault keys, secrets and certificates, the `azure-keyvault`  package is split into separate packages.
+In the interest of simplifying the API for working with Key Vault keys, secrets and certificates, the `azure-keyvault` package is split into separate packages.
 
 - [`@azure/keyvault-keys`][kvk-npm] contains `KeyClient` for working with Key Vault keys, and `CryptographyClient` for performing cryptographic operations.
 - [`@azure/keyvault-secrets`][kvs-npm] contains `SecretClient` for working with Key Vault secrets.
@@ -51,10 +52,9 @@ Across all of the new Azure client libraries, clients consistently take an endpo
 
 Previously in `azure-keyvault` you could create a `KeyVaultClient` by using credentials from `ms-rest-azure` (up to the version `^2.6.0`. Higher versions are not supported).
 
-
 ```js
-var KeyVault = require('azure-keyvault');
-var msRestAzure = require('ms-rest-azure');
+var KeyVault = require("azure-keyvault");
+var msRestAzure = require("ms-rest-azure");
 
 const clientId = "client id";
 const secret = "client secret";
@@ -62,11 +62,7 @@ const domain = "tenant id";
 const vaultUrl = `https://my-vault.vault.azure.net/`;
 
 async function main() {
-  const credentials = await msRestAzure.loginWithServicePrincipalSecret(
-    clientId,
-    secret,
-    domain
-  );
+  const credentials = await msRestAzure.loginWithServicePrincipalSecret(clientId, secret, domain);
   const client = new KeyVault.KeyVaultClient(credentials);
   const keyVaultKey = await client.getKey(vaultUrl, "MyKey", "");
   console.log(keyVaultKey);
@@ -83,7 +79,7 @@ You can install them by simply running the following command at the root of your
 npm install --save @azure/identity @azure/keyvault-keys
 ```
 
-Below is a simple example using both `@azure/keyvault-keys` and [`DefaultAzureCredential`][identity-readme-DAC]:
+Below is a simple example using both `@azure/keyvault-keys` and [`DefaultAzureCredential`][identity-readme-dac]:
 
 ```ts
 // The default credential first checks environment variables for configuration as described above.
@@ -134,7 +130,7 @@ let keyBundle = await client.createKey(vaultUrl, "myRSAKey", "RSA");
 console.log(keyBundle);
 
 // create an elliptic curve key
-keyBundle = await client.createKey(vaultUrl, "myECKey", "EC")
+keyBundle = await client.createKey(vaultUrl, "myECKey", "EC");
 console.log(keyBundle);
 ```
 
@@ -180,7 +176,9 @@ console.log(keyVaultKey.properties.version);
 
 for await (let versionProperties of client.listPropertiesOfKeyVersions("MyKey")) {
   console.log("Name:", versionProperties.name, "Version:", versionProperties.version);
-  const keyVaultKey = await client.getKey(versionProperties.name, { version: versionProperties.version });
+  const keyVaultKey = await client.getKey(versionProperties.name, {
+    version: versionProperties.version
+  });
   console.log(keyVaultKey.properties.version);
 }
 ```
@@ -230,7 +228,13 @@ In `azure-keyvault` you could perform cryptographic operations with keys by usin
 ```js
 const keyName = "MyKey";
 await client.createKey(vaultUrl, keyName, "RSA");
-const operationResult = await client.encrypt(vaultUrl, keyName, "", "RSA1_5", Buffer.from("plaintext"));
+const operationResult = await client.encrypt(
+  vaultUrl,
+  keyName,
+  "",
+  "RSA1_5",
+  Buffer.from("plaintext")
+);
 console.log(operationResult.result);
 ```
 
@@ -245,14 +249,14 @@ console.log(operationResult.result);
 
 ## Additional samples
 
-* [Key Vault keys samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/javascript)
-* [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
-* [Key Vault keys samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/typescript)
-* [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
+- [Key Vault keys samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/v4/javascript)
+- [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
+- [Key Vault keys samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples/v4/typescript)
+- [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
 
 [kvk-npm]: https://www.npmjs.com/package/@azure/keyvault-keys
 [kvs-npm]: https://www.npmjs.com/package/@azure/keyvault-secrets
 [kvc-npm]: https://www.npmjs.com/package/@azure/keyvault-certificates
 [ts-guidelines]: https://azure.github.io/azure-sdk/typescript_introduction.html
 [identity-npm]: https://www.npmjs.com/package/@azure/identity
-[identity-readme-DAC]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential
+[identity-readme-dac]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/README.md#defaultazurecredential


### PR DESCRIPTION
In #15023 we moved to samples to the V2 flow, but some links were still pointing to the old URL.
This commit updates the links that were reported broken in [ADO](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=867335) to point to the right sample.