### PR TITLE
Update order of resources in the support.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,30 +2,32 @@
 
 ## How to file issues and get help  
 
-Customers with a [support plan](https://azure.microsoft.com/support/options/) can open an Azure Support ticket [here](https://azure.microsoft.com/support/create-ticket/).
+### Azure support ticket
+
+Customers with an [Azure support plan](https://azure.microsoft.com/support/options/) can open an [Azure support ticket](https://azure.microsoft.com/support/create-ticket/).
 **We recommend this option if your problem requires immediate attention.**
+
+### GitHub issues
+
+We use [GitHub Issues](https://github.com/Azure/azure-sdk-for-js/issues/new/choose) to track bugs, questions, and feature requests.
+GitHub issues are free, but **response time is not guaranteed.** See [GitHub issues support process](https://devblogs.microsoft.com/azure-sdk/github-issue-support-process/) for more details.
 
 ### Community resources
 
+- Take a look at the [Azure SDK blog](https://devblogs.microsoft.com/azure-sdk/).
+- Search for similar issues in [our GitHub repository](https://github.com/Azure/azure-sdk-for-js/issues)
+- Chat with other community members on [gitter](https://gitter.im/Azure/azure-sdk-for-js?source=orgpage)
 - Ask a question on [StackOverflow](https://stackoverflow.com/questions/tagged/azure-sdk-js) and tag it with azure-sdk-js
 - Share or upvote feature requests on [Feedback Page](https://feedback.azure.com/forums/34192--general-feedback).
-- Take a look at the [Azure SDK blog](https://devblogs.microsoft.com/azure-sdk/).
-- Chat with other community members on [gitter](https://gitter.im/Azure/azure-sdk-for-js?source=orgpage)
 - Ask a question on [Twitter](https://twitter.com/AzureSDK)
 - Ask a question at [Microsoft Q&A](https://docs.microsoft.com/answers/products/azure?WT.mc_id=Portal-Microsoft_Azure_Support&product=all)
 - Ask a question at [Microsoft Tech Community](https://techcommunity.microsoft.com/t5/azure/ct-p/Azure)
-- Search for similar issues in [our GitHub repository](https://github.com/Azure/azure-sdk-for-js/issues)
 
 ### Security bugs
 
 Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center(secure@microsoft.com).
 You should receive a response within 24 hours.
 Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue?rtc=1)
-
-### Github issues
-
-We use [GitHub Issues](https://github.com/Azure/azure-sdk-for-js/issues/new/choose) to track bugs, questions, and feature requests.
-GitHub issues are free, but **response time is not guaranteed.** See [GitHub issues support process](https://devblogs.microsoft.com/azure-sdk/github-issue-support-process/) for more details.
 
 ## Microsoft Support Policy
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## How to file issues and get help  
 
-### Azure support ticket
+### Azure support tickets
 
 Customers with an [Azure support plan](https://azure.microsoft.com/support/options/) can open an [Azure support ticket](https://azure.microsoft.com/support/create-ticket/).
 **We recommend this option if your problem requires immediate attention.**


### PR DESCRIPTION
GitHub issues should not be the last thing we mention in the support doc after community resources.
This PR re-orders the resources in the order that we expect people to use