### PR TITLE
[Key Vault] Fixed pollers that wouldn't bubble up unknown errors to end users

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.0-beta.4 (Unreleased)
 
 - Marked `ErrorModel` as deprecated. It was erronously exported publicly in 4.1 and should not be used. Please change the type to use `CertificateOperationError` instead.
+- Fixed a bug with `beginDeleteCertificate` and `beginRecoverDeletedCertificate` in which unknown service errors wouldn't bubble up properly to the end users.
 
 ## 4.2.0-beta.3 (2021-04-06)
 

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
@@ -119,7 +119,6 @@ export class DeleteCertificatePollOperation extends KeyVaultCertificatePollOpera
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
@@ -119,6 +119,8 @@ export class DeleteCertificatePollOperation extends KeyVaultCertificatePollOpera
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
@@ -117,7 +117,6 @@ export class RecoverDeletedCertificatePollOperation extends KeyVaultCertificateP
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
@@ -117,6 +117,8 @@ export class RecoverDeletedCertificatePollOperation extends KeyVaultCertificateP
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as assert from "assert";
+import { assert } from "chai";
+import { RestError } from "@azure/core-http";
 import { DeleteCertificatePoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedCertificatePoller } from "../../src/lro/recover/poller";
 
@@ -19,9 +20,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedCertificate(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteCertificatePoller({
@@ -32,7 +31,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -45,9 +44,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedCertificate(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteCertificatePoller({
@@ -59,12 +56,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async deleteCertificate(): Promise<any> {
             return {
@@ -73,9 +70,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getDeletedCertificate(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new DeleteCertificatePoller({
@@ -111,9 +106,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getCertificate(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedCertificatePoller({
@@ -124,7 +117,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -141,9 +134,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getCertificate(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedCertificatePoller({
@@ -155,12 +146,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async recoverDeletedCertificate(): Promise<any> {
             return {
@@ -173,9 +164,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getCertificate(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new RecoverDeletedCertificatePoller({

--- a/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { DeleteCertificatePoller } from "../../src/lro/delete/poller";
+import { RecoverDeletedCertificatePoller } from "../../src/lro/recover/poller";
+
+describe("The LROs properly throw on unexpected errors", () => {
+  const vaultUrl = `https://keyVaultName.vault.azure.net`;
+
+  describe("delete LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async deleteCertificate(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getDeletedCertificate(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteCertificatePoller({
+        vaultUrl,
+        certificateName: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async deleteCertificate(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getDeletedCertificate(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteCertificatePoller({
+        vaultUrl,
+        certificateName: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async deleteCertificate(): Promise<any> {
+            return {
+              id: "/version/name/version",
+              recoveryId: "something"
+            };
+          },
+          async getDeletedCertificate(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new DeleteCertificatePoller({
+          vaultUrl,
+          certificateName: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+
+  describe("recover LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async recoverDeletedCertificate(): Promise<any> {
+          return {
+            _response: {
+              parsedBody: {
+                id: "/version/name/version",
+                recoveryId: "something"
+              }
+            }
+          };
+        },
+        async getCertificate(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedCertificatePoller({
+        vaultUrl,
+        certificateName: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async recoverDeletedCertificate(): Promise<any> {
+          return {
+            _response: {
+              parsedBody: {
+                id: "/version/name/version",
+                recoveryId: "something"
+              }
+            }
+          };
+        },
+        async getCertificate(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedCertificatePoller({
+        vaultUrl,
+        certificateName: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async recoverDeletedCertificate(): Promise<any> {
+            return {
+              _response: {
+                parsedBody: {
+                  id: "/version/name/version",
+                  recoveryId: "something"
+                }
+              }
+            };
+          },
+          async getCertificate(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new RecoverDeletedCertificatePoller({
+          vaultUrl,
+          certificateName: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+});

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed the now obsolete `KeyOperationsOptions` and replaced it with `CryptographyOptions`.
   - Introduced in 4.2.0-beta.1 to support additional encryption parameters for AES encryption, we have since moved these parameters outside of the options bag so a separate `KeyOperationsOptions` is now redundant.
+- Fixed a bug with `beginDeleteKey` and `beginRecoverDeletedKey` in which unknown service errors wouldn't bubble up properly to the end users.
 
 ## 4.2.0-beta.5 (2021-04-06)
 

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
@@ -85,7 +85,6 @@ export class DeleteKeyPollOperation extends KeyVaultKeyPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
@@ -85,6 +85,8 @@ export class DeleteKeyPollOperation extends KeyVaultKeyPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -99,6 +99,8 @@ export class RecoverDeletedKeyPollOperation extends KeyVaultKeyPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -99,7 +99,6 @@ export class RecoverDeletedKeyPollOperation extends KeyVaultKeyPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { DeleteKeyPoller } from "../../src/lro/delete/poller";
+import { RecoverDeletedKeyPoller } from "../../src/lro/recover/poller";
+
+describe("The LROs properly throw on unexpected errors", () => {
+  const vaultUrl = `https://keyVaultName.vault.azure.net`;
+
+  describe("delete LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async deleteKey(): Promise<any> {
+          return {
+            key: {
+              kid: "/version/name/version"
+            },
+            recoveryId: "something"
+          };
+        },
+        async getDeletedKey(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteKeyPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async deleteKey(): Promise<any> {
+          return {
+            key: {
+              kid: "/version/name/version"
+            },
+            recoveryId: "something"
+          };
+        },
+        async getDeletedKey(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteKeyPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async deleteKey(): Promise<any> {
+            return {
+              key: {
+                kid: "/version/name/version"
+              },
+              recoveryId: "something"
+            };
+          },
+          async getDeletedKey(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new DeleteKeyPoller({
+          vaultUrl,
+          name: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+
+  describe("recover LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async recoverDeletedKey(): Promise<any> {
+          return {
+            key: {
+              kid: "/version/name/version"
+            },
+            recoveryId: "something"
+          };
+        },
+        async getKey(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedKeyPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async recoverDeletedKey(): Promise<any> {
+          return {
+            key: {
+              kid: "/version/name/version"
+            },
+            recoveryId: "something"
+          };
+        },
+        async getKey(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedKeyPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async recoverDeletedKey(): Promise<any> {
+            return {
+              key: {
+                kid: "/version/name/version"
+              },
+              recoveryId: "something"
+            };
+          },
+          async getKey(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new RecoverDeletedKeyPoller({
+          vaultUrl,
+          name: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+});

--- a/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as assert from "assert";
+import { assert } from "chai";
+import { RestError } from "@azure/core-http";
 import { DeleteKeyPoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedKeyPoller } from "../../src/lro/recover/poller";
 
@@ -21,9 +22,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedKey(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteKeyPoller({
@@ -34,7 +33,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -49,9 +48,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedKey(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteKeyPoller({
@@ -63,12 +60,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async deleteKey(): Promise<any> {
             return {
@@ -79,9 +76,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getDeletedKey(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new DeleteKeyPoller({
@@ -115,9 +110,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getKey(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedKeyPoller({
@@ -128,7 +121,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -143,9 +136,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getKey(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedKeyPoller({
@@ -157,12 +148,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async recoverDeletedKey(): Promise<any> {
             return {
@@ -173,9 +164,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getKey(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new RecoverDeletedKeyPoller({

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.2.0-beta.5 (Unreleased)
 
+- Fixed a bug with `beginDeleteSecret` and `beginRecoverDeletedSecret` in which unknown service errors wouldn't bubble up properly to the end users.
 
 ## 4.2.0-beta.4 (2021-04-06)
 

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
@@ -95,7 +95,6 @@ export class DeleteSecretPollOperation extends KeyVaultSecretPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
@@ -95,6 +95,8 @@ export class DeleteSecretPollOperation extends KeyVaultSecretPollOperation<
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
@@ -110,6 +110,8 @@ export class RecoverDeletedSecretPollOperation extends KeyVaultSecretPollOperati
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
+        } else {
+          throw error;
         }
       }
     }

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
@@ -110,7 +110,6 @@ export class RecoverDeletedSecretPollOperation extends KeyVaultSecretPollOperati
         } else if (error.statusCode !== 404) {
           state.error = error;
           state.isCompleted = true;
-        } else {
           throw error;
         }
       }

--- a/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { DeleteSecretPoller } from "../../src/lro/delete/poller";
+import { RecoverDeletedSecretPoller } from "../../src/lro/recover/poller";
+
+describe("The LROs properly throw on unexpected errors", () => {
+  const vaultUrl = `https://keyVaultName.vault.azure.net`;
+
+  describe("delete LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async deleteSecret(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getDeletedSecret(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteSecretPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async deleteSecret(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getDeletedSecret(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new DeleteSecretPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async deleteSecret(): Promise<any> {
+            return {
+              id: "/version/name/version",
+              recoveryId: "something"
+            };
+          },
+          async getDeletedSecret(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new DeleteSecretPoller({
+          vaultUrl,
+          name: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+
+  describe("recover LRO", () => {
+    it("403 doesn't throw", async function() {
+      const code = 403;
+      const client: any = {
+        async recoverDeletedSecret(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getSecret(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedSecretPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.pollUntilDone();
+
+      assert.ok(poller.getOperationState().isCompleted);
+    });
+
+    it("404 doesn't throw", async function() {
+      const code = 404;
+      const client: any = {
+        async recoverDeletedSecret(): Promise<any> {
+          return {
+            id: "/version/name/version",
+            recoveryId: "something"
+          };
+        },
+        async getSecret(): Promise<any> {
+          const error = new Error(`${code}`);
+          (error as any).statusCode = code;
+          throw error;
+        }
+      };
+      const poller = new RecoverDeletedSecretPoller({
+        vaultUrl,
+        name: "name",
+        client
+      });
+
+      await poller.poll();
+      await poller.poll();
+
+      assert.ok(!poller.getOperationState().isCompleted);
+    });
+
+    it("Errors other than 403 and 404 throw", async function() {
+      const codes = [401, 402, 405, 500];
+      for (const code in codes) {
+        const client: any = {
+          async recoverDeletedSecret(): Promise<any> {
+            return {
+              id: "/version/name/version",
+              recoveryId: "something"
+            };
+          },
+          async getSecret(): Promise<any> {
+            const error = new Error(`${code}`);
+            (error as any).statusCode = code;
+            throw error;
+          }
+        };
+        const poller = new RecoverDeletedSecretPoller({
+          vaultUrl,
+          name: "name",
+          client
+        });
+
+        let error: Error | null = null;
+        try {
+          await poller.pollUntilDone();
+        } catch (e) {
+          error = e;
+        }
+
+        assert.equal((error as any).statusCode, code);
+      }
+    });
+  });
+});

--- a/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/internal/lroUnexpectedErrors.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as assert from "assert";
+import { assert } from "chai";
+import { RestError } from "@azure/core-http";
 import { DeleteSecretPoller } from "../../src/lro/delete/poller";
 import { RecoverDeletedSecretPoller } from "../../src/lro/recover/poller";
 
@@ -19,9 +20,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedSecret(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteSecretPoller({
@@ -32,7 +31,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -45,9 +44,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getDeletedSecret(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new DeleteSecretPoller({
@@ -59,12 +56,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async deleteSecret(): Promise<any> {
             return {
@@ -73,9 +70,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getDeletedSecret(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new DeleteSecretPoller({
@@ -107,9 +102,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getSecret(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedSecretPoller({
@@ -120,7 +113,7 @@ describe("The LROs properly throw on unexpected errors", () => {
 
       await poller.pollUntilDone();
 
-      assert.ok(poller.getOperationState().isCompleted);
+      assert.isTrue(poller.getOperationState().isCompleted);
     });
 
     it("404 doesn't throw", async function() {
@@ -133,9 +126,7 @@ describe("The LROs properly throw on unexpected errors", () => {
           };
         },
         async getSecret(): Promise<any> {
-          const error = new Error(`${code}`);
-          (error as any).statusCode = code;
-          throw error;
+          throw new RestError(`${code}`, undefined, code);
         }
       };
       const poller = new RecoverDeletedSecretPoller({
@@ -147,12 +138,12 @@ describe("The LROs properly throw on unexpected errors", () => {
       await poller.poll();
       await poller.poll();
 
-      assert.ok(!poller.getOperationState().isCompleted);
+      assert.isUndefined(poller.getOperationState().isCompleted);
     });
 
     it("Errors other than 403 and 404 throw", async function() {
       const codes = [401, 402, 405, 500];
-      for (const code in codes) {
+      for (const code of codes) {
         const client: any = {
           async recoverDeletedSecret(): Promise<any> {
             return {
@@ -161,9 +152,7 @@ describe("The LROs properly throw on unexpected errors", () => {
             };
           },
           async getSecret(): Promise<any> {
-            const error = new Error(`${code}`);
-            (error as any).statusCode = code;
-            throw error;
+            throw new RestError(`${code}`, undefined, code);
           }
         };
         const poller = new RecoverDeletedSecretPoller({


### PR DESCRIPTION
Recently we found that if Azure had unexpected errors, they wouldn't properly bubble up in these Key Vault pollers. This PR ensures the errors bubble up.