### PR TITLE
[Key Vault Keys] API alignment updates

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -66,10 +66,10 @@ export interface CreateEcKeyOptions extends CreateKeyOptions {
 
 // @public
 export interface CreateKeyOptions extends coreHttp.OperationOptions {
-    curve?: KeyCurveName;
+    curveName?: KeyCurveName;
     enabled?: boolean;
     readonly expiresOn?: Date;
-    hsm?: boolean;
+    hardwareProtected?: boolean;
     keyOps?: KeyOperation[];
     keySize?: number;
     notBefore?: Date;
@@ -300,16 +300,19 @@ export const enum KnownDeletionRecoveryLevel {
 }
 
 // @public
-export const enum KnownEncryptionAlgorithms {
+export enum KnownEncryptionAlgorithms {
     A128CBC = "A128CBC",
+    A128CbcHS256 = "A128CBC-HS256",
     A128Cbcpad = "A128CBCPAD",
     A128GCM = "A128GCM",
     A128KW = "A128KW",
     A192CBC = "A192CBC",
+    A192CbcHS384 = "A192CBC-HS384",
     A192Cbcpad = "A192CBCPAD",
     A192GCM = "A192GCM",
     A192KW = "A192KW",
     A256CBC = "A256CBC",
+    A256CbcHS512 = "A256CBC-HS512",
     A256Cbcpad = "A256CBCPAD",
     A256GCM = "A256GCM",
     A256KW = "A256KW",

--- a/sdk/keyvault/keyvault-keys/samples-dev/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples-dev/helloWorld.ts
@@ -32,7 +32,7 @@ export async function main(): Promise<void> {
   console.log("key: ", result);
 
   // Or using specialized key creation methods
-  const ecResult = await client.createEcKey(ecKeyName, { curve: "P-256" });
+  const ecResult = await client.createEcKey(ecKeyName, { curveName: "P-256" });
   const rsaResult = await client.createRsaKey(rsaKeyName, { keySize: 2048 });
   console.log("Elliptic curve key: ", ecResult);
   console.log("RSA Key: ", rsaResult);

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/helloWorld.js
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/helloWorld.js
@@ -32,7 +32,7 @@ async function main() {
   console.log("key: ", result);
 
   // Or using specialized key creation methods
-  const ecResult = await client.createEcKey(ecKeyName, { curve: "P-256" });
+  const ecResult = await client.createEcKey(ecKeyName, { curveName: "P-256" });
   const rsaResult = await client.createRsaKey(rsaKeyName, { keySize: 2048 });
   console.log("Elliptic curve key: ", ecResult);
   console.log("RSA Key: ", rsaResult);

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/src/helloWorld.ts
@@ -32,7 +32,7 @@ export async function main(): Promise<void> {
   console.log("key: ", result);
 
   // Or using specialized key creation methods
-  const ecResult = await client.createEcKey(ecKeyName, { curve: "P-256" });
+  const ecResult = await client.createEcKey(ecKeyName, { curveName: "P-256" });
   const rsaResult = await client.createRsaKey(rsaKeyName, { keySize: 2048 });
   console.log("Elliptic curve key: ", ecResult);
   console.log("RSA Key: ", rsaResult);

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -14,7 +14,7 @@ import {
 export { KeyCurveName, KnownKeyCurveNames, SignatureAlgorithm, KnownSignatureAlgorithms };
 
 /**
- * Defines values for JsonWebKeyEncryptionAlgorithm. \
+ * Defines values for JsonWebKeyEncryptionAlgorithm.
  * {@link KnownEncryptionAlgorithms} can be used interchangeably with JsonWebKeyEncryptionAlgorithm,
  *  this enum contains the known values that the service supports.
  */

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -7,20 +7,89 @@ import {
   JsonWebKey,
   JsonWebKeyCurveName as KeyCurveName,
   KnownJsonWebKeyCurveName as KnownKeyCurveNames,
-  JsonWebKeyEncryptionAlgorithm as EncryptionAlgorithm,
-  KnownJsonWebKeyEncryptionAlgorithm as KnownEncryptionAlgorithms,
   JsonWebKeySignatureAlgorithm as SignatureAlgorithm,
   KnownJsonWebKeySignatureAlgorithm as KnownSignatureAlgorithms
 } from "./generated/models";
 
-export {
-  KeyCurveName,
-  KnownKeyCurveNames,
-  EncryptionAlgorithm,
-  KnownEncryptionAlgorithms,
-  SignatureAlgorithm,
-  KnownSignatureAlgorithms
-};
+export { KeyCurveName, KnownKeyCurveNames, SignatureAlgorithm, KnownSignatureAlgorithms };
+
+/**
+ * Defines values for JsonWebKeyEncryptionAlgorithm. \
+ * {@link KnownEncryptionAlgorithms} can be used interchangeably with JsonWebKeyEncryptionAlgorithm,
+ *  this enum contains the known values that the service supports.
+ */
+export enum EncryptionAlgorithm {
+  /** RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
+  PS256 = "PS256",
+  /** RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
+  PS384 = "PS384",
+  /** RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
+  PS512 = "PS512",
+  /** RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
+  RS256 = "RS256",
+  /** RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
+  RS384 = "RS384",
+  /** RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
+  RS512 = "RS512",
+  /** Reserved */
+  Rsnull = "RSNULL",
+  /** ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518. */
+  ES256 = "ES256",
+  /** ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
+  ES384 = "ES384",
+  /** ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
+  ES512 = "ES512",
+  /** ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
+  ES256K = "ES256K",
+
+  // To match Java:
+
+  A128CbcHS256 = "A128CBC-HS256",
+  A192CbcHS384 = "A192CBC-HS384",
+  A256CbcHS512 = "A256CBC-HS512"
+}
+
+/**
+ * Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts.
+ */
+export enum KnownEncryptionAlgorithms {
+  /** Encryption Algorithm - RSA-OAEP */
+  RSAOaep = "RSA-OAEP",
+  /** Encryption Algorithm - RSA-OAEP-256 */
+  RSAOaep256 = "RSA-OAEP-256",
+  /** Encryption Algorithm - RSA1_5 */
+  RSA15 = "RSA1_5",
+  /** Encryption Algorithm - A128GCM */
+  A128GCM = "A128GCM",
+  /** Encryption Algorithm - A192GCM */
+  A192GCM = "A192GCM",
+  /** Encryption Algorithm - A256GCM */
+  A256GCM = "A256GCM",
+  /** Encryption Algorithm - A128KW */
+  A128KW = "A128KW",
+  /** Encryption Algorithm - A192KW */
+  A192KW = "A192KW",
+  /** Encryption Algorithm - A256KW */
+  A256KW = "A256KW",
+  /** Encryption Algorithm - A128CBC */
+  A128CBC = "A128CBC",
+  /** Encryption Algorithm - A192CBC */
+  A192CBC = "A192CBC",
+  /** Encryption Algorithm - A256CBC */
+  A256CBC = "A256CBC",
+  /** Encryption Algorithm - A128CBCPAD */
+  A128Cbcpad = "A128CBCPAD",
+  /** Encryption Algorithm - A192CBCPAD */
+  A192Cbcpad = "A192CBCPAD",
+  /** Encryption Algorithm - A256CBCPAD */
+  A256Cbcpad = "A256CBCPAD",
+
+  // To match Java:
+
+  A128CbcHS256 = "A128CBC-HS256",
+  A192CbcHS384 = "A192CBC-HS384",
+  A256CbcHS512 = "A256CBC-HS512"
+}
 
 /**
  * Supported algorithms for key wrapping/unwrapping

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -18,36 +18,7 @@ export { KeyCurveName, KnownKeyCurveNames, SignatureAlgorithm, KnownSignatureAlg
  * {@link KnownEncryptionAlgorithms} can be used interchangeably with JsonWebKeyEncryptionAlgorithm,
  *  this enum contains the known values that the service supports.
  */
-export enum EncryptionAlgorithm {
-  /** RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
-  PS256 = "PS256",
-  /** RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
-  PS384 = "PS384",
-  /** RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
-  PS512 = "PS512",
-  /** RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
-  RS256 = "RS256",
-  /** RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
-  RS384 = "RS384",
-  /** RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
-  RS512 = "RS512",
-  /** Reserved */
-  Rsnull = "RSNULL",
-  /** ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518. */
-  ES256 = "ES256",
-  /** ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518 */
-  ES384 = "ES384",
-  /** ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518 */
-  ES512 = "ES512",
-  /** ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518 */
-  ES256K = "ES256K",
-
-  // To match Java:
-
-  A128CbcHS256 = "A128CBC-HS256",
-  A192CbcHS384 = "A192CBC-HS384",
-  A256CbcHS512 = "A256CBC-HS512"
-}
+export type EncryptionAlgorithm = string;
 
 /**
  * Known values of {@link JsonWebKeyEncryptionAlgorithm} that the service accepts.
@@ -83,11 +54,11 @@ export enum KnownEncryptionAlgorithms {
   A192Cbcpad = "A192CBCPAD",
   /** Encryption Algorithm - A256CBCPAD */
   A256Cbcpad = "A256CBCPAD",
-
-  // To match Java:
-
+  /** Encryption Algorithm - A128CBC-HS256 */
   A128CbcHS256 = "A128CBC-HS256",
+  /** Encryption Algorithm - A192CBC-HS384 */
   A192CbcHS384 = "A192CBC-HS384",
+  /** Encryption Algorithm - A256CBC-HS512 */
   A256CbcHS512 = "A256CBC-HS512"
 }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -278,9 +278,18 @@ export class KeyClient {
     let unflattenedOptions = {};
 
     if (options) {
-      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = options;
+      const {
+        enabled,
+        notBefore,
+        expiresOn: expires,
+        curveName,
+        hardwareProtected,
+        ...remainingOptions
+      } = options;
       unflattenedOptions = {
         ...remainingOptions,
+        curve: curveName,
+        hsm: hardwareProtected,
         keyAttributes: {
           enabled,
           notBefore,

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -309,7 +309,7 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public async createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey> {
-    const keyType = options?.hsm ? KnownJsonWebKeyType.ECHSM : KnownJsonWebKeyType.EC;
+    const keyType = options?.hardwareProtected ? KnownJsonWebKeyType.ECHSM : KnownJsonWebKeyType.EC;
     return this.createKey(name, keyType, options);
   }
 
@@ -328,7 +328,9 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public async createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey> {
-    const keyType = options?.hsm ? KnownJsonWebKeyType.RSAHSM : KnownJsonWebKeyType.RSA;
+    const keyType = options?.hardwareProtected
+      ? KnownJsonWebKeyType.RSAHSM
+      : KnownJsonWebKeyType.RSA;
     return this.createKey(name, keyType, options);
   }
 
@@ -347,7 +349,9 @@ export class KeyClient {
    * @param options - The optional parameters.
    */
   public async createOctKey(name: string, options?: CreateOctKeyOptions): Promise<KeyVaultKey> {
-    const keyType = options?.hsm ? KnownJsonWebKeyType.OctHSM : KnownJsonWebKeyType.Oct;
+    const keyType = options?.hardwareProtected
+      ? KnownJsonWebKeyType.OctHSM
+      : KnownJsonWebKeyType.Oct;
     return this.createKey(name, keyType, options);
   }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -299,11 +299,11 @@ export interface CreateKeyOptions extends coreHttp.OperationOptions {
    * Elliptic curve name. For valid values, see KeyCurveName.
    * Possible values include: 'P-256', 'P-384', 'P-521', 'P-256K'
    */
-  curve?: KeyCurveName;
+  curveName?: KeyCurveName;
   /**
    * Whether to import as a hardware key (HSM) or software key.
    */
-  hsm?: boolean;
+  hardwareProtected?: boolean;
 }
 
 /**

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.hsm.spec.ts
@@ -42,7 +42,7 @@ onVersions({ minVer: "7.2" }).describe(
     it("can create an OCT key with options", async function(this: Context) {
       const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
       const options: CreateOctKeyOptions = {
-        hsm: true
+        hardwareProtected: true
       };
       const result = await hsmClient.createOctKey(keyName, options);
       assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");

--- a/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/CRUD.spec.ts
@@ -141,7 +141,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can create an EC key with curve", async function(this: Context) {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const options: CreateEcKeyOptions = {
-      curve: "P-256"
+      curveName: "P-256"
     };
     const result = await client.createEcKey(keyName, options);
     assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");


### PR DESCRIPTION
API alignment updates:

- CreateKeyOptions's "curve" to "curveName".
- CreateKeyOptions's "hsm" to "hardwareProtected".
- Added encryption algorithms A128CBC-HS256, A192CBC-HS384 and A256CBC-HS512, to match Java.

There were other comments to add special types to help users navigate the AES parameters. We already have that! In this form:

```ts
export type EncryptParameters =
  | RsaEncryptParameters
  | AesGcmEncryptParameters
  | AesCbcEncryptParameters;
```

Through which users will have to pick any of these sets of parameters (just one, it will fail if they input properties that aren't specific to one).

Fixes #15245
Fixes #15186