### PR TITLE
[Key Vault Admin] One last API alignment item

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Renamed `KeyVaultBeginSelectiveRestoreOptions` to `KeyVaultBeginSelectiveKeyRestoreOptions`.
 - Renamed `KeyVaultSelectiveRestoreOperationState` to `KeyVaultSelectiveKeyRestoreOperationState`.
 - Renamed `KeyVaultSelectiveRestoreResult` to `KeyVaultSelectiveKeyRestoreResult`.
+- Renamed the `KeyVaultRoleAssignmentProperties`'s property `scope` to `roleScope`.
 
 ## 4.0.0-beta.3 (2021-04-06)
 

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -133,7 +133,7 @@ export interface KeyVaultRoleAssignment {
 export interface KeyVaultRoleAssignmentProperties {
     principalId: string;
     roleDefinitionId: string;
-    scope?: KeyVaultRoleScope;
+    roleScope?: KeyVaultRoleScope;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -147,7 +147,7 @@ export interface KeyVaultRoleAssignmentProperties {
   /**
    * The role assignment scope.
    */
-  scope?: KeyVaultRoleScope;
+  roleScope?: KeyVaultRoleScope;
 }
 
 /**

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -18,7 +18,7 @@ export const mappings = {
         name: name!,
         kind: type!,
         properties: {
-          scope: scope as KeyVaultRoleScope,
+          roleScope: scope as KeyVaultRoleScope,
           roleDefinitionId: roleDefinitionId!,
           principalId: principalId!
         }

--- a/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/accessControlClient.spec.ts
@@ -242,13 +242,13 @@ describe("KeyVaultAccessControlClient", () => {
     assert.equal(assignment.name, assignmentName);
     assert.equal(assignment.properties?.roleDefinitionId, roleDefinition.id);
     assert.equal(assignment.properties?.principalId, env.CLIENT_OBJECT_ID);
-    assert.equal(assignment.properties.scope, globalScope);
+    assert.equal(assignment.properties.roleScope, globalScope);
 
     assignment = await client.getRoleAssignment(globalScope, assignmentName);
     assert.equal(assignment.name, assignmentName);
     assert.equal(assignment.properties?.roleDefinitionId, roleDefinition.id);
     assert.equal(assignment.properties?.principalId, env.CLIENT_OBJECT_ID);
-    assert.equal(assignment.properties.scope, globalScope);
+    assert.equal(assignment.properties.roleScope, globalScope);
 
     assignment = await client.deleteRoleAssignment(globalScope, assignmentName);
     assert.equal(assignment.name, assignmentName);


### PR DESCRIPTION
After reviewing Java’s API alignment PRs, I realized that I had forgotten about this rename. How does this look?

This PR renames the `KeyVaultRoleAssignmentProperties`'s property `scope` to `roleScope`.