### PR TITLE
[core-rest-pipeline] make CAE policy options' `credential` optional

### DIFF
--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -64,7 +64,7 @@ export const bearerTokenChallengeAuthenticationPolicyName = "bearerTokenChalleng
 // @public
 export interface BearerTokenChallengeAuthenticationPolicyOptions {
     challengeCallbacks?: ChallengeCallbacks;
-    credential: TokenCredential;
+    credential?: TokenCredential;
     scopes: string[];
 }
 

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenChallengeAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenChallengeAuthenticationPolicy.ts
@@ -138,7 +138,7 @@ export function bearerTokenChallengeAuthenticationPolicy(
   // in order to pass through the `options` object.
   const getAccessToken = credential
     ? createTokenCycler(credential /* , options */).getToken
-    : (_scopes: string | string[], _options: GetTokenOptions) => Promise.resolve(null);
+    : () => Promise.resolve(null);
 
   return {
     name: bearerTokenChallengeAuthenticationPolicyName,

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenChallengeAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenChallengeAuthenticationPolicy.ts
@@ -76,7 +76,7 @@ export interface BearerTokenChallengeAuthenticationPolicyOptions {
   /**
    * The TokenCredential implementation that can supply the bearer token.
    */
-  credential: TokenCredential;
+  credential?: TokenCredential;
   /**
    * The scopes for which the bearer token applies.
    */
@@ -136,7 +136,9 @@ export function bearerTokenChallengeAuthenticationPolicy(
   // The options are left out of the public API until there's demand to configure this.
   // Remember to extend `BearerTokenChallengeAuthenticationPolicyOptions` with `TokenCyclerOptions`
   // in order to pass through the `options` object.
-  const cycler = createTokenCycler(credential /* , options */);
+  const getAccessToken = credential
+    ? createTokenCycler(credential /* , options */).getToken
+    : (_scopes: string | string[], _options: GetTokenOptions) => Promise.resolve(null);
 
   return {
     name: bearerTokenChallengeAuthenticationPolicyName,
@@ -157,7 +159,7 @@ export function bearerTokenChallengeAuthenticationPolicy(
       await callbacks.authorizeRequest({
         scopes,
         request,
-        getAccessToken: cycler.getToken
+        getAccessToken
       });
 
       let response: PipelineResponse;
@@ -179,7 +181,7 @@ export function bearerTokenChallengeAuthenticationPolicy(
           scopes,
           request,
           response,
-          getAccessToken: cycler.getToken
+          getAccessToken
         });
 
         if (shouldSendRequest) {


### PR DESCRIPTION
Azure Container Registry allows anonymous pull access, in which case,
TokenCredential is not required for its challenge-based auth
flow. This PR makes `credential` optional in the bearer token
challenge auth policy options so that an `undefined` value is allowed.

ACR SDK library would send an unauthorized initial request to ACR Api
endpoint, get a challenge back then continue to handle the challenge.