### PR TITLE
[KeyVault] - Update broken links for Key Vault Secrets

### DIFF
--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -520,8 +520,8 @@ setLogLevel("info");
 
 You can find more code samples through the following links:
 
-- [KeyVault Secrets Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/javascript)
-- [KeyVault Secrets Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/typescript)
+- [KeyVault Secrets Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/v4/javascript)
+- [KeyVault Secrets Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/samples/v4/typescript)
 - [KeyVault Secrets Test Cases](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/test/)
 
 ## Contributing

--- a/sdk/keyvault/keyvault-secrets/migration-guide.md
+++ b/sdk/keyvault/keyvault-secrets/migration-guide.md
@@ -188,10 +188,10 @@ await client.purgeDeletedSecret(deletedSecret.name);
 
 ## Additional samples
 
-* [Key Vault Secrets samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples/javascript)
-* [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
-* [Key Vault Secrets samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples/typescript)
-* [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
+- [Key Vault Secrets samples for JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples/v4/javascript)
+- [General Key Vault samples for JavaScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=javascript)
+- [Key Vault Secrets samples for TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples/v4/typescript)
+- [General Key Vault samples for TypeScript](https://docs.microsoft.com/samples/browse/?products=azure-key-vault&languages=typescript)
 
 [kvk-npm]: https://www.npmjs.com/package/@azure/keyvault-keys
 [kvs-npm]: https://www.npmjs.com/package/@azure/keyvault-secrets


### PR DESCRIPTION
In a previous commit (f77c21842c2b8244f76641b454768aa1a3c9f415) we cleaned up some duplicated
samples that were left behind. Unfortunately, we still had a few links pointing to the old samples - mainly
the README and migration guide for secrets.

This PR cleans that up and points to the new sample folder, which should make the [link verification check](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=920933) happy again.