### PR TITLE
Revert "Temporarily replace macOS CI tests with ubuntu CI tests (#14785)

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -56,13 +56,8 @@ stages:
             - TestType=node|browser
             - DependencyVersion=^$
             - ${{ each filter in parameters.MatrixFilters }}:
-              - ${{ filter }}
-          MatrixReplace:
-            # Temporarily replace macOS agents with ubuntu agents because of ongoing pool capacity issues
-            - Pool=Azure.Pipelines/azsdk-pool-mms-ubuntu-1804-general
-            - OsVmImage=macOS-10.15/MMSUbuntu18.04
-            - ${{ each replacement in parameters.MatrixReplace }}:
-              - ${{ replacement }}
+              - ${{ filter}}
+          MatrixReplace: ${{ parameters.MatrixReplace }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq(parameters.IncludeRelease,true))}}:


### PR DESCRIPTION
This reverts commit 5a3c2d84f275b66f134b3819cda368cc0d6e3b4d.

Azure Pipelines macOS agent capacity seems to be restored now (https://status.dev.azure.com/_event/233282345).