### PR TITLE
[dev-tool] [KeyVault] - Fix TypeScript sample README

### DIFF
--- a/common/tools/dev-tool/src/templates/sampleReadme.md.ts
+++ b/common/tools/dev-tool/src/templates/sampleReadme.md.ts
@@ -214,10 +214,8 @@ ${fence(
   "bash",
   `node ${(() => {
     const firstSource = filterModules(info)[0].relativeSourcePath;
-    const fileName = info.useTypeScript
-      ? "dist/" + firstSource
-      : firstSource.replace(/\.ts$/, ".js");
-    return fileName;
+    const filePath = info.useTypeScript ? "dist/" : "";
+    return filePath + firstSource.replace(/\.ts$/, ".js");
   })()}`
 )}
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/README.md
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/README.md
@@ -63,7 +63,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/accessControlHelloWorld.ts
+node dist/accessControlHelloWorld.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):

--- a/sdk/keyvault/keyvault-certificates/samples/v4/typescript/README.md
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/typescript/README.md
@@ -70,7 +70,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/backupAndRestore.ts
+node dist/backupAndRestore.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/README.md
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/README.md
@@ -63,7 +63,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/cryptography.ts
+node dist/cryptography.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/README.md
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/README.md
@@ -65,7 +65,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/backupAndRestore.ts
+node dist/backupAndRestore.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):


### PR DESCRIPTION
## What

- Always use `.js` extension in samples README

## Why

Our README assumes that TS samples will be compiled to JS and that the users run the JS files in either case, the only 
difference between the run commands in our README is where the JS file will be run from. Since these are now generated,
it required a fix in dev-tool.

Fixes #15073 