### PR TITLE
[core lro] add initialResponse to PollOperationState

### DIFF
--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -74,6 +74,7 @@ export interface PollOperation<TState, TResult> {
 // @public
 export interface PollOperationState<TResult> {
     error?: Error;
+    initialRawResponse?: unknown;
     isCancelled?: boolean;
     isCompleted?: boolean;
     isStarted?: boolean;

--- a/sdk/core/core-lro/src/pollOperation.ts
+++ b/sdk/core/core-lro/src/pollOperation.ts
@@ -35,6 +35,11 @@ export interface PollOperationState<TResult> {
    * Will exist if the operation concluded in a result of an expected type.
    */
   result?: TResult;
+  /**
+   * The response of the initial begin operation. It is used to calculate polling
+   * details such as the polling URL and the provisioned resource location.
+   */
+  initialRawResponse?: unknown;
 }
 
 /**


### PR DESCRIPTION
`PollOperationState` is our standard type for typing the state of our LROs. However, this type does not contain all the needed pieces for polling. If something happened and the connection dropped, we can resume polling back from the last known serialized state (using the `resumeFrom` option) but the state does not have all the information needed. The most important piece missing is the URL to poll from. This PR adds the initial raw response to the state type so any poller can use it to figure out the polling URL even if it is resuming from a serialized state. Furthermore, there are LRO scenarios where the result will live in another URL that is provided in a header in the initial response only.

This PR is conservative in the sense that it stores the entire initial raw response even though we could store just the needed pieces from it. However, I am worried about future compatibility if a new LRO scenario needs to be supported where important information is located in other response headers which could force us to update the type in a breaking way. It is also worth noting that Python does the same but they pickle it (is that something we are interested in doing?).

This change paves the way for Track 2 packages to use auto-gened LROs, similar to Python's.