### PR TITLE
update botservice api version to 2021-03-01

### DIFF
--- a/sdk/botservice/arm-botservice/src/azureBotServiceContext.ts
+++ b/sdk/botservice/arm-botservice/src/azureBotServiceContext.ts
@@ -44,7 +44,7 @@ export class AzureBotServiceContext extends msRestAzure.AzureServiceClient {
 
     super(credentials, options);
 
-    this.apiVersion = '2020-06-02';
+    this.apiVersion = '2021-03-01';
     this.acceptLanguage = 'en-US';
     this.longRunningOperationRetryTimeout = 30;
     this.baseUri = options.baseUri || this.baseUri || "https://management.azure.com";


### PR DESCRIPTION
Update botservice js-sdk to use the latest version of  swagger 2021-03-01, this has been merged in azure-rest-api-spec as https://github.com/Azure/azure-rest-api-specs/pull/12995