### PR TITLE
[Text Analytics] Rename PiiEntityDomainType to PiiEntityDomain

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.1.0-beta.7 (Unreleased)
 
+### Breaking Changes
+
+- `PiiEntityDomainType` was renamed to `PiiEntityDomain`.
 
 ## 5.1.0-beta.6 (2021-05-18)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -365,7 +365,7 @@ export interface PiiEntity extends Entity {
 export type PiiEntityCategory = string;
 
 // @public
-export enum PiiEntityDomainType {
+export enum PiiEntityDomain {
     PROTECTED_HEALTH_INFORMATION = "PHI"
 }
 
@@ -451,7 +451,7 @@ export interface RecognizeLinkedEntitiesSuccessResult extends TextAnalyticsSucce
 
 // @public
 export type RecognizePiiEntitiesAction = {
-    domain?: PiiEntityDomainType;
+    domain?: PiiEntityDomain;
     modelVersion?: string;
     stringIndexType?: StringIndexType;
     disableServiceLogs?: boolean;
@@ -474,7 +474,7 @@ export type RecognizePiiEntitiesErrorResult = TextAnalyticsErrorResult;
 // @public
 export interface RecognizePiiEntitiesOptions extends TextAnalyticsOperationOptions {
     categoriesFilter?: PiiEntityCategory[];
-    domainFilter?: PiiEntityDomainType;
+    domainFilter?: PiiEntityDomain;
     stringIndexType?: StringIndexType;
 }
 

--- a/sdk/textanalytics/ai-text-analytics/samples-dev/recognizePii.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples-dev/recognizePii.ts
@@ -12,11 +12,7 @@
  * @azsdk-weight 100
  */
 
-import {
-  TextAnalyticsClient,
-  AzureKeyCredential,
-  PiiEntityDomain
-} from "@azure/ai-text-analytics";
+import { TextAnalyticsClient, AzureKeyCredential, PiiEntityDomain } from "@azure/ai-text-analytics";
 import { assert } from "console";
 
 // Load the .env file if it exists

--- a/sdk/textanalytics/ai-text-analytics/samples-dev/recognizePii.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples-dev/recognizePii.ts
@@ -15,7 +15,7 @@
 import {
   TextAnalyticsClient,
   AzureKeyCredential,
-  PiiEntityDomainType
+  PiiEntityDomain
 } from "@azure/ai-text-analytics";
 import { assert } from "console";
 
@@ -49,7 +49,7 @@ export async function main() {
 
   console.log(`There are no PHI entities in this text: "${textNoPHI}"`);
   const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
-    domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
+    domainFilter: PiiEntityDomain.PROTECTED_HEALTH_INFORMATION
   });
   if (!resultWithPHI.error) {
     console.log(`Also there is nothing to redact: "${resultWithPHI.redactedText}"`);

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/recognizePii.js
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/recognizePii.js
@@ -14,7 +14,7 @@
 const {
   TextAnalyticsClient,
   AzureKeyCredential,
-  PiiEntityDomainType
+  PiiEntityDomain
 } = require("@azure/ai-text-analytics");
 const { assert } = require("console");
 
@@ -48,7 +48,7 @@ async function main() {
 
   console.log(`There are no PHI entities in this text: "${textNoPHI}"`);
   const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
-    domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
+    domainFilter: PiiEntityDomain.PROTECTED_HEALTH_INFORMATION
   });
   if (!resultWithPHI.error) {
     console.log(`Also there is nothing to redact: "${resultWithPHI.redactedText}"`);

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/recognizePii.ts
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/src/recognizePii.ts
@@ -14,7 +14,7 @@
 import {
   TextAnalyticsClient,
   AzureKeyCredential,
-  PiiEntityDomainType
+  PiiEntityDomain
 } from "@azure/ai-text-analytics";
 import { assert } from "console";
 
@@ -48,7 +48,7 @@ export async function main() {
 
   console.log(`There are no PHI entities in this text: "${textNoPHI}"`);
   const [resultWithPHI] = await client.recognizePiiEntities([textNoPHI], "en", {
-    domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION
+    domainFilter: PiiEntityDomain.PROTECTED_HEALTH_INFORMATION
   });
   if (!resultWithPHI.error) {
     console.log(`Also there is nothing to redact: "${resultWithPHI.redactedText}"`);

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -16,7 +16,7 @@ export {
   ExtractKeyPhrasesOptions,
   RecognizePiiEntitiesOptions,
   RecognizeLinkedEntitiesOptions,
-  PiiEntityDomainType,
+  PiiEntityDomain,
   TextAnalyticsActions,
   RecognizeCategorizedEntitiesAction,
   RecognizePiiEntitiesAction,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -146,7 +146,7 @@ export interface AnalyzeSentimentOptions extends TextAnalyticsOperationOptions {
 /**
  * The types of PII domains the user can choose from.
  */
-export enum PiiEntityDomainType {
+export enum PiiEntityDomain {
   /**
    * @see {@link https://aka.ms/tanerpii} for more information.
    */
@@ -162,7 +162,7 @@ export interface RecognizePiiEntitiesOptions extends TextAnalyticsOperationOptio
    * set to 'PHI', entities in the Protected Healthcare Information domain will
    * only be returned). @see {@link https://aka.ms/tanerpii} for more information.
    */
-  domainFilter?: PiiEntityDomainType;
+  domainFilter?: PiiEntityDomain;
   /**
    * Specifies the measurement unit used to calculate the offset and length properties.
    * Possible units are "TextElements_v8", "UnicodeCodePoint", and "Utf16CodeUnit".
@@ -224,7 +224,7 @@ export type RecognizePiiEntitiesAction = {
    * set to 'PHI', entities in the Protected Healthcare Information domain will
    * only be returned). @see {@link https://aka.ms/tanerpii} for more information.
    */
-  domain?: PiiEntityDomainType;
+  domain?: PiiEntityDomain;
   /**
    * The version of the text analytics model used by this operation on this
    * batch of input documents.

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -20,7 +20,7 @@ import {
   SentenceSentiment,
   Opinion,
   AssessmentSentiment,
-  PiiEntityDomainType
+  PiiEntityDomain
 } from "../../src";
 import { assertAllSuccess, isSuccess } from "./utils/resultHelper";
 import { checkEntityTextOffset, checkOffsetAndLength } from "./utils/stringIndexTypeHelpers";
@@ -587,7 +587,7 @@ describe("[AAD] TextAnalyticsClient", function(this: Suite) {
               language: "en"
             }
           ],
-          { domainFilter: PiiEntityDomainType.PROTECTED_HEALTH_INFORMATION }
+          { domainFilter: PiiEntityDomain.PROTECTED_HEALTH_INFORMATION }
         );
         if (!result.error) {
           assert.equal(result.entities.length, 2);


### PR DESCRIPTION
This change has been proposed by .NET architect and discussed by the TA crew. The motivation is to shorten it a bit.