### PR TITLE
[service-bus] Re-enabling the AMQP body type encoding feature.

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
-## 7.1.1 (Unreleased)
+## 7.2.0-beta.1 (Unreleased)
 
+### New Features
+
+- Enable encoding the body of a message to the 'value' or 'sequence' sections (via AmqpAnnotatedMessage.bodyType). Using this encoding is not required but does allow you to take advantage of native AMQP serialization for supported primitives or sequences.
 
 ## 7.1.0 (2021-05-11)
 

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "7.1.1",
+  "version": "7.2.0-beta.1",
   "license": "MIT",
   "description": "Azure Service Bus SDK for JavaScript",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/",

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -620,33 +620,11 @@ export function isServiceBusMessage(possible: unknown): possible is ServiceBusMe
   return isObjectWithProperties(possible, ["body"]);
 }
 
-let _featureAmqpBodyTypeEnabled = false;
-
-/**
- * Disables preview AMQP body type support.
- * @internal
- */
-export function getFeatureAmqpBodyTypeEnabled(): boolean {
-  return _featureAmqpBodyTypeEnabled;
-}
-
-/**
- * Enables preview AMQP body type support.
- * @internal
- */
-export function setFeatureAmqpBodyTypeEnabledForTesting(enable: boolean): void {
-  _featureAmqpBodyTypeEnabled = enable;
-}
-
 /**
  * @internal
  * @ignore
  */
 export function isAmqpAnnotatedMessage(possible: unknown): possible is AmqpAnnotatedMessage {
-  if (!_featureAmqpBodyTypeEnabled) {
-    return false;
-  }
-
   return (
     isObjectWithProperties(possible, ["body", "bodyType"]) &&
     possible.constructor.name !== ServiceBusMessageImpl.name

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "7.1.1"
+  version: "7.2.0-beta.1"
 };
 
 /**

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logger, receiverLogger } from "../log";
 import Long from "long";
 import { ConnectionContext } from "../connectionContext";
+import { logger, receiverLogger } from "../log";
+import { ReceiveMode } from "../models";
 import {
-  getFeatureAmqpBodyTypeEnabled,
   isAmqpAnnotatedMessage,
   isServiceBusMessage,
   ServiceBusReceivedMessage
 } from "../serviceBusMessage";
-import { ReceiveMode } from "../models";
 import { isDefined } from "./typeGuards";
 
 /**
@@ -270,11 +269,9 @@ export function throwIfNotValidServiceBusMessage(
 }
 
 /** @internal */
-export const errorInvalidMessageTypeSingleOrArray = getFeatureAmqpBodyTypeEnabled()
-  ? "Provided value for 'messages' must be of type: ServiceBusMessage, AmqpAnnotatedMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage or AmqpAnnotatedMessage."
-  : "Provided value for 'messages' must be of type: ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage";
+export const errorInvalidMessageTypeSingleOrArray =
+  "Provided value for 'messages' must be of type: ServiceBusMessage, AmqpAnnotatedMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage or AmqpAnnotatedMessage.";
 
 /** @internal */
-export const errorInvalidMessageTypeSingle = getFeatureAmqpBodyTypeEnabled()
-  ? "Provided value for 'message' must be of type: ServiceBusMessage or AmqpAnnotatedMessage."
-  : "Provided value for 'message' must be of type: ServiceBusMessage";
+export const errorInvalidMessageTypeSingle =
+  "Provided value for 'message' must be of type: ServiceBusMessage or AmqpAnnotatedMessage.";

--- a/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
@@ -2,13 +2,11 @@
 // Licensed under the MIT license.
 
 import {
-  getFeatureAmqpBodyTypeEnabled,
   isAmqpAnnotatedMessage,
   isServiceBusMessage,
   ServiceBusMessage,
   ServiceBusMessageImpl,
   ServiceBusReceivedMessage,
-  setFeatureAmqpBodyTypeEnabledForTesting,
   toRheaMessage
 } from "../../../src/serviceBusMessage";
 import * as chai from "chai";
@@ -29,22 +27,14 @@ const assert = chai.assert;
 describe("AMQP message encoding", () => {
   beforeEach(() => {
     assert.equal(
-      "Provided value for 'messages' must be of type: ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage",
+      "Provided value for 'messages' must be of type: ServiceBusMessage, AmqpAnnotatedMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage or AmqpAnnotatedMessage.",
       errorInvalidMessageTypeSingleOrArray
     );
 
     assert.equal(
-      "Provided value for 'message' must be of type: ServiceBusMessage",
+      "Provided value for 'message' must be of type: ServiceBusMessage or AmqpAnnotatedMessage.",
       errorInvalidMessageTypeSingle
     );
-
-    const previousState = getFeatureAmqpBodyTypeEnabled();
-    assert.isFalse(previousState);
-
-    setFeatureAmqpBodyTypeEnabledForTesting(true);
-  });
-  afterEach(() => {
-    setFeatureAmqpBodyTypeEnabledForTesting(false);
   });
 
   const exampleReceivedMessage: () => ServiceBusReceivedMessage = () =>

--- a/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
@@ -14,10 +14,6 @@ import {
 } from "../public/utils/testutils2";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
 import { generateUuid } from "@azure/core-http";
-import {
-  getFeatureAmqpBodyTypeEnabled,
-  setFeatureAmqpBodyTypeEnabledForTesting
-} from "../../src/serviceBusMessage";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -71,15 +67,10 @@ function getSampleAmqpAnnotatedMessage(randomTag?: string): AmqpAnnotatedMessage
 
 describe("AmqpAnnotatedMessage", function(): void {
   before(() => {
-    const previousState = getFeatureAmqpBodyTypeEnabled();
-    assert.isFalse(previousState);
-
-    setFeatureAmqpBodyTypeEnabledForTesting(true);
     serviceBusClient = createServiceBusClientForTests();
   });
 
   after(() => {
-    setFeatureAmqpBodyTypeEnabledForTesting(false);
     return serviceBusClient.test.after();
   });
 


### PR DESCRIPTION
Re-enabling the AMQP body type encoding feature. We disabled this temporarily when we released 7.1.0 and are now re-enabling this in time for our new preview: 7.2.0-beta.1