### PR TITLE
[KeyVault] - Add Managed HSM contributing docs and remove KEYVAULT_NAME

### DIFF
--- a/sdk/keyvault/keyvault-admin/samples-dev/backupRestoreHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples-dev/backupRestoreHelloWorld.ts
@@ -17,13 +17,10 @@ export async function main(): Promise<void> {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"];
+  const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {
-    throw new Error("Missing environment variable KEYVAULT_URI.");
+    throw new Error("Missing environment variable AZURE_MANAGEDHSM_URI.");
   }
   const client = new KeyVaultBackupClient(url, credential);
 

--- a/sdk/keyvault/keyvault-admin/samples-dev/backupSelectiveRestore.ts
+++ b/sdk/keyvault/keyvault-admin/samples-dev/backupSelectiveRestore.ts
@@ -18,9 +18,6 @@ export async function main(): Promise<void> {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
   const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupRestoreHelloWorld.js
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupRestoreHelloWorld.js
@@ -17,13 +17,10 @@ async function main() {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"];
+  const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {
-    throw new Error("Missing environment variable KEYVAULT_URI.");
+    throw new Error("Missing environment variable AZURE_MANAGEDHSM_URI.");
   }
   const client = new KeyVaultBackupClient(url, credential);
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupSelectiveRestore.js
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupSelectiveRestore.js
@@ -18,9 +18,6 @@ async function main() {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
   const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
@@ -18,9 +18,9 @@ export async function main(): Promise<void> {
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
   const credential = new DefaultAzureCredential();
-  const url = process.env["KEYVAULT_URI"];
+  const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {
-    throw new Error("Missing environment variable KEYVAULT_URI.");
+    throw new Error("Missing environment variable AZURE_MANAGEDHSM_URI.");
   }
   const client = new KeyVaultBackupClient(url, credential);
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
@@ -17,9 +17,6 @@ export async function main(): Promise<void> {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
   const url = process.env["KEYVAULT_URI"];
   if (!url) {

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupSelectiveRestore.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupSelectiveRestore.ts
@@ -18,9 +18,6 @@ export async function main(): Promise<void> {
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  // - BLOB_STORAGE_URI: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - BLOB_STORAGE_SAS_TOKEN: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated
-  // - CLIENT_OBJECT_ID: Object ID of the application, tenant or principal to whom the role will be assigned to
   const credential = new DefaultAzureCredential();
   const url = process.env["AZURE_MANAGEDHSM_URI"];
   if (!url) {

--- a/sdk/keyvault/keyvault-admin/test/README.md
+++ b/sdk/keyvault/keyvault-admin/test/README.md
@@ -4,7 +4,7 @@ To test this project, make sure to build it by following our [building instructi
 
 You can use existing Azure resources for the live tests, or generate new ones by using our [New-TestResources.ps1](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/common/TestResources/New-TestResources.ps1) script, which will use an [ARM template](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/test-resources.json) that already has all of the the necessary configurations.
 
-> Only Managed HSM instances support the KeyVault Administration client package, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enabledHsm` as an ARM template parameter.
+> Only Managed HSM instances support the KeyVault Administration client package, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enableHsm` as an ARM template parameter.
 >
 > As an example:
 >
@@ -12,7 +12,7 @@ You can use existing Azure resources for the live tests, or generate new ones by
 > New-TestResources.ps1 -ServiceDirectory 'keyvault' -ArmTemplateParameters @{ "enableHsm" = $true }
 > ```
 
-The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are using an existing Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
+The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are creating your own Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
 
 > Managed HSMs do have an hourly cost even when not in-use. Please review the [Azure Dedicated HSM Pricing page](https://azure.microsoft.com/pricing/details/azure-dedicated-hsm/#pricing) and clean up the resources when not in use.
 

--- a/sdk/keyvault/keyvault-admin/test/README.md
+++ b/sdk/keyvault/keyvault-admin/test/README.md
@@ -4,9 +4,21 @@ To test this project, make sure to build it by following our [building instructi
 
 You can use existing Azure resources for the live tests, or generate new ones by using our [New-TestResources.ps1](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/common/TestResources/New-TestResources.ps1) script, which will use an [ARM template](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/test-resources.json) that already has all of the the necessary configurations.
 
+> Only Managed HSM instances support the KeyVault Administration client package, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enabledHsm` as an ARM template parameter.
+>
+> As an example:
+>
+> ```powershell
+> New-TestResources.ps1 -ServiceDirectory 'keyvault' -ArmTemplateParameters @{ "enableHsm" = $true }
+> ```
+
+The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are using an existing Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
+
+> Managed HSMs do have an hourly cost even when not in-use. Please review the [Azure Dedicated HSM Pricing page](https://azure.microsoft.com/pricing/details/azure-dedicated-hsm/#pricing) and clean up the resources when not in use.
+
 The Azure resource that is used by the tests in this project is:
 
-- An [Azure Key Vault](https://docs.microsoft.com/azure/key-vault/general/basic-concepts). Your Azure Active Directory application needs to be added to the Access Policies of the Key Vault. The steps are provided [below](#aad-based-authentication).
+- An [Azure Managed HSM](https://docs.microsoft.com/azure/key-vault/managed-hsm/overview). Your Azure Active Directory application needs to be added to the Access Policies of the Key Vault. The steps are provided [below](#aad-based-authentication).
 
 To run the live tests, you will also need to set the below environment variables:
 
@@ -14,7 +26,7 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `KEYVAULT_URI`: The name of the key vault to use in the samples.
+- `AZURE_MANAGEDHSM_URI`: The name of the key vault managed HSM to use in the tests.
 - `BLOB_STORAGE_URI`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `BLOB_STORAGE_SAS_TOKEN`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `CLIENT_OBJECT_ID`: Object ID of the application, tenant or principal to whom the role will be assigned to. These tests add and remove roles to and from this ID. **Do not use the same Object Id of the application, tenant or principal you're using to authenticate the client.**
@@ -39,6 +51,6 @@ The following steps will help you setup the AAD credentials.
 - For the `Select principal` field, click on the `None selected`. A panel will appear at the right of the window. Search for your Azure Active Directory application, click the application on the search results, then click "Select" at the bottom.
 - Once your application is selected, click the "Add" button.
 - Click the `Save` button at the top of the Access Policies section of your Key Vault.
-- For more information on securing your Key Vault: [Learn more](https://docs.microsoft.com/azure/key-vault/general/secure-your-key-vault)
+- For more information on securing your Key Vault: [Learn more](https://docs.microsoft.com/azure/key-vault/managed-hsm/access-controls)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2Fkeyvault-admin%2Ftest%2FREADME.png)

--- a/sdk/keyvault/keyvault-admin/test/README.md
+++ b/sdk/keyvault/keyvault-admin/test/README.md
@@ -51,6 +51,6 @@ The following steps will help you setup the AAD credentials.
 - For the `Select principal` field, click on the `None selected`. A panel will appear at the right of the window. Search for your Azure Active Directory application, click the application on the search results, then click "Select" at the bottom.
 - Once your application is selected, click the "Add" button.
 - Click the `Save` button at the top of the Access Policies section of your Key Vault.
-- For more information on securing your Key Vault: [Learn more](https://docs.microsoft.com/azure/key-vault/managed-hsm/access-controls)
+- For more information on securing your Key Vault: [Learn more](https://docs.microsoft.com/azure/key-vault/managed-hsm/access-control)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2Fkeyvault-admin%2Ftest%2FREADME.png)

--- a/sdk/keyvault/keyvault-admin/test/README.md
+++ b/sdk/keyvault/keyvault-admin/test/README.md
@@ -26,7 +26,7 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `AZURE_MANAGEDHSM_URI`: The name of the key vault managed HSM to use in the tests.
+- `AZURE_MANAGEDHSM_URI`: The URI of the Azure Managed HSM to use in the tests.
 - `BLOB_STORAGE_URI`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `BLOB_STORAGE_SAS_TOKEN`: URI of the Blob Storage instance, with the name of the container where the Key Vault backups will be generated.
 - `CLIENT_OBJECT_ID`: Object ID of the application, tenant or principal to whom the role will be assigned to. These tests add and remove roles to and from this ID. **Do not use the same Object Id of the application, tenant or principal you're using to authenticate the client.**

--- a/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/serviceVersionParameter.spec.ts
@@ -22,7 +22,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
           headers: new HttpHeaders(),
           request: httpRequest,
           parsedBody: {
-            id: `${env.KEYVAULT_URI}${path}`,
+            id: `${env.AZURE_MANAGEDHSM_URI}${path}`,
             startTime: new Date(),
             attributes: {}
           }
@@ -56,7 +56,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
     });
 
     it("it should default to the latest API version", async function() {
-      const client = new KeyVaultAccessControlClient(env.KEYVAULT_URI, credential, {
+      const client = new KeyVaultAccessControlClient(env.AZURE_MANAGEDHSM_URI, credential, {
         httpClient: mockHttpClient
       });
       await client.listRoleDefinitions("/").next();
@@ -69,7 +69,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
 
     it("it should allow us to specify an API version from a specific set of versions", async function() {
       const serviceVersion = "7.2";
-      const client = new KeyVaultAccessControlClient(env.KEYVAULT_URI, credential, {
+      const client = new KeyVaultAccessControlClient(env.AZURE_MANAGEDHSM_URI, credential, {
         serviceVersion: serviceVersion as ApIVersions,
         httpClient: mockHttpClient
       });
@@ -89,7 +89,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
     });
 
     it("it should default to the latest API version", async function() {
-      const client = new KeyVaultBackupClient(env.KEYVAULT_URI, credential, {
+      const client = new KeyVaultBackupClient(env.AZURE_MANAGEDHSM_URI, credential, {
         httpClient: mockHttpClient
       });
       await client.beginBackup("secretName", "value");
@@ -102,7 +102,7 @@ describe("The keyvault-admin clients should set the serviceVersion", () => {
 
     it("it should allow us to specify an API version from a specific set of versions", async function() {
       const serviceVersion = "7.2";
-      const client = new KeyVaultBackupClient(env.KEYVAULT_URI, credential, {
+      const client = new KeyVaultBackupClient(env.AZURE_MANAGEDHSM_URI, credential, {
         serviceVersion: serviceVersion as ApIVersions,
         httpClient: mockHttpClient
       });

--- a/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
+++ b/sdk/keyvault/keyvault-admin/test/utils/authentication.ts
@@ -29,7 +29,6 @@ export async function authenticate(that: any): Promise<any> {
       AZURE_CLIENT_ID: "azure_client_id",
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "12345678-1234-1234-1234-123456789012",
-      KEYVAULT_URI: "https://keyvault_name.vault.azure.net/",
       BLOB_CONTAINER_NAME: "uri",
       BLOB_STORAGE_ACCOUNT_NAME: "blob_storage_account_name",
       BLOB_STORAGE_SAS_TOKEN: "blob_storage_sas_token",

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -48,7 +48,6 @@ module.exports = function(config) {
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
-      "KEYVAULT_NAME",
       "KEYVAULT_URI",
       "TEST_MODE"
     ],

--- a/sdk/keyvault/keyvault-keys/test/README.md
+++ b/sdk/keyvault/keyvault-keys/test/README.md
@@ -28,7 +28,8 @@ To run the live tests, you will also need to set the below environment variables
 - `AZURE_CLIENT_ID`: The client ID of an Azure Active Directory application.
 - `AZURE_CLIENT_SECRET`: The client secret of an Azure Active Directory application.
 - `AZURE_TENANT_ID`: The Tenant ID of your organization in Azure Active Directory.
-- `KEYVAULT_URI`: The name of the KeyVault to use.
+- `KEYVAULT_URI`: The URI of the KeyVault to use.
+- `AZURE_MANAGEDHSM_URI`: The URI of the Azure Managed HSM to use in the Managed HSM tests.
 
 The live tests in this project will create, modify and delete [keys](https://docs.microsoft.com/azure/key-vault/keys/about-keys) inside of the provided Azure Key Vault.
 

--- a/sdk/keyvault/keyvault-keys/test/README.md
+++ b/sdk/keyvault/keyvault-keys/test/README.md
@@ -4,6 +4,20 @@ To test this project, make sure to build it by following our [building instructi
 
 You can use existing Azure resources for the live tests, or generate new ones by using our [New-TestResources.ps1](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/common/TestResources/New-TestResources.ps1) script, which will use an [ARM template](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/test-resources.json) that already has all of the the necessary configurations.
 
+> Some tests require an Azure Managed HSM to run in live mode, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enabledHsm` as an ARM template parameter.
+>
+> As an example:
+>
+> ```powershell
+> New-TestResources.ps1 -ServiceDirectory 'keyvault' -ArmTemplateParameters @{ "enableHsm" = $true }
+> ```
+
+The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are using an existing Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
+
+> Managed HSMs do have an hourly cost even when not in-use. Please review the [Azure Dedicated HSM Pricing page](https://azure.microsoft.com/pricing/details/azure-dedicated-hsm/#pricing) and clean up the resources when not in use.
+
+Tests that require a managed HSM will be skipped if the `AZURE_MANAGEDHSM_URI` environment variable is not defined in live mode.
+
 The Azure resource that is used by the tests in this project is:
 
 - An [Azure Key Vault](https://docs.microsoft.com/azure/key-vault/general/basic-concepts). Your Azure Active Directory application needs to be added to the Access Policies of the Key Vault. The steps are provided [below](#aad-based-authentication).

--- a/sdk/keyvault/keyvault-keys/test/README.md
+++ b/sdk/keyvault/keyvault-keys/test/README.md
@@ -4,7 +4,7 @@ To test this project, make sure to build it by following our [building instructi
 
 You can use existing Azure resources for the live tests, or generate new ones by using our [New-TestResources.ps1](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/common/TestResources/New-TestResources.ps1) script, which will use an [ARM template](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/test-resources.json) that already has all of the the necessary configurations.
 
-> Some tests require an Azure Managed HSM to run in live mode, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enabledHsm` as an ARM template parameter.
+> Some tests require an Azure Managed HSM to run in live mode, as such you'll need to ensure one is deployed to run these tests. To do so you'll want to pass `enableHsm` as an ARM template parameter.
 >
 > As an example:
 >
@@ -12,7 +12,7 @@ You can use existing Azure resources for the live tests, or generate new ones by
 > New-TestResources.ps1 -ServiceDirectory 'keyvault' -ArmTemplateParameters @{ "enableHsm" = $true }
 > ```
 
-The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are using an existing Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
+The `New-TestResources` script will ensure that the Managed HSM is activated; however, if you are creating your own Managed HSM there are additional steps required to set up the correct permissions and activate the HSM. Please see [Activate Your Managed HSM](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md#activate-your-managed-hsm) for more information.
 
 > Managed HSMs do have an hourly cost even when not in-use. Please review the [Azure Dedicated HSM Pricing page](https://azure.microsoft.com/pricing/details/azure-dedicated-hsm/#pricing) and clean up the resources when not in use.
 

--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -48,7 +48,6 @@ module.exports = function(config) {
       "AZURE_CLIENT_ID",
       "AZURE_CLIENT_SECRET",
       "AZURE_TENANT_ID",
-      "KEYVAULT_NAME",
       "KEYVAULT_URI",
       "TEST_MODE"
     ],

--- a/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testAuthentication.ts
@@ -15,7 +15,6 @@ export async function authenticate(that: Context): Promise<any> {
       AZURE_CLIENT_ID: "azure_client_id",
       AZURE_CLIENT_SECRET: "azure_client_secret",
       AZURE_TENANT_ID: "azure_tenant_id",
-      KEYVAULT_NAME: "keyvault_name",
       KEYVAULT_URI: "https://keyvault_name.vault.azure.net/"
     },
     customizationsOnRecordings: [


### PR DESCRIPTION
## What

1. Add some information about deploying, testing, and using a Managed HSM for KV Admin and KV Keys
2. Replace KEYVAULT_URI with AZURE_MANAGEDHSM_URI in KV Admin
3. Remove any remaining traces of KEYVAULT_NAME env var

## Why

1. Deploying a Managed HSM is a more involved process but one that is required for any KV Admin tests and some KV Keys tests. A bit of documentation helps there
2. KV Admin only supports AZURE_MANAGEDHSM_URI so it makes sense to make that explicit
3. We can no longer use KEYVAULT_NAME because it's always expected that the URI will be https://<name>.vault.azure.net

We removed most of the KEYVAULT_NAME usages in prior commits, but this just cleans up the remaining for (3)

Resolves #15095 
Resolves #15064 