### PR TITLE
[Identity] Add note on Node.js support

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -20,7 +20,6 @@ npm install --save @azure/identity
 
 - An [Azure subscription](https://azure.microsoft.com/free/).
 - Optional: The [Azure CLI][azure_cli] can also be useful for authenticating in a development environment and managing account roles.
-- As of v2.0.0-beta.1, the credentials `InteractiveBrowserCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ClientCertificateCredential` and `UsernamePasswordCredential` allow specifying `tokenCachePersistenceOptions` to enable persistent caching. To use this feature, developers will also need to install [@azure/msal-node-extensions](https://www.npmjs.com/package/@azure/msal-node-extensions).
 
 #### Supported Node.js versions
 

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -18,11 +18,15 @@ npm install --save @azure/identity
 
 ### Prerequisites
 
-- Node.js 8 LTS or higher.
 - An [Azure subscription](https://azure.microsoft.com/free/).
-- The [Azure CLI][azure_cli] can also be useful for authenticating in a development environment and managing account roles.
+- Optional: The [Azure CLI][azure_cli] can also be useful for authenticating in a development environment and managing account roles.
+- As of v2.0.0-beta.1, the credentials `InteractiveBrowserCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ClientCertificateCredential` and `UsernamePasswordCredential` allow specifying `tokenCachePersistenceOptions` to enable persistent caching. To use this feature, developers will also need to install [@azure/msal-node-extensions](https://www.npmjs.com/package/@azure/msal-node-extensions).
 
-Credentials `InteractiveBrowserCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ClientCertificateCredential` and `UsernamePasswordCredential` allow specifying `tokenCachePersistenceOptions` to enable persistent caching. To use this feature, developers will also need to install [@azure/msal-node-extensions](https://www.npmjs.com/package/@azure/msal-node-extensions).
+#### Supported Node.js versions
+
+This version of `@azure/identity` supports stable (even numbered) versions of Node.js starting from v10. While it may run in Node.js v8, no support is guaranteed.
+
+> **Note:** If your application runs on Node.js v8 or lower, we strongly recommend you to upgrade your Node.js version to latest stable version or pin your `@azure/identity` dependency to version 1.1.0.
 
 ### Authenticate the client in development environment
 


### PR DESCRIPTION
This PR has the below changes
- Removed note on the persistent cache feature as the feature was reverted in #15041
- Add note on the last version of the `@azure/identity` package that is guaranteed to work in Node.js v8
- Add note on the min Node.js version that the package does support

The messaging has been reviewed offline by @bterlson, @xirzec, @chradek  and @elraikhm 

cc @schaabs, @joshfree  