### PR TITLE
[communication][phone-numbers] increase test timeouts

### DIFF
--- a/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/get.spec.ts
@@ -30,7 +30,7 @@ matrix([[true, false]], async function(useAad) {
       const { phoneNumber } = await client.getPurchasedPhoneNumber(purchasedPhoneNumber);
 
       assert.strictEqual(purchasedPhoneNumber, phoneNumber);
-    }).timeout(10000);
+    }).timeout(60000);
 
     it("errors if phone number not found", async function() {
       const fake = "+14155550100";

--- a/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/list.spec.ts
@@ -33,6 +33,6 @@ matrix([[true, false]], async function(useAad) {
       }
 
       assert.isTrue(all > 0);
-    }).timeout(20000);
+    }).timeout(60000);
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.purchaseAndRelease.spec.ts
@@ -75,6 +75,6 @@ matrix([[true, false]], async function(useAad) {
       assert.ok(releasePoller.getOperationState().isCompleted);
 
       console.log(`Released: ${purchasedPhoneNumber}`);
-    }).timeout(60000);
+    }).timeout(90000);
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -40,7 +40,7 @@ matrix([[true, false]], async function(useAad) {
       const results = await searchPoller.pollUntilDone();
       assert.equal(results.phoneNumbers.length, 1);
       assert.ok(searchPoller.getOperationState().isCompleted);
-    }).timeout(20000);
+    }).timeout(60000);
 
     it("throws on invalid search request", async function() {
       // person and toll free is an invalid combination


### PR DESCRIPTION
This PR adds a baseline 1 minute timeout to phone number tests we do not expect to throw, and 1:30 seconds timeout to tests we know will take a little longer. This is an attempt to stabilize the phone numbers pipeline after the recent changes to have INT pipeline runs.