### PR TITLE
Update RequestHandler.ts

### DIFF
--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -18,7 +18,6 @@ import { bodyFromData } from "./request";
 import { RequestContext } from "./RequestContext";
 import { Response as CosmosResponse } from "./Response";
 import { TimeoutError } from "./TimeoutError";
-import { URL } from "url";
 
 /** @hidden */
 const log = logger("RequestHandler");


### PR DESCRIPTION
Class URL is a global after node version 10.0.0. If import { URL } from "url", it will cause errors like Uncaught (in promise) TypeError: xxxxxx.URL is not a constructor