### PR TITLE
[Cosmos] Sanitizes AAD dataplane RBAC URL

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 3.11.3 (Unreleased)
+## 3.11.3 (2021-05-21)
 
+- BUGFIX: Sanitize user endpoint URLs for AAD DataPlane RBAC token generation.
 
 ## 3.11.2 (2021-05-11)
 

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -10,6 +10,7 @@ import {
 } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { CosmosHeaders } from "./queryExecutionContext";
+import { sanitizeEndpoint } from "./utils/checkURL";
 
 /** @hidden */
 export interface RequestInfo {
@@ -66,7 +67,8 @@ export async function setAuthorizationHeader(
     if (typeof clientOptions.aadCredentials?.getToken !== "function") {
       throw new Error("Cannot use AAD Credentials without `getToken`. See @azure/identity docs");
     }
-    const token = await clientOptions.aadCredentials.getToken(`${clientOptions.endpoint}/.default`);
+    const hrefEndpoint = sanitizeEndpoint(clientOptions.endpoint);
+    const token = await clientOptions.aadCredentials.getToken(`${hrefEndpoint}/.default`);
     const AUTH_PREFIX = `type=aad&ver=1.0&sig=`;
     const authorizationToken = `${AUTH_PREFIX}${token.token}`;
     headers[Constants.HttpHeaders.Authorization] = encodeURIComponent(authorizationToken);

--- a/sdk/cosmosdb/cosmos/src/utils/checkURL.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/checkURL.ts
@@ -6,3 +6,7 @@ import { URL } from "./url";
 export function checkURL(testString: string): URL {
   return new URL(testString);
 }
+
+export function sanitizeEndpoint(url: string): string {
+  return new URL(url).href.replace(/\/$/, "");
+}

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/checkURL.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/checkURL.spec.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import assert from "assert";
+import { sanitizeEndpoint } from "../../../../src/utils/checkURL";
+
+describe("URL utils", function() {
+  describe("sanitizeEndpoint", function() {
+    it("correctly formats URL with scope", function() {
+      const testURLs = [
+        "https://sample.documents.azure.com",
+        "https://sample.documents.azure.com/",
+        "https://sample.documents.azure.com:443/",
+        "https://sample.documents.azure.com:443",
+        "https://sample.documents.azure.com"
+      ];
+      const correctURL = "https://sample.documents.azure.com";
+
+      testURLs.forEach((url) => {
+        assert.equal(sanitizeEndpoint(url), correctURL);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We were passing unsanitized URLs to fetch the AAD credentials for RBAC data plane, like leaving in the :443 port and trailing slashes. This should fix and give the correct endpoint