### PR TITLE
[core] Improve the sanitizer to handle recursive objects

### DIFF
--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -268,3 +268,22 @@ export function getEnvironmentValue(name: string): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * @internal
+ */
+export type UnknownObject = { [s: string]: unknown };
+
+/**
+ * @internal
+ * @returns true when input is an object type that is not null, Array, RegExp, or Date.
+ */
+export function isObject(input: unknown): input is UnknownObject {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    !Array.isArray(input) &&
+    !(input instanceof RegExp) &&
+    !(input instanceof Date)
+  );
+}

--- a/sdk/core/core-http/test/sanitizerTests.ts
+++ b/sdk/core/core-http/test/sanitizerTests.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { Sanitizer } from "../src/util/sanitizer";
+
+describe("Sanitizer", function() {
+  it("Redacts query parameters in url properties", function() {
+    const expected = `{
+  "url": "http://example.com/foo?api-version=123&secret=REDACTED"
+}`;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize({ url: "http://example.com/foo?api-version=123&secret=42" });
+    assert.strictEqual(result, expected);
+  });
+
+  it("Handles recursive data structures", function() {
+    const recursive: { a: number; b: unknown } = {
+      a: 42,
+      b: undefined
+    };
+    const expected = `{
+  "a": 42,
+  "b": "[Circular]"
+}`;
+    recursive.b = recursive;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize(recursive);
+    assert.strictEqual(result, expected);
+  });
+});

--- a/sdk/core/core-rest-pipeline/src/util/helpers.ts
+++ b/sdk/core/core-rest-pipeline/src/util/helpers.ts
@@ -3,12 +3,14 @@
 
 /**
  * A constant that indicates whether the environment the code is running is Node.JS.
+ * @internal
  */
 export const isNode =
   typeof process !== "undefined" && Boolean(process.version) && Boolean(process.versions?.node);
 
 /**
  * A wrapper for setTimeout that resolves a promise after t milliseconds.
+ * @internal
  * @param t - The number of milliseconds to be delayed.
  * @param value - The value to be resolved with after a timeout of t milliseconds.
  * @returns Resolved promise
@@ -35,4 +37,18 @@ export function getRandomIntegerInclusive(min: number, max: number): number {
   // in order to be inclusive of the maximum value after we take the floor.
   const offset = Math.floor(Math.random() * (max - min + 1));
   return offset + min;
+}
+
+/**
+ * @internal
+ * @returns true when input is an object type that is not null, Array, RegExp, or Date.
+ */
+export function isObject(input: unknown): input is Object {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    !Array.isArray(input) &&
+    !(input instanceof RegExp) &&
+    !(input instanceof Date)
+  );
 }

--- a/sdk/core/core-rest-pipeline/src/util/helpers.ts
+++ b/sdk/core/core-rest-pipeline/src/util/helpers.ts
@@ -41,9 +41,14 @@ export function getRandomIntegerInclusive(min: number, max: number): number {
 
 /**
  * @internal
+ */
+export type UnknownObject = { [s: string]: unknown };
+
+/**
+ * @internal
  * @returns true when input is an object type that is not null, Array, RegExp, or Date.
  */
-export function isObject(input: unknown): input is Object {
+export function isObject(input: unknown): input is UnknownObject {
   return (
     typeof input === "object" &&
     input !== null &&

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isObject } from "./helpers";
 import { URL } from "./url";
 
 /**
@@ -93,38 +94,46 @@ export class Sanitizer {
   }
 
   public sanitize(obj: unknown): string {
-    return JSON.stringify(obj, this.replacer.bind(this), 2);
-  }
+    const seen = new Set<unknown>();
+    return JSON.stringify(
+      obj,
+      (key: string, value: unknown) => {
+        // Ensure Errors include their interesting non-enumerable members
+        if (value instanceof Error) {
+          return {
+            ...value,
+            name: value.name,
+            message: value.message
+          };
+        }
 
-  private replacer(key: string, value: unknown): unknown {
-    // Ensure Errors include their interesting non-enumerable members
-    if (value instanceof Error) {
-      return {
-        ...value,
-        name: value.name,
-        message: value.message
-      };
-    }
+        if (key === "headers") {
+          return this.sanitizeHeaders(value as UnknownObject);
+        } else if (key === "url") {
+          return this.sanitizeUrl(value as string);
+        } else if (key === "query") {
+          return this.sanitizeQuery(value as UnknownObject);
+        } else if (key === "body") {
+          // Don't log the request body
+          return undefined;
+        } else if (key === "response") {
+          // Don't log response again
+          return undefined;
+        } else if (key === "operationSpec") {
+          // When using sendOperationRequest, the request carries a massive
+          // field with the autorest spec. No need to log it.
+          return undefined;
+        } else if (Array.isArray(value) || isObject(value)) {
+          if (seen.has(value)) {
+            return "[Circular]";
+          }
+          seen.add(value);
+        }
 
-    if (key === "headers") {
-      return this.sanitizeHeaders(value as UnknownObject);
-    } else if (key === "url") {
-      return this.sanitizeUrl(value as string);
-    } else if (key === "query") {
-      return this.sanitizeQuery(value as UnknownObject);
-    } else if (key === "body") {
-      // Don't log the request body
-      return undefined;
-    } else if (key === "response") {
-      // Don't log response again
-      return undefined;
-    } else if (key === "operationSpec") {
-      // When using sendOperationRequest, the request carries a massive
-      // field with the autorest spec. No need to log it.
-      return undefined;
-    }
-
-    return value;
+        return value;
+      },
+      2
+    );
   }
 
   private sanitizeHeaders(obj: UnknownObject): UnknownObject {

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isObject } from "./helpers";
+import { isObject, UnknownObject } from "./helpers";
 import { URL } from "./url";
 
 /**
@@ -22,11 +22,6 @@ export interface SanitizerOptions {
    */
   additionalAllowedQueryParameters?: string[];
 }
-
-/**
- * @internal
- */
-export type UnknownObject = { [s: string]: unknown };
 
 const RedactedString = "REDACTED";
 

--- a/sdk/core/core-rest-pipeline/test/sanitizer.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/sanitizer.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { Sanitizer } from "../src/util/sanitizer";
+
+describe("Sanitizer", function() {
+  it("Redacts query parameters in url properties", function() {
+    const expected = `{
+  "url": "http://example.com/foo?api-version=123&secret=REDACTED"
+}`;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize({ url: "http://example.com/foo?api-version=123&secret=42" });
+    assert.strictEqual(result, expected);
+  });
+
+  it("Handles recursive data structures", function() {
+    const recursive: { a: number; b: unknown } = {
+      a: 42,
+      b: undefined
+    };
+    const expected = `{
+  "a": 42,
+  "b": "[Circular]"
+}`;
+    recursive.b = recursive;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize(recursive);
+    assert.strictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
JSON.stringify can't handle recursive data structures, so when we use it internally inside Sanitizer.sanitize, we need to be smart enough to cut not re-visit objects we've already seen.

Fixes #15402