### PR TITLE
[core] preserve header key casing for x-ms-meta-* headers

### DIFF
--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -5,7 +5,7 @@
  * A collection of HttpHeaders that can be sent with a HTTP request.
  */
 function getHeaderKey(headerName: string): string {
-  return headerName.toLowerCase();
+  return headerName.startsWith("x-ms-meta-") ? headerName : headerName.toLowerCase();
 }
 
 /**
@@ -178,7 +178,8 @@ export class HttpHeaders implements HttpHeadersLike {
     const result: RawHttpHeaders = {};
     for (const headerKey in this._headersMap) {
       const header: HttpHeader = this._headersMap[headerKey];
-      result[header.name.toLowerCase()] = header.value;
+      const key = header.name.startsWith("x-ms-meta-") ? header.name : header.name.toLowerCase();
+      result[key] = header.value;
     }
     return result;
   }


### PR DESCRIPTION
Blob Storage retrieves metadata through these when `*Client.getProperties()` functions are called. Enforcing lower case will
leads to their metadata key losing proper casing.

This PR relax it for just x-ms-meta-* keys to avoid other breaking changes.