### PR TITLE
[Tables] Support bigint

### DIFF
--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -27,7 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     MatrixFilters:
-      - ^((?!8x_node).)*$
+      - TestType=^(?!8.x).*
     ServiceDirectory: tables
     Artifacts:
       - name: azure-data-tables

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -23,13 +23,11 @@ pr:
     include:
       - sdk/tables/
 
-variables:
-    jobMatrixFilter: ^((?!8x_node).)*$
-
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     MatrixFilters:
+      # Skip Node 8 validation as Node8 doesn't support bigint
       - DisplayName=^((?!8x_node).)*$
     ServiceDirectory: tables
     Artifacts:

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -26,6 +26,8 @@ pr:
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    MatrixFilters:
+      - TestType=^(?!8x_node).*
     ServiceDirectory: tables
     Artifacts:
       - name: azure-data-tables

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -23,12 +23,12 @@ pr:
     include:
       - sdk/tables/
 
+variables:
+    jobMatrixFilter: ^((?!8x_node).)*$
+
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    MatrixFilters:
-      # Skip Node 8 validation as Node8 doesn't support bigint
-      - DisplayName=^((?!8x_node).)*$
     ServiceDirectory: tables
     Artifacts:
       - name: azure-data-tables

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -27,7 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     MatrixFilters:
-      - TestType=^(?!8x_node).*
+      - ^((?!8x_node).)*$
     ServiceDirectory: tables
     Artifacts:
       - name: azure-data-tables

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -23,11 +23,14 @@ pr:
     include:
       - sdk/tables/
 
+variables:
+    jobMatrixFilter: ^((?!8x_node).)*$
+
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     MatrixFilters:
-      - TestType=^(?!8.x).*
+      - DisplayName=^((?!8x_node).)*$
     ServiceDirectory: tables
     Artifacts:
       - name: azure-data-tables

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -69,7 +69,7 @@ export type GetStatisticsResponse = ServiceGetStatisticsHeaders & TableServiceSt
 // @public
 export type GetTableEntityOptions = OperationOptions & {
     queryOptions?: TableEntityQueryOptions;
-    disableDeserialization?: boolean;
+    disableTypeConversion?: boolean;
 };
 
 // @public
@@ -88,7 +88,7 @@ export const enum KnownGeoReplicationStatusType {
 // @public
 export type ListTableEntitiesOptions = OperationOptions & {
     queryOptions?: TableEntityQueryOptions;
-    disableDeserialization?: boolean;
+    disableTypeConversion?: boolean;
 };
 
 // @public
@@ -180,7 +180,7 @@ export class TableClient {
     deleteTable(options?: OperationOptions): Promise<void>;
     static fromConnectionString(connectionString: string, tableName: string, options?: TableServiceClientOptions): TableClient;
     getAccessPolicy(options?: OperationOptions): Promise<GetAccessPolicyResponse>;
-    getEntity<T extends object = Record<string, any>>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
+    getEntity<T extends object = Record<string, unknown>>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
     listEntities<T extends object = Record<string, unknown>>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<TableEntityResult<T>, TableEntityResult<T>[]>;
     setAccessPolicy(tableAcl: SignedIdentifier[], options?: OperationOptions): Promise<SetAccessPolicyResponse>;
     submitTransaction(actions: TransactionAction[]): Promise<TableTransactionResponse>;

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -69,6 +69,7 @@ export type GetStatisticsResponse = ServiceGetStatisticsHeaders & TableServiceSt
 // @public
 export type GetTableEntityOptions = OperationOptions & {
     queryOptions?: TableEntityQueryOptions;
+    disableDeserialization?: boolean;
 };
 
 // @public
@@ -87,6 +88,7 @@ export const enum KnownGeoReplicationStatusType {
 // @public
 export type ListTableEntitiesOptions = OperationOptions & {
     queryOptions?: TableEntityQueryOptions;
+    disableDeserialization?: boolean;
 };
 
 // @public
@@ -178,7 +180,7 @@ export class TableClient {
     deleteTable(options?: OperationOptions): Promise<void>;
     static fromConnectionString(connectionString: string, tableName: string, options?: TableServiceClientOptions): TableClient;
     getAccessPolicy(options?: OperationOptions): Promise<GetAccessPolicyResponse>;
-    getEntity<T extends object = Record<string, unknown>>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
+    getEntity<T extends object = Record<string, any>>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
     listEntities<T extends object = Record<string, unknown>>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<TableEntityResult<T>, TableEntityResult<T>[]>;
     setAccessPolicy(tableAcl: SignedIdentifier[], options?: OperationOptions): Promise<SetAccessPolicyResponse>;
     submitTransaction(actions: TransactionAction[]): Promise<TableTransactionResponse>;

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -7,6 +7,7 @@
 import { CommonClientOptions } from '@azure/core-client';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
+import { Pipeline } from '@azure/core-rest-pipeline';
 import { PipelinePolicy } from '@azure/core-rest-pipeline';
 
 // @public
@@ -182,6 +183,7 @@ export class TableClient {
     getAccessPolicy(options?: OperationOptions): Promise<GetAccessPolicyResponse>;
     getEntity<T extends object = Record<string, unknown>>(partitionKey: string, rowKey: string, options?: GetTableEntityOptions): Promise<GetTableEntityResponse<TableEntityResult<T>>>;
     listEntities<T extends object = Record<string, unknown>>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<TableEntityResult<T>, TableEntityResult<T>[]>;
+    pipeline: Pipeline;
     setAccessPolicy(tableAcl: SignedIdentifier[], options?: OperationOptions): Promise<SetAccessPolicyResponse>;
     submitTransaction(actions: TransactionAction[]): Promise<TableTransactionResponse>;
     readonly tableName: string;
@@ -288,6 +290,7 @@ export class TableServiceClient {
     getProperties(options?: OperationOptions): Promise<GetPropertiesResponse>;
     getStatistics(options?: OperationOptions): Promise<GetStatisticsResponse>;
     listTables(options?: ListTableItemsOptions): PagedAsyncIterableIterator<TableItem, TableItem[]>;
+    pipeline: Pipeline;
     setProperties(properties: ServiceProperties, options?: SetPropertiesOptions): Promise<SetPropertiesResponse>;
     url: string;
 }

--- a/sdk/tables/data-tables/samples-dev/workingWithBigInt.ts
+++ b/sdk/tables/data-tables/samples-dev/workingWithBigInt.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * This sample demonstrates how to create and consume Int64 values using bigint
+ *
+ * @summary creates and works with an entity containing a bigint
+ * @azsdk-weight 70
+ */
+
+import { TableClient, TablesSharedKeyCredential } from "@azure/data-tables";
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const tablesUrl = process.env["TABLES_URL"] || "";
+const accountName = process.env["ACCOUNT_NAME"] || "";
+const accountKey = process.env["ACCOUNT_KEY"] || "";
+
+async function workingWithBigint() {
+  console.log("Working with bigint sample");
+  const client = new TableClient(
+    tablesUrl,
+    "testbigint",
+    new TablesSharedKeyCredential(accountName, accountKey)
+  );
+
+  await client.createTable();
+
+  type FooEntity = {
+    foo: bigint;
+  };
+
+  await client.createEntity<FooEntity>({ partitionKey: "p1", rowKey: "1", foo: BigInt("12345") });
+
+  const entity = await client.getEntity<FooEntity>("p1", "1");
+
+  // Do arithmetic operations with bigint
+  const resultPlusOne = entity.foo + BigInt(1);
+
+  console.log(resultPlusOne);
+
+  await client.deleteTable();
+}
+
+export async function main() {
+  await workingWithBigint();
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/tables/data-tables/samples-dev/workingWithInt64.ts
+++ b/sdk/tables/data-tables/samples-dev/workingWithInt64.ts
@@ -39,7 +39,7 @@ async function workingWithInt64() {
     foo: { value: "12345", type: "Int64" }
   });
 
-  const entity = await client.getEntity<FooEntity>("p1", "1", { disableDeserialization: true });
+  const entity = await client.getEntity<FooEntity>("p1", "1", { disableTypeConversion: true });
 
   // In order to do arithmetic operations with Int64 you need to use
   // bigint or a third party library such as 'long'

--- a/sdk/tables/data-tables/samples-dev/workingWithInt64.ts
+++ b/sdk/tables/data-tables/samples-dev/workingWithInt64.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * This sample demonstrates how to create and consume Int64 values
+ *
+ * @summary creates and works with an entity containing an Int64 value
+ * @azsdk-weight 70
+ */
+
+import { Edm, TableClient, TablesSharedKeyCredential } from "@azure/data-tables";
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const tablesUrl = process.env["TABLES_URL"] || "";
+const accountName = process.env["ACCOUNT_NAME"] || "";
+const accountKey = process.env["ACCOUNT_KEY"] || "";
+
+async function workingWithInt64() {
+  console.log("working with Int64 sample");
+  const client = new TableClient(
+    tablesUrl,
+    "testInt64",
+    new TablesSharedKeyCredential(accountName, accountKey)
+  );
+
+  await client.createTable();
+
+  type FooEntity = {
+    foo: Edm<"Int64">;
+  };
+
+  await client.createEntity<FooEntity>({
+    partitionKey: "p1",
+    rowKey: "1",
+    // To work with Int64 we need to use an object that includes
+    // the value as a string and a notation of the type, in this case Int64
+    foo: { value: "12345", type: "Int64" }
+  });
+
+  const entity = await client.getEntity<FooEntity>("p1", "1", { disableDeserialization: true });
+
+  // In order to do arithmetic operations with Int64 you need to use
+  // bigint or a third party library such as 'long'
+  console.log(entity);
+
+  await client.deleteTable();
+}
+
+export async function main() {
+  await workingWithInt64();
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -687,7 +687,7 @@ interface InternalListTableEntitiesOptions extends ListTableEntitiesOptions {
   nextRowKey?: string;
   /**
    * If true, automatic type conversion will be disabled and entity properties will
-   * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
+   * be represented by full metadata types. For example, an Int32 value will be \{value: "123", type: "Int32"\} instead of 123.
    * This option applies for all the properties
    */
   disableTypeConversion?: boolean;

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -233,7 +233,7 @@ export class TableClient {
    * @param rowKey - The row key of the entity.
    * @param options - The options parameters.
    */
-  public async getEntity<T extends object = Record<string, any>>(
+  public async getEntity<T extends object = Record<string, unknown>>(
     partitionKey: string,
     rowKey: string,
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
@@ -250,7 +250,7 @@ export class TableClient {
     }
 
     try {
-      const { disableDeserialization, queryOptions, ...getEntityOptions } = updatedOptions || {};
+      const { disableTypeConversion, queryOptions, ...getEntityOptions } = updatedOptions || {};
       await this.table.queryEntitiesWithPartitionAndRowKey(this.tableName, partitionKey, rowKey, {
         ...getEntityOptions,
         queryOptions: this.convertQueryOptions(queryOptions || {}),
@@ -258,7 +258,7 @@ export class TableClient {
       });
       const tableEntity = deserialize<TableEntityResult<T>>(
         parsedBody,
-        disableDeserialization ?? false
+        disableTypeConversion ?? false
       );
 
       return tableEntity;
@@ -353,7 +353,7 @@ export class TableClient {
     tableName: string,
     options: InternalListTableEntitiesOptions = {}
   ): Promise<ListEntitiesResponse<TableEntityResult<T>>> {
-    const { disableDeserialization = false } = options;
+    const { disableTypeConversion = false } = options;
     const queryOptions = this.convertQueryOptions(options.queryOptions || {});
     const {
       xMsContinuationNextPartitionKey: nextPartitionKey,
@@ -366,7 +366,7 @@ export class TableClient {
 
     const tableEntities = deserializeObjectsArray<TableEntityResult<T>>(
       value ?? [],
-      disableDeserialization
+      disableTypeConversion
     );
 
     return Object.assign([...tableEntities], {
@@ -686,11 +686,11 @@ interface InternalListTableEntitiesOptions extends ListTableEntitiesOptions {
    */
   nextRowKey?: string;
   /**
-   * If true, automatic deserialization will be disabled and entity properties will
+   * If true, automatic type conversion will be disabled and entity properties will
    * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
    * This option applies for all the properties
    */
-  disableDeserialization?: boolean;
+  disableTypeConversion?: boolean;
 }
 
 function isInternalClientOptions(options: any): options is InternalTransactionClientOptions {

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -52,6 +52,7 @@ import {
 } from "./utils/internalModels";
 import { Uuid } from "./utils/uuid";
 import { parseXML, stringifyXML } from "@azure/core-xml";
+import { Pipeline } from "@azure/core-rest-pipeline";
 
 /**
  * A TableClient represents a Client to the Azure Tables service allowing you
@@ -62,6 +63,11 @@ export class TableClient {
    * Table Account URL
    */
   public url: string;
+  /**
+   * Represents a pipeline for making a HTTP request to a URL.
+   * Pipelines can have multiple policies to manage manipulating each request before and after it is made to the server.
+   */
+  public pipeline: Pipeline;
   private table: Table;
   private credential: TablesSharedKeyCredentialLike | undefined;
   private interceptClient: TableClientLike | undefined;
@@ -183,6 +189,7 @@ export class TableClient {
       generatedClient.pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
     }
     this.table = generatedClient.table;
+    this.pipeline = generatedClient.pipeline;
   }
 
   /**

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -29,6 +29,7 @@ import { createSpan } from "./utils/tracing";
 import { tablesSharedKeyCredentialPolicy } from "./TablesSharedKeyCredentialPolicy";
 import { parseXML, stringifyXML } from "@azure/core-xml";
 import { ListTableItemsResponse } from "./utils/internalModels";
+import { Pipeline } from "@azure/core-rest-pipeline";
 
 /**
  * A TableServiceClient represents a Client to the Azure Tables service allowing you
@@ -39,6 +40,11 @@ export class TableServiceClient {
    * Table Account URL
    */
   public url: string;
+  /**
+   * Represents a pipeline for making a HTTP request to a URL.
+   * Pipelines can have multiple policies to manage manipulating each request before and after it is made to the server.
+   */
+  public pipeline: Pipeline;
   private table: Table;
   private service: Service;
 
@@ -132,6 +138,7 @@ export class TableServiceClient {
     if (credential) {
       client.pipeline.addPolicy(tablesSharedKeyCredentialPolicy(credential));
     }
+    this.pipeline = client.pipeline;
     this.table = client.table;
     this.service = client.service;
   }

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -121,11 +121,11 @@ export type ListTableEntitiesOptions = OperationOptions & {
    */
   queryOptions?: TableEntityQueryOptions;
   /**
-   * If true, automatic deserialization will be disabled and entity properties will
+   * If true, automatic type conversion will be disabled and entity properties will
    * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
    * This option applies for all the properties
    */
-  disableDeserialization?: boolean;
+  disableTypeConversion?: boolean;
 };
 
 /**
@@ -137,11 +137,11 @@ export type GetTableEntityOptions = OperationOptions & {
    */
   queryOptions?: TableEntityQueryOptions;
   /**
-   * If true, automatic deserialization will be disabled and entity properties will
+   * If true, automatic type conversion will be disabled and entity properties will
    * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
    * This option applies for all the properties
    */
-  disableDeserialization?: boolean;
+  disableTypeConversion?: boolean;
 };
 
 /**

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -122,7 +122,7 @@ export type ListTableEntitiesOptions = OperationOptions & {
   queryOptions?: TableEntityQueryOptions;
   /**
    * If true, automatic type conversion will be disabled and entity properties will
-   * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
+   * be represented by full metadata types. For example, an Int32 value will be \{value: "123", type: "Int32"\} instead of 123.
    * This option applies for all the properties
    */
   disableTypeConversion?: boolean;
@@ -138,7 +138,7 @@ export type GetTableEntityOptions = OperationOptions & {
   queryOptions?: TableEntityQueryOptions;
   /**
    * If true, automatic type conversion will be disabled and entity properties will
-   * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
+   * be represented by full metadata types. For example, an Int32 value will be \{value: "123", type: "Int32"\} instead of 123.
    * This option applies for all the properties
    */
   disableTypeConversion?: boolean;

--- a/sdk/tables/data-tables/src/models.ts
+++ b/sdk/tables/data-tables/src/models.ts
@@ -120,6 +120,12 @@ export type ListTableEntitiesOptions = OperationOptions & {
    * Query options group
    */
   queryOptions?: TableEntityQueryOptions;
+  /**
+   * If true, automatic deserialization will be disabled and entity properties will
+   * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
+   * This option applies for all the properties
+   */
+  disableDeserialization?: boolean;
 };
 
 /**
@@ -130,6 +136,12 @@ export type GetTableEntityOptions = OperationOptions & {
    * Parameter group
    */
   queryOptions?: TableEntityQueryOptions;
+  /**
+   * If true, automatic deserialization will be disabled and entity properties will
+   * be represented by full metadata types. For example, an Int32 value will be {value: "123", type: "Int32"} instead of 123.
+   * This option applies for all the properties
+   */
+  disableDeserialization?: boolean;
 };
 
 /**

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -108,24 +108,24 @@ export function serialize(obj: object): object {
   return serialized;
 }
 
-function getTypedObject(value: any, type: string, disableDeserialization: boolean): any {
+function getTypedObject(value: any, type: string, disableTypeConversion: boolean): any {
   switch (type) {
     case Edm.Boolean:
-      return disableDeserialization ? { value, type: "Boolean" } : value;
+      return disableTypeConversion ? { value, type: "Boolean" } : value;
     case Edm.Double:
-      return disableDeserialization ? { value, type: "Double" } : value;
+      return disableTypeConversion ? { value, type: "Double" } : value;
     case Edm.Int32:
-      return disableDeserialization ? { value, type: "Int32" } : value;
+      return disableTypeConversion ? { value, type: "Int32" } : value;
     case Edm.String:
-      return disableDeserialization ? { value, type: "String" } : value;
+      return disableTypeConversion ? { value, type: "String" } : value;
     case Edm.DateTime:
-      return disableDeserialization ? { value, type: "DateTime" } : new Date(value);
+      return disableTypeConversion ? { value, type: "DateTime" } : new Date(value);
     case Edm.Int64:
-      return disableDeserialization ? { value, type: "Int64" } : BigInt(value);
+      return disableTypeConversion ? { value, type: "Int64" } : BigInt(value);
     case Edm.Guid:
       return { value, type: "Guid" };
     case Edm.Binary:
-      return disableDeserialization ? { value, type: "Binary" } : base64Decode(value);
+      return disableTypeConversion ? { value, type: "Binary" } : base64Decode(value);
     default:
       throw new Error(`Unknown EDM type ${type}`);
   }
@@ -133,7 +133,7 @@ function getTypedObject(value: any, type: string, disableDeserialization: boolea
 
 export function deserialize<T extends object = Record<string, any>>(
   obj: object,
-  disableDeserialization: boolean = false
+  disableTypeConversion: boolean = false
 ): T {
   const deserialized: any = {};
   for (const [key, value] of Object.entries(obj)) {
@@ -142,7 +142,7 @@ export function deserialize<T extends object = Record<string, any>>(
       let typedValue = value;
       if (`${key}@odata.type` in obj) {
         const type = (obj as any)[`${key}@odata.type`];
-        typedValue = getTypedObject(value, type, disableDeserialization);
+        typedValue = getTypedObject(value, type, disableTypeConversion);
       }
       deserialized[transformedKey] = typedValue;
     }
@@ -152,7 +152,7 @@ export function deserialize<T extends object = Record<string, any>>(
 
 export function deserializeObjectsArray<T extends object>(
   objArray: object[],
-  disableDeserialization: boolean
+  disableTypeConversion: boolean
 ): T[] {
-  return objArray.map((obj) => deserialize<T>(obj, disableDeserialization));
+  return objArray.map((obj) => deserialize<T>(obj, disableTypeConversion));
 }

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -172,7 +172,7 @@ describe("Deserializer", () => {
     assert.strictEqual(deserialized.int64ObjProp, BigInt(int64Value));
   });
 
-  it("should not deserialize an Int64 when disableDeserialization is true", () => {
+  it("should not deserialize an Int64 when disableTypeConversion is true", () => {
     const int64Value = "12345678910";
     const deserialized = deserialize(
       {

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -163,22 +163,46 @@ describe("Deserializer", () => {
     assert.strictEqual(deserialized.int32Prop, int32Value);
   });
 
-  it("should deserialize an Int64 value", () => {
+  it("should deserialize an Int64 value to bigint", () => {
     const int64Value = "12345678910";
-    const deserialized: Entity = deserialize<Entity>({
+    const deserialized = deserialize({
       int64ObjProp: int64Value,
       "int64ObjProp@odata.type": "Edm.Int64"
     });
-    assert.strictEqual(deserialized.int64ObjProp?.value, int64Value);
-    assert.strictEqual(deserialized.int64ObjProp?.type, "Int64");
+    assert.strictEqual(deserialized.int64ObjProp, BigInt(int64Value));
+  });
+
+  it("should not deserialize an Int64 when disableDeserialization is true", () => {
+    const int64Value = "12345678910";
+    const deserialized = deserialize(
+      {
+        int64ObjProp: int64Value,
+        "int64ObjProp@odata.type": "Edm.Int64"
+      },
+      true
+    );
+    assert.strictEqual(deserialized.int64ObjProp.value, int64Value);
+    assert.strictEqual(deserialized.int64ObjProp.type, "Int64");
   });
 
   it("should deserialize a Date value", () => {
     const dateValue = new Date();
-    const deserialized = deserialize<{ dateProp: Edm<"DateTime"> }>({
+    const deserialized = deserialize({
       dateProp: dateValue.toJSON(),
       "dateProp@odata.type": "Edm.DateTime"
     });
+    assert.deepEqual(deserialized.dateProp, dateValue);
+  });
+
+  it("should not deserialize a Date value", () => {
+    const dateValue = new Date();
+    const deserialized = deserialize<{ dateProp: Edm<"DateTime"> }>(
+      {
+        dateProp: dateValue.toJSON(),
+        "dateProp@odata.type": "Edm.DateTime"
+      },
+      true
+    );
     assert.deepEqual(deserialized.dateProp, { type: "DateTime", value: dateValue.toISOString() });
   });
 

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -172,10 +172,6 @@ describe("TableClient", () => {
     });
 
     it("should createEntity with Date", async () => {
-      type TestType = {
-        testField: Edm<"DateTime">;
-      };
-
       const testDate = "2020-09-17T00:00:00.111Z";
       const testEntity = {
         partitionKey: `P2_${suffix}`,
@@ -185,7 +181,7 @@ describe("TableClient", () => {
       let createResult: FullOperationResponse | undefined;
       let deleteResult: FullOperationResponse | undefined;
       await client.createEntity(testEntity, { onResponse: (res) => (createResult = res) });
-      const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey);
+      const result = await client.getEntity(testEntity.partitionKey, testEntity.rowKey);
       await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey, {
         onResponse: (res) => (deleteResult = res)
       });
@@ -194,7 +190,7 @@ describe("TableClient", () => {
       assert.equal(createResult?.status, 204);
       assert.equal(result.partitionKey, testEntity.partitionKey);
       assert.equal(result.rowKey, testEntity.rowKey);
-      assert.deepEqual(result.testField.value, testDate);
+      assert.deepEqual(result.testField, new Date(testDate));
     });
 
     it("should createEntity with Guid", async () => {
@@ -242,7 +238,7 @@ describe("TableClient", () => {
       let createResult: FullOperationResponse | undefined;
       let deleteResult: FullOperationResponse | undefined;
       await client.createEntity(testEntity, { onResponse: (res) => (createResult = res) });
-      const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey);
+      const result = await client.getEntity(testEntity.partitionKey, testEntity.rowKey);
       await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey, {
         onResponse: (res) => (deleteResult = res)
       });
@@ -250,7 +246,8 @@ describe("TableClient", () => {
       assert.equal(deleteResult?.status, 204);
       assert.equal(createResult?.status, 204);
       assert.equal(result.rowKey, testEntity.rowKey);
-      assert.deepEqual(result.testField, testInt64);
+      assert.equal(typeof result.testField, "bigint");
+      assert.deepEqual(result.testField, BigInt(testInt64.value));
     });
 
     it("should createEntity with Int32", async () => {
@@ -344,7 +341,9 @@ describe("TableClient", () => {
       let createResult: FullOperationResponse | undefined;
       let deleteResult: FullOperationResponse | undefined;
       await client.createEntity(testEntity, { onResponse: (res) => (createResult = res) });
-      const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey);
+      const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey, {
+        disableDeserialization: true
+      });
       await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey, {
         onResponse: (res) => (deleteResult = res)
       });

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -342,7 +342,7 @@ describe("TableClient", () => {
       let deleteResult: FullOperationResponse | undefined;
       await client.createEntity(testEntity, { onResponse: (res) => (createResult = res) });
       const result = await client.getEntity<TestType>(testEntity.partitionKey, testEntity.rowKey, {
-        disableDeserialization: true
+        disableTypeConversion: true
       });
       await client.deleteEntity(testEntity.partitionKey, testEntity.rowKey, {
         onResponse: (res) => (deleteResult = res)


### PR DESCRIPTION
* Support bigint on entities creation and retrieval.

Working with bigint

```typescript
await client.createEntity({partitionKey: "p1", rowKey: "1", foo: BigInt(12345678)});
const entity = await client.getEntity("p1", "1");

// You can do arithmetic operations with big int
const fooPlusOne = entity.foo + BigInt(1);
// 12345679
```


* Add an option to disable automatic deserialization. If this option is true, when retreiving entities all the properties will be in the "metadata" from. For example:

Entity by default
```typescript
// Foo is a number
console.log(entity.foo);
// 123
```

Entity with disableDeserialization
```typescript
// Foo is a number
console.log(entity.foo);
// {value: 123, type: "Int32"}
```