### PR TITLE
[communication] phonenumber enable browser aad test

### DIFF
--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -116,7 +116,7 @@ module.exports = function(config) {
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
+        flags: ["--no-sandbox", "--disable-web-security"]
       }
     },
 

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -61,7 +61,10 @@ module.exports = function(config) {
       "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING",
       "INCLUDE_PHONENUMBER_LIVE_TESTS",
       "AZURE_PHONE_NUMBER",
-      "COMMUNICATION_ENDPOINT"
+      "COMMUNICATION_ENDPOINT",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_TENANT_ID"
     ],
 
     // test results reporter to use

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number/recording_can_get_a_purchased_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number/recording_can_get_a_purchased_phone_number.json
@@ -10,7 +10,14 @@
    "status": 200,
    "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-02-10T17:52:41.818335+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:36 GMT",
+    "ms-cv": "0y4VnZUfoEOBmth+TDejbA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0Q1SUYAAAAACJQjlmwq3DQb7CqAk7bZSTWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1055ms"
    }
   }
  ],

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number/recording_errors_if_phone_number_not_found.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number/recording_errors_if_phone_number_not_found.json
@@ -10,7 +10,14 @@
    "status": 404,
    "response": "{\"error\":{\"code\":\"PhoneNumberNotFound\",\"message\":\"The specified phone number +14155550100 cannot be found.\",\"target\":\"phonenumber\"}}",
    "responseHeaders": {
-    "content-type": "application/json"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json",
+    "date": "Thu, 06 May 2021 20:40:37 GMT",
+    "ms-cv": "JsEm3ZVF902FuE2TJ4DgJA.0",
+    "request-context": "appId=",
+    "status": "404",
+    "x-azure-ref": "0RFSUYAAAAAB8MOgUCy4HR47lUgmzOymVWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "917ms"
    }
   }
  ],

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:32 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.25 - NCUS ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-02-10T17:52:41.818335+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:34 GMT",
+    "ms-cv": "1OoSOlzdYUmOdbtuG5K/DQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0QVSUYAAAAAAHUNTFYdBkTZaMPv/XDZv2WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1861ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "9b48c99747b8d694d1693146c9f46244"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:35 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.25 - NCUS ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"PhoneNumberNotFound\",\"message\":\"The specified phone number +14155550100 cannot be found.\",\"target\":\"phonenumber\"}}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json",
+    "date": "Thu, 06 May 2021 20:40:35 GMT",
+    "ms-cv": "abcwXPRsLEig5VIXfQ82ww.0",
+    "request-context": "appId=",
+    "status": "404",
+    "x-azure-ref": "0Q1SUYAAAAAAYwNBCv7e3TYDMbDCQ5inMWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "293ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "b2f9e435061a983cbe93b0b5d3cc32d1"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.json
@@ -1,6 +1,30 @@
 {
  "recordings": [
   {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:37 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.25 - SCUS ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
    "method": "GET",
    "url": "https://endpoint/phoneNumbers",
    "query": {
@@ -13,12 +37,12 @@
    "responseHeaders": {
     "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "date": "Thu, 06 May 2021 20:40:48 GMT",
-    "ms-cv": "jnIVB3sqD0q70Llu/mdrpg.0",
+    "date": "Thu, 06 May 2021 20:40:40 GMT",
+    "ms-cv": "HkjChlGggk60c8PSEz751g.0",
     "request-context": "appId=",
     "status": "200",
-    "x-azure-ref": "0SVSUYAAAAADjIMiCboZMSo6ZNeW59uR8WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-    "x-processing-time": "7441ms"
+    "x-azure-ref": "0RVSUYAAAAADXTJ+zEgmAQIgFiA0jq+A9WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "3198ms"
    }
   }
  ],

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release/recording_can_purchase_and_release_a_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release/recording_can_purchase_and_release_a_phone_number.json
@@ -10,11 +10,19 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
+    "access-control-expose-headers": "Location,Operation-Location,operation-id,search-id",
+    "api-supported-versions": "2021-03-07",
     "content-length": "0",
+    "date": "Thu, 06 May 2021 20:41:39 GMT",
     "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "TwzusDqyzEKZ2fbl+q3mEg.0",
     "operation-id": "search_sanitized",
     "operation-location": "/phoneNumbers/operations/search_sanitized?api-version=2021-03-07",
-    "search-id": "sanitized"
+    "request-context": "appId=",
+    "search-id": "sanitized",
+    "status": "202",
+    "x-azure-ref": "0glSUYAAAAAAuix4NO7QgT7lQ58QK3LZDWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1858ms"
    }
   },
   {
@@ -25,10 +33,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:41:39 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "OBxdtrbUVk+ARXZm8pKTAQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0hFSUYAAAAABr6Zx6lb2lS4veY99IGF8mWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "348ms"
    }
   },
   {
@@ -39,24 +55,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
-   "query": {
-    "api-version": "2021-03-07"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
-   "responseHeaders": {
-    "content-type": "application/json; charset=utf-8",
-    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:41:41 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "zDIDXTzIB0WigH6AzNs2Qw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0hlSUYAAAAAC3agYUP2L+TalyxJezDpbPWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "304ms"
    }
   },
   {
@@ -67,9 +77,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-04-06T22:21:48.9536397+00:00\"}",
+   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-05-06T20:57:41.9440970+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:44 GMT",
+    "ms-cv": "aVM5nj/gdUiVkKBTzWf4Cg.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0iFSUYAAAAADUaNVTgF7YTJvcoNC+6fPoWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "744ms"
    }
   },
   {
@@ -82,10 +99,18 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,operation-id,purchase-id",
+    "api-supported-versions": "2021-03-07",
     "content-length": "0",
+    "date": "Thu, 06 May 2021 20:41:48 GMT",
+    "ms-cv": "pYTzoPNU2EmMjw1KbBZnsg.0",
     "operation-id": "purchase_sanitized",
     "operation-location": "/phoneNumbers/operations/purchase_sanitized?api-version=2021-03-07",
-    "purchase-id": "sanitized"
+    "purchase-id": "sanitized",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "0i1SUYAAAAACcu8uPIwi6SrQ8lw+nSKMDWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1852ms"
    }
   },
   {
@@ -96,9 +121,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:48 GMT",
+    "ms-cv": "BJO59WuAlECgHnQvrLPFYw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0jVSUYAAAAADgOI2jCC7sSahRx99UOeUNWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "360ms"
    }
   },
   {
@@ -109,9 +141,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:51 GMT",
+    "ms-cv": "wr03qW4VeUe0uzK55VfvTQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0j1SUYAAAAADKKlqjDXNkR7iUcFmHNB3nWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "432ms"
    }
   },
   {
@@ -122,9 +161,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:53 GMT",
+    "ms-cv": "yYaFF3Hk1EGFIfm6v+1NcQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0klSUYAAAAAC8oxgB5HKCS60Q+13VxOy1WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "313ms"
    }
   },
   {
@@ -135,9 +181,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:56 GMT",
+    "ms-cv": "XiFaDJymjEm4f1QyBnTfnw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0lFSUYAAAAAD2GZ02KhROTarttKoezPK0WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "360ms"
    }
   },
   {
@@ -148,9 +201,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:58 GMT",
+    "ms-cv": "4sqNPHW+9kuqlXvU4xW78w.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0l1SUYAAAAAArOXzK8hjrRpBHUdL6FlskWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "396ms"
    }
   },
   {
@@ -161,9 +221,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:01 GMT",
+    "ms-cv": "fNKQ+NJv2EOcW8dgJJyLFQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0mVSUYAAAAADRBDs90+baQbk5CfENdnzJWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "298ms"
    }
   },
   {
@@ -174,9 +241,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:03 GMT",
+    "ms-cv": "8c/+p5fAvkSybwGxgqt3SA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0nFSUYAAAAAB1AYwPRdWnR6BNA2Jb0y65WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "448ms"
    }
   },
   {
@@ -187,9 +261,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:05 GMT",
+    "ms-cv": "qzXRoHJrQ0WTvzPsnCbwrA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0nlSUYAAAAAA7Wr14m7nsRYhvdOFaxYPwWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "289ms"
    }
   },
   {
@@ -200,22 +281,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:39.6012423+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
-   "query": {
-    "api-version": "2021-03-07"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:05:43.1562414+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
-   "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:09 GMT",
+    "ms-cv": "jpNceUcFUU6ACYeEbpPniA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0oFSUYAAAAACPX6fisQTMSJugXYPIzps1WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "281ms"
    }
   },
   {
@@ -226,9 +301,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-04-06T22:06:18.4380182+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
+   "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-05-06T20:42:06.5006268+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:16 GMT",
+    "ms-cv": "ZJlMDT/AWU+dp3LRJHRuyw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0pVSUYAAAAACf3UDHzJrSQaIAPwP85uyQWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "3021ms"
    }
   },
   {
@@ -241,10 +323,18 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,operation-id,release-id",
+    "api-supported-versions": "2021-03-07",
     "content-length": "0",
+    "date": "Thu, 06 May 2021 20:42:18 GMT",
+    "ms-cv": "glhUzcN+9EGEjXmwWn1UZw.0",
     "operation-id": "release_sanitized",
     "operation-location": "/phoneNumbers/operations/release_sanitized?api-version=2021-03-07",
-    "release-id": "sanitized"
+    "release-id": "sanitized",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "0qFSUYAAAAAAhCmqFemBpTK7yZqYMq9x8WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1789ms"
    }
   },
   {
@@ -255,9 +345,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:42:16.702957+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:18 GMT",
+    "ms-cv": "WGdrus8RxUqBf0pjNF0jjw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0qlSUYAAAAAAWmVznwRA+R7KZivcm7r8yWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "274ms"
    }
   },
   {
@@ -268,9 +365,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:42:16.702957+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:20 GMT",
+    "ms-cv": "mSlSbX4eQUyhcIqOKq+nYw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0rFSUYAAAAABakPd75q9QQo68F3xRhFqRWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "249ms"
    }
   },
   {
@@ -281,9 +385,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:42:16.702957+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:23 GMT",
+    "ms-cv": "w9/Mv04cu0aVniLcXADckA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0rlSUYAAAAAChr9tCfcdiTaEZPUZeK6L4WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "322ms"
    }
   },
   {
@@ -294,48 +405,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:42:16.702957+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
-   "query": {
-    "api-version": "2021-03-07"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
-   "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
-   "query": {
-    "api-version": "2021-03-07"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
-   "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
-   "query": {
-    "api-version": "2021-03-07"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-04-06T22:06:28.4644514+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
-   "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:25 GMT",
+    "ms-cv": "364lO3StO0SBf8yDFFoiHA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0sVSUYAAAAAAPf3Vu7BmjRJxe1RzW+sukWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "266ms"
    }
   }
  ],
@@ -343,5 +422,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "67a8d99cd8c671db64f6746efa5b06a3"
+ "hash": "0146db22b1c4d3d6eb8bd9e7ed41b960"
 }

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.json
@@ -1,0 +1,450 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:48 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11722.17 - WUS2 ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/availablePhoneNumbers/countries/US/:search",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"quantity\":1}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location,Operation-Location,operation-id,search-id",
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:40:50 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "bJa4Yn6BS0S02gkLX5Dxag.0",
+    "operation-id": "search_sanitized",
+    "operation-location": "/phoneNumbers/operations/search_sanitized?api-version=2021-03-07",
+    "request-context": "appId=",
+    "search-id": "sanitized",
+    "status": "202",
+    "x-azure-ref": "0UVSUYAAAAACckGEpcuCHSJJn4mEi61bbWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "2272ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:51 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "OmtBuiFgmkWPOBvHjMiGzw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0U1SUYAAAAAACTUjrbA1gQ4G5zUuid4LnWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "291ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:53 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "ATRMzM/ezUeQKVTyNBiWeA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0VVSUYAAAAAC9IWyvbXjTQ5BLwRPb1Ak5WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "358ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/availablePhoneNumbers/searchResults/sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-05-06T20:56:53.8131203+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:40:56 GMT",
+    "ms-cv": "gkTjPLHly0qXVSK/3uu/VA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0WFSUYAAAAAB2wu/Me7MvQYe7elra/05NWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "652ms"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/availablePhoneNumbers/:purchase",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"searchId\":\"sanitized\"}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,operation-id,purchase-id",
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:41:00 GMT",
+    "ms-cv": "4CijZrtA+0Scn1IQe8D7VQ.0",
+    "operation-id": "purchase_sanitized",
+    "operation-location": "/phoneNumbers/operations/purchase_sanitized?api-version=2021-03-07",
+    "purchase-id": "sanitized",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "0WlSUYAAAAABfTQ/zxuAmTbQzu4p8vM/fWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1840ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:00 GMT",
+    "ms-cv": "yLflT2C3eU+HmwvB3sgbFQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0XFSUYAAAAAAG7vko86FSQb5e+Yo7tyuoWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "301ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:02 GMT",
+    "ms-cv": "/nw7BuXl5UauoI+P7LhlRg.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0X1SUYAAAAACt9Dj7IUI+Ta+VBULd7fdQWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "281ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:05 GMT",
+    "ms-cv": "YQ1JMbGE+EK4koaZsY0A5g.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0YVSUYAAAAADeM0Z98mD2SYsq/xIIM3lbWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "275ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:07 GMT",
+    "ms-cv": "3bwFsfomhkCKShxN8GGlsA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0Y1SUYAAAAAAQspX2RapNTY9HJNWSikC/WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "293ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:09 GMT",
+    "ms-cv": "l7wLjvXmBU+PBKlV0m8XNg.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0ZlSUYAAAAACYNbLqJy8eRp0AbGlP4AXNWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "294ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:12 GMT",
+    "ms-cv": "uLkUJud5xU6QYY9PaQ2Sow.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0aFSUYAAAAAByv2fGyTEKRohVHDw70gJ7WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "270ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:14 GMT",
+    "ms-cv": "ADKYDzRI+kKW3bOAYpJSvQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0alSUYAAAAABjmMFX3CfsT51Ong0IajfZWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "278ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/purchase_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:40:50.8942178+00:00\",\"id\":\"purchase_sanitized\",\"operationType\":\"purchase\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:16 GMT",
+    "ms-cv": "uDklKirGnU+3VTBoyL/yNw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0bVSUYAAAAADiy9+RN+TGTKS6gq6zV86CWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "295ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-05-06T20:41:15.913193+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:21 GMT",
+    "ms-cv": "ZNoFsojHhUu3nn5u19ftKw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0cVSUYAAAAADNPFziFlD9TZyaC9/R004RWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "922ms"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,operation-id,release-id",
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:41:22 GMT",
+    "ms-cv": "xu8w7beq10WStx9MGtIoSg.0",
+    "operation-id": "release_sanitized",
+    "operation-location": "/phoneNumbers/operations/release_sanitized?api-version=2021-03-07",
+    "release-id": "sanitized",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "0clSUYAAAAACWiIBOJKi0R53CTET2QkdgWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "862ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:22.8000789+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:23 GMT",
+    "ms-cv": "RZmsnI8el0qoAShxGIjXXQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0c1SUYAAAAABduUC0Cma0S7NdZ8UvQWt7WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "479ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:22.8000789+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:25 GMT",
+    "ms-cv": "Edh/juUIakWy92EgaNJzwA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0dVSUYAAAAABC+uCAoqSTSoVQ9cawCekxWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "683ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:22.8000789+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:28 GMT",
+    "ms-cv": "vwricN/bQE2aLRKgTZSvrQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0eFSUYAAAAADZ436F+riyRLfaZo/EnsO/WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "584ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:22.8000789+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:30 GMT",
+    "ms-cv": "/Xw6j9G1SEiNkCQnNMmz0A.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0e1SUYAAAAADcnkHV3pilRLztIKZSOSPoWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "334ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/release_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":null,\"createdDateTime\":\"2021-05-06T20:41:22.8000789+00:00\",\"id\":\"release_sanitized\",\"operationType\":\"releasePhoneNumber\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:41:33 GMT",
+    "ms-cv": "Y8Kh/zI/UEq/d11Ro4BTHw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0fVSUYAAAAAD4Y0FCAAjQSYtASFPiILlUWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "310ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "0146db22b1c4d3d6eb8bd9e7ed41b960"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search/recording_can_search_for_1_available_phone_number_by_default.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search/recording_can_search_for_1_available_phone_number_by_default.json
@@ -10,11 +10,19 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
+    "access-control-expose-headers": "Location,Operation-Location,operation-id,search-id",
+    "api-supported-versions": "2021-03-07",
     "content-length": "0",
+    "date": "Thu, 06 May 2021 20:42:46 GMT",
     "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "Hy5ASWHD8EKKhFeH7B207w.0",
     "operation-id": "search_sanitized",
     "operation-location": "/phoneNumbers/operations/search_sanitized?api-version=2021-03-07",
-    "search-id": "sanitized"
+    "request-context": "appId=",
+    "search-id": "sanitized",
+    "status": "202",
+    "x-azure-ref": "0xFSUYAAAAACFUItb7He4TqzbCYq5URFuWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1889ms"
    }
   },
   {
@@ -25,10 +33,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-13T21:19:59.7107018+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:46.0980005+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:42:46 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "rJ1QQEptQU6CTNyJckWFIw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0xlSUYAAAAADz5q7YnrWqSofpxRuG59dgWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "306ms"
    }
   },
   {
@@ -39,10 +55,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-13T21:19:59.7107018+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:46.0980005+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:42:48 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "2H2vGRyQYkS69UHpXpaTTw.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0yFSUYAAAAAAWUJyuUXUkSYVgsPRZ3yDZWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "310ms"
    }
   },
   {
@@ -53,9 +77,16 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"outboubd\",\"sms\":\"none\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-04-13T21:36:02.8085754+00:00\"}",
+   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"outbound\",\"sms\":\"none\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-05-06T20:58:48.1192923+00:00\"}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:51 GMT",
+    "ms-cv": "E6ApRrS1Zk+R7uwtIvIuNg.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0y1SUYAAAAABJOBwF6gVLSb2Pga6MtTOBWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "949ms"
    }
   }
  ],

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search/recording_throws_on_invalid_search_request.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search/recording_throws_on_invalid_search_request.json
@@ -8,9 +8,16 @@
    },
    "requestBody": "{\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"person\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"quantity\":1}",
    "status": 400,
-   "response": "{\"error\":{\"code\":\"InvalidInput\",\"message\":\"We are unable to find phone plans to match your requested capabilities.\",\"target\":\"areacode\"}}",
+   "response": "{\"error\":{\"code\":\"InternalError\",\"message\":\"The server encountered an internal error.\",\"innererror\":{\"code\":\"BadRequest\",\"message\":\"We are unable to find phone plans to match your requested capabilities.\"}}}",
    "responseHeaders": {
-    "content-type": "application/json"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json",
+    "date": "Thu, 06 May 2021 20:42:55 GMT",
+    "ms-cv": "nxiMESxKHkCSFvws78nI6A.0",
+    "request-context": "appId=",
+    "status": "400",
+    "x-azure-ref": "0zlSUYAAAAACas4Db+v2PQIvWmn7Ca0XTWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1529ms"
    }
   }
  ],
@@ -18,5 +25,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "3e08c47962194f8a87528e88f091ed7a"
+ "hash": "0c0cd4df2ebe90fafb50cbd9dc7b6505"
 }

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.json
@@ -1,0 +1,144 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:29 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11722.17 - WUS2 ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/availablePhoneNumbers/countries/US/:search",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"outbound\",\"sms\":\"none\"},\"quantity\":1}",
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location,Operation-Location,operation-id,search-id",
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:42:32 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "etOfmgt0o0i5G4rWk2/Zyg.0",
+    "operation-id": "search_sanitized",
+    "operation-location": "/phoneNumbers/operations/search_sanitized?api-version=2021-03-07",
+    "request-context": "appId=",
+    "search-id": "sanitized",
+    "status": "202",
+    "x-azure-ref": "0tVSUYAAAAAAgk+NNlUJfTJPyoAHMJESkWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "2478ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:32.005688+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:32 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "aBHNEJu3/0uh3Cme5rWMyQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0uFSUYAAAAAA+/ijf+GEjSal3O1yh2G5JWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "442ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:32.005688+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:35 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "HKQDtLxiSEmDZEp0f/lkDA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0ulSUYAAAAAAC78PdnapjQIx4PGF0kKfEWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "513ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/search_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:32.005688+00:00\",\"id\":\"search_sanitized\",\"operationType\":\"search\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:37 GMT",
+    "location": "/availablePhoneNumbers/searchResults/sanitized?api-version=2021-03-07",
+    "ms-cv": "8L41/J+5wE6+22Pn4hCSWg.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0vVSUYAAAAAAYNH9YzdGFSoTwRBb43V4TWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "358ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/availablePhoneNumbers/searchResults/sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"searchId\":\"sanitized\",\"phoneNumbers\":[\"+14155550100\"],\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"application\",\"capabilities\":{\"calling\":\"outbound\",\"sms\":\"none\"},\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"},\"searchExpiresBy\":\"2021-05-06T20:58:36.6965049+00:00\"}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:40 GMT",
+    "ms-cv": "hVXVS+ATxke7V4z0KiUCKA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "0v1SUYAAAAACAGNZZFfdzRr3S8c3RXFruWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "750ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "0ffca6a1d0eb0737c769d14361532cd8"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:42 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.25 - EUS ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/availablePhoneNumbers/countries/US/:search",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"phoneNumberType\":\"tollFree\",\"assignmentType\":\"person\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"inbound+outbound\"},\"quantity\":1}",
+   "status": 400,
+   "response": "{\"error\":{\"code\":\"InternalError\",\"message\":\"The server encountered an internal error.\",\"innererror\":{\"code\":\"BadRequest\",\"message\":\"We are unable to find phone plans to match your requested capabilities.\"}}}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json",
+    "date": "Thu, 06 May 2021 20:42:44 GMT",
+    "ms-cv": "aWBJOe4VKkmRAMfuihQQTw.0",
+    "request-context": "appId=",
+    "status": "400",
+    "x-azure-ref": "0wlSUYAAAAADcj67aP82YRJzxIW/rh1aCWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1640ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "0c0cd4df2ebe90fafb50cbd9dc7b6505"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update/recording_can_update_a_phone_numbers_capabilities.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update/recording_can_update_a_phone_numbers_capabilities.json
@@ -10,11 +10,19 @@
    "status": 202,
    "response": "{\"capabilitiesUpdateId\":\"sanitized\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,Location,operation-id,capabilities-id",
+    "api-supported-versions": "2021-03-07",
     "capabilities-id": "sanitized",
     "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:22 GMT",
     "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "yrEu4XxpAE64/8csqjssgQ.0",
     "operation-id": "capabilities_sanitized",
-    "operation-location": "/phoneNumbers/operations/capabilities_sanitized?api-version=2021-03-07"
+    "operation-location": "/phoneNumbers/operations/capabilities_sanitized?api-version=2021-03-07",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "06VSUYAAAAACrgtKmAaIXR75bxKM4d0WLWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "1543ms"
    }
   },
   {
@@ -25,10 +33,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-17T01:45:55.0806316+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"notStarted\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:43:22.5939262+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:43:22 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "xOOE3UIaWUCRRWwncTcr9g.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "061SUYAAAAAD5zyG/YZShRbLydERFJIFcWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "382ms"
    }
   },
   {
@@ -39,10 +55,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-17T01:45:55.0806316+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:43:22.5939262+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:43:25 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "xMAEHG+4ZUS7syCAgHFB8w.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "07VSUYAAAAAC7jDdAU4RNRa/gghDya4tdWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "317ms"
    }
   },
   {
@@ -53,10 +77,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-17T01:45:55.0806316+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:43:22.5939262+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:43:27 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "zF3kuigHk0a6EgkPJB9yXQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "071SUYAAAAAB+GUvHznuiQ6WtIkhU1bCDWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "272ms"
    }
   },
   {
@@ -67,10 +99,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-17T01:45:55.0806316+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:43:22.5939262+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:43:29 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "WkyWdDTXZkat3Pr4LDWRow.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "08lSUYAAAAABFXG4FtDCoSI3OFXqD8G87WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "317ms"
    }
   },
   {
@@ -81,10 +121,18 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-04-17T01:45:55.0806316+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:43:22.5939262+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
    "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
     "content-type": "application/json; charset=utf-8",
-    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07"
+    "date": "Thu, 06 May 2021 20:43:32 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "vBxiuxlt40yUOtt6718DOQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "09FSUYAAAAACm1oAlIaY8To4Apg8nxgilWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "274ms"
    }
   },
   {
@@ -97,7 +145,14 @@
    "status": 200,
    "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-02-10T17:52:41.818335+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
    "responseHeaders": {
-    "content-type": "application/json; charset=utf-8"
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:38 GMT",
+    "ms-cv": "n3VS3vGr4E+A9Zl0zWAOgA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "09lSUYAAAAACbxWbSlq3ER5Ay0yX3EmlPWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "4089ms"
    }
   }
  ],
@@ -105,5 +160,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "743b855a72fc22d672c9a1425ccb0354"
+ "hash": "bc0d3c040f4257989e64826eb468a2d3"
 }

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update/recording_update_throws_when_phone_number_isnt_owned.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update/recording_update_throws_when_phone_number_isnt_owned.json
@@ -10,7 +10,14 @@
    "status": 404,
    "response": "",
    "responseHeaders": {
-    "content-length": "0"
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:43:40 GMT",
+    "ms-cv": "Hq2qy/HWh0mlWoge0/hA+A.0",
+    "request-context": "appId=",
+    "status": "404",
+    "x-azure-ref": "0/VSUYAAAAAAAYAHLFzatT5xC02Qg+2njWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "286ms"
    }
   }
  ],

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.json
@@ -1,0 +1,210 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:55 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11722.17 - WUS2 ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "PATCH",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100/capabilities",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"calling\":\"none\",\"sms\":\"outbound\"}",
+   "status": 202,
+   "response": "{\"capabilitiesUpdateId\":\"sanitized\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Operation-Location,Location,operation-id,capabilities-id",
+    "api-supported-versions": "2021-03-07",
+    "capabilities-id": "sanitized",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:57 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "nxEDFz7NWUisjVD5t+x8dA.0",
+    "operation-id": "capabilities_sanitized",
+    "operation-location": "/phoneNumbers/operations/capabilities_sanitized?api-version=2021-03-07",
+    "request-context": "appId=",
+    "status": "202",
+    "x-azure-ref": "00FSUYAAAAACSqFk15CqwTKz49nu49xLjWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "2299ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:42:58 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "Yb0Fx91coUuony1XCERIbA.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "00lSUYAAAAABrUHjsim0iQK1x2vrQCl4UWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "428ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:00 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "3eVh5Vnz2E2ABPyoeVeS9A.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "01FSUYAAAAABMUMjuYjQRS65opsGmHH+vWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "431ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:03 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "PsSHkrx+nEu1/R0bUuFr4Q.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "011SUYAAAAAC0txzTLRSSSYiJR8taMxC1WVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "384ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:05 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "YibO9q+6o06r0iqkM3dC6w.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "02VSUYAAAAACt8ENqeGbjT4y6dfJ1d4rlWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "264ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"running\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:08 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "nRZUv48SLkyO9VsY6MN14g.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "03FSUYAAAAAA9FooksTpGRo8W7SjEDnvwWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "521ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/operations/capabilities_sanitized",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"status\":\"succeeded\",\"resourceLocation\":\"/phoneNumbers/+14155550100?api-version=2021-03-07\",\"createdDateTime\":\"2021-05-06T20:42:57.6939798+00:00\",\"id\":\"capabilities_sanitized\",\"operationType\":\"updatePhoneNumberCapabilities\",\"lastActionDateTime\":\"0001-01-01T00:00:00+00:00\"}",
+   "responseHeaders": {
+    "access-control-expose-headers": "Location",
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:10 GMT",
+    "location": "/phoneNumbers/+14155550100?api-version=2021-03-07",
+    "ms-cv": "sQ9hit3T60CbV5go9ha2bQ.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "03lSUYAAAAAA8XcRm7+5jTL4vGYLiZMZzWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "268ms"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://endpoint/phoneNumbers/+14155550100",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"14155550100\",\"phoneNumber\":\"+14155550100\",\"countryCode\":\"US\",\"phoneNumberType\":\"tollFree\",\"capabilities\":{\"calling\":\"none\",\"sms\":\"outbound\"},\"assignmentType\":\"application\",\"purchaseDate\":\"2021-02-10T17:52:41.818335+00:00\",\"cost\":{\"amount\":2.0,\"currencyCode\":\"USD\",\"billingFrequency\":\"monthly\"}}",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:18 GMT",
+    "ms-cv": "psdU2YmYmUSIRVZW+l6//A.0",
+    "request-context": "appId=",
+    "status": "200",
+    "x-azure-ref": "04VSUYAAAAADdXcPRJoyyQ6UVB1PKkkyVWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "5801ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "bc0d3c040f4257989e64826eb468a2d3"
+}

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.json
@@ -1,0 +1,53 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-store, no-cache",
+    "content-length": "1327",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 May 2021 20:43:20 GMT",
+    "expires": "-1",
+    "nel": "{\"report_to\":\"network-errors\",\"max_age\":86400,\"success_fraction\":0.001,\"failure_fraction\":1.0}",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "report-to": "{\"group\":\"network-errors\",\"max_age\":86400,\"endpoints\":[{\"url\":\"https://endpoint/api/report?catId=GW+estsfd+chi\"}]}",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.11654.25 - NCUS ProdSlices",
+    "x-ms-request-id": "sanitized"
+   }
+  },
+  {
+   "method": "PATCH",
+   "url": "https://endpoint/phoneNumbers/%2B14155550100/capabilities",
+   "query": {
+    "api-version": "2021-03-07"
+   },
+   "requestBody": "{\"calling\":\"none\",\"sms\":\"outbound\"}",
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "api-supported-versions": "2021-03-07",
+    "content-length": "0",
+    "date": "Thu, 06 May 2021 20:43:20 GMT",
+    "ms-cv": "Ql0Z+J1SQkm6+j/DmVNoCw.0",
+    "request-context": "appId=",
+    "status": "404",
+    "x-azure-ref": "06VSUYAAAAADZ0JkpOGVARoURTpM/XcAhWVZSMzBFREdFMDQxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+    "x-processing-time": "280ms"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "1b01834067bf928c6bbe8df5701149c4"
+}

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -3,14 +3,14 @@
 
 import { AzureKeyCredential } from "@azure/core-auth";
 import { isNode, WebResourceLike } from "@azure/core-http";
-import { ClientSecretCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
-import { env, isPlaybackMode } from "@azure/test-utils-recorder";
+import { TokenCredential } from "@azure/identity";
 import { assert } from "chai";
 import sinon from "sinon";
 import { PhoneNumbersClient } from "../../src/phoneNumbersClient";
 import { getPhoneNumberHttpClient } from "../public/utils/mockHttpClients";
 import { SDK_VERSION } from "../../src/utils/constants";
 import { Context } from "mocha";
+import { createMockToken } from "../public/utils/recordedClient";
 
 describe("PhoneNumbersClient - headers", function() {
   const endpoint = "https://contoso.spool.azure.local";
@@ -32,7 +32,7 @@ describe("PhoneNumbersClient - headers", function() {
     request = spy.getCall(0).args[0];
   });
 
-  it("sets correct host", function(this: Context) {
+  it("[node] sets correct host", function(this: Context) {
     if (!isNode) {
       this.skip();
     }
@@ -78,16 +78,7 @@ describe("PhoneNumbersClient - headers", function() {
   });
 
   it("sets bearer authorization header with TokenCredential", async function(this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-    const credential: TokenCredential = isNode
-      ? new DefaultAzureCredential()
-      : new ClientSecretCredential(
-          env.AZURE_TENANT_ID,
-          env.AZURE_CLIENT_ID,
-          env.AZURE_CLIENT_SECRET
-        );
+    const credential: TokenCredential = createMockToken();
 
     client = new PhoneNumbersClient(endpoint, credential, {
       httpClient: getPhoneNumberHttpClient

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -81,7 +81,7 @@ describe("PhoneNumbersClient - headers", function() {
     if (isPlaybackMode()) {
       this.skip();
     }
-    let credential: TokenCredential = isNode
+    const credential: TokenCredential = isNode
       ? new DefaultAzureCredential()
       : new ClientSecretCredential(
           env.AZURE_TENANT_ID,

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -3,15 +3,14 @@
 
 import { AzureKeyCredential } from "@azure/core-auth";
 import { isNode, WebResourceLike } from "@azure/core-http";
-import { DefaultAzureCredential } from "@azure/identity";
-import { isPlaybackMode } from "@azure/test-utils-recorder";
+import { ClientSecretCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { env, isPlaybackMode } from "@azure/test-utils-recorder";
 import { assert } from "chai";
 import sinon from "sinon";
 import { PhoneNumbersClient } from "../../src/phoneNumbersClient";
 import { getPhoneNumberHttpClient } from "../public/utils/mockHttpClients";
 import { SDK_VERSION } from "../../src/utils/constants";
 import { Context } from "mocha";
-import { canCreateRecordedClientWithToken } from "../public/utils/recordedClient";
 
 describe("PhoneNumbersClient - headers", function() {
   const endpoint = "https://contoso.spool.azure.local";
@@ -79,11 +78,18 @@ describe("PhoneNumbersClient - headers", function() {
   });
 
   it("sets bearer authorization header with TokenCredential", async function(this: Context) {
-    if (!canCreateRecordedClientWithToken() || isPlaybackMode()) {
+    if (isPlaybackMode()) {
       this.skip();
     }
+    let credential: TokenCredential = isNode
+      ? new DefaultAzureCredential()
+      : new ClientSecretCredential(
+          env.AZURE_TENANT_ID,
+          env.AZURE_CLIENT_ID,
+          env.AZURE_CLIENT_SECRET
+        );
 
-    client = new PhoneNumbersClient(endpoint, new DefaultAzureCredential(), {
+    client = new PhoneNumbersClient(endpoint, credential, {
       httpClient: getPhoneNumberHttpClient
     });
 

--- a/sdk/communication/communication-phone-numbers/test/public/ctor.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/ctor.spec.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 import { AzureKeyCredential } from "@azure/core-auth";
-import { isNode } from "@azure/core-http";
-import { DefaultAzureCredential } from "@azure/identity";
 import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
+import { createMockToken } from "./utils/recordedClient";
 
 describe("PhoneNumbersClient - constructor", function() {
   const endpoint = "https://contoso.spool.azure.local";
@@ -29,11 +28,7 @@ describe("PhoneNumbersClient - constructor", function() {
   });
 
   it("successfully instantiates with with endpoint and managed identity", function(this: Context) {
-    if (!isNode) {
-      this.skip();
-    }
-
-    const client = new PhoneNumbersClient(endpoint, new DefaultAzureCredential());
+    const client = new PhoneNumbersClient(endpoint, createMockToken());
     assert.instanceOf(client, PhoneNumbersClient);
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
@@ -6,10 +6,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
 import { matrix } from "./utils/matrix";
-import {
-  createRecordedClient,
-  createRecordedClientWithToken
-} from "./utils/recordedClient";
+import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 
 matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - get phone number${useAad ? " [AAD]" : ""}`, function() {

--- a/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
@@ -7,7 +7,6 @@ import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
 import { matrix } from "./utils/matrix";
 import {
-  canCreateRecordedClientWithToken,
   createRecordedClient,
   createRecordedClientWithToken
 } from "./utils/recordedClient";
@@ -16,12 +15,6 @@ matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - get phone number${useAad ? " [AAD]" : ""}`, function() {
     let recorder: Recorder;
     let client: PhoneNumbersClient;
-
-    before(function(this: Context) {
-      if (useAad && !canCreateRecordedClientWithToken()) {
-        this.skip();
-      }
-    });
 
     beforeEach(function(this: Context) {
       ({ client, recorder } = useAad

--- a/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
@@ -6,10 +6,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
 import { matrix } from "./utils/matrix";
-import {
-  createRecordedClient,
-  createRecordedClientWithToken
-} from "./utils/recordedClient";
+import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 
 matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - lists${useAad ? " [AAD]" : ""}`, function() {

--- a/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
@@ -7,7 +7,6 @@ import { Context } from "mocha";
 import { PhoneNumbersClient } from "../../src";
 import { matrix } from "./utils/matrix";
 import {
-  canCreateRecordedClientWithToken,
   createRecordedClient,
   createRecordedClientWithToken
 } from "./utils/recordedClient";
@@ -16,12 +15,6 @@ matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - lists${useAad ? " [AAD]" : ""}`, function() {
     let recorder: Recorder;
     let client: PhoneNumbersClient;
-
-    before(function(this: Context) {
-      if (useAad && !canCreateRecordedClientWithToken()) {
-        this.skip();
-      }
-    });
 
     beforeEach(function(this: Context) {
       ({ client, recorder } = useAad

--- a/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
@@ -7,7 +7,6 @@ import { Context } from "mocha";
 import { PhoneNumbersClient, SearchAvailablePhoneNumbersRequest } from "../../src";
 import { matrix } from "./utils/matrix";
 import {
-  canCreateRecordedClientWithToken,
   createRecordedClient,
   createRecordedClientWithToken
 } from "./utils/recordedClient";
@@ -18,10 +17,6 @@ matrix([[true, false]], async function(useAad) {
     let client: PhoneNumbersClient;
 
     before(function(this: Context) {
-      if (useAad && !canCreateRecordedClientWithToken()) {
-        this.skip();
-      }
-
       const includePhoneNumberLiveTests = env.INCLUDE_PHONENUMBER_LIVE_TESTS === "true";
       if (!includePhoneNumberLiveTests && !isPlaybackMode()) {
         this.skip();

--- a/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
@@ -6,10 +6,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient, SearchAvailablePhoneNumbersRequest } from "../../src";
 import { matrix } from "./utils/matrix";
-import {
-  createRecordedClient,
-  createRecordedClientWithToken
-} from "./utils/recordedClient";
+import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 
 matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - lro - purchase and release${useAad ? " [AAD]" : ""}`, function() {

--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -7,7 +7,6 @@ import { Context } from "mocha";
 import { PhoneNumbersClient, SearchAvailablePhoneNumbersRequest } from "../../src";
 import { matrix } from "./utils/matrix";
 import {
-  canCreateRecordedClientWithToken,
   createRecordedClient,
   createRecordedClientWithToken
 } from "./utils/recordedClient";
@@ -25,12 +24,6 @@ matrix([[true, false]], async function(useAad) {
         calling: "outbound"
       }
     };
-
-    before(function(this: Context) {
-      if (useAad && !canCreateRecordedClientWithToken()) {
-        this.skip();
-      }
-    });
 
     beforeEach(function(this: Context) {
       ({ client, recorder } = useAad

--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -6,10 +6,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient, SearchAvailablePhoneNumbersRequest } from "../../src";
 import { matrix } from "./utils/matrix";
-import {
-  createRecordedClient,
-  createRecordedClientWithToken
-} from "./utils/recordedClient";
+import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 
 matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - lro - search${useAad ? " [AAD]" : ""}`, function() {

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -6,10 +6,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient, PhoneNumberCapabilitiesRequest } from "../../src";
 import { matrix } from "./utils/matrix";
-import {
-  createRecordedClient,
-  createRecordedClientWithToken
-} from "./utils/recordedClient";
+import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 
 matrix([[true, false]], async function(useAad) {
   describe(`PhoneNumbersClient - lro - update${useAad ? " [AAD]" : ""}`, function() {

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -7,7 +7,6 @@ import { Context } from "mocha";
 import { PhoneNumbersClient, PhoneNumberCapabilitiesRequest } from "../../src";
 import { matrix } from "./utils/matrix";
 import {
-  canCreateRecordedClientWithToken,
   createRecordedClient,
   createRecordedClientWithToken
 } from "./utils/recordedClient";
@@ -18,12 +17,6 @@ matrix([[true, false]], async function(useAad) {
     const update: PhoneNumberCapabilitiesRequest = { calling: "none", sms: "outbound" };
     let recorder: Recorder;
     let client: PhoneNumbersClient;
-
-    before(function(this: Context) {
-      if (useAad && !canCreateRecordedClientWithToken()) {
-        this.skip();
-      }
-    });
 
     beforeEach(function(this: Context) {
       ({ client, recorder } = useAad

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -39,7 +39,7 @@ matrix([[true, false]], async function(useAad) {
       await updatePoller.pollUntilDone();
       assert.ok(updatePoller.getOperationState().isCompleted);
       // assert.deepEqual(phoneNumber.capabilities, update);
-    }).timeout(60000);
+    }).timeout(90000);
 
     it("update throws when phone number isn't owned", async function() {
       const fakeNumber = "+14155550100";

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -88,9 +88,9 @@ export function createRecordedClientWithToken(
     };
   }
 
-  try {
+  if (isNode) {
     credential = new DefaultAzureCredential();
-  } catch {
+  } else {
     credential = new ClientSecretCredential(
       env.AZURE_TENANT_ID,
       env.AZURE_CLIENT_ID,

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -65,6 +65,14 @@ export function createRecordedClient(context: Context): RecordedClient<PhoneNumb
   };
 }
 
+export function createMockToken(): TokenCredential {
+  return {
+    getToken: async (_scopes) => {
+      return { token: "testToken", expiresOnTimestamp: 11111 };
+    }
+  };
+}
+
 export function createRecordedClientWithToken(
   context: Context
 ): RecordedClient<PhoneNumbersClient> | undefined {
@@ -73,11 +81,7 @@ export function createRecordedClientWithToken(
   const endpoint = parseConnectionString(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING)
     .endpoint;
   if (isPlaybackMode()) {
-    credential = {
-      getToken: async (_scopes) => {
-        return { token: "testToken", expiresOnTimestamp: 11111 };
-      }
-    };
+    credential = createMockToken();
 
     // casting is a workaround to enable min-max testing
     return {

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -21,7 +21,7 @@ import {
 } from "@azure/core-http";
 import { PhoneNumbersClient, PhoneNumbersClientOptions } from "../../../src";
 import { parseConnectionString } from "@azure/communication-common";
-import { DefaultAzureCredential } from "@azure/identity";
+import { ClientSecretCredential, DefaultAzureCredential } from "@azure/identity";
 
 if (isNode) {
   dotenv.config();
@@ -65,15 +65,6 @@ export function createRecordedClient(context: Context): RecordedClient<PhoneNumb
   };
 }
 
-export const canCreateRecordedClientWithToken = (): boolean => {
-  try {
-    new DefaultAzureCredential();
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 export function createRecordedClientWithToken(
   context: Context
 ): RecordedClient<PhoneNumbersClient> | undefined {
@@ -100,7 +91,11 @@ export function createRecordedClientWithToken(
   try {
     credential = new DefaultAzureCredential();
   } catch {
-    return undefined;
+    credential = new ClientSecretCredential(
+      env.AZURE_TENANT_ID,
+      env.AZURE_CLIENT_ID,
+      env.AZURE_CLIENT_SECRET
+    );
   }
 
   // casting is a workaround to enable min-max testing


### PR DESCRIPTION
Use ClientSecretCredential for AAD Browser tests so we no longer need to skip them
Also updated some tests to use mock tokens as they did not need to test with real token creds, and we no longer skip them