### PR TITLE
Log ms-cv header for every request during tests

### DIFF
--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -81,7 +81,11 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
+    console.log(
+      `MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${
+        requestResponse.status
+      } - ${httpRequest.url})`
+    );
 
     return requestResponse;
   };

--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -81,9 +81,7 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    if (requestResponse.status < 200 || requestResponse.status > 299) {
-      console.log(`MS-CV header for failed request: ${requestResponse.headers.get("ms-cv")}`);
-    }
+    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
 
     return requestResponse;
   };

--- a/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
@@ -129,7 +129,11 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
+    console.log(
+      `MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${
+        requestResponse.status
+      } - ${httpRequest.url})`
+    );
 
     return requestResponse;
   };

--- a/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
@@ -129,9 +129,7 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    if (requestResponse.status < 200 || requestResponse.status > 299) {
-      console.log(`MS-CV header for failed request: ${requestResponse.headers.get("ms-cv")}`);
-    }
+    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
 
     return requestResponse;
   };

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -125,9 +125,7 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    if (requestResponse.status < 200 || requestResponse.status > 299) {
-      console.log(`MS-CV header for failed request: ${requestResponse.headers.get("ms-cv")}`);
-    }
+    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
 
     return requestResponse;
   };

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -125,7 +125,11 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
+    console.log(
+      `MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${
+        requestResponse.status
+      } - ${httpRequest.url})`
+    );
 
     return requestResponse;
   };

--- a/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
@@ -80,7 +80,11 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
+    console.log(
+      `MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${
+        requestResponse.status
+      } - ${httpRequest.url})`
+    );
 
     return requestResponse;
   };

--- a/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
@@ -80,9 +80,7 @@ function createTestHttpClient(): HttpClient {
   ): Promise<HttpOperationResponse> {
     const requestResponse = await originalSendRequest.apply(this, [httpRequest]);
 
-    if (requestResponse.status < 200 || requestResponse.status > 299) {
-      console.log(`MS-CV header for failed request: ${requestResponse.headers.get("ms-cv")}`);
-    }
+    console.log(`MS-CV header for request: ${requestResponse.headers.get("ms-cv")} (${requestResponse.status} - ${httpRequest.url})`);
 
     return requestResponse;
   };


### PR DESCRIPTION
Remove condition that would not log the ms-cv header if the network request was successful