### PR TITLE
[core] Fix core-http and core-asynciterator-polyfill packaging issue

### DIFF
--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -17,6 +17,7 @@
   "main": "./dist-esm/index.js",
   "files": [
     "dist-esm/index.js",
+    "dist-esm/index.js.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -28,7 +28,7 @@
     "cloud"
   ],
   "main": "dist/index.js",
-  "module": "./es/src/coreHttp.js",
+  "module": "./dist-esm/src/coreHttp.js",
   "types": "./types/latest/src/coreHttp.d.ts",
   "typesVersions": {
     "<3.6": {
@@ -38,25 +38,23 @@
     }
   },
   "files": [
-    "dist/**/*.node.js",
-    "dist/**/*.node.js.map",
+    "dist/",
+    "dist-esm/src/",
     "dom-shim.d.ts",
-    "es/src/**/*.js",
-    "es/src/**/*.js.map",
     "types/*/src/**/*.d.ts",
     "types/*/src/**/*.d.ts.map",
     "README.md",
     "LICENSE"
   ],
   "browser": {
-    "./es/src/policies/msRestUserAgentPolicy.js": "./es/src/policies/msRestUserAgentPolicy.browser.js",
-    "./es/src/policies/disableResponseDecompressionPolicy.js": "./es/src/policies/disableResponseDecompressionPolicy.browser.js",
-    "./es/src/policies/proxyPolicy.js": "./es/src/policies/proxyPolicy.browser.js",
-    "./es/src/util/base64.js": "./es/src/util/base64.browser.js",
-    "./es/src/util/xml.js": "./es/src/util/xml.browser.js",
-    "./es/src/defaultHttpClient.js": "./es/src/defaultHttpClient.browser.js",
-    "./es/src/util/inspect.js": "./es/src/util/inspect.browser.js",
-    "./es/src/util/url.js": "./es/src/util/url.browser.js"
+    "./dist-esm/src/policies/msRestUserAgentPolicy.js": "./dist-esm/src/policies/msRestUserAgentPolicy.browser.js",
+    "./dist-esm/src/policies/disableResponseDecompressionPolicy.js": "./dist-esm/src/policies/disableResponseDecompressionPolicy.browser.js",
+    "./dist-esm/src/policies/proxyPolicy.js": "./dist-esm/src/policies/proxyPolicy.browser.js",
+    "./dist-esm/src/util/base64.js": "./dist-esm/src/util/base64.browser.js",
+    "./dist-esm/src/util/xml.js": "./dist-esm/src/util/xml.browser.js",
+    "./dist-esm/src/defaultHttpClient.js": "./dist-esm/src/defaultHttpClient.browser.js",
+    "./dist-esm/src/util/inspect.js": "./dist-esm/src/util/inspect.browser.js",
+    "./dist-esm/src/util/url.js": "./dist-esm/src/util/url.browser.js"
   },
   "license": "MIT",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-http/README.md",

--- a/sdk/core/core-http/rollup.base.config.js
+++ b/sdk/core/core-http/rollup.base.config.js
@@ -11,7 +11,7 @@ import { openTelemetryCommonJs } from "@azure/dev-tool/shared-config/rollup";
 const pkg = require("./package.json");
 const depNames = Object.keys(pkg.dependencies);
 const devDepNames = Object.keys(pkg.devDependencies);
-const input = "./es/src/coreHttp.js";
+const input = "./dist-esm/src/coreHttp.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
@@ -36,7 +36,7 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // Entry points - test files under the `test` folder(common for both browser and node), node specific test files
-    baseConfig.input = ["es/test/**/*[^browser.].js"];
+    baseConfig.input = ["dist-esm/test/**/*[^browser.].js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
     // different output file
@@ -61,7 +61,7 @@ export function browserConfig(test = false, production = false) {
     input: input,
     external: [],
     output: {
-      file: "./dist/index.browser.js",
+      file: "./dist-browser/core-http.js",
       format: "umd",
       name: "Azure.Core.HTTP",
       sourcemap: true
@@ -93,7 +93,7 @@ export function browserConfig(test = false, production = false) {
 
   if (test) {
     // Entry points - test files under the `test` folder(common for both browser and node), browser specific test files
-    baseConfig.input = ["es/test/**/*[^node.].js"];
+    baseConfig.input = ["dist-esm/test/**/*[^node.].js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "dist-test/coreHttp.browser.test.js";
     baseConfig.external.push("fetch-mock");

--- a/sdk/core/core-http/tsconfig.es.json
+++ b/sdk/core/core-http/tsconfig.es.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "es6",
-    "outDir": "es"
+    "outDir": "dist-esm"
   }
 }


### PR DESCRIPTION
- .map files are now included
- change the esm output directory of core-http to dist-esm to align with other
  client libraries in this repository

Fixes #15254 