### PR TITLE
 [schema registry] Return undefined for not found

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/README.md
@@ -45,7 +45,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/schemaRegistryAvroSample.ts
+node dist/schemaRegistryAvroSample.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1/typescript/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2018",
     "module": "commonjs",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -205,7 +205,9 @@ export class SchemaRegistryAvroSerializer {
     } else {
       const response = await this.registry.getSchemaId(description);
       if (!response) {
-        throw new Error(`Schema '${description.name}' not found in registry group '${description.group}', or not found to have matching content.`);
+        throw new Error(
+          `Schema '${description.name}' not found in registry group '${description.group}', or not found to have matching content.`
+        );
       }
       id = response.id;
     }

--- a/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/schemaRegistryAvroSerializer.ts
@@ -137,7 +137,7 @@ export class SchemaRegistryAvroSerializer {
 
     const format = buffer.readUInt32BE(0);
     if (format !== FORMAT_INDICATOR) {
-      throw new TypeError(`Buffer has unknown format indicator: 0x${format.toString(16)}`);
+      throw new TypeError(`Buffer has unknown format indicator: 0x${format.toString(16)}.`);
     }
 
     const schemaIdBuffer = buffer.slice(SCHEMA_ID_OFFSET, PAYLOAD_OFFSET);
@@ -168,7 +168,7 @@ export class SchemaRegistryAvroSerializer {
 
     const schemaResponse = await this.registry.getSchemaById(schemaId);
     if (!schemaResponse) {
-      throw new Error(`Schema with ID '${schemaId}' not found`);
+      throw new Error(`Schema with ID '${schemaId}' not found.`);
     }
 
     if (!schemaResponse.serializationType.match(/^avro$/i)) {
@@ -205,7 +205,7 @@ export class SchemaRegistryAvroSerializer {
     } else {
       const response = await this.registry.getSchemaId(description);
       if (!response) {
-        throw new Error("Schema not found in registry.");
+        throw new Error(`Schema '${description.name}' not found in registry group '${description.group}', or not found to have matching content.`);
       }
       id = response.id;
     }

--- a/sdk/schemaregistry/schema-registry/README.md
+++ b/sdk/schemaregistry/schema-registry/README.md
@@ -104,7 +104,9 @@ const description = {
 }
 
 const found = await client.getSchemaId(description);
-console.log(`Got schema ID=${found.id}`);
+if (found) {
+  console.log(`Got schema ID=${found.id}`);
+}
 ```
 
 ### Get content of existing schema by ID
@@ -115,7 +117,9 @@ const { SchemaRegistryClient } = require("@azure/schema-registry");
 
 const client = new SchemaRegistryClient("<endpoint>", new DefaultAzureCredential());
 const foundSchema = await client.getSchemaById("<id>");
-console.log(`Got schema content=${foundSchema.content}`);
+if (foundSchema) {
+  console.log(`Got schema content=${foundSchema.content}`);
+}
 ```
 
 ## Troubleshooting

--- a/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
+++ b/sdk/schemaregistry/schema-registry/review/schema-registry.api.md
@@ -44,8 +44,8 @@ export interface SchemaId {
 
 // @public
 export interface SchemaRegistry {
-    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema>;
-    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId>;
+    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema | undefined>;
+    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId | undefined>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaId>;
 }
 
@@ -53,8 +53,8 @@ export interface SchemaRegistry {
 export class SchemaRegistryClient implements SchemaRegistry {
     constructor(endpoint: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
     readonly endpoint: string;
-    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema>;
-    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId>;
+    getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema | undefined>;
+    getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId | undefined>;
     registerSchema(schema: SchemaDescription, options?: RegisterSchemaOptions): Promise<SchemaId>;
 }
 

--- a/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples-dev/schemaRegistrySample.ts
@@ -49,14 +49,18 @@ export async function main() {
   const registered = await client.registerSchema(schemaDescription);
   console.log(`Registered schema with ID=${registered.id}`);
 
-  // Get ID for exisiting schema by its description.
+  // Get ID for existing schema by its description.
   // Note that this would throw if it had not been previously registered.
   const found = await client.getSchemaId(schemaDescription);
-  console.log(`Got schema ID=${found.id}`);
+  if (found) {
+    console.log(`Got schema ID=${found.id}`);
+  }
 
   // Get content of existing schema by its ID
   const foundSchema = await client.getSchemaById(registered.id);
-  console.log(`Got schema content=${foundSchema.content}`);
+  if (foundSchema) {
+    console.log(`Got schema content=${foundSchema.content}`);
+  }
 }
 
 main().catch((err) => {

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@azure/schema-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.3"
   }
 }

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/schemaRegistrySample.js
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/schemaRegistrySample.js
@@ -49,14 +49,18 @@ async function main() {
   const registered = await client.registerSchema(schemaDescription);
   console.log(`Registered schema with ID=${registered.id}`);
 
-  // Get ID for exisiting schema by its description.
+  // Get ID for existing schema by its description.
   // Note that this would throw if it had not been previously registered.
   const found = await client.getSchemaId(schemaDescription);
-  console.log(`Got schema ID=${found.id}`);
+  if (found) {
+    console.log(`Got schema ID=${found.id}`);
+  }
 
   // Get content of existing schema by its ID
   const foundSchema = await client.getSchemaById(registered.id);
-  console.log(`Got schema content=${foundSchema.content}`);
+  if (foundSchema) {
+    console.log(`Got schema content=${foundSchema.content}`);
+  }
 }
 
 main().catch((err) => {

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/README.md
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/README.md
@@ -45,7 +45,7 @@ npm run build
 4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
 
 ```bash
-node dist/schemaRegistrySample.ts
+node dist/schemaRegistrySample.js
 ```
 
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/schema-registry": "next",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.3"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/src/schemaRegistrySample.ts
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/src/schemaRegistrySample.ts
@@ -49,14 +49,18 @@ export async function main() {
   const registered = await client.registerSchema(schemaDescription);
   console.log(`Registered schema with ID=${registered.id}`);
 
-  // Get ID for exisiting schema by its description.
+  // Get ID for existing schema by its description.
   // Note that this would throw if it had not been previously registered.
   const found = await client.getSchemaId(schemaDescription);
-  console.log(`Got schema ID=${found.id}`);
+  if (found) {
+    console.log(`Got schema ID=${found.id}`);
+  }
 
   // Get content of existing schema by its ID
   const foundSchema = await client.getSchemaById(registered.id);
-  console.log(`Got schema content=${foundSchema.content}`);
+  if (foundSchema) {
+    console.log(`Got schema content=${foundSchema.content}`);
+  }
 }
 
 main().catch((err) => {

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2018",
     "module": "commonjs",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -98,15 +98,18 @@ export interface SchemaRegistry {
    * content.
    *
    * @param schema - Schema to match.
-   * @returns Matched schema's ID.
+   * @returns Matched schema's ID or undefined if no matching schema was found.
    */
-  getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId>;
+  getSchemaId(
+    schema: SchemaDescription,
+    options?: GetSchemaIdOptions
+  ): Promise<SchemaId | undefined>;
 
   /**
    * Gets an existing schema by ID.
    *
    * @param id - Unique schema ID.
-   * @returns Schema with given ID.
+   * @returns Schema with given ID or undefined if no schema was found with the given ID.
    */
-  getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema>;
+  getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema | undefined>;
 }

--- a/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
@@ -74,28 +74,44 @@ export class SchemaRegistryClient implements SchemaRegistry {
    * content.
    *
    * @param schema - Schema to match.
-   * @returns Matched schema's ID.
+   * @returns Matched schema's ID or undefined if no matching schema was found.
    */
-  async getSchemaId(schema: SchemaDescription, options?: GetSchemaIdOptions): Promise<SchemaId> {
-    const response = await this.client.schema.queryIdByContent(
-      schema.group,
-      schema.name,
-      schema.serializationType,
-      schema.content,
-      options
-    );
-    return convertSchemaIdResponse(response);
+  async getSchemaId(
+    schema: SchemaDescription,
+    options?: GetSchemaIdOptions
+  ): Promise<SchemaId | undefined> {
+    try {
+      const response = await this.client.schema.queryIdByContent(
+        schema.group,
+        schema.name,
+        schema.serializationType,
+        schema.content,
+        options
+      );
+      return convertSchemaIdResponse(response);
+    } catch (error) {
+      if (typeof error === "object" && error?.statusCode === 404) {
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   /**
-   * Gets the ID of an existing schema with matching name, group, type, and
-   * content.
+   * Gets an existing schema by ID.
    *
-   * @param schema - Schema to match.
-   * @returns Matched schema's ID.
+   * @param id - Unique schema ID.
+   * @returns Schema with given ID or undefined if no schema was found with the given ID.
    */
-  async getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema> {
-    const response = await this.client.schema.getById(id, options);
-    return convertSchemaResponse(response);
+  async getSchemaById(id: string, options?: GetSchemaByIdOptions): Promise<Schema | undefined> {
+    try {
+      const response = await this.client.schema.getById(id, options);
+      return convertSchemaResponse(response);
+    } catch (error) {
+      if (typeof error === "object" && error?.statusCode === 404) {
+        return undefined;
+      }
+      throw error;
+    }
   }
 }

--- a/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/schemaRegistry.spec.ts
@@ -39,13 +39,17 @@ const schema: SchemaDescription = {
   })
 };
 
-function assertIsNotNullUndefinedOrEmpty(x: string | null | undefined): void {
+function assertIsNotNullUndefinedOrEmpty(x: SchemaId | string | null | undefined): asserts x {
   assert.isTrue(x !== undefined, "should not be undefined");
   assert.isNotNull(x);
   assert.isNotEmpty(x);
 }
 
-function assertIsValidSchemaId(schemaId: SchemaId, expectedSerializationType = "avro"): void {
+function assertIsValidSchemaId(
+  schemaId: SchemaId | undefined,
+  expectedSerializationType = "avro"
+): asserts schemaId {
+  assertIsNotNullUndefinedOrEmpty(schemaId);
   assertIsNotNullUndefinedOrEmpty(schemaId.id);
   assertIsNotNullUndefinedOrEmpty(schemaId.location);
   assertIsNotNullUndefinedOrEmpty(schemaId.locationById);
@@ -120,10 +124,7 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema ID when no matching schema exists", async () => {
-    await assert.isRejected(
-      client.getSchemaId({ ...schema, name: "never-registered" }),
-      /never-registered/
-    );
+    assert.isUndefined(await client.getSchemaId({ ...schema, name: "never-registered" }));
   });
 
   it("gets schema ID", async () => {
@@ -143,10 +144,7 @@ describe("SchemaRegistryClient", function() {
   });
 
   it("fails to get schema when no schema exists with given ID", async () => {
-    await assert.isRejected(
-      client.getSchemaById("ffffffffffffffffffffffffffffffff"),
-      /ffffffffffffffffffffffffffffffff/
-    );
+    assert.isUndefined(await client.getSchemaById("ffffffffffffffffffffffffffffffff"));
   });
 
   it("gets schema by ID", async () => {
@@ -155,8 +153,8 @@ describe("SchemaRegistryClient", function() {
     assertIsValidSchemaId(registered);
 
     const found = await client.getSchemaById(registered.id);
-    assertStatus(found, 200);
     assertIsValidSchemaId(found);
+    assertStatus(found, 200);
     assert.equal(found.content, schema.content);
   });
 });


### PR DESCRIPTION
Fix #15130 

This turns 404 into undefined for SchemaRegistryClient.getSchemaId and SchemaRegistryClient.getSchemaById.

Note, however, that the higher level avro serializer still throws on not found. While it feels natural enough when you're interacting directly with the schema registry to say "can I have a schema that matches this description or id" and get back undefined for "sorry no such schema", there is no natural return value for when you try to serialize/deserialize with a schema that is not found in the registry, so I think this should remain an exception, but I'm open to different design ideas.