### PR TITLE
[Key Vault Admin] API Alignment

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 4.0.0-beta.4 (Unreleased)
 
-- Breaking changes:
-  - Added the "KeyVault" prefix to all of the Key Vault Admin client operations.
-  - Made the AesGcmDecryptParameters authenticationTag required.
+### Breaking changes:
+
+- Added the "KeyVault" prefix to all of the Key Vault Admin client operations.
+- Made the AesGcmDecryptParameters authenticationTag required.
 - Collapsed `KeyVaultRoleAssignmentPropertiesWithScope` to `KeyVaultRoleAssignmentProperties`.
 - Renamed `KeyVaultKeyId` to `KeyVaultKeyIdentifier`.
 - Renamed `beginRestore`'s `blobStorageUri` to `folderUri`.

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 4.0.0-beta.4 (Unreleased)
 
+- Breaking changes:
+  - Added the "KeyVault" prefix to all of the Key Vault Admin client operations.
+  - Made the AesGcmDecryptParameters authenticationTag required.
+- Collapsed `KeyVaultRoleAssignmentPropertiesWithScope` to `KeyVaultRoleAssignmentProperties`.
+- Renamed `KeyVaultKeyId` to `KeyVaultKeyIdentifier`.
+- Renamed `beginRestore`'s `blobStorageUri` to `folderUri`.
+- Renamed `beginSelectiveRestore`'s `blobStorageUri` to `folderUri`.
+- Removed `folderName` from `beginSelectiveRestore`. Now the folder name will be inferred from the `folderUri`.
+- Reordered the parameters of `beginSelectiveRestore` to `keyName`, `folderUrl`, `sasToken`, `[options]`.
+- Renamed `KeyVaultBackupResult`'s `backupFolderUri` to `folderUri`.
+
 ## 4.0.0-beta.3 (2021-04-06)
 
 - Updated the Latest service version to 7.2.

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Collapsed `KeyVaultRoleAssignmentPropertiesWithScope` to `KeyVaultRoleAssignmentProperties`.
 - Renamed `KeyVaultKeyId` to `KeyVaultKeyIdentifier`.
 - Renamed `beginRestore`'s `blobStorageUri` to `folderUri`.
+- Removed `folderName` from `beginRestore`. Now the folder name will be inferred from the `folderUri`.
 - Renamed `beginSelectiveRestore`'s `blobStorageUri` to `folderUri`.
 - Removed `folderName` from `beginSelectiveRestore`. Now the folder name will be inferred from the `folderUri`.
 - Reordered the parameters of `beginSelectiveRestore` to `keyName`, `folderUrl`, `sasToken`, `[options]`.

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -62,8 +62,8 @@ export interface KeyVaultAdminPollOperationState<TResult> extends PollOperationS
 export class KeyVaultBackupClient {
     constructor(vaultUrl: string, credential: TokenCredential, options?: KeyVaultBackupClientOptions);
     beginBackup(blobStorageUri: string, sasToken: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
-    beginRestore(folderUri: string, sasToken: string, folderName: string, options?: KeyVaultBeginRestoreOptions): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>>;
-    beginSelectiveRestore(folderUri: string, sasToken: string, folderName: string, keyName: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>>;
+    beginRestore(folderUri: string, sasToken: string, options?: KeyVaultBeginRestoreOptions): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>>;
+    beginSelectiveRestore(keyName: string, folderUri: string, sasToken: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>>;
     readonly vaultUrl: string;
 }
 
@@ -83,8 +83,8 @@ export interface KeyVaultBackupPollerOptions extends coreHttp.OperationOptions {
 
 // @public
 export interface KeyVaultBackupResult {
-    backupFolderUri?: string;
     endTime?: Date;
+    folderUri?: string;
     startTime: Date;
 }
 

--- a/sdk/keyvault/keyvault-admin/samples-dev/backupRestoreHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples-dev/backupRestoreHelloWorld.ts
@@ -33,12 +33,10 @@ export async function main(): Promise<void> {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri!, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
+  await backupPoller.pollUntilDone();
 
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri!.split("/").pop();
-
-  const restorePoller = await client.beginRestore(blobStorageUri, sasToken, folderName!);
+  // The folder name should be at the end of the backupFolderUri, as in: ht
+  const restorePoller = await client.beginRestore(blobStorageUri, sasToken);
   await restorePoller.pollUntilDone();
 }
 

--- a/sdk/keyvault/keyvault-admin/samples-dev/backupSelectiveRestore.ts
+++ b/sdk/keyvault/keyvault-admin/samples-dev/backupSelectiveRestore.ts
@@ -38,16 +38,12 @@ export async function main(): Promise<void> {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
-
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri!.split("/").pop();
+  await backupPoller.pollUntilDone();
 
   const selectiveRestorePoller = await client.beginSelectiveRestore(
+    key.name,
     blobStorageUri,
-    sasToken,
-    folderName!,
-    key.name
+    sasToken
   );
   await selectiveRestorePoller.pollUntilDone();
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupRestoreHelloWorld.js
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupRestoreHelloWorld.js
@@ -33,12 +33,9 @@ async function main() {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
+  await backupPoller.pollUntilDone();
 
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri.split("/").pop();
-
-  const restorePoller = await client.beginRestore(blobStorageUri, sasToken, folderName);
+  const restorePoller = await client.beginRestore(blobStorageUri, sasToken);
   await restorePoller.pollUntilDone();
 }
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupSelectiveRestore.js
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/backupSelectiveRestore.js
@@ -38,16 +38,12 @@ async function main() {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
-
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri.split("/").pop();
+  await backupPoller.pollUntilDone();
 
   const selectiveRestorePoller = await client.beginSelectiveRestore(
+    key.name,
     blobStorageUri,
-    sasToken,
-    folderName,
-    key.name
+    sasToken
   );
   await selectiveRestorePoller.pollUntilDone();
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupRestoreHelloWorld.ts
@@ -33,12 +33,9 @@ export async function main(): Promise<void> {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri!, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
+  await backupPoller.pollUntilDone();
 
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri!.split("/").pop();
-
-  const restorePoller = await client.beginRestore(blobStorageUri, sasToken, folderName!);
+  const restorePoller = await client.beginRestore(blobStorageUri, sasToken);
   await restorePoller.pollUntilDone();
 }
 

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupSelectiveRestore.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/backupSelectiveRestore.ts
@@ -38,16 +38,12 @@ export async function main(): Promise<void> {
     throw new Error("Missing environment variable BLOB_STORAGE_SAS_TOKEN.");
   }
   const backupPoller = await client.beginBackup(blobStorageUri, sasToken);
-  const backupResult = await backupPoller.pollUntilDone();
-
-  // The folder name should be at the end of the backupFolderUri, as in: https://<blob-storage-endpoint>/<folder-name>
-  const folderName = backupResult.backupFolderUri!.split("/").pop();
+  await backupPoller.pollUntilDone();
 
   const selectiveRestorePoller = await client.beginSelectiveRestore(
+    key.name,
     blobStorageUri,
-    sasToken,
-    folderName!,
-    key.name
+    sasToken
   );
   await selectiveRestorePoller.pollUntilDone();
 

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -29,6 +29,7 @@ import { KeyVaultRestoreOperationState } from "./lro/restore/operation";
 import { KeyVaultAdminPollOperationState } from "./lro/keyVaultAdminPoller";
 import { KeyVaultSelectiveRestoreOperationState } from "./lro/selectiveRestore/operation";
 import { KeyVaultClientOptionalParams } from "./generated/models";
+import { mappings } from "./mappings";
 
 export {
   KeyVaultBackupOperationState,
@@ -203,18 +204,9 @@ export class KeyVaultBackupClient {
     sasToken: string,
     options: KeyVaultBeginRestoreOptions = {}
   ): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>> {
-    const uriParts = folderUri.split("/");
-    const folderName = uriParts.pop();
-    const storageUri = uriParts.join("/");
-
-    if (!folderName) {
-      throw new Error("The provided folder URI is missing the folder name.");
-    }
-
     const poller = new KeyVaultRestorePoller({
-      folderUri: storageUri,
+      ...mappings.folderUriParts(folderUri),
       sasToken,
-      folderName,
       client: this.client,
       vaultUrl: this.vaultUrl,
       intervalInMs: options.intervalInMs,
@@ -267,19 +259,10 @@ export class KeyVaultBackupClient {
     sasToken: string,
     options: KeyVaultBeginBackupOptions = {}
   ): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>> {
-    const uriParts = folderUri.split("/");
-    const folderName = uriParts.pop();
-    const storageUri = uriParts.join("/");
-
-    if (!folderName) {
-      throw new Error("The provided folder URI is missing the folder name.");
-    }
-
     const poller = new KeyVaultSelectiveRestorePoller({
+      ...mappings.folderUriParts(folderUri),
       keyName,
-      folderUri: storageUri,
       sasToken,
-      folderName,
       client: this.client,
       vaultUrl: this.vaultUrl,
       intervalInMs: options.intervalInMs,

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -178,8 +178,7 @@ export class KeyVaultBackupClient {
    *
    * const blobStorageUri = "<blob-storage-uri>"; // <Blob storage URL>/<folder name>
    * const sasToken = "<sas-token>";
-   * const folderName = "<folder-name>";
-   * const poller = await client.beginRestore(blobStorageUri, sasToken, folderName);
+   * const poller = await client.beginRestore(blobStorageUri, sasToken);
    *
    * // The poller can be serialized with:
    * //
@@ -187,7 +186,7 @@ export class KeyVaultBackupClient {
    * //
    * // A new poller can be created with:
    * //
-   * //   await client.beginRestore(blobStorageUri, sasToken, folderName, { resumeFrom: serialized });
+   * //   await client.beginRestore(blobStorageUri, sasToken, { resumeFrom: serialized });
    * //
    *
    * // Waiting until it's done
@@ -197,15 +196,19 @@ export class KeyVaultBackupClient {
    * Starts a full restore operation.
    * @param folderUri - The URL of the blob storage resource where the previous successful full backup was stored.
    * @param sasToken - The SAS token.
-   * @param folderName - The folder name of the blob where the previous successful full backup was stored. The URL segment after the container name.
    * @param options - The optional parameters.
    */
   public async beginRestore(
     folderUri: string,
     sasToken: string,
-    folderName: string,
     options: KeyVaultBeginRestoreOptions = {}
   ): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>> {
+    const folderName = folderUri.split("/")[4];
+
+    if (!folderName) {
+      throw new Error("The provided folder URI is missing the folder name.");
+    }
+
     const poller = new KeyVaultRestorePoller({
       folderUri,
       sasToken,
@@ -235,9 +238,8 @@ export class KeyVaultBackupClient {
    *
    * const blobStorageUri = "<blob-storage-uri>";
    * const sasToken = "<sas-token>";
-   * const folderName = "<folder-name>";
    * const keyName = "<key-name>";
-   * const poller = await client.beginSelectiveRestore(blobStorageUri, sasToken, folderName, keyName);
+   * const poller = await client.beginSelectiveRestore(keyName, blobStorageUri, sasToken);
    *
    * // Serializing the poller
    * //
@@ -245,7 +247,7 @@ export class KeyVaultBackupClient {
    * //
    * // A new poller can be created with:
    * //
-   * //   await client.beginSelectiveRestore(blobStorageUri, sasToken, folderName, keyName, { resumeFrom: serialized });
+   * //   await client.beginSelectiveRestore(keyName, blobStorageUri, sasToken, { resumeFrom: serialized });
    * //
    *
    * // Waiting until it's done

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -203,14 +203,16 @@ export class KeyVaultBackupClient {
     sasToken: string,
     options: KeyVaultBeginRestoreOptions = {}
   ): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>> {
-    const folderName = folderUri.split("/")[4];
+    const uriParts = folderUri.split("/");
+    const folderName = uriParts.pop();
+    const storageUri = uriParts.join("/");
 
     if (!folderName) {
       throw new Error("The provided folder URI is missing the folder name.");
     }
 
     const poller = new KeyVaultRestorePoller({
-      folderUri,
+      folderUri: storageUri,
       sasToken,
       folderName,
       client: this.client,
@@ -265,7 +267,9 @@ export class KeyVaultBackupClient {
     sasToken: string,
     options: KeyVaultBeginBackupOptions = {}
   ): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>> {
-    const folderName = folderUri.split("/")[4];
+    const uriParts = folderUri.split("/");
+    const folderName = uriParts.pop();
+    const storageUri = uriParts.join("/");
 
     if (!folderName) {
       throw new Error("The provided folder URI is missing the folder name.");
@@ -273,7 +277,7 @@ export class KeyVaultBackupClient {
 
     const poller = new KeyVaultSelectiveRestorePoller({
       keyName,
-      folderUri,
+      folderUri: storageUri,
       sasToken,
       folderName,
       client: this.client,

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -252,19 +252,23 @@ export class KeyVaultBackupClient {
    * await poller.pollUntilDone();
    * ```
    * Creates a new role assignment.
+   * @param keyName - The name of the key that wants to be restored.
    * @param folderUri - The URL of the blob storage resource, with the folder name of the blob where the previous successful full backup was stored.
    * @param sasToken - The SAS token.
-   * @param folderName - The Folder name of the blob where the previous successful full backup was stored. The URL segment after the container name.
-   * @param keyName - The name of the key that wants to be restored.
    * @param options - The optional parameters.
    */
   public async beginSelectiveRestore(
+    keyName: string,
     folderUri: string,
     sasToken: string,
-    folderName: string,
-    keyName: string,
     options: KeyVaultBeginBackupOptions = {}
   ): Promise<PollerLike<KeyVaultSelectiveRestoreOperationState, KeyVaultRestoreResult>> {
+    const folderName = folderUri.split("/")[4];
+
+    if (!folderName) {
+      throw new Error("The provided folder URI is missing the folder name.");
+    }
+
     const poller = new KeyVaultSelectiveRestorePoller({
       keyName,
       folderUri,

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -33,19 +33,19 @@ export interface KeyVaultBackupPollerOptions extends coreHttp.OperationOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link beginBackup}
  */
-export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {}
+export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions { }
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginRestore}
  */
-export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {}
+export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions { }
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginSelectiveRestore}
  */
-export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions {}
+export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions { }
 
 /**
  * An interface representing the result of a backup operation.
@@ -54,7 +54,7 @@ export interface KeyVaultBackupResult {
   /**
    * The location of the full backup.
    */
-  backupFolderUri?: string;
+  folderUri?: string;
 
   /**
    * The start time of the backup operation.

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -33,19 +33,19 @@ export interface KeyVaultBackupPollerOptions extends coreHttp.OperationOptions {
  * An interface representing the optional parameters that can be
  * passed to {@link beginBackup}
  */
-export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions { }
+export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginRestore}
  */
-export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions { }
+export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginSelectiveRestore}
  */
-export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions { }
+export interface KeyVaultBeginSelectiveRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the result of a backup operation.

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -145,7 +145,7 @@ export class KeyVaultBackupPollOperation extends KeyVaultAdminPollOperation<
 
     if (state.isCompleted) {
       state.result = {
-        backupFolderUri: azureStorageBlobContainerUri,
+        folderUri: azureStorageBlobContainerUri,
         startTime,
         endTime
       };

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -48,5 +48,19 @@ export const mappings = {
         assignableScopes: assignableScopes!
       };
     }
+  },
+  folderUriParts(folderUri: string): { folderName: string; folderUri: string } {
+    const uriParts = folderUri.split("/");
+    const folderName = uriParts.pop();
+    const storageUri = uriParts.join("/");
+
+    if (!folderName) {
+      throw new Error("The provided folder URI is missing the folder name.");
+    }
+
+    return {
+      folderName,
+      folderUri: storageUri
+    };
   }
 };

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
@@ -7,7 +7,7 @@ import { AbortController } from "@azure/abort-controller";
 import { KeyVaultBackupClient } from "../../src";
 import { authenticate } from "../utils/authentication";
 import { testPollerProperties } from "../utils/recorder";
-import { assertThrowsAbortError, getFolderName, getSasToken } from "../utils/common";
+import { assertThrowsAbortError, getSasToken } from "../utils/common";
 
 describe("Aborting KeyVaultBackupClient's requests", () => {
   let client: KeyVaultBackupClient;
@@ -46,13 +46,11 @@ describe("Aborting KeyVaultBackupClient's requests", () => {
 
   it("can abort beginRestore", async function() {
     const backupURI = `${blobStorageUri}/${generateFakeUUID()}`;
-    const folderName = getFolderName(backupURI);
-
     const controller = new AbortController();
     controller.abort();
 
     await assertThrowsAbortError(async () => {
-      await client.beginRestore(blobStorageUri, blobSasToken, folderName, {
+      await client.beginRestore(backupURI, blobSasToken, {
         ...testPollerProperties,
         abortSignal: controller.signal
       });
@@ -61,13 +59,12 @@ describe("Aborting KeyVaultBackupClient's requests", () => {
 
   it("can abort beginSelectiveRestore", async function() {
     const backupURI = `${blobStorageUri}/${generateFakeUUID()}`;
-    const folderName = getFolderName(backupURI);
 
     const controller = new AbortController();
     controller.abort();
 
     await assertThrowsAbortError(async () => {
-      await client.beginSelectiveRestore(blobStorageUri, blobSasToken, folderName, "Key Name", {
+      await client.beginSelectiveRestore("Key Name", backupURI, blobSasToken, {
         ...testPollerProperties,
         abortSignal: controller.signal
       });

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
@@ -64,7 +64,7 @@ describe("Aborting KeyVaultBackupClient's requests", () => {
     controller.abort();
 
     await assertThrowsAbortError(async () => {
-      await client.beginSelectiveRestore("Key Name", backupURI, blobSasToken, {
+      await client.beginSelectiveRestore("key-name", backupURI, blobSasToken, {
         ...testPollerProperties,
         abortSignal: controller.signal
       });

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -22,7 +22,7 @@ describe("KeyVaultBackupClient", () => {
   let blobStorageUri: string;
   let blobSasToken: string;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     const authentication = await authenticate(this);
     client = authentication.backupClient;
     keyClient = authentication.keyClient;
@@ -32,12 +32,12 @@ describe("KeyVaultBackupClient", () => {
     blobSasToken = sasTokenData.blobSasToken;
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await recorder.stop();
   });
 
-  describe("beginBackup", function() {
-    it("returns the correct backup result when successful", async function() {
+  describe("beginBackup", function () {
+    it("returns the correct backup result when successful", async function () {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         blobSasToken,
@@ -64,7 +64,7 @@ describe("KeyVaultBackupClient", () => {
 
     // There is a service issue that prevents errors from showing up in the
     // error field. Pending until it's resolved. ADO 8750375
-    it.skip("returns the correct backup result when fails to authenticate", async function() {
+    it.skip("returns the correct backup result when fails to authenticate", async function () {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         "invalid_sas_token",
@@ -74,8 +74,8 @@ describe("KeyVaultBackupClient", () => {
     });
   });
 
-  describe("beginRestore", function() {
-    it("full restore completes successfully", async function() {
+  describe("beginRestore", function () {
+    it("full restore completes successfully", async function () {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         blobSasToken,
@@ -118,7 +118,7 @@ describe("KeyVaultBackupClient", () => {
       }
     });
 
-    it("selectiveRestore completes successfully", async function() {
+    it("selectiveRestore completes successfully", async function () {
       // This test can only be run in playback mode because running a backup
       // or restore puts the instance in a bad state (tracked in IcM).
       if (!isPlaybackMode()) {
@@ -133,27 +133,24 @@ describe("KeyVaultBackupClient", () => {
       );
       const backupURI = await backupPoller.pollUntilDone();
       assert.exists(backupURI.backupFolderUri);
-      const folderName = getFolderName(backupURI.backupFolderUri!);
 
       // Delete the key (purging it is required), then restore and ensure it's restored
       await (await keyClient.beginDeleteKey(keyName, testPollerProperties)).pollUntilDone();
       await keyClient.purgeDeletedKey(keyName);
 
       const selectiveRestorePoller = await client.beginSelectiveRestore(
+        keyName,
         blobStorageUri,
         blobSasToken,
-        folderName,
-        keyName,
         testPollerProperties
       );
       await selectiveRestorePoller.poll();
 
       // A poller can be serialized and then resumed
       const resumedPoller = await client.beginSelectiveRestore(
+        keyName,
         blobStorageUri,
         blobSasToken,
-        folderName,
-        keyName,
         {
           ...testPollerProperties,
           resumeFrom: selectiveRestorePoller.toString()
@@ -174,7 +171,7 @@ describe("KeyVaultBackupClient", () => {
 
     // There is a service issue that prevents errors from showing up in the
     // error field. Pending until it's resolved. ADO 8750375
-    it.skip("contains an error when fails to authenticate", async function() {
+    it.skip("contains an error when fails to authenticate", async function () {
       const restorePoller = await client.beginRestore(
         blobStorageUri,
         "bad_token",

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -85,14 +85,14 @@ describe("KeyVaultBackupClient", () => {
       assert.exists(backupResult.folderUri);
 
       const restorePoller = await client.beginRestore(
-        blobStorageUri,
+        backupResult.folderUri!,
         blobSasToken,
         testPollerProperties
       );
       await restorePoller.poll();
 
       // A poller can be serialized and then resumed
-      const resumedPoller = await client.beginRestore(blobStorageUri, blobSasToken, {
+      const resumedPoller = await client.beginRestore(backupResult.folderUri!, blobSasToken, {
         ...testPollerProperties,
         resumeFrom: restorePoller.toString()
       });
@@ -138,7 +138,7 @@ describe("KeyVaultBackupClient", () => {
 
       const selectiveRestorePoller = await client.beginSelectiveRestore(
         keyName,
-        blobStorageUri,
+        backupURI.folderUri!,
         blobSasToken,
         testPollerProperties
       );

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -9,7 +9,7 @@ import { isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
 import { KeyVaultBackupClient } from "../../src";
 import { authenticate } from "../utils/authentication";
 import { testPollerProperties } from "../utils/recorder";
-import { getFolderName, getSasToken } from "../utils/common";
+import { getSasToken } from "../utils/common";
 import { delay } from "@azure/core-http";
 import { assert } from "chai";
 import { KeyClient } from "@azure/keyvault-keys";
@@ -22,7 +22,7 @@ describe("KeyVaultBackupClient", () => {
   let blobStorageUri: string;
   let blobSasToken: string;
 
-  beforeEach(async function () {
+  beforeEach(async function() {
     const authentication = await authenticate(this);
     client = authentication.backupClient;
     keyClient = authentication.keyClient;
@@ -32,12 +32,12 @@ describe("KeyVaultBackupClient", () => {
     blobSasToken = sasTokenData.blobSasToken;
   });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await recorder.stop();
   });
 
-  describe("beginBackup", function () {
-    it("returns the correct backup result when successful", async function () {
+  describe("beginBackup", function() {
+    it("returns the correct backup result when successful", async function() {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         blobSasToken,
@@ -56,15 +56,15 @@ describe("KeyVaultBackupClient", () => {
 
       const backupResult = await backupPoller.pollUntilDone();
       assert.notExists(backupPoller.getOperationState().error);
-      assert.exists(backupResult.backupFolderUri);
+      assert.exists(backupResult.folderUri);
       assert.equal(backupResult.startTime, backupPoller.getOperationState().startTime);
       assert.equal(backupResult.endTime, backupPoller.getOperationState().endTime);
-      assert.match(backupResult.backupFolderUri!, new RegExp(blobStorageUri));
+      assert.match(backupResult.folderUri!, new RegExp(blobStorageUri));
     });
 
     // There is a service issue that prevents errors from showing up in the
     // error field. Pending until it's resolved. ADO 8750375
-    it.skip("returns the correct backup result when fails to authenticate", async function () {
+    it.skip("returns the correct backup result when fails to authenticate", async function() {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         "invalid_sas_token",
@@ -74,27 +74,25 @@ describe("KeyVaultBackupClient", () => {
     });
   });
 
-  describe("beginRestore", function () {
-    it("full restore completes successfully", async function () {
+  describe("beginRestore", function() {
+    it("full restore completes successfully", async function() {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         blobSasToken,
         testPollerProperties
       );
       const backupResult = await backupPoller.pollUntilDone();
-      assert.exists(backupResult.backupFolderUri);
-      const folderName = getFolderName(backupResult.backupFolderUri!);
+      assert.exists(backupResult.folderUri);
 
       const restorePoller = await client.beginRestore(
         blobStorageUri,
         blobSasToken,
-        folderName,
         testPollerProperties
       );
       await restorePoller.poll();
 
       // A poller can be serialized and then resumed
-      const resumedPoller = await client.beginRestore(blobStorageUri, blobSasToken, folderName, {
+      const resumedPoller = await client.beginRestore(blobStorageUri, blobSasToken, {
         ...testPollerProperties,
         resumeFrom: restorePoller.toString()
       });
@@ -118,7 +116,7 @@ describe("KeyVaultBackupClient", () => {
       }
     });
 
-    it("selectiveRestore completes successfully", async function () {
+    it("selectiveRestore completes successfully", async function() {
       // This test can only be run in playback mode because running a backup
       // or restore puts the instance in a bad state (tracked in IcM).
       if (!isPlaybackMode()) {
@@ -132,7 +130,7 @@ describe("KeyVaultBackupClient", () => {
         testPollerProperties
       );
       const backupURI = await backupPoller.pollUntilDone();
-      assert.exists(backupURI.backupFolderUri);
+      assert.exists(backupURI.folderUri);
 
       // Delete the key (purging it is required), then restore and ensure it's restored
       await (await keyClient.beginDeleteKey(keyName, testPollerProperties)).pollUntilDone();
@@ -171,11 +169,10 @@ describe("KeyVaultBackupClient", () => {
 
     // There is a service issue that prevents errors from showing up in the
     // error field. Pending until it's resolved. ADO 8750375
-    it.skip("contains an error when fails to authenticate", async function () {
+    it.skip("contains an error when fails to authenticate", async function() {
       const restorePoller = await client.beginRestore(
         blobStorageUri,
         "bad_token",
-        "bad_folder",
         testPollerProperties
       );
       await assert.isRejected(restorePoller.pollUntilDone());


### PR DESCRIPTION
Besides what Maor did:

- Renamed `beginRestore`'s `blobStorageUri` to `folderUri`.
- Removed `folderName` from `beginRestore`. Now the folder name will be inferred from the `folderUri`.
- Renamed `beginSelectiveRestore`'s `blobStorageUri` to `folderUri`.
- Removed `folderName` from `beginSelectiveRestore`. Now the folder name will be inferred from the `folderUri`.
- Reordered the parameters of `beginSelectiveRestore` to `keyName`, `folderUrl`, `sasToken`, `[options]`.
- Renamed `KeyVaultBackupResult`'s `backupFolderUri` to `folderUri`.