### PR TITLE
Ensure AccessTokens are interpreted as milliseconds-since-epoch values.

### DIFF
--- a/sdk/mixedreality/mixedreality-authentication/src/util/jwt.ts
+++ b/sdk/mixedreality/mixedreality-authentication/src/util/jwt.ts
@@ -36,5 +36,6 @@ export function retrieveJwtExpirationTimestamp(jwtValue: string): number {
     throw new Error("Invalid JWT payload structure. No expiration.");
   }
 
-  return Number.parseInt(jwtPayload.exp);
+  // The JWT expiry value is in seconds-since-epoch whereas JS Dates are in milliseconds-since-epoch.
+  return 1000 * Number.parseInt(jwtPayload.exp);
 }

--- a/sdk/mixedreality/mixedreality-authentication/test/jwt.spec.ts
+++ b/sdk/mixedreality/mixedreality-authentication/test/jwt.spec.ts
@@ -9,7 +9,7 @@ describe("jwt", () => {
     // Note: The trailing "." on the end indicates an empty signature indicating that this JWT is not signed.
     const jwtValue =
       "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYxMDgxMjI1MCIsIm5iZiI6IjE2MTA4MTI1NTAiLCJleHAiOiIxNjEwODk4NjUwIn0.";
-    const expectedExpirationTimestamp = 1610898650; // 1/17/2021 3:50:50 PM UTC
+    const expectedExpirationTimestamp = 1610898650000; // 1/17/2021 3:50:50 PM UTC
 
     const expirationTimestamp = retrieveJwtExpirationTimestamp(jwtValue);
 


### PR DESCRIPTION
JWT expiry values are in seconds-since-epoch whereas JS Dates are in milliseconds-since-epoch. 