### PR TITLE
Updating Network Traversal change in CHANGELOG

### DIFF
--- a/sdk/communication/communication-network-traversal/CHANGELOG.md
+++ b/sdk/communication/communication-network-traversal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2021-05-25)
+## 1.0.0-beta.1 (2021-05-24)
 
 The first preview of the Azure Communication Relay Client has the following features:
 


### PR DESCRIPTION
Updating the communication-network-traversal changelog date to reflect Public beta release.