### PR TITLE
[KeyVault] - Admin and Keys API unification

### DIFF
--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -95,8 +95,8 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 export class KeyVaultBackupClient {
     constructor(vaultUrl: string, credential: TokenCredential, options?: BackupClientOptions);
     beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, BackupResult>>;
-    beginRestore(blobStorageUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, RestoreResult>>;
-    beginSelectiveRestore(blobStorageUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>>;
+    beginRestore(folderUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, RestoreResult>>;
+    beginSelectiveRestore(folderUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>>;
     readonly vaultUrl: string;
 }
 

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -126,17 +126,11 @@ export interface KeyVaultRoleAssignment {
     readonly id: string;
     readonly kind: string;
     readonly name: string;
-    properties: KeyVaultRoleAssignmentPropertiesWithScope;
+    properties: KeyVaultRoleAssignmentProperties;
 }
 
 // @public
 export interface KeyVaultRoleAssignmentProperties {
-    principalId: string;
-    roleDefinitionId: string;
-}
-
-// @public
-export interface KeyVaultRoleAssignmentPropertiesWithScope {
     principalId: string;
     roleDefinitionId: string;
     scope?: KeyVaultRoleScope;

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -16,39 +16,6 @@ export interface AccessControlClientOptions extends coreHttp.PipelineOptions {
 }
 
 // @public
-export interface BackupClientOptions extends coreHttp.PipelineOptions {
-    serviceVersion?: SUPPORTED_API_VERSIONS;
-}
-
-// @public
-export type BackupOperationState = KeyVaultAdminPollOperationState<BackupResult>;
-
-// @public
-export interface BackupPollerOptions extends coreHttp.OperationOptions {
-    intervalInMs?: number;
-    resumeFrom?: string;
-}
-
-// @public
-export interface BackupResult {
-    backupFolderUri?: string;
-    endTime?: Date;
-    startTime: Date;
-}
-
-// @public
-export interface BeginBackupOptions extends BackupPollerOptions {
-}
-
-// @public
-export interface BeginRestoreOptions extends BackupPollerOptions {
-}
-
-// @public
-export interface BeginSelectiveRestoreOptions extends BackupPollerOptions {
-}
-
-// @public
 export interface CreateRoleAssignmentOptions extends coreHttp.OperationOptions {
 }
 
@@ -93,11 +60,44 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 
 // @public
 export class KeyVaultBackupClient {
-    constructor(vaultUrl: string, credential: TokenCredential, options?: BackupClientOptions);
-    beginBackup(blobStorageUri: string, sasToken: string, options?: BeginBackupOptions): Promise<PollerLike<BackupOperationState, BackupResult>>;
-    beginRestore(folderUri: string, sasToken: string, folderName: string, options?: BeginRestoreOptions): Promise<PollerLike<RestoreOperationState, RestoreResult>>;
-    beginSelectiveRestore(folderUri: string, sasToken: string, folderName: string, keyName: string, options?: BeginBackupOptions): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>>;
+    constructor(vaultUrl: string, credential: TokenCredential, options?: KeyVaultBackupClientOptions);
+    beginBackup(blobStorageUri: string, sasToken: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
+    beginRestore(folderUri: string, sasToken: string, folderName: string, options?: KeyVaultBeginRestoreOptions): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>>;
+    beginSelectiveRestore(folderUri: string, sasToken: string, folderName: string, keyName: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>>;
     readonly vaultUrl: string;
+}
+
+// @public
+export interface KeyVaultBackupClientOptions extends coreHttp.PipelineOptions {
+    serviceVersion?: SUPPORTED_API_VERSIONS;
+}
+
+// @public
+export type KeyVaultBackupOperationState = KeyVaultAdminPollOperationState<KeyVaultBackupResult>;
+
+// @public
+export interface KeyVaultBackupPollerOptions extends coreHttp.OperationOptions {
+    intervalInMs?: number;
+    resumeFrom?: string;
+}
+
+// @public
+export interface KeyVaultBackupResult {
+    backupFolderUri?: string;
+    endTime?: Date;
+    startTime: Date;
+}
+
+// @public
+export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {
+}
+
+// @public
+export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {
+}
+
+// @public
+export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions {
 }
 
 // @public
@@ -109,6 +109,16 @@ export interface KeyVaultPermission {
     dataActions?: KeyVaultDataAction[];
     notActions?: string[];
     notDataActions?: KeyVaultDataAction[];
+}
+
+// @public
+export interface KeyVaultRestoreOperationState extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
+}
+
+// @public
+export interface KeyVaultRestoreResult {
+    endTime?: Date;
+    startTime: Date;
 }
 
 // @public
@@ -148,6 +158,10 @@ export interface KeyVaultRoleDefinition {
 export type KeyVaultRoleScope = "/" | "/keys" | string;
 
 // @public
+export interface KeyVaultSelectiveRestoreOperationState extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
+}
+
+// @public
 export const LATEST_API_VERSION = "7.2";
 
 // @public
@@ -169,21 +183,7 @@ export interface ListRoleDefinitionsPageSettings {
 }
 
 // @public
-export interface RestoreOperationState extends KeyVaultAdminPollOperationState<RestoreResult> {
-}
-
-// @public
-export interface RestoreResult {
-    endTime?: Date;
-    startTime: Date;
-}
-
-// @public
 export const SDK_VERSION: string;
-
-// @public
-export interface SelectiveRestoreOperationState extends KeyVaultAdminPollOperationState<RestoreResult> {
-}
 
 // @public
 export type SUPPORTED_API_VERSIONS = "7.2";

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -33,7 +33,7 @@ export interface KeyVaultRoleAssignment {
   /**
    * Role assignment properties.
    */
-  properties: KeyVaultRoleAssignmentPropertiesWithScope;
+  properties: KeyVaultRoleAssignmentProperties;
 }
 
 /**
@@ -144,6 +144,10 @@ export interface KeyVaultRoleAssignmentProperties {
    * The principal ID.
    */
   principalId: string;
+  /**
+   * The role assignment scope.
+   */
+  scope?: KeyVaultRoleScope;
 }
 
 /**
@@ -151,24 +155,6 @@ export interface KeyVaultRoleAssignmentProperties {
  * The valid scopes are: "/", "/keys" and any a specific resource Id followed by a slash, as in "ID/".
  */
 export type KeyVaultRoleScope = "/" | "/keys" | string;
-
-/**
- * Role assignment properties with the scope property.
- */
-export interface KeyVaultRoleAssignmentPropertiesWithScope {
-  /**
-   * The role assignment scope.
-   */
-  scope?: KeyVaultRoleScope;
-  /**
-   * The role definition ID.
-   */
-  roleDefinitionId: string;
-  /**
-   * The principal ID.
-   */
-  principalId: string;
-}
 
 /**
  * An interface representing the optional parameters that can be

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -191,19 +191,19 @@ export class KeyVaultBackupClient {
    * console.log(backupUri);
    * ```
    * Starts a full restore operation.
-   * @param blobStorageUri - The URL of the blob storage resource where the previous successful full backup was stored.
+   * @param folderUri - The URL of the blob storage resource where the previous successful full backup was stored.
    * @param sasToken - The SAS token.
    * @param folderName - The folder name of the blob where the previous successful full backup was stored. The URL segment after the container name.
    * @param options - The optional parameters.
    */
   public async beginRestore(
-    blobStorageUri: string,
+    folderUri: string,
     sasToken: string,
     folderName: string,
     options: BeginRestoreOptions = {}
   ): Promise<PollerLike<RestoreOperationState, RestoreResult>> {
     const poller = new RestorePoller({
-      blobStorageUri,
+      folderUri,
       sasToken,
       folderName,
       client: this.client,
@@ -248,14 +248,14 @@ export class KeyVaultBackupClient {
    * await poller.pollUntilDone();
    * ```
    * Creates a new role assignment.
-   * @param blobStorageUri - The URL of the blob storage resource, with the folder name of the blob where the previous successful full backup was stored.
+   * @param folderUri - The URL of the blob storage resource, with the folder name of the blob where the previous successful full backup was stored.
    * @param sasToken - The SAS token.
    * @param folderName - The Folder name of the blob where the previous successful full backup was stored. The URL segment after the container name.
    * @param keyName - The name of the key that wants to be restored.
    * @param options - The optional parameters.
    */
   public async beginSelectiveRestore(
-    blobStorageUri: string,
+    folderUri: string,
     sasToken: string,
     folderName: string,
     keyName: string,
@@ -263,7 +263,7 @@ export class KeyVaultBackupClient {
   ): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>> {
     const poller = new SelectiveRestorePoller({
       keyName,
-      blobStorageUri,
+      folderUri,
       sasToken,
       folderName,
       client: this.client,

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -13,27 +13,27 @@ import { PollerLike } from "@azure/core-lro";
 import { challengeBasedAuthenticationPolicy } from "../../keyvault-common";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import {
-  BackupClientOptions,
-  BackupResult,
-  BeginBackupOptions,
-  BeginRestoreOptions,
-  RestoreResult
+  KeyVaultBackupClientOptions,
+  KeyVaultBackupResult,
+  KeyVaultBeginBackupOptions,
+  KeyVaultBeginRestoreOptions,
+  KeyVaultRestoreResult
 } from "./backupClientModels";
 import { LATEST_API_VERSION, SDK_VERSION } from "./constants";
 import { logger } from "./log";
-import { BackupPoller } from "./lro/backup/poller";
-import { RestorePoller } from "./lro/restore/poller";
-import { SelectiveRestorePoller } from "./lro/selectiveRestore/poller";
-import { BackupOperationState } from "./lro/backup/operation";
-import { RestoreOperationState } from "./lro/restore/operation";
+import { KeyVaultBackupPoller } from "./lro/backup/poller";
+import { KeyVaultRestorePoller } from "./lro/restore/poller";
+import { KeyVaultSelectiveRestorePoller } from "./lro/selectiveRestore/poller";
+import { KeyVaultBackupOperationState } from "./lro/backup/operation";
+import { KeyVaultRestoreOperationState } from "./lro/restore/operation";
 import { KeyVaultAdminPollOperationState } from "./lro/keyVaultAdminPoller";
-import { SelectiveRestoreOperationState } from "./lro/selectiveRestore/operation";
+import { KeyVaultSelectiveRestoreOperationState } from "./lro/selectiveRestore/operation";
 import { KeyVaultClientOptionalParams } from "./generated/models";
 
 export {
-  BackupOperationState,
-  RestoreOperationState,
-  SelectiveRestoreOperationState,
+  KeyVaultBackupOperationState,
+  KeyVaultRestoreOperationState,
+  KeyVaultSelectiveRestoreOperationState,
   KeyVaultAdminPollOperationState
 };
 
@@ -72,7 +72,11 @@ export class KeyVaultBackupClient {
    * @param credential - An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the \@azure/identity package to create a credential that suits your needs.
    * @param options - options used to configure Key Vault API requests.
    */
-  constructor(vaultUrl: string, credential: TokenCredential, options: BackupClientOptions = {}) {
+  constructor(
+    vaultUrl: string,
+    credential: TokenCredential,
+    options: KeyVaultBackupClientOptions = {}
+  ) {
     this.vaultUrl = vaultUrl;
 
     const libInfo = `azsdk-js-keyvault-admin/${SDK_VERSION}`;
@@ -144,9 +148,9 @@ export class KeyVaultBackupClient {
   public async beginBackup(
     blobStorageUri: string,
     sasToken: string,
-    options: BeginBackupOptions = {}
-  ): Promise<PollerLike<BackupOperationState, BackupResult>> {
-    const poller = new BackupPoller({
+    options: KeyVaultBeginBackupOptions = {}
+  ): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>> {
+    const poller = new KeyVaultBackupPoller({
       blobStorageUri,
       sasToken,
       client: this.client,
@@ -200,9 +204,9 @@ export class KeyVaultBackupClient {
     folderUri: string,
     sasToken: string,
     folderName: string,
-    options: BeginRestoreOptions = {}
-  ): Promise<PollerLike<RestoreOperationState, RestoreResult>> {
-    const poller = new RestorePoller({
+    options: KeyVaultBeginRestoreOptions = {}
+  ): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>> {
+    const poller = new KeyVaultRestorePoller({
       folderUri,
       sasToken,
       folderName,
@@ -259,9 +263,9 @@ export class KeyVaultBackupClient {
     sasToken: string,
     folderName: string,
     keyName: string,
-    options: BeginBackupOptions = {}
-  ): Promise<PollerLike<SelectiveRestoreOperationState, RestoreResult>> {
-    const poller = new SelectiveRestorePoller({
+    options: KeyVaultBeginBackupOptions = {}
+  ): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>> {
+    const poller = new KeyVaultSelectiveRestorePoller({
       keyName,
       folderUri,
       sasToken,

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -7,7 +7,7 @@ import { SUPPORTED_API_VERSIONS } from "./constants";
 /**
  * The optional parameters accepted by the KeyVaultBackupClient
  */
-export interface BackupClientOptions extends coreHttp.PipelineOptions {
+export interface KeyVaultBackupClientOptions extends coreHttp.PipelineOptions {
   /**
    * The accepted versions of the Key Vault's service API.
    */
@@ -18,7 +18,7 @@ export interface BackupClientOptions extends coreHttp.PipelineOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link beginBackup}
  */
-export interface BackupPollerOptions extends coreHttp.OperationOptions {
+export interface KeyVaultBackupPollerOptions extends coreHttp.OperationOptions {
   /**
    * Time between each polling
    */
@@ -33,24 +33,24 @@ export interface BackupPollerOptions extends coreHttp.OperationOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link beginBackup}
  */
-export interface BeginBackupOptions extends BackupPollerOptions {}
+export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginRestore}
  */
-export interface BeginRestoreOptions extends BackupPollerOptions {}
+export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginSelectiveRestore}
  */
-export interface BeginSelectiveRestoreOptions extends BackupPollerOptions {}
+export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the result of a backup operation.
  */
-export interface BackupResult {
+export interface KeyVaultBackupResult {
   /**
    * The location of the full backup.
    */
@@ -70,14 +70,14 @@ export interface BackupResult {
 /**
  * An interface representing the result of a restore operation.
  */
-export interface RestoreResult {
+export interface KeyVaultRestoreResult {
   /**
-   * The start time of the backup operation.
+   * The start time of the restore operation.
    */
   startTime: Date;
 
   /**
-   * The end time of the backup operation.
+   * The end time of the restore operation.
    */
   endTime?: Date;
 }

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -10,7 +10,7 @@ import {
   KeyVaultClientFullBackupResponse,
   KeyVaultClientFullBackupStatusResponse
 } from "../../generated/models";
-import { BackupResult, BeginBackupOptions } from "../../backupClientModels";
+import { KeyVaultBackupResult, KeyVaultBeginBackupOptions } from "../../backupClientModels";
 import {
   KeyVaultAdminPollOperation,
   KeyVaultAdminPollOperationState
@@ -20,12 +20,13 @@ import { withTrace } from "./poller";
 /**
  * An interface representing the publicly available properties of the state of a backup Key Vault's poll operation.
  */
-export type BackupOperationState = KeyVaultAdminPollOperationState<BackupResult>;
+export type KeyVaultBackupOperationState = KeyVaultAdminPollOperationState<KeyVaultBackupResult>;
 
 /**
  * An internal interface representing the state of a backup Key Vault's poll operation.
  */
-export interface BackupPollOperationState extends KeyVaultAdminPollOperationState<BackupResult> {
+export interface KeyVaultBackupPollOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultBackupResult> {
   /**
    * The URI of the blob storage account.
    */
@@ -39,12 +40,12 @@ export interface BackupPollOperationState extends KeyVaultAdminPollOperationStat
 /**
  * The backup Key Vault's poll operation.
  */
-export class BackupPollOperation extends KeyVaultAdminPollOperation<
-  BackupPollOperationState,
+export class KeyVaultBackupPollOperation extends KeyVaultAdminPollOperation<
+  KeyVaultBackupPollOperationState,
   string
 > {
   constructor(
-    public state: BackupPollOperationState,
+    public state: KeyVaultBackupPollOperationState,
     private vaultUrl: string,
     private client: KeyVaultClient,
     private requestOptions: RequestOptionsBase = {}
@@ -68,7 +69,7 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
    */
   private fullBackupStatus(
     jobId: string,
-    options: BeginBackupOptions
+    options: KeyVaultBeginBackupOptions
   ): Promise<KeyVaultClientFullBackupStatusResponse> {
     return withTrace("fullBackupStatus", options, (updatedOptions) =>
       this.client.fullBackupStatus(this.vaultUrl, jobId, updatedOptions)
@@ -81,9 +82,9 @@ export class BackupPollOperation extends KeyVaultAdminPollOperation<
   async update(
     options: {
       abortSignal?: AbortSignalLike;
-      fireProgress?: (state: BackupPollOperationState) => void;
+      fireProgress?: (state: KeyVaultBackupPollOperationState) => void;
     } = {}
-  ): Promise<BackupPollOperation> {
+  ): Promise<KeyVaultBackupPollOperation> {
     const state = this.state;
     const { blobStorageUri, sasToken } = state;
 

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { BackupPollOperation, BackupOperationState, BackupPollOperationState } from "./operation";
+import {
+  KeyVaultBackupPollOperation,
+  KeyVaultBackupOperationState,
+  KeyVaultBackupPollOperationState
+} from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
-import { BackupResult } from "../../backupClientModels";
+import { KeyVaultBackupResult } from "../../backupClientModels";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
-export interface BackupPollerOptions extends KeyVaultAdminPollerOptions {
+export interface KeyVaultBackupPollerOptions extends KeyVaultAdminPollerOptions {
   blobStorageUri: string;
   sasToken: string;
 }
@@ -14,13 +18,16 @@ export interface BackupPollerOptions extends KeyVaultAdminPollerOptions {
 /**
  * @internal
  */
-export const withTrace = createTraceFunction("Azure.KeyVault.Admin.BackupPoller");
+export const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultBackupPoller");
 
 /**
  * Class that creates a poller that waits until the backup of a Key Vault ends up being generated.
  */
-export class BackupPoller extends KeyVaultAdminPoller<BackupOperationState, BackupResult> {
-  constructor(options: BackupPollerOptions) {
+export class KeyVaultBackupPoller extends KeyVaultAdminPoller<
+  KeyVaultBackupOperationState,
+  KeyVaultBackupResult
+> {
+  constructor(options: KeyVaultBackupPollerOptions) {
     const {
       client,
       vaultUrl,
@@ -31,13 +38,13 @@ export class BackupPoller extends KeyVaultAdminPoller<BackupOperationState, Back
       resumeFrom
     } = options;
 
-    let state: BackupPollOperationState | undefined;
+    let state: KeyVaultBackupPollOperationState | undefined;
 
     if (resumeFrom) {
       state = JSON.parse(resumeFrom).state;
     }
 
-    const operation = new BackupPollOperation(
+    const operation = new KeyVaultBackupPollOperation(
       {
         ...state,
         blobStorageUri,

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -30,7 +30,7 @@ export interface RestorePollOperationState extends KeyVaultAdminPollOperationSta
   /**
    * The URI of the blob storage account.
    */
-  blobStorageUri: string;
+  folderUri: string;
   /**
    * The SAS token.
    */
@@ -92,7 +92,7 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
     } = {}
   ): Promise<RestorePollOperation> {
     const state = this.state;
-    const { blobStorageUri, sasToken, folderName } = state;
+    const { folderUri, sasToken, folderName } = state;
 
     if (options.abortSignal) {
       this.requestOptions.abortSignal = options.abortSignal;
@@ -104,7 +104,7 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
         restoreBlobDetails: {
           folderToRestore: folderName,
           sasTokenParameters: {
-            storageResourceUri: blobStorageUri,
+            storageResourceUri: folderUri,
             token: sasToken
           }
         }

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -14,19 +14,21 @@ import {
   KeyVaultAdminPollOperation,
   KeyVaultAdminPollOperationState
 } from "../keyVaultAdminPoller";
-import { RestoreResult } from "../../backupClientModels";
+import { KeyVaultRestoreResult } from "../../backupClientModels";
 import { withTrace } from "./poller";
 
 /**
  * An interface representing the publicly available properties of the state of a restore Key Vault's poll operation.
  */
-export interface RestoreOperationState extends KeyVaultAdminPollOperationState<RestoreResult> {}
+export interface KeyVaultRestoreOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {}
 
 /**
  * An internal interface representing the state of a restore Key Vault's poll operation.
  * @internal
  */
-export interface RestorePollOperationState extends KeyVaultAdminPollOperationState<RestoreResult> {
+export interface KeyVaultRestorePollOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
   /**
    * The URI of the blob storage account.
    */
@@ -44,12 +46,12 @@ export interface RestorePollOperationState extends KeyVaultAdminPollOperationSta
 /**
  * An interface representing a restore Key Vault's poll operation.
  */
-export class RestorePollOperation extends KeyVaultAdminPollOperation<
-  RestorePollOperationState,
-  RestoreResult
+export class KeyVaultRestorePollOperation extends KeyVaultAdminPollOperation<
+  KeyVaultRestorePollOperationState,
+  KeyVaultRestoreResult
 > {
   constructor(
-    public state: RestorePollOperationState,
+    public state: KeyVaultRestorePollOperationState,
     private vaultUrl: string,
     private client: KeyVaultClient,
     private requestOptions: RequestOptionsBase = {}
@@ -88,9 +90,9 @@ export class RestorePollOperation extends KeyVaultAdminPollOperation<
   async update(
     options: {
       abortSignal?: AbortSignalLike;
-      fireProgress?: (state: RestorePollOperationState) => void;
+      fireProgress?: (state: KeyVaultRestorePollOperationState) => void;
     } = {}
-  ): Promise<RestorePollOperation> {
+  ): Promise<KeyVaultRestorePollOperation> {
     const state = this.state;
     const { folderUri, sasToken, folderName } = state;
 

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
@@ -11,7 +11,7 @@ import { RestoreResult } from "../../backupClientModels";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface RestorePollerOptions extends KeyVaultAdminPollerOptions {
-  blobStorageUri: string;
+  folderUri: string;
   sasToken: string;
   folderName: string;
 }
@@ -29,7 +29,7 @@ export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, Re
     const {
       client,
       vaultUrl,
-      blobStorageUri,
+      folderUri,
       sasToken,
       folderName,
       requestOptions,
@@ -46,7 +46,7 @@ export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, Re
     const operation = new RestorePollOperation(
       {
         ...state,
-        blobStorageUri,
+        folderUri,
         sasToken,
         folderName
       },

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
@@ -2,15 +2,15 @@
 // Licensed under the MIT license.
 
 import {
-  RestorePollOperation,
-  RestoreOperationState,
-  RestorePollOperationState
+  KeyVaultRestorePollOperation,
+  KeyVaultRestoreOperationState,
+  KeyVaultRestorePollOperationState
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
-import { RestoreResult } from "../../backupClientModels";
+import { KeyVaultRestoreResult } from "../../backupClientModels";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
-export interface RestorePollerOptions extends KeyVaultAdminPollerOptions {
+export interface KeyVaultRestorePollerOptions extends KeyVaultAdminPollerOptions {
   folderUri: string;
   sasToken: string;
   folderName: string;
@@ -19,13 +19,16 @@ export interface RestorePollerOptions extends KeyVaultAdminPollerOptions {
 /**
  * @internal
  */
-export const withTrace = createTraceFunction("Azure.KeyVault.Admin.RestorePoller");
+export const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultRestorePoller");
 
 /**
  * Class that creates a poller that waits until a Key Vault ends up being restored.
  */
-export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, RestoreResult> {
-  constructor(options: RestorePollerOptions) {
+export class KeyVaultRestorePoller extends KeyVaultAdminPoller<
+  KeyVaultRestoreOperationState,
+  KeyVaultRestoreResult
+> {
+  constructor(options: KeyVaultRestorePollerOptions) {
     const {
       client,
       vaultUrl,
@@ -37,13 +40,13 @@ export class RestorePoller extends KeyVaultAdminPoller<RestoreOperationState, Re
       resumeFrom
     } = options;
 
-    let state: RestorePollOperationState | undefined;
+    let state: KeyVaultRestorePollOperationState | undefined;
 
     if (resumeFrom) {
       state = JSON.parse(resumeFrom).state;
     }
 
-    const operation = new RestorePollOperation(
+    const operation = new KeyVaultRestorePollOperation(
       {
         ...state,
         folderUri,

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
@@ -37,9 +37,9 @@ export interface SelectiveRestorePollOperationState
    */
   folderName: string;
   /**
-   * The URI of the blob storage account.
+   * The URI of the blob storage account where the previous successful full backup was stored.
    */
-  blobStorageUri: string;
+  folderUri: string;
   /**
    * The SAS token.
    */
@@ -96,7 +96,7 @@ export class SelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
     } = {}
   ): Promise<SelectiveRestorePollOperation> {
     const state = this.state;
-    const { keyName, blobStorageUri, sasToken, folderName } = state;
+    const { keyName, folderUri, sasToken, folderName } = state;
 
     if (options.abortSignal) {
       this.requestOptions.abortSignal = options.abortSignal;
@@ -108,7 +108,7 @@ export class SelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
         restoreBlobDetails: {
           folder: folderName,
           sasTokenParameters: {
-            storageResourceUri: blobStorageUri,
+            storageResourceUri: folderUri,
             token: sasToken
           }
         }

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/operation.ts
@@ -14,20 +14,20 @@ import {
   KeyVaultAdminPollOperation,
   KeyVaultAdminPollOperationState
 } from "../keyVaultAdminPoller";
-import { RestoreResult } from "../../backupClientModels";
+import { KeyVaultRestoreResult } from "../../backupClientModels";
 import { withTrace } from "./poller";
 
 /**
  * An interface representing the publicly available properties of the state of a restore Key Vault's poll operation.
  */
-export interface SelectiveRestoreOperationState
-  extends KeyVaultAdminPollOperationState<RestoreResult> {}
+export interface KeyVaultSelectiveRestoreOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {}
 
 /**
  * An internal interface representing the state of a restore Key Vault's poll operation.
  */
-export interface SelectiveRestorePollOperationState
-  extends KeyVaultAdminPollOperationState<RestoreResult> {
+export interface KeyVaultSelectiveRestorePollOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
   /**
    * The name of a Key Vault Key.
    */
@@ -49,12 +49,12 @@ export interface SelectiveRestorePollOperationState
 /**
  * The selective restore Key Vault's poll operation.
  */
-export class SelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
-  SelectiveRestorePollOperationState,
+export class KeyVaultSelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
+  KeyVaultSelectiveRestorePollOperationState,
   string
 > {
   constructor(
-    public state: SelectiveRestorePollOperationState,
+    public state: KeyVaultSelectiveRestorePollOperationState,
     private vaultUrl: string,
     private client: KeyVaultClient,
     private requestOptions: RequestOptionsBase = {}
@@ -92,9 +92,9 @@ export class SelectiveRestorePollOperation extends KeyVaultAdminPollOperation<
   async update(
     options: {
       abortSignal?: AbortSignalLike;
-      fireProgress?: (state: SelectiveRestorePollOperationState) => void;
+      fireProgress?: (state: KeyVaultSelectiveRestorePollOperationState) => void;
     } = {}
-  ): Promise<SelectiveRestorePollOperation> {
+  ): Promise<KeyVaultSelectiveRestorePollOperation> {
     const state = this.state;
     const { keyName, folderUri, sasToken, folderName } = state;
 

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/poller.ts
@@ -12,7 +12,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface SelectiveRestorePollerOptions extends KeyVaultAdminPollerOptions {
   keyName: string;
-  blobStorageUri: string;
+  folderUri: string;
   sasToken: string;
   folderName: string;
 }
@@ -34,7 +34,7 @@ export class SelectiveRestorePoller extends KeyVaultAdminPoller<
       client,
       vaultUrl,
       keyName,
-      blobStorageUri,
+      folderUri,
       sasToken,
       folderName,
       requestOptions,
@@ -52,7 +52,7 @@ export class SelectiveRestorePoller extends KeyVaultAdminPoller<
       {
         ...state,
         keyName,
-        blobStorageUri,
+        folderUri: folderUri,
         sasToken,
         folderName
       },

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveRestore/poller.ts
@@ -2,15 +2,15 @@
 // Licensed under the MIT license.
 
 import {
-  SelectiveRestorePollOperation,
-  SelectiveRestoreOperationState,
-  SelectiveRestorePollOperationState
+  KeyVaultSelectiveRestorePollOperation,
+  KeyVaultSelectiveRestoreOperationState,
+  KeyVaultSelectiveRestorePollOperationState
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
-import { RestoreResult } from "../../backupClientModels";
+import { KeyVaultRestoreResult } from "../../backupClientModels";
 import { createTraceFunction } from "../../../../keyvault-common/src";
 
-export interface SelectiveRestorePollerOptions extends KeyVaultAdminPollerOptions {
+export interface KeyVaultSelectiveRestorePollerOptions extends KeyVaultAdminPollerOptions {
   keyName: string;
   folderUri: string;
   sasToken: string;
@@ -20,16 +20,16 @@ export interface SelectiveRestorePollerOptions extends KeyVaultAdminPollerOption
 /**
  * @internal
  */
-export const withTrace = createTraceFunction("Azure.KeyVault.Admin.SelectiveRestorePoller");
+export const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultSelectiveRestorePoller");
 
 /**
  * Class that creates a poller that waits until a key of a Key Vault backup ends up being restored.
  */
-export class SelectiveRestorePoller extends KeyVaultAdminPoller<
-  SelectiveRestoreOperationState,
-  RestoreResult
+export class KeyVaultSelectiveRestorePoller extends KeyVaultAdminPoller<
+  KeyVaultSelectiveRestoreOperationState,
+  KeyVaultRestoreResult
 > {
-  constructor(options: SelectiveRestorePollerOptions) {
+  constructor(options: KeyVaultSelectiveRestorePollerOptions) {
     const {
       client,
       vaultUrl,
@@ -42,13 +42,13 @@ export class SelectiveRestorePoller extends KeyVaultAdminPoller<
       resumeFrom
     } = options;
 
-    let state: SelectiveRestorePollOperationState | undefined;
+    let state: KeyVaultSelectiveRestorePollOperationState | undefined;
 
     if (resumeFrom) {
       state = JSON.parse(resumeFrom).state;
     }
 
-    const operation = new SelectiveRestorePollOperation(
+    const operation = new KeyVaultSelectiveRestorePollOperation(
       {
         ...state,
         keyName,

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
@@ -231,11 +231,13 @@ describe("KeyVaultAccessControlClient", () => {
     assert.equal(assignment.name, assignmentName);
     assert.equal(assignment.properties?.roleDefinitionId, roleDefinition.id);
     assert.equal(assignment.properties?.principalId, env.CLIENT_OBJECT_ID);
+    assert.equal(assignment.properties.scope, globalScope);
 
     assignment = await client.getRoleAssignment(globalScope, assignmentName);
     assert.equal(assignment.name, assignmentName);
     assert.equal(assignment.properties?.roleDefinitionId, roleDefinition.id);
     assert.equal(assignment.properties?.principalId, env.CLIENT_OBJECT_ID);
+    assert.equal(assignment.properties.scope, globalScope);
 
     assignment = await client.deleteRoleAssignment(globalScope, assignmentName);
     assert.equal(assignment.name, assignmentName);

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -33,7 +33,7 @@ export interface AesCbcEncryptParameters {
 export interface AesGcmDecryptParameters {
     additionalAuthenticatedData?: Uint8Array;
     algorithm: AesGcmEncryptionAlgorithm;
-    authenticationTag?: Uint8Array;
+    authenticationTag: Uint8Array;
     ciphertext: Uint8Array;
     iv: Uint8Array;
 }
@@ -278,7 +278,7 @@ export interface KeyVaultKey {
 }
 
 // @public
-export interface KeyVaultKeyId {
+export interface KeyVaultKeyIdentifier {
     name: string;
     sourceId: string;
     vaultUrl: string;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -296,7 +296,7 @@ export interface AesGcmDecryptParameters {
   /**
    * The authentication tag generated during encryption.
    */
-  authenticationTag?: Uint8Array;
+  authenticationTag: Uint8Array;
   /**
    * Optional data that is authenticated but not encrypted.
    */

--- a/sdk/keyvault/keyvault-keys/src/identifier.ts
+++ b/sdk/keyvault/keyvault-keys/src/identifier.ts
@@ -6,7 +6,7 @@ import { parseKeyvaultIdentifier } from "../../keyvault-common/src";
 /**
  * Represents the segments that compose a Key Vault Key Id.
  */
-export interface KeyVaultKeyId {
+export interface KeyVaultKeyIdentifier {
   /**
    * The complete representation of the Key Vault Key Id. For example:
    *
@@ -49,7 +49,7 @@ export interface KeyVaultKeyId {
  * @param id - The Id of the Key Vault Key.
  * @internal
  */
-export function parseKeyVaultKeyId(id: string): KeyVaultKeyId {
+export function parseKeyVaultKeyId(id: string): KeyVaultKeyIdentifier {
   const urlParts = id.split("/");
   const collection = urlParts[3];
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -99,7 +99,7 @@ import {
   VerifyDataOptions
 } from "./cryptographyClientModels";
 
-import { parseKeyVaultKeyId, KeyVaultKeyId } from "./identifier";
+import { parseKeyVaultKeyId, KeyVaultKeyIdentifier } from "./identifier";
 import { getKeyFromKeyBundle } from "./transformations";
 import { createTraceFunction } from "../../keyvault-common/src";
 
@@ -156,7 +156,7 @@ export {
   ListDeletedKeysOptions,
   PageSettings,
   PagedAsyncIterableIterator,
-  KeyVaultKeyId,
+  KeyVaultKeyIdentifier,
   PipelineOptions,
   PollOperationState,
   PollerLike,

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.hsm.spec.ts
@@ -58,7 +58,7 @@ onVersions({ minVer: "7.2" }).describe(
           algorithm: "A256GCM",
           ciphertext: encryptResult.result!,
           iv: encryptResult.iv!,
-          authenticationTag: encryptResult.authenticationTag
+          authenticationTag: encryptResult.authenticationTag!
         });
         assert.equal(text, uint8ArrayToString(decryptResult.result));
         await testClient?.flushKey(keyName);


### PR DESCRIPTION
## What

- Admin client operations prefixed with KeyVault
- AesGcmDecryptParameters' authenticationTag is required
- Rename KeyVaultKeyId to KeyVaultKeyIdentifier
- Rename beginRestore's blobStorageUri to folderUri
- Rename beginSelectiveRestore's blobStorageUri to folderUri
- Collapse KeyVaultRoleAssignmentPropertiesWithScope to KeyVaultRoleAssignmentProperties

## Why

- These tasks are the result of cross-language API unification for KeyVault

Resolves #15186
Resolves #15210
Resolves #15212