### PR TITLE
Clean up entries in docsettings.yml

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -1,4 +1,5 @@
 omitted_paths:
+  - README.md
   - common/*
   - documentation/ServicePrincipal/*
   - eng/*
@@ -33,7 +34,6 @@ required_readme_sections:
   - ^Contributing$
 
 known_content_issues:
-  - ["README.md",  "#1583"]
   - ["sdk/appconfiguration/app-configuration/README.md",  "#1583"]
   - ["sdk/core/abort-controller/README.md",  "#14714"]
   - ["sdk/core/core-amqp/README.md",  "#14715"]

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -41,14 +41,13 @@ known_content_issues:
   - ["sdk/core/logger/README.md",  "#14726"]
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/eventhub/README.md", "#1583"],
-  - ["sdk/keyvault/keyvault-common/*", "#1583"],
-  - ["sdk/keyvault/README.md", "#1583"],
-  - ["sdk/schemaregistry/README.md", "#1583"],
-  - ["sdk/servicebus/README.md", "#1583"],
-  - ["sdk/storage/README.md", "#1583"],
+  - ["sdk/eventhub/README.md", "#1583"]
+  - ["sdk/keyvault/README.md", "#1583"]
+  - ["sdk/schemaregistry/README.md", "#1583"]
+  - ["sdk/servicebus/README.md", "#1583"]
+  - ["sdk/storage/README.md", "#1583"]
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
-  - ["sdk/web-pubsub/web-pubsub-express/README.md", "#1583"],
+  - ["sdk/web-pubsub/web-pubsub-express/README.md", "#1583"]
 
 package_indexing_exclusion_list:
   - "@azure/template"

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -42,8 +42,10 @@ known_content_issues:
   - ["sdk/core/logger/README.md",  "#14726"]
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/keyvault/keyvault-common/README.md",  "#15587"]
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
+
+known_presence_issues:
+  - ["sdk/keyvault/keyvault-common/README.md",  "#15587"]
 
 package_indexing_exclusion_list:
   - "@azure/template"

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -1,42 +1,25 @@
 omitted_paths:
+  - common/*
   - documentation/ServicePrincipal/*
   - eng/*
+  - samples/*
+  - sdk/**/samples-*/*
+  - sdk/**/samples/*
+  - sdk/**/swagger/*
+  - sdk/**/test/**
   - sdk/*/arm-*
   - sdk/*/perf-tests/*
   - sdk/appconfiguration/app-configuration/sample-react/README.md
-  - sdk/core/README.md
+  - sdk/applicationinsights/applicationinsights-query/README.md
+  - sdk/batch/batch/README.md
   - sdk/cognitiveservices/*
-  - sdk/communication/*/test/README.md
-  - sdk/identity/identity/test/manual/*
-  - sdk/identity/identity/test/manual-integration/*
-  - sdk/test-utils/perfstress/README.md
-  - sdk/keyvault/*/test/README.md
-  - sdk/keyvault/README.md
-  - sdk/keyvault/keyvault-common/*
-  - sdk/appconfiguration/*/test/README.md
-  - sdk/eventhub/*/test/README.md
-  - sdk/eventhub/README.md
-  - sdk/search/*/test/README.md
-  - sdk/servicebus/*/test/README.md
-  - sdk/servicebus/README.md
-  - sdk/servicebus/service-bus/test/perf-js-libs/service-bus-*
-  - sdk/servicebus/service-bus/test/perf/**
-  - sdk/servicebus/service-bus/test/stress/*
-  - sdk/web-pubsub/web-pubsub-express/README.md
-  - sdk/eventhub/event-hubs/test/perf/track-1/*
-  - sdk/eventhub/event-hubs/test/perf/track-2/*
-  - sdk/schemaregistry/README.md
-  - sdk/storage/*/test/README.md
-  - sdk/storage/README.md
+  - sdk/core/README.md
+  - sdk/graphrbac/graph/README.md
+  - sdk/operationalinsights/loganalytics/README.md
+  - sdk/servicefabric/servicefabric/README.md
+  - sdk/storage/storage-datalake/README.md
   - sdk/storage/storage-internal-avro/*
-  - sdk/storage/*/test/perfstress/track-1/*
-  - sdk/storage/*/test/perfstress/track-2/*
-  - sdk/textanalytics/*/test/README.md
-  - sdk/**/samples/*
-  - sdk/**/samples-*/*
-  - sdk/**/swagger/*
-  - common/*
-  - samples/*
+  - sdk/test-utils/perfstress/README.md
 language: js
 root_check_enabled: True
 required_readme_sections:
@@ -51,71 +34,21 @@ required_readme_sections:
 known_content_issues:
   - ["README.md",  "#1583"]
   - ["sdk/appconfiguration/app-configuration/README.md",  "#1583"]
-  - ["sdk/applicationinsights/applicationinsights-query/README.md",  "#1583"]
-  - ["sdk/batch/batch/README.md",  "#1583"]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-anomalydetector/README.md",
-       "#1583",
-    ]
-  - ["sdk/cognitiveservices/cognitiveservices-autosuggest/README.md",  "#Azure/autorest.typescript#895"]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-computervision/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-contentmoderator/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-customimagesearch/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - ["sdk/cognitiveservices/cognitiveservices-customsearch/README.md",  "#Azure/autorest.typescript#895"]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-customvision-training/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - ["sdk/cognitiveservices/cognitiveservices-entitysearch/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-face/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-imagesearch/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-localsearch/README.md",  "#Azure/autorest.typescript#895"]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-luis-authoring/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - ["sdk/cognitiveservices/cognitiveservices-luis-runtime/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-newssearch/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-qnamaker/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-spellcheck/README.md",  "#Azure/autorest.typescript#895"]
-  - [
-      "sdk/cognitiveservices/cognitiveservices-textanalytics/README.md",
-       "#Azure/autorest.typescript#895",
-    ]
-  - ["sdk/cognitiveservices/cognitiveservices-videosearch/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-visualsearch/README.md",  "#Azure/autorest.typescript#895"]
-  - ["sdk/cognitiveservices/cognitiveservices-websearch/README.md",  "#Azure/autorest.typescript#895"]
   - ["sdk/core/abort-controller/README.md",  "#14714"]
   - ["sdk/core/core-amqp/README.md",  "#14715"]
   - ["sdk/core/core-auth/README.md",  "#14716"]
   - ["sdk/core/core-tracing/README.md",  "#14725"]
   - ["sdk/core/logger/README.md",  "#14726"]
-  - ["sdk/cosmosdb/cosmos/test/readme.md",  "azure-sdk-tools/issues/1530"]
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/graphrbac/graph/README.md",  "#deprecated"]
-  - ["sdk/operationalinsights/loganalytics/README.md",  "#14729"]
-  - ["sdk/servicebus/service-bus/test/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/servicefabric/servicefabric/README.md",  "#14732"]
-  - ["sdk/storage/storage-datalake/README.md",  "#14731"]
-  - ["sdk/storage/storage-blob/test/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/storage/storage-file-datalake/test/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/storage/storage-file-share/test/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/storage/storage-queue/test/README.md",  "azure-sdk-tools/issues/1530"]
+  - ["sdk/eventhub/README.md", "#1583"],
+  - ["sdk/keyvault/keyvault-common/*", "#1583"],
+  - ["sdk/keyvault/README.md", "#1583"],
+  - ["sdk/schemaregistry/README.md", "#1583"],
+  - ["sdk/servicebus/README.md", "#1583"],
+  - ["sdk/storage/README.md", "#1583"],
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
+  - ["sdk/web-pubsub/web-pubsub-express/README.md", "#1583"],
 
 package_indexing_exclusion_list:
   - "@azure/template"

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -18,7 +18,6 @@ omitted_paths:
   - sdk/core/README.md
   - sdk/eventhub/event-processor-host/README.md
   - sdk/graphrbac/graph/README.md
-  - sdk/keyvault/keyvault-common/README.md
   - sdk/operationalinsights/loganalytics/README.md
   - sdk/servicefabric/servicefabric/README.md
   - sdk/storage/storage-datalake/README.md
@@ -43,6 +42,7 @@ known_content_issues:
   - ["sdk/core/logger/README.md",  "#14726"]
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
+  - ["sdk/keyvault/keyvault-common/README.md",  "#15587"]
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
 
 package_indexing_exclusion_list:

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -44,7 +44,6 @@ known_content_issues:
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
-  - ["sdk/web-pubsub/web-pubsub-express/README.md", "#1583"]
 
 package_indexing_exclusion_list:
   - "@azure/template"

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -3,6 +3,7 @@ omitted_paths:
   - documentation/ServicePrincipal/*
   - eng/*
   - samples/*
+  - sdk/*/README.md
   - sdk/**/samples-*/*
   - sdk/**/samples/*
   - sdk/**/swagger/*
@@ -41,11 +42,6 @@ known_content_issues:
   - ["sdk/core/logger/README.md",  "#14726"]
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
-  - ["sdk/eventhub/README.md", "#1583"]
-  - ["sdk/keyvault/README.md", "#1583"]
-  - ["sdk/schemaregistry/README.md", "#1583"]
-  - ["sdk/servicebus/README.md", "#1583"]
-  - ["sdk/storage/README.md", "#1583"]
   - ["sdk/test-utils/multi-version/README.md", "#14728"]
   - ["sdk/web-pubsub/web-pubsub-express/README.md", "#1583"]
 

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -18,6 +18,7 @@ omitted_paths:
   - sdk/core/README.md
   - sdk/eventhub/event-processor-host/README.md
   - sdk/graphrbac/graph/README.md
+  - sdk/keyvault/keyvault-common/README.md
   - sdk/operationalinsights/loganalytics/README.md
   - sdk/servicefabric/servicefabric/README.md
   - sdk/storage/storage-datalake/README.md

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -35,7 +35,6 @@ required_readme_sections:
   - ^Contributing$
 
 known_content_issues:
-  - ["sdk/appconfiguration/app-configuration/README.md",  "#1583"]
   - ["sdk/core/abort-controller/README.md",  "#14714"]
   - ["sdk/core/core-amqp/README.md",  "#14715"]
   - ["sdk/core/core-auth/README.md",  "#14716"]

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -16,6 +16,7 @@ omitted_paths:
   - sdk/batch/batch/README.md
   - sdk/cognitiveservices/*
   - sdk/core/README.md
+  - sdk/eventhub/event-processor-host/README.md
   - sdk/graphrbac/graph/README.md
   - sdk/operationalinsights/loganalytics/README.md
   - sdk/servicefabric/servicefabric/README.md


### PR DESCRIPTION
We expect the readme files in each of the packages to follow a particular template. 
The docsettings.yml file is where we have added exceptions for this rule.

The `omitted_paths` is for those readmes that intentionally do not follow this rule
The `known_content_issues` is for those readmes that we believe should follow the rule and so there is a tracking issue to update it
The `known_presence_issues` is for those readmes that dont exist but should

This PR cleans up this file as follows:
- Add Track 1 packages into the omitted path list. Since these are auto generated, they will not be following the rule
- Add service level readmes into the omitted path list. /sdk/*/README.md
- Use glob patterns when possible
- Sort alphabetically