### PR TITLE
[Dev tool] Support samples v2 directory structure in check node versions command

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -73,7 +73,7 @@ function findSamplesDir(samplesDir: string, rootDir: string): string {
   for (const file of fs.readdirSync(samplesDir)) {
     const stats = fs.statSync(path.join(samplesDir, file));
     if (stats.isDirectory()) {
-      if (file.match(/^v([0-9]*.*)$/)) {
+      if (file.match(/^v[0-9]*.*$/)) {
         dirs.push(file);
       }
     }

--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -73,16 +73,19 @@ function findSamplesDir(samplesDir: string, rootDir: string): string {
   for (const file of fs.readdirSync(samplesDir)) {
     const stats = fs.statSync(path.join(samplesDir, file));
     if (stats.isDirectory()) {
-      const matchResult = file.match(/^v([0-9]*)$/);
+      const matchResult = file.match(/^v([0-9]*.*)$/);
       if (matchResult !== null) {
-        dirs.push(parseInt(matchResult[1]));
+        dirs.push(matchResult[1]);
       }
     }
   }
   if (dirs.length === 0) {
     return `${rootDir}/samples`;
   } else {
-    return `${rootDir}/samples/v${Math.max(...dirs)}`;
+    return `${rootDir}/samples/v${dirs
+      .sort()
+      .slice(-1)
+      .pop()}`;
   }
 }
 function buildRunSamplesScript(

--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -73,16 +73,15 @@ function findSamplesDir(samplesDir: string, rootDir: string): string {
   for (const file of fs.readdirSync(samplesDir)) {
     const stats = fs.statSync(path.join(samplesDir, file));
     if (stats.isDirectory()) {
-      const matchResult = file.match(/^v([0-9]*.*)$/);
-      if (matchResult !== null) {
-        dirs.push(matchResult[1]);
+      if (file.match(/^v([0-9]*.*)$/)) {
+        dirs.push(file);
       }
     }
   }
   if (dirs.length === 0) {
     return `${rootDir}/samples`;
   } else {
-    return `${rootDir}/samples/v${dirs
+    return `${rootDir}/samples/${dirs
       .sort()
       .slice(-1)
       .pop()}`;


### PR DESCRIPTION
Samples v2 uses a directory structure like this `samples/v<some package version>` instead of the good old `samples`. Furthermore, it is not guaranteed that the package version is the most recent major one because a package author can decide to change it to another number. This PR adds logic to handle both samples v1 and v2 and make sure to use the appropriate corresponding path. If there is more than one samples v2 directory, the command will run the samples in the directory with the largest version number.