### PR TITLE
Skip track1 perf projects from gulp pack

### DIFF
--- a/.scripts/common.ts
+++ b/.scripts/common.ts
@@ -108,7 +108,7 @@ function isPackageFolderPath(folderPath: string, packagesToIgnore: string[]): bo
   if (fileExistsSync(packageJsonFilePath)) {
     const packageJson: PackageJson = readPackageJsonFileSync(packageJsonFilePath);
     // Skip all perf framework projects from gulp pack
-    if (packageJson.name.startsWith("@azure-tests")) {
+    if (packageJson.name.startsWith("@azure-tests/")) {
       return false;
     }
     result = !contains(packagesToIgnore, packageJson.name!);

--- a/.scripts/common.ts
+++ b/.scripts/common.ts
@@ -107,6 +107,10 @@ function isPackageFolderPath(folderPath: string, packagesToIgnore: string[]): bo
   const packageJsonFilePath: string = joinPath(folderPath, "package.json");
   if (fileExistsSync(packageJsonFilePath)) {
     const packageJson: PackageJson = readPackageJsonFileSync(packageJsonFilePath);
+    // Skip all perf framework projects from gulp pack
+    if (packageJson.name.startsWith("@azure-tests")) {
+      return false;
+    }
     result = !contains(packagesToIgnore, packageJson.name!);
   }
   return result;


### PR DESCRIPTION
Skip all projects in @azure-tests org from gulp pack. These are perf test framework projects for track1 and should not be included in gulp pack