### PR TITLE
[service-bus] getMaxMessages needs to retry if link doesn't initialize

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 7.2.0-beta.2 (Unreleased)
 
+### Bug fixes
+
+- ServiceBusSender could throw an error (`TypeError: Cannot read property 'maxMessageSize' of undefined`) if a link was being restarted while calling sendMessages().
+  [PR#15409](https://github.com/Azure/azure-sdk-for-js/pull/15409)
 
 ## 7.2.0-beta.1 (2021-05-18)
 

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { MessageSender } from "../../../src/core/messageSender";
+import { assertThrows } from "../../public/utils/testUtils";
+import { createConnectionContextForTests } from "./unittestUtils";
+import * as assert from "assert";
+
+describe("MessageSender unit tests", () => {
+  it("getMaxMessageSize should retry (exhaust retries)", async () => {
+    const retryOptions = {
+      maxRetries: 3,
+      retryDelayInMs: 0,
+      timeoutInMs: 1000
+    };
+
+    const messageSender = new MessageSender(
+      createConnectionContextForTests(),
+      "entityPath",
+      retryOptions
+    );
+
+    let openCalled = 0;
+
+    messageSender["open"] = () => {
+      ++openCalled;
+
+      // Simulating this result:
+      // getMaxMessageSize() starts.
+      //   open() called.
+      //   open() finishes, control not yet returned to getMaxMessagesSize()
+      //   onDetach() happens, link detaches and sets this._link to undefined.
+      //   control returned back to getMaxMessagesSize()
+      // code assumes link is initialized from open() (it was, but was closed) and then tries
+      //   to get maxMessageSize, throwing an exception.
+      return new Promise((resolve) => {
+        messageSender["_link"] = undefined;
+        resolve();
+      });
+    };
+
+    await assertThrows(
+      () =>
+        messageSender.getMaxMessageSize({
+          abortSignal: undefined,
+          retryOptions
+        }),
+      {
+        name: "ServiceBusError",
+        code: "GeneralError",
+        message: "Link failed to initialize, cannot get max message size."
+      }
+    );
+
+    assert.equal(openCalled, retryOptions.maxRetries + 1);
+  });
+
+  it("getMaxMessageSize should retry (success)", async () => {
+    const retryOptions = {
+      maxRetries: 3,
+      retryDelayInMs: 0,
+      timeoutInMs: 1000
+    };
+
+    const messageSender = new MessageSender(
+      createConnectionContextForTests(),
+      "entityPath",
+      retryOptions
+    );
+
+    let openCalled = 0;
+
+    messageSender["open"] = async () => {
+      ++openCalled;
+
+      messageSender["_link"] = {
+        maxMessageSize: 101
+      } as any;
+    };
+
+    const maxMessageSize = await messageSender.getMaxMessageSize({
+      abortSignal: undefined,
+      retryOptions
+    });
+
+    assert.equal(maxMessageSize, 101);
+    assert.equal(openCalled, 1);
+  });
+});


### PR DESCRIPTION
getMaxMessages had an edge case where the link being closed just after open would cause us to access a link that was undefined and throw a non-retryable exception.

This PR fixes that by checking that the link is defined, and throwing a retryable exception if it is not.

Fixes #15398 