### PR TITLE
[core-http] add missing dev dependency @rollup/plugin-replace

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -153,6 +153,7 @@
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
+    "@rollup/plugin-replace": "^2.2.0",
     "@types/chai": "^4.1.6",
     "@types/express": "^4.16.0",
     "@types/glob": "^7.1.1",


### PR DESCRIPTION
to fix build error:

    [!] Error: Cannot find module '@rollup/plugin-replace'

This plugin is used in rollup.config.base.js.