### PR TITLE
[identity] Rework AzurePowerShellCredential fallback sequence

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.3 (Unreleased)
+## 2.0.0-beta.3 (2021-05-11)
 
 ### New features
 
@@ -10,6 +10,7 @@
 - The feature of persistence caching of credentials (introduced in 2.0.0-beta.1) is now supported on Node.js 15 as well.
 - `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now has the same impact on `ChainedTokenCredential` as the `CredentialUnavailableError` which is to allow the next credential in the chain to be tried.
 - `ManagedIdentityCredential` now retries with exponential back-off when a request for a token fails with a 404 status code on environments with available IMDS endpoints.
+- Added an `AzurePowerShellCredential` which will use the authenticated user session from the `Az.Account` PowerShell module. This credential will attempt to use PowerShell Core by calling `pwsh`, and on Windows it will fall back to Windows PowerShell (`powershell`) if PowerShell Core is not available.
 
 ### Breaking changes from 2.0.0-beta.1
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.3 (2021-05-11)
+## 2.0.0-beta.3 (2021-05-12)
 
 ### New features
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -76,13 +76,8 @@ export class AzureCliCredential implements TokenCredential {
 
 // @public
 export class AzurePowerShellCredential implements TokenCredential {
-    constructor(options?: AzurePowerShellCredentialOptions);
+    constructor();
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
-    }
-
-// @public
-export interface AzurePowerShellCredentialOptions {
-    useLegacyPowerShell?: boolean;
 }
 
 // @public
@@ -218,7 +213,7 @@ export const logger: AzureLogger;
 export class ManagedIdentityCredential implements TokenCredential {
     constructor(clientId: string, options?: TokenCredentialOptions);
     constructor(options?: TokenCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
 
 // @public

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -213,7 +213,7 @@ export const logger: AzureLogger;
 export class ManagedIdentityCredential implements TokenCredential {
     constructor(clientId: string, options?: TokenCredentialOptions);
     constructor(options?: TokenCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
     }
 
 // @public

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -71,8 +71,7 @@ const isNotInstalledError = (err: Error) => err.message.match(powerShellErrors.i
 /**
  * This credential will use the currently logged-in user information from the
  * Azure PowerShell module. To do so, it will read the user access token and
- * expire time with Azure PowerShell command `Get-AzAccessToken -ResourceUrl
- * {ResourceScope}`.
+ * expire time with Azure PowerShell command `Get-AzAccessToken -ResourceUrl {ResourceScope}`
  *
  * To be able to use this credential:
  * - Install the Azure Az PowerShell module with:

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -10,12 +10,15 @@ import { processUtils } from "../util/processUtils";
 
 const logger = credentialLogger("AzurePowerShellCredential");
 
+const isWindows = process.platform === "win32";
+
 /**
- * Formats a command based on the platform executing it.
+ * Returns a platform-appropriate command name by appending ".exe" on Windows.
+ *
  * @internal
  */
 export function formatCommand(commandName: string): string {
-  if (process.platform === "win32") {
+  if (isWindows) {
     return `${commandName}.exe`;
   } else {
     return commandName;
@@ -55,7 +58,7 @@ export const powerShellErrors = {
  */
 export const powerShellPublicErrorMessages = {
   login:
-    "Please run 'Connect-AzAccount' from powershell to authenticate before using this credential.",
+    "Please run 'Connect-AzAccount' from PowerShell to authenticate before using this credential.",
   installed: `The 'Az.Account' module >= 2.2.0 is not installed. Install the Azure Az PowerShell module with: "Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force".`
 };
 
@@ -63,75 +66,70 @@ export const powerShellPublicErrorMessages = {
 const isLoginError = (err: Error) => err.message.match(`(.*)${powerShellErrors.login}(.*)`);
 
 // Az Module not Installed in Azure PowerShell check.
-const isNotInstallError = (err: Error) => err.message.match(powerShellErrors.installed);
+const isNotInstalledError = (err: Error) => err.message.match(powerShellErrors.installed);
 
 /**
- * Optional parameters for the {@link AzurePowerShellCredential} class.
- */
-export interface AzurePowerShellCredentialOptions {
-  /**
-   * If specified, this credential will use the legacy `powershell` command instead of the newest `pwsh`.
-   */
-  useLegacyPowerShell?: boolean;
-}
-
-/**
- * This credential will use the currently logged-in user login information via the Azure Power Shell command line tool.
- * To do so, it will read the user access token and expire time with Azure Power Shell command `Get-AzAccessToken -ResourceUrl {ResourceScope}`.
- * To be able to use this credential, ensure that:
- * - Install the Azure Az PowerShell module with: `Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force`.
- * - You have already logged in via the 'az' tool using the command "Connect-AzAccount" from the command line.
+ * This credential will use the currently logged-in user information from the
+ * Azure PowerShell module. To do so, it will read the user access token and
+ * expire time with Azure PowerShell command `Get-AzAccessToken -ResourceUrl
+ * {ResourceScope}`.
+ *
+ * To be able to use this credential:
+ * - Install the Azure Az PowerShell module with:
+ *   `Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force`.
+ * - You have already logged in to Azure PowerShell using the command
+ * `Connect-AzAccount` from the command line.
  */
 export class AzurePowerShellCredential implements TokenCredential {
-  private readonly powerShellCommand: string;
+  private commandStack: string[] = [formatCommand("pwsh")];
 
   /**
-   * Creates an instance of the ClientCertificateCredential with the details
-   * needed to authenticate against Azure Active Directory with a certificate.
-   *
-   * @param AzurePowerShellCredentialOptions - Optional parameters. For now accepts a `useLegacyPowerShell` property to indicate if legacy powershell should be used for authentication.
+   * Creates an AzurePowerShellCredential, which will authenticate against
+   * Azure Active Directory using an existing login session created using
+   * `Connect-AzAccount` in PowerShell.
    */
-  constructor(options?: AzurePowerShellCredentialOptions) {
-    if (options?.useLegacyPowerShell) {
-      this.powerShellCommand = formatCommand("powershell");
-    } else {
-      this.powerShellCommand = formatCommand("pwsh");
+  constructor() {
+    if (isWindows) {
+      this.commandStack.push(formatCommand("powershell"));
     }
   }
+
   /**
-   * Gets the access token from Azure Power Shell
+   * Gets the access token from Azure PowerShell
    * @param resource - The resource to use when getting the token
    */
   private async getAzurePowerShellAccessToken(
     resource: string
   ): Promise<{ Token: string; ExpiresOn: string }> {
-    try {
-      await runCommands([[this.powerShellCommand, "/?"]]);
-    } catch (e) {
-      throw new Error(
-        `Unable to execute "${this.powerShellCommand}". Ensure that it is installed in your system.`
-      );
+    for (const powerShellCommand of this.commandStack) {
+      try {
+        await runCommands([[powerShellCommand, "/?"]]);
+      } catch (e) {
+        continue;
+      }
+
+      const results = await runCommands([
+        [
+          powerShellCommand,
+          "-Command",
+          "Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru"
+        ],
+        [
+          powerShellCommand,
+          "-Command",
+          `Get-AzAccessToken -ResourceUrl "${resource}" | ConvertTo-Json`
+        ]
+      ]);
+
+      const result = results[1];
+      try {
+        return JSON.parse(result);
+      } catch (e) {
+        throw new Error(`Unable to parse the output of PowerShell. Received output: ${result}`);
+      }
     }
 
-    const results = await runCommands([
-      [
-        this.powerShellCommand,
-        "-Command",
-        "Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru"
-      ],
-      [
-        this.powerShellCommand,
-        "-Command",
-        `Get-AzAccessToken -ResourceUrl "${resource}" | ConvertTo-Json`
-      ]
-    ]);
-
-    const result = results[1];
-    try {
-      return JSON.parse(result);
-    } catch (e) {
-      throw new Error(`Unable to parse the output of PowerShell. Received output: ${result}`);
-    }
+    throw new Error(`Unable to execute PowerShell. Ensure that it is installed in your system.`);
   }
 
   /**
@@ -163,7 +161,7 @@ export class AzurePowerShellCredential implements TokenCredential {
           expiresOnTimestamp: new Date(response.ExpiresOn).getTime()
         };
       } catch (err) {
-        if (isNotInstallError(err)) {
+        if (isNotInstalledError(err)) {
           const error = new CredentialUnavailableError(powerShellPublicErrorMessages.installed);
           logger.getToken.info(formatError(scope, error));
           throw error;

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -6,6 +6,7 @@ import { ChainedTokenCredential } from "./chainedTokenCredential";
 import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 import { AzureCliCredential } from "./azureCliCredential";
+import { AzurePowerShellCredential } from "./azurePowerShellCredential";
 
 /**
  * Provides options to configure the {@link DefaultAzureCredential} class.
@@ -30,7 +31,7 @@ export interface DefaultAzureCredentialOptions extends TokenCredentialOptions {
  * - {@link EnvironmentCredential}
  * - {@link ManagedIdentityCredential}
  * - {@link AzureCliCredential}
- * - {@link VisualStudioCodeCredential}
+ * - {@link AzurePowerShellCredential}
  *
  * Consult the documentation of these credential types for more information
  * on how they attempt authentication.
@@ -57,6 +58,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     }
 
     credentials.push(new AzureCliCredential());
+    credentials.push(new AzurePowerShellCredential());
 
     super(...credentials);
     this.UnavailableMessage =

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -37,10 +37,7 @@ export { DeviceCodeCredentialOptions } from "./credentials/deviceCodeCredentialO
 export { UsernamePasswordCredential } from "./credentials/usernamePasswordCredential";
 export { UsernamePasswordCredentialOptions } from "./credentials/usernamePasswordCredentialOptions";
 export { AuthorizationCodeCredential } from "./credentials/authorizationCodeCredential";
-export {
-  AzurePowerShellCredential,
-  AzurePowerShellCredentialOptions
-} from "./credentials/azurePowerShellCredential";
+export { AzurePowerShellCredential } from "./credentials/azurePowerShellCredential";
 
 export {
   AuthenticationError,

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -7,7 +7,6 @@ import assert from "assert";
 import Sinon from "sinon";
 import { AzurePowerShellCredential } from "../../../src";
 import {
-  formatCommand,
   powerShellErrors,
   powerShellPublicErrorMessages
 } from "../../../src/credentials/azurePowerShellCredential";
@@ -15,6 +14,15 @@ import { processUtils } from "../../../src/util/processUtils";
 
 describe("AzurePowerShellCredential", function() {
   const scope = "https://vault.azure.net/.default";
+
+  it("command stack is configured correctly by platform", function() {
+    const cred = new AzurePowerShellCredential();
+
+    assert.deepStrictEqual(
+      (cred as any).commandStack,
+      process.platform === "win32" ? ["pwsh.exe", "powershell.exe"] : ["pwsh"]
+    );
+  });
 
   it("throws an expected error if the user hasn't logged in through PowerShell", async function() {
     const sandbox = Sinon.createSandbox();
@@ -64,10 +72,14 @@ describe("AzurePowerShellCredential", function() {
 
   it("throws an expected error if PowerShell isn't installed", async function() {
     const sandbox = Sinon.createSandbox();
-    const pwshCommand = formatCommand("pwsh");
 
     const stub = sandbox.stub(processUtils, "execFile");
     stub.onCall(0).throws(new Error());
+
+    // Additionally stub the second call on windows, for the fallback to Windows PowerShell
+    if (process.platform === "win32") {
+      stub.onCall(1).throws(new Error());
+    }
 
     const credential = new AzurePowerShellCredential();
 
@@ -82,33 +94,7 @@ describe("AzurePowerShellCredential", function() {
     assert.equal(error?.name, "CredentialUnavailableError");
     assert.equal(
       error?.message,
-      `Error: Unable to execute "${pwshCommand}". Ensure that it is installed in your system.`
-    );
-
-    sandbox.restore();
-  });
-
-  it("throws an expected error if PowerShell isn't installed (legacy mode)", async function() {
-    const sandbox = Sinon.createSandbox();
-    const pwshCommand = formatCommand("powershell");
-
-    const stub = sandbox.stub(processUtils, "execFile");
-    stub.onCall(0).throws(new Error());
-
-    const credential = new AzurePowerShellCredential({ useLegacyPowerShell: true });
-
-    let error: Error | null = null;
-    try {
-      await credential.getToken(scope);
-    } catch (e) {
-      error = e;
-    }
-
-    assert.ok(error);
-    assert.equal(error?.name, "CredentialUnavailableError");
-    assert.equal(
-      error?.message,
-      `Error: Unable to execute "${pwshCommand}". Ensure that it is installed in your system.`
+      `Error: Unable to execute PowerShell. Ensure that it is installed in your system.`
     );
 
     sandbox.restore();
@@ -118,9 +104,10 @@ describe("AzurePowerShellCredential", function() {
     const sandbox = Sinon.createSandbox();
 
     const stub = sandbox.stub(processUtils, "execFile");
-    stub.onCall(0).returns(Promise.resolve("")); // The first call checks that the command is available.
-    stub.onCall(1).returns(Promise.resolve("This one we ignore."));
-    stub.onCall(2).returns(Promise.resolve("Not valid JSON"));
+    let idx = 0;
+    stub.onCall(idx++).returns(Promise.resolve("")); // The first call checks that the command is available.
+    stub.onCall(idx++).returns(Promise.resolve("This one we ignore."));
+    stub.onCall(idx++).returns(Promise.resolve("Not valid JSON"));
 
     const credential = new AzurePowerShellCredential();
 
@@ -140,6 +127,37 @@ describe("AzurePowerShellCredential", function() {
 
     sandbox.restore();
   });
+
+  if (process.platform === "win32") {
+    it("throws an expected error if PowerShell returns something that isn't valid JSON (Windows PowerShell fallback)", async function() {
+      const sandbox = Sinon.createSandbox();
+
+      const stub = sandbox.stub(processUtils, "execFile");
+      let idx = 0;
+      stub.onCall(idx++).throws(new Error());
+      stub.onCall(idx++).returns(Promise.resolve("")); // The first call checks that the command is available.
+      stub.onCall(idx++).returns(Promise.resolve("This one we ignore."));
+      stub.onCall(idx++).returns(Promise.resolve("Not valid JSON"));
+
+      const credential = new AzurePowerShellCredential();
+
+      let error: Error | null = null;
+      try {
+        await credential.getToken(scope);
+      } catch (e) {
+        error = e;
+      }
+
+      assert.ok(error);
+      assert.equal(error?.name, "CredentialUnavailableError");
+      assert.equal(
+        error?.message,
+        `Error: Unable to parse the output of PowerShell. Received output: Not valid JSON`
+      );
+
+      sandbox.restore();
+    });
+  }
 
   it("authenticates", async function() {
     const sandbox = Sinon.createSandbox();


### PR DESCRIPTION
This PR reworks the AzurePowerShellCredential's logic to remove the `useLegacyPowerShell` option. I also cleaned up some of the terms around PowerShell branding, specifically replaced all instances of "powershell", "power shell", "Powershell" and "Power Shell" with "PowerShell".

I also updated the CHANGELOG and set the release date (for tomorrow). There will be one final PR with some changes to samples and the README.

- Removed option `useLegacyPowerShell`
  - Use `pwsh`/`pwsh.exe` by default, fall back to `powershell.exe` on Windows.
- Added CHANGELOG entry for AzurePowerShellCredential
- Added release information to CHANGELOG.
- Reworked tests to account for new behavior.