### PR TITLE
[web-pubsub][test] verify just the prefix of ERROR_INVALID_URL message

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
@@ -18,6 +18,11 @@ describe("Can creat event handler", function() {
   });
 
   it("Throw with invalid endpoints", function() {
-    assert.throws(() => new WebPubSubEventHandler("hub", ["b.com"]), "Invalid URL: b.com");
+    try {
+      new WebPubSubEventHandler("hub", ["b.com"]);
+      assert.fail("Should have thrown ERROR_INVALID_URL");
+    } catch (err) {
+      assert.isTrue((err as any).message.startsWith("Invalid URL"));
+    }
   });
 });


### PR DESCRIPTION
as in the latest version of node the input url has been removed from the message:

https://github.com/nodejs/node/commit/417c31b69a2ee63649600ece471d9e1a5bba9f55