### PR TITLE
Update test results titles to include service directory and cloud names

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -202,7 +202,7 @@ jobs:
         inputs:
           searchFolder: "$(System.DefaultWorkingDirectory)/sdk"
           testResultsFiles: "$(TestResultsFiles)"
-          testRunTitle: "$(OSName) - $(TestType) - Integration Tests - [Node $(NodeTestVersion)]"
+          testRunTitle: "${{ parameters.ServiceDirectory }} ${{ parameters.CloudConfig.Cloud }} $(Agent.JobName)"
         condition: >
           and(
             always(),


### PR DESCRIPTION
When testing with multiple clouds, it can be hard to tell from the coverage view which failures come from which cloud and/or job.