### PR TITLE
[Dev tool] Hide docker pull output

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -156,6 +156,7 @@ async function runDockerContainer(
   stdoutListener: (chunk: string | Buffer) => void,
   stderrListener: (chunk: string | Buffer) => void
 ): Promise<void> {
+  pr.execSync(`docker pull ${dockerImageName}`);
   const args = [
     "run",
     "--name",


### PR DESCRIPTION
So we do not get the log of that command in red color which could indicate something is wrong going on.

Related to the first item in https://github.com/Azure/azure-sdk-for-js/issues/14234.