### PR TITLE
[Dev tool] Clean doc for artifact-path

### DIFF
--- a/common/tools/dev-tool/src/util/findSamplesDir.ts
+++ b/common/tools/dev-tool/src/util/findSamplesDir.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license
+
+import fs from "fs-extra";
+import path from "path";
+
+export function findSamplesRelativeDir(samplesDir: string): string {
+  const dirs = [];
+  for (const file of fs.readdirSync(samplesDir)) {
+    const stats = fs.statSync(path.join(samplesDir, file));
+    if (stats.isDirectory()) {
+      if (file.match(/^v[0-9]*.*$/)) {
+        dirs.push(file);
+      }
+    }
+  }
+  if (dirs.length === 0) {
+    return `samples`;
+  } else {
+    return `samples/${dirs
+      .sort()
+      .slice(-1)
+      .pop()}`;
+  }
+}


### PR DESCRIPTION
renames `findSamplesDir` to `findSamplesRelativeDir` and moves it to its own module so we have a uniform way for samples directory discovery. It also updates the `artifact-path` arg docs to reflect that it can also be a URL to the built artifact.