### PR TITLE
[Key Vault Keys] Fixed bad references.

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed the now obsolete `KeyOperationsOptions` and replaced it with `CryptographyOptions`.
   - Introduced in 4.2.0-beta.1 to support additional encryption parameters for AES encryption, we have since moved these parameters outside of the options bag so a separate `KeyOperationsOptions` is now redundant.
 - Fixed a bug with `beginDeleteKey` and `beginRecoverDeletedKey` in which unknown service errors wouldn't bubble up properly to the end users.
+- Fixed bug with the list operations which were returning misplaced properties. Fixes customer issue: [15353](https://github.com/Azure/azure-sdk-for-js/issues/15353).
 
 ## 4.2.0-beta.5 (2021-04-06)
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -100,7 +100,7 @@ import {
 
 import { KeyVaultKeyIdentifier } from "./identifier";
 import {
-  getDeletedKeyFromKeyItem,
+  getDeletedKeyFromDeletedKeyItem,
   getKeyFromKeyBundle,
   getKeyPropertiesFromKeyItem
 } from "./transformations";
@@ -862,7 +862,7 @@ export class KeyClient {
       );
       continuationState.continuationToken = currentSetResponse.nextLink;
       if (currentSetResponse.value) {
-        yield currentSetResponse.value.map(getDeletedKeyFromKeyItem, this);
+        yield currentSetResponse.value.map(getDeletedKeyFromDeletedKeyItem, this);
       }
     }
     while (continuationState.continuationToken) {
@@ -874,7 +874,7 @@ export class KeyClient {
       );
       continuationState.continuationToken = currentSetResponse.nextLink;
       if (currentSetResponse.value) {
-        yield currentSetResponse.value.map(getDeletedKeyFromKeyItem, this);
+        yield currentSetResponse.value.map(getDeletedKeyFromDeletedKeyItem, this);
       } else {
         break;
       }

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DeletedKeyBundle, KeyAttributes, KeyBundle, KeyItem } from "./generated/models";
+import {
+  DeletedKeyBundle,
+  DeletedKeyItem,
+  KeyAttributes,
+  KeyBundle,
+  KeyItem
+} from "./generated/models";
 import { parseKeyVaultKeyId } from "./identifier";
 import { DeletedKey, KeyVaultKey, JsonWebKey, KeyOperation, KeyProperties } from "./keysModels";
 
@@ -59,10 +65,9 @@ export function getKeyFromKeyBundle(
  * @internal
  * Shapes the exposed {@link DeletedKey} based on a received KeyItem.
  */
-export function getDeletedKeyFromKeyItem(keyItem: KeyItem): DeletedKey {
+export function getDeletedKeyFromDeletedKeyItem(keyItem: DeletedKeyItem): DeletedKey {
   const parsedId = parseKeyVaultKeyId(keyItem.kid!);
   const attributes = keyItem.attributes || {};
-  const deletedBundle = keyItem as DeletedKeyBundle;
 
   const abstractProperties: KeyProperties = {
     createdOn: attributes?.created,
@@ -81,16 +86,16 @@ export function getDeletedKeyFromKeyItem(keyItem: KeyItem): DeletedKey {
   };
 
   return {
-    key: keyItem,
+    key: {
+      kid: keyItem.kid
+    },
     id: keyItem.kid,
     name: abstractProperties.name,
-    keyOperations: deletedBundle.key?.keyOps,
-    keyType: deletedBundle.key?.kty,
     properties: {
       ...abstractProperties,
-      recoveryId: deletedBundle.recoveryId,
-      scheduledPurgeDate: deletedBundle.scheduledPurgeDate,
-      deletedOn: deletedBundle?.deletedDate
+      recoveryId: keyItem.recoveryId,
+      scheduledPurgeDate: keyItem.scheduledPurgeDate,
+      deletedOn: keyItem.deletedDate
     }
   };
 }

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -66,33 +66,16 @@ export function getKeyFromKeyBundle(
  * Shapes the exposed {@link DeletedKey} based on a received KeyItem.
  */
 export function getDeletedKeyFromDeletedKeyItem(keyItem: DeletedKeyItem): DeletedKey {
-  const parsedId = parseKeyVaultKeyId(keyItem.kid!);
-  const attributes = keyItem.attributes || {};
-
-  const abstractProperties: KeyProperties = {
-    createdOn: attributes?.created,
-    enabled: attributes?.enabled,
-    expiresOn: attributes?.expires,
-    id: keyItem.kid,
-    managed: keyItem.managed,
-    name: parsedId.name,
-    notBefore: attributes?.notBefore,
-    recoverableDays: attributes?.recoverableDays,
-    recoveryLevel: attributes?.recoveryLevel,
-    tags: keyItem.tags,
-    updatedOn: attributes.updated,
-    vaultUrl: parsedId.vaultUrl,
-    version: parsedId.version
-  };
+  const commonProperties = getKeyPropertiesFromKeyItem(keyItem);
 
   return {
     key: {
       kid: keyItem.kid
     },
     id: keyItem.kid,
-    name: abstractProperties.name,
+    name: commonProperties.name,
     properties: {
-      ...abstractProperties,
+      ...commonProperties,
       recoveryId: keyItem.recoveryId,
       scheduledPurgeDate: keyItem.scheduledPurgeDate,
       deletedOn: keyItem.deletedDate

--- a/sdk/keyvault/keyvault-keys/src/transformations.ts
+++ b/sdk/keyvault/keyvault-keys/src/transformations.ts
@@ -40,6 +40,7 @@ export function getKeyFromKeyBundle(
       vaultUrl: parsedId.vaultUrl,
       version: parsedId.version,
       name: parsedId.name,
+      managed: keyBundle.managed,
 
       id: keyBundle.key ? keyBundle.key.kid : undefined
     }

--- a/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { KeyBundle } from "../../src/generated";
+import { KeyVaultKey } from "../../src/keysModels";
+import { getKeyFromKeyBundle } from "../../src/transformations";
+
+describe("Transformations", () => {
+  it("Key Bundle to KeyVaultKey", () => {
+    const date = new Date();
+    const bundle: KeyBundle = {
+      key: {
+        kid:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        kty: "oct-HSM",
+        keyOps: ["encrypt", "decrypt"]
+      },
+      attributes: {
+        recoverableDays: 1,
+        recoveryLevel: "Recoverable",
+        enabled: true,
+        notBefore: date,
+        expires: date,
+        created: date,
+        updated: date
+      },
+      tags: {
+        tag_name: "tag_value"
+      },
+      managed: false
+    };
+
+    const expectedResult: KeyVaultKey = {
+      key: {
+        kid:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        kty: "oct-HSM",
+        keyOps: ["encrypt", "decrypt"]
+      },
+      name: "transformations",
+      id:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      keyType: "oct-HSM",
+      keyOperations: ["encrypt", "decrypt"],
+      properties: {
+        id:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        name: "transformations",
+        vaultUrl: "https://azure_managedhsm.managedhsm.azure.net",
+        version: "f03e8b3d76554e8b9749994bcf72fc61",
+        enabled: true,
+        notBefore: date,
+        expiresOn: date,
+        tags: {
+          tag_name: "tag_value"
+        },
+        createdOn: date,
+        updatedOn: date,
+        recoveryLevel: "Recoverable",
+        recoverableDays: 1,
+        managed: false
+      }
+    };
+
+    const key: KeyVaultKey = getKeyFromKeyBundle(bundle);
+    assert.deepEqual(key, expectedResult);
+  });
+});

--- a/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/transformations.spec.ts
@@ -2,12 +2,16 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { KeyBundle } from "../../src/generated";
-import { KeyVaultKey } from "../../src/keysModels";
-import { getKeyFromKeyBundle } from "../../src/transformations";
+import { DeletedKeyBundle, DeletedKeyItem, KeyBundle } from "../../src/generated";
+import { DeletedKey, KeyProperties, KeyVaultKey } from "../../src/keysModels";
+import {
+  getDeletedKeyFromDeletedKeyItem,
+  getKeyFromKeyBundle,
+  getKeyPropertiesFromKeyItem
+} from "../../src/transformations";
 
 describe("Transformations", () => {
-  it("Key Bundle to KeyVaultKey", () => {
+  it("KeyBundle to KeyVaultKey", () => {
     const date = new Date();
     const bundle: KeyBundle = {
       key: {
@@ -64,6 +68,176 @@ describe("Transformations", () => {
     };
 
     const key: KeyVaultKey = getKeyFromKeyBundle(bundle);
+    assert.deepEqual(key, expectedResult);
+  });
+
+  it("KeyBundle to DeletedKey", () => {
+    const date = new Date();
+    const bundle: DeletedKeyBundle = {
+      key: {
+        kid:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        kty: "oct-HSM",
+        keyOps: ["encrypt", "decrypt"]
+      },
+      attributes: {
+        recoverableDays: 1,
+        recoveryLevel: "Recoverable",
+        enabled: true,
+        notBefore: date,
+        expires: date,
+        created: date,
+        updated: date
+      },
+      tags: {
+        tag_name: "tag_value"
+      },
+      managed: false,
+      recoveryId: "recovery-id",
+      scheduledPurgeDate: date,
+      deletedDate: date
+    };
+
+    const expectedResult: DeletedKey = {
+      key: {
+        kid:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        kty: "oct-HSM",
+        keyOps: ["encrypt", "decrypt"]
+      },
+      name: "transformations",
+      id:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      keyType: "oct-HSM",
+      keyOperations: ["encrypt", "decrypt"],
+      properties: {
+        id:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        name: "transformations",
+        vaultUrl: "https://azure_managedhsm.managedhsm.azure.net",
+        version: "f03e8b3d76554e8b9749994bcf72fc61",
+        enabled: true,
+        notBefore: date,
+        expiresOn: date,
+        tags: {
+          tag_name: "tag_value"
+        },
+        createdOn: date,
+        updatedOn: date,
+        recoveryLevel: "Recoverable",
+        recoverableDays: 1,
+        managed: false,
+        recoveryId: "recovery-id",
+        scheduledPurgeDate: date,
+        deletedOn: date
+      }
+    };
+
+    const key: DeletedKey = getKeyFromKeyBundle(bundle);
+    assert.deepEqual(key, expectedResult);
+  });
+
+  it("DeletedKeyItem to DeletedKey", () => {
+    const date = new Date();
+    const item: DeletedKeyItem = {
+      kid:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      attributes: {
+        recoverableDays: 1,
+        recoveryLevel: "Recoverable",
+        enabled: true,
+        notBefore: date,
+        expires: date,
+        created: date,
+        updated: date
+      },
+      tags: {
+        tag_name: "tag_value"
+      },
+      managed: false,
+      recoveryId: "recovery-id",
+      scheduledPurgeDate: date,
+      deletedDate: date
+    };
+
+    const expectedResult: DeletedKey = {
+      key: {
+        kid:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61"
+      },
+      name: "transformations",
+      id:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      properties: {
+        id:
+          "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+        name: "transformations",
+        vaultUrl: "https://azure_managedhsm.managedhsm.azure.net",
+        version: "f03e8b3d76554e8b9749994bcf72fc61",
+        enabled: true,
+        notBefore: date,
+        expiresOn: date,
+        tags: {
+          tag_name: "tag_value"
+        },
+        createdOn: date,
+        updatedOn: date,
+        recoveryLevel: "Recoverable",
+        recoverableDays: 1,
+        managed: false,
+        recoveryId: "recovery-id",
+        scheduledPurgeDate: date,
+        deletedOn: date
+      }
+    };
+
+    const key: DeletedKey = getDeletedKeyFromDeletedKeyItem(item);
+    assert.deepEqual(key, expectedResult);
+  });
+
+  it("KeyItem to KeyProperties", () => {
+    const date = new Date();
+    const item: DeletedKeyItem = {
+      kid:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      attributes: {
+        recoverableDays: 1,
+        recoveryLevel: "Recoverable",
+        enabled: true,
+        notBefore: date,
+        expires: date,
+        created: date,
+        updated: date
+      },
+      tags: {
+        tag_name: "tag_value"
+      },
+      managed: false,
+      recoveryId: "recovery-id",
+      scheduledPurgeDate: date,
+      deletedDate: date
+    };
+
+    const expectedResult: KeyProperties = {
+      id:
+        "https://azure_managedhsm.managedhsm.azure.net/keys/transformations/f03e8b3d76554e8b9749994bcf72fc61",
+      name: "transformations",
+      vaultUrl: "https://azure_managedhsm.managedhsm.azure.net",
+      version: "f03e8b3d76554e8b9749994bcf72fc61",
+      enabled: true,
+      notBefore: date,
+      expiresOn: date,
+      tags: {
+        tag_name: "tag_value"
+      },
+      createdOn: date,
+      updatedOn: date,
+      recoveryLevel: "Recoverable",
+      recoverableDays: 1,
+      managed: false
+    };
+
+    const key: KeyProperties = getKeyPropertiesFromKeyItem(item);
     assert.deepEqual(key, expectedResult);
   });
 });


### PR DESCRIPTION
A customer recently found an issue with our output values: https://github.com/Azure/azure-sdk-for-js/issues/15353

Once we reach an exit strategy, we'll need to make a hotfix out of this PR.

A while ago I made a PR showcasing how we could use the spread operator less ([PR link](https://github.com/Azure/azure-sdk-for-js/pull/12697)). That PR got reviewed and approved as usual, but it had some deep issues that didn't become obvious to the reviewer, nor raised any issues during tests. I find that reasonable, but I regret it.

What happened in detail was that, because of:

- The use of "any".
- Not having structural tests.

Because this being an instance of both cases, we couldn't:

- Trust our types.
- Trust our tests.

So, besides solving the underlying issue, we should take this opportunity to reflect on the matter.

Feedback appreciated.