### PR TITLE
[core-amqp] improve doc comment for AcquireLockProperties.abortSignal

### DIFF
--- a/sdk/core/core-amqp/src/util/lock.ts
+++ b/sdk/core/core-amqp/src/util/lock.ts
@@ -12,6 +12,8 @@ import { logger } from "../log";
 export interface AcquireLockProperties {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel lock acquisition.
+   * This only applies to the acquisition of a lock. Once the lock is acquired, the task is invoked and `acquire`
+   * can no longer be cancelled.
    * This does not cancel running the task passed to `acquire()` if the lock has been acquired,
    * but will prevent it from running if cancelled before the task is invoked.
    */


### PR DESCRIPTION
My attempt at improving the doc comments based on feedback: https://github.com/Azure/azure-sdk-for-js/pull/15349#pullrequestreview-668348615

> The CancellableAsyncLockImpl.acquire() should mention that the behavior for both abort and timeout are the same (they only are in effect prior to the inner task being invoked). It's clear for task but not for abort.