### PR TITLE
[Tables] Fix core-ci <=> skip int64 tests in node 8

### DIFF
--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -121,6 +121,7 @@
     "util": "^0.12.1",
     "dotenv": "^8.2.0",
     "@azure/test-utils-recorder": "^1.0.0",
+    "@azure/test-utils": "^1.0.0",
     "rollup-plugin-shim": "^1.0.0",
     "@rollup/plugin-inject": "^4.0.0",
     "ts-node": "^9.0.0",

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/* eslint-disable no-invalid-this */
 import { assert } from "chai";
 
 import { Edm } from "../../src";

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -5,6 +5,7 @@ import { assert } from "chai";
 
 import { Edm } from "../../src";
 import { serialize, deserialize } from "../../src/serialization";
+import { isNode8 } from "../testUtils";
 
 interface Entity {
   strProp?: string;
@@ -79,7 +80,10 @@ describe("Serializer", () => {
     assert.strictEqual(serialized["int32ObjProp@odata.type"], "Edm.Int32");
   });
 
-  it("should serialize an Int64 value", () => {
+  it("should serialize an Int64 value", function() {
+    if (isNode8()) {
+      this.skip();
+    }
     const int64Value = "12345678910";
     const serialized: any = serialize({
       int64ObjProp: { value: int64Value, type: "Int64" }

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -81,10 +81,7 @@ describe("Serializer", () => {
     assert.strictEqual(serialized["int32ObjProp@odata.type"], "Edm.Int32");
   });
 
-  it("should serialize an Int64 value", function(this: Mocha.Context) {
-    if (isNode8()) {
-      this.skip();
-    }
+  it("should serialize an Int64 value", () => {
     const int64Value = "12345678910";
     const serialized: any = serialize({
       int64ObjProp: { value: int64Value, type: "Int64" }
@@ -168,7 +165,10 @@ describe("Deserializer", () => {
     assert.strictEqual(deserialized.int32Prop, int32Value);
   });
 
-  it("should deserialize an Int64 value to bigint", () => {
+  it("should deserialize an Int64 value to bigint", function(this: Mocha.Context) {
+    if (isNode8()) {
+      this.skip();
+    }
     const int64Value = "12345678910";
     const deserialized = deserialize({
       int64ObjProp: int64Value,

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/* eslint-disable no-invalid-this */
 import { assert } from "chai";
 
 import { Edm } from "../../src";

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import { Edm } from "../../src";
 import { serialize, deserialize } from "../../src/serialization";
-import { isNode8 } from "../testUtils";
+import { isNode8 } from "@azure/test-utils";
 
 interface Entity {
   strProp?: string;
@@ -165,7 +165,7 @@ describe("Deserializer", () => {
   });
 
   it("should deserialize an Int64 value to bigint", function(this: Mocha.Context) {
-    if (isNode8()) {
+    if (isNode8) {
       this.skip();
     }
     const int64Value = "12345678910";

--- a/sdk/tables/data-tables/test/internal/serialization.spec.ts
+++ b/sdk/tables/data-tables/test/internal/serialization.spec.ts
@@ -81,7 +81,7 @@ describe("Serializer", () => {
     assert.strictEqual(serialized["int32ObjProp@odata.type"], "Edm.Int32");
   });
 
-  it("should serialize an Int64 value", function() {
+  it("should serialize an Int64 value", function(this: Mocha.Context) {
     if (isNode8()) {
       this.skip();
     }

--- a/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
+++ b/sdk/tables/data-tables/test/internal/sharedKeyCredential.spec.ts
@@ -9,7 +9,7 @@ import {
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { isNode } from "../testUtils";
+import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
 
 import { TablesSharedKeyCredential } from "../../src/TablesSharedKeyCredential";

--- a/sdk/tables/data-tables/test/internal/utils.spec.ts
+++ b/sdk/tables/data-tables/test/internal/utils.spec.ts
@@ -4,7 +4,7 @@
 import { extractConnectionStringParts } from "../../src/utils/connectionString";
 import { Context } from "mocha";
 import { base64Encode, base64Decode } from "../../src/utils/bufferSerializer";
-import { isNode } from "../testUtils";
+import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
 import { ConnectionString } from "../../src/utils/internalModels";
 

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/* eslint-disable no-invalid-this */
 import { TableClient, TableEntity, Edm, odata } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { assert } from "chai";
 import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure/test-utils-recorder";
 import { recordedEnvironmentSetup, createTableClient } from "./utils/recordedClient";
-import { isNode } from "../testUtils";
+import { isNode, isNode8 } from "../testUtils";
 import { FullOperationResponse } from "@azure/core-client";
 
 describe("TableClient", () => {
@@ -222,7 +222,10 @@ describe("TableClient", () => {
       assert.deepEqual(result.testField, testGuid);
     });
 
-    it("should createEntity with Int64", async () => {
+    it("should createEntity with Int64", async function() {
+      if (isNode8()) {
+        this.skip();
+      }
       type TestType = {
         testField: Edm<"Int64">;
       };

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/* eslint-disable no-invalid-this */
 import { TableClient, TableEntity, Edm, odata } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { assert } from "chai";
 import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure/test-utils-recorder";
 import { recordedEnvironmentSetup, createTableClient } from "./utils/recordedClient";
-import { isNode, isNode8 } from "../testUtils";
+import { isNode, isNode8 } from "@azure/test-utils";
 import { FullOperationResponse } from "@azure/core-client";
 
 describe("TableClient", () => {
@@ -223,7 +223,7 @@ describe("TableClient", () => {
     });
 
     it("should createEntity with Int64", async function(this: Mocha.Context) {
-      if (isNode8()) {
+      if (isNode8) {
         this.skip();
       }
       type TestType = {

--- a/sdk/tables/data-tables/test/public/tableclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableclient.spec.ts
@@ -223,7 +223,7 @@ describe("TableClient", () => {
       assert.deepEqual(result.testField, testGuid);
     });
 
-    it("should createEntity with Int64", async function() {
+    it("should createEntity with Int64", async function(this: Mocha.Context) {
       if (isNode8()) {
         this.skip();
       }

--- a/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
+++ b/sdk/tables/data-tables/test/public/tableserviceclient.spec.ts
@@ -5,7 +5,7 @@ import { TableItem, TableServiceClient } from "../../src";
 import { Context } from "mocha";
 import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure/test-utils-recorder";
 import { recordedEnvironmentSetup, createTableServiceClient } from "./utils/recordedClient";
-import { isNode } from "../testUtils";
+import { isNode } from "@azure/test-utils";
 import { assert } from "chai";
 import { FullOperationResponse } from "@azure/core-client";
 

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { assert } from "chai";
 import { record, Recorder, isPlaybackMode, isLiveMode } from "@azure/test-utils-recorder";
 import { recordedEnvironmentSetup, createTableClient } from "./utils/recordedClient";
-import { isNode } from "../testUtils";
+import { isNode } from "@azure/test-utils";
 import { Uuid } from "../../src/utils/uuid";
 import * as sinon from "sinon";
 

--- a/sdk/tables/data-tables/test/testUtils.ts
+++ b/sdk/tables/data-tables/test/testUtils.ts
@@ -10,4 +10,4 @@ export const isNode =
   !!process.versions &&
   !!process.versions.node;
 
-export const isNode8 = () => isNode && Number(process.versions.node.split(".")[0]) === 8;
+export const isNode8 = (): boolean => isNode && Number(process.versions.node.split(".")[0]) === 8;

--- a/sdk/tables/data-tables/test/testUtils.ts
+++ b/sdk/tables/data-tables/test/testUtils.ts
@@ -9,3 +9,5 @@ export const isNode =
   !!process.version &&
   !!process.versions &&
   !!process.versions.node;
+
+export const isNode8 = () => isNode && Number(process.versions.node.split(".")[0]) === 8;

--- a/sdk/test-utils/test-utils/src/index.ts
+++ b/sdk/test-utils/test-utils/src/index.ts
@@ -10,3 +10,4 @@ export {
 } from "./multiVersion";
 
 export { matrix } from "./matrix";
+export { isNode, isNode8 } from "./utils";

--- a/sdk/test-utils/test-utils/src/utils.ts
+++ b/sdk/test-utils/test-utils/src/utils.ts
@@ -10,4 +10,7 @@ export const isNode =
   !!process.versions &&
   !!process.versions.node;
 
-export const isNode8 = (): boolean => isNode && Number(process.versions.node.split(".")[0]) === 8;
+/**
+ * A constant that indicates whether the environment is node.js version 8.
+ */
+export const isNode8 = isNode && Number(process.versions.node.split(".")[0]) === 8;


### PR DESCRIPTION
core - ci was failing for the following two tests in node 8 since bigint is being used.
![image](https://user-images.githubusercontent.com/10452642/118705419-0da49280-b7cd-11eb-8a2e-b456f997c3ae.png)

Talked to @joheredi and decided to skip these tests in node 8 to unblock.