### PR TITLE
Add spellcheck to analysis

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.1",
+  "language": "en",
+  "languageId": "typescript,javascript",
+  "dictionaries": ["powershell"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/recordings/**",
+    "**/pnpm-lock.yaml",
+    "common/temp/**",
+    "**/*-lintReport.html",
+    "*.avro",
+    "*.tgz",
+    "*.png",
+    "*.jpg",
+    "*.pdf",
+    "*.tiff",
+    "*.svg",
+    "*.crt",
+    "*.key"
+  ],
+  "words": [],
+  "allowCompoundWords": true
+}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -17,8 +17,9 @@
     "*.tiff",
     "*.svg",
     "*.crt",
-    "*.key"
+    "*.key",
+    ".vscode/cspell.json"
   ],
-  "words": [],
+  "words": ["deps", "pwsh"],
   "allowCompoundWords": true
 }

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -4,6 +4,8 @@ parameters:
   TestPipeline: false
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+
   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
     parameters:
       PackageName: "@azure/template"


### PR DESCRIPTION
Example spelling error warning: 

![image](https://user-images.githubusercontent.com/2158838/116761539-ce083900-a9cc-11eb-90b1-331d092534be.png)

Adding this in does not block the build or turn the build yellow/red. Additional information at: https://aka.ms/azsdk/engsys/spellcheck