### PR TITLE
Revert "Pin identity dev dependency to avoid re-recording"

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -69,7 +69,7 @@
     // @azure/event-processor-host is on a much lower major version
     "@azure/ms-rest-nodeauth": ["^0.9.2"],
     // Idenity is moving from v1 to v2. Moving all packages to v2 is going to take a bit of time, in the mean time we could use v2 on the perf-identity tests.
-    "@azure/identity": ["2.0.0-beta.3", "~1.3.0"],
+    "@azure/identity": ["2.0.0-beta.3", "^1.1.0"],
     // Issue #14771 tracks updating to these versions
     "@microsoft/api-extractor": ["7.13.2"],
     "prettier": ["2.2.1"]

--- a/sdk/anomalydetector/ai-anomaly-detector/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -25,7 +25,7 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -88,7 +88,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -76,7 +76,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -113,7 +113,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -88,7 +88,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@types/chai": "^4.1.6",

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -73,7 +73,7 @@
     "@azure/storage-blob": "^12.5.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -131,7 +131,7 @@
     "@azure/core-rest-pipeline": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/identity": "~1.3.0",
+    "@azure/identity": "^1.1.0",
     "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@types/chai": "^4.1.6",


### PR DESCRIPTION
## What
Reverting d79b27726e0aeb96629e9de87ded8da17b8067aa since we are now no longer pinning to 1.3.0.
But we still have multiple Identity versions in-flight, so we need the common-versions config

## Why
This will resolve https://dev.azure.com/azure-sdk/internal/_build/results?buildId=873579&view=results
As per https://github.com/Azure/azure-sdk-for-js/issues/14909#issuecomment-827980215 we no longer need to prep a v1 update to identity so we can standardize on ^1.1.0 (as there will be no changes in v1 that will force re-recording)