### PR TITLE
Renaming to standard static EV

### DIFF
--- a/sdk/communication/CONTRIBUTING.md
+++ b/sdk/communication/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If the tests are successful, we can proceed to run the tests in LIVE mode.
 
 ### Live mode
 
-Since in LIVE mode we are hitting an actual resource, we must set the appropriate environment variables to make sure the code tests against the resource we want. Set up an env variable called `AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING` for Phone Number and SMS packages and set it to the connection string of the resource you want to test against. For all other communication packages, set up an environment variable called `COMMUNICATION_CONNECTION_STRING` and set it to the connection string of the resource you want to test against.
+Since in LIVE mode we are hitting an actual resource, we must set the appropriate environment variables to make sure the code tests against the resource we want. Set up an env variable called `COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING` for Phone Number and SMS packages and set it to the connection string of the resource you want to test against. For all other communication packages, set up an environment variable called `COMMUNICATION_CONNECTION_STRING` and set it to the connection string of the resource you want to test against.
 
 Depending on which package you are testing, it may need special environment variables to test succesfully. In each package, there is a `recordedClient.ts` file; In that file you will find `const replaceableVariables` with the names of the variables the package uses. Make sure to set these variables before running the tests themselves.
 

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function(config) {
     // https://www.npmjs.com/package/karma-env-preprocessor
     envPreprocessor: [
       "TEST_MODE",
-      "AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING",
+      "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING",
       "INCLUDE_PHONENUMBER_LIVE_TESTS",
       "AZURE_PHONE_NUMBER",
       "COMMUNICATION_ENDPOINT"

--- a/sdk/communication/communication-phone-numbers/test.env
+++ b/sdk/communication/communication-phone-numbers/test.env
@@ -1,6 +1,6 @@
 # Used in test to retrieve these values from a Communication Services resource
 # in the Azure Portal.
-AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
+COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/communication/communication-phone-numbers/test/README.md
+++ b/sdk/communication/communication-phone-numbers/test/README.md
@@ -11,7 +11,7 @@ The Azure resource that is used by the tests in this project is:
 To run the live tests, you will need to set the below environment variables:
 
 - `TEST_MODE`: Should have `live` assigned if you want to run live without recording. Assign `record` to run live with recording.
-- `COMMUNICATION_CONNECTION_STRING`: The primary connection string of the Communication Services resource in your account.
+- `COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING`: The primary connection string of the Communication Services resource in your account.
 
 [azure_sub]: https://azure.microsoft.com/free/
 [azure_portal]: https://portal.azure.com

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -33,7 +33,7 @@ export interface RecordedClient<T> {
 }
 
 const replaceableVariables: { [k: string]: string } = {
-  AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
+  COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
   INCLUDE_PHONENUMBER_LIVE_TESTS: "false",
   COMMUNICATION_ENDPOINT: "https://endpoint/",
   AZURE_CLIENT_ID: "SomeClientId",
@@ -58,7 +58,7 @@ export function createRecordedClient(context: Context): RecordedClient<PhoneNumb
 
   // casting is a workaround to enable min-max testing
   return {
-    client: new PhoneNumbersClient(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING, {
+    client: new PhoneNumbersClient(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING, {
       httpClient: createTestHttpClient()
     } as PhoneNumbersClientOptions),
     recorder
@@ -79,7 +79,7 @@ export function createRecordedClientWithToken(
 ): RecordedClient<PhoneNumbersClient> | undefined {
   const recorder = record(context, environmentSetup);
   let credential: TokenCredential;
-  const endpoint = parseConnectionString(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING)
+  const endpoint = parseConnectionString(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING)
     .endpoint;
   if (isPlaybackMode()) {
     credential = {

--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -57,7 +57,7 @@ module.exports = function(config) {
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
     envPreprocessor: [
-      "AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING",
+      "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING",
       "AZURE_PHONE_NUMBER",
       "TEST_MODE",
       "AZURE_CLIENT_ID",

--- a/sdk/communication/communication-sms/test.env
+++ b/sdk/communication/communication-sms/test.env
@@ -1,4 +1,4 @@
-AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
+COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/communication/communication-sms/test/README.md
+++ b/sdk/communication/communication-sms/test/README.md
@@ -11,7 +11,7 @@ The Azure resource that is used by the tests in this project is:
 To run the live tests, you will need to set the below environment variables:
 
 - `TEST_MODE`: Should have `live` assigned if you want to run live without recording. Assign `record` to run live with recording.
-- `AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING`: The primary connection string of the Communication Services resource in your account.
+- `COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING`: The primary connection string of the Communication Services resource in your account.
 - `AZURE_PHONE_NUMBER`: an SMS enabled phone number associated with the Communication Services resource.
 
 [azure_sub]: https://azure.microsoft.com/free/

--- a/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
@@ -15,7 +15,7 @@ import { SmsClient, SmsClientOptions } from "../../../src";
 
 export const recorderConfiguration: RecorderEnvironmentSetup = {
   replaceableVariables: {
-    AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
+    COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
     AZURE_PHONE_NUMBER: "+14255550123",
     AZURE_CLIENT_ID: "SomeClientId",
     AZURE_CLIENT_SECRET: "SomeClientSecret",
@@ -61,13 +61,13 @@ function createCredential(): TokenCredential {
 
 export function createSmsClient(): SmsClient {
   // workaround: casting because min testing has issues with httpClient newer versions having extra optional fields
-  return new SmsClient(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING, {
+  return new SmsClient(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING, {
     httpClient: createTestHttpClient()
   } as SmsClientOptions);
 }
 
 export function createSmsClientWithToken(): SmsClient {
-  const { endpoint } = parseConnectionString(env.AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING);
+  const { endpoint } = parseConnectionString(env.COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING);
   const credential: TokenCredential = createCredential();
   // workaround: casting because min testing has issues with httpClient newer versions having extra optional fields
   return new SmsClient(endpoint, credential, {


### PR DESCRIPTION
This change only renames `AZURE_COMMUNICATION_LIVETEST_CONNECTION_STRING` to `COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING` to comply with other languages.

Will have an upcoming change for updating dynamic connection string for chat and identity.