### PR TITLE
[service-bus] Remove dead code in MessageSender.sendMessages

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -82,12 +82,6 @@ describe("AbortSignal", () => {
       });
 
       assert.equal(passedInOptions?.abortSignal, abortSignal);
-
-      await sender.sendMessages([testMessageThatDoesntMatter], {
-        abortSignal
-      });
-
-      assert.equal(passedInOptions?.abortSignal, abortSignal);
     });
 
     it("_trySend with an already aborted AbortSignal", async () => {


### PR DESCRIPTION
We always send messages via the 'batch' version of the method now, so the original array-based version with `sendMessages` is no longer used.