### PR TITLE
[core] allow logging of Accept-Encoding header value

### DIFF
--- a/sdk/core/core-http/src/util/sanitizer.ts
+++ b/sdk/core/core-http/src/util/sanitizer.ts
@@ -43,6 +43,7 @@ const defaultAllowedHeaderNames = [
   "Origin",
 
   "Accept",
+  "Accept-Encoding",
   "Cache-Control",
   "Connection",
   "Content-Length",

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -51,6 +51,7 @@ const defaultAllowedHeaderNames = [
   "Origin",
 
   "Accept",
+  "Accept-Encoding",
   "Cache-Control",
   "Connection",
   "Content-Length",


### PR DESCRIPTION
Looking at the MDN doc about Accept-Encoding, it doesn't contain sensitive information.

  "The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand."

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding

This PR adds it to the allowed header name list so its value is not sanitized in logging.