### PR TITLE
Refactor SubmitTransaction to fix multiple send issue

### DIFF
--- a/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_multiple_transactions_with_the_same_partition_key.json
+++ b/sdk/tables/data-tables/recordings/browsers/batch_operations/recording_should_send_multiple_transactions_with_the_same_partition_key.json
@@ -1,0 +1,88 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/Tables",
+   "query": {},
+   "requestBody": "{\"TableName\":\"batchTableTestbrowser\"}",
+   "status": 201,
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#Tables/@Element\",\"TableName\":\"batchTableTestbrowser\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 01 Jun 2021 17:51:48 GMT",
+    "location": "https://fakestorageaccount.table.core.windows.net/Tables('batchTableTestbrowser')",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "9a6e4529-c933-44d3-86e2-0af4272e3597",
+    "x-ms-request-id": "2bdef6f7-8002-0028-0b0e-57f600000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r1\",\"value\":\"1\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r2\",\"value\":\"2\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r3\",\"value\":\"3\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_c75b7306-cc54-4450-b216-42d47a9aaaec\r\nContent-Type: multipart/mixed; boundary=changesetresponse_9d7e7528-2eb3-4137-8eca-a6bd23cee8f8\r\n\r\n--changesetresponse_9d7e7528-2eb3-4137-8eca-a6bd23cee8f8\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r1')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r1')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.725642Z'\"\r\n\r\n\r\n--changesetresponse_9d7e7528-2eb3-4137-8eca-a6bd23cee8f8\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r2')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r2')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.725642Z'\"\r\n\r\n\r\n--changesetresponse_9d7e7528-2eb3-4137-8eca-a6bd23cee8f8\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r3')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r3')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.725642Z'\"\r\n\r\n\r\n--changesetresponse_9d7e7528-2eb3-4137-8eca-a6bd23cee8f8--\r\n--batchresponse_c75b7306-cc54-4450-b216-42d47a9aaaec--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_c75b7306-cc54-4450-b216-42d47a9aaaec",
+    "date": "Tue, 01 Jun 2021 17:51:48 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "fc560ee5-6d8c-4298-847a-3237a3d887a6",
+    "x-ms-request-id": "2bdef714-8002-0028-240e-57f600000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://fakestorageaccount.table.core.windows.net/$batch",
+   "query": {},
+   "requestBody": "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r4\",\"value\":\"4\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r5\",\"value\":\"5\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r6\",\"value\":\"6\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n",
+   "status": 202,
+   "response": "--batchresponse_80a963cc-bc0b-4c10-8479-bb947fd11dd1\r\nContent-Type: multipart/mixed; boundary=changesetresponse_63e77d76-ac1b-4eb4-848b-4907c051d7fa\r\n\r\n--changesetresponse_63e77d76-ac1b-4eb4-848b-4907c051d7fa\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r4')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r4')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\"\r\n\r\n\r\n--changesetresponse_63e77d76-ac1b-4eb4-848b-4907c051d7fa\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r5')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r5')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\"\r\n\r\n\r\n--changesetresponse_63e77d76-ac1b-4eb4-848b-4907c051d7fa\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r6')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser(PartitionKey='multiBatch1',RowKey='r6')\r\nETag: W/\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\"\r\n\r\n\r\n--changesetresponse_63e77d76-ac1b-4eb4-848b-4907c051d7fa--\r\n--batchresponse_80a963cc-bc0b-4c10-8479-bb947fd11dd1--\r\n",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "multipart/mixed; boundary=batchresponse_80a963cc-bc0b-4c10-8479-bb947fd11dd1",
+    "date": "Tue, 01 Jun 2021 17:51:48 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "b89f760c-9824-42a5-af39-429378e96a06",
+    "x-ms-request-id": "2bdef73a-8002-0028-470e-57f600000000",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.table.core.windows.net/batchTableTestbrowser()",
+   "query": {
+    "$filter": "PartitionKey eq 'multiBatch1'"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"odata.metadata\":\"https://fakestorageaccount.table.core.windows.net/$metadata#batchTableTestbrowser\",\"value\":[{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.725642Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r1\",\"Timestamp\":\"2021-06-01T17:51:48.725642Z\",\"value\":\"1\"},{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.725642Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r2\",\"Timestamp\":\"2021-06-01T17:51:48.725642Z\",\"value\":\"2\"},{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.725642Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r3\",\"Timestamp\":\"2021-06-01T17:51:48.725642Z\",\"value\":\"3\"},{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r4\",\"Timestamp\":\"2021-06-01T17:51:48.8137036Z\",\"value\":\"4\"},{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r5\",\"Timestamp\":\"2021-06-01T17:51:48.8137036Z\",\"value\":\"5\"},{\"odata.etag\":\"W/\\\"datetime'2021-06-01T17%3A51%3A48.8137036Z'\\\"\",\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r6\",\"Timestamp\":\"2021-06-01T17:51:48.8137036Z\",\"value\":\"6\"}]}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-type": "application/json;odata=minimalmetadata;streaming=true;charset=utf-8",
+    "date": "Tue, 01 Jun 2021 17:51:48 GMT",
+    "server": "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-ms-client-request-id": "c43b6c2c-15d5-4317-9798-e76734715542",
+    "x-ms-request-id": "2bdef751-8002-0028-5e0e-57f600000000",
+    "x-ms-version": "2019-02-02"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "c9699701aaea0fee411293abbe4268e5"
+}

--- a/sdk/tables/data-tables/recordings/node/batch_operations/recording_should_send_multiple_transactions_with_the_same_partition_key.js
+++ b/sdk/tables/data-tables/recordings/node/batch_operations/recording_should_send_multiple_transactions_with_the_same_partition_key.js
@@ -1,0 +1,95 @@
+let nock = require('nock');
+
+module.exports.hash = "f0a834722cfc3432a47a34ce99f2bdd6";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/Tables', {"TableName":"batchTableTestnode"})
+  .query(true)
+  .reply(201, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#Tables/@Element","TableName":"batchTableTestnode"}, [ 'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Location',
+  'https://fakestorageaccount.table.core.windows.net/Tables(\'batchTableTestnode\')',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '31cc3a90-8002-0127-6807-575da3000000',
+  'x-ms-client-request-id',
+  '938b5a21-d8b5-45cf-86d0-19df3bc334f9',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 01 Jun 2021 16:56:15 GMT' ]);
+
+nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/$batch', "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r1\",\"value\":\"1\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r2\",\"value\":\"2\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r3\",\"value\":\"3\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n")
+  .query(true)
+  .reply(202, "--batchresponse_66ac1a09-28b5-474d-821f-d993ec447cac\r\nContent-Type: multipart/mixed; boundary=changesetresponse_7d8d1546-0848-442f-9284-7dc35897a6a4\r\n\r\n--changesetresponse_7d8d1546-0848-442f-9284-7dc35897a6a4\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r1')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r1')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"\r\n\r\n\r\n--changesetresponse_7d8d1546-0848-442f-9284-7dc35897a6a4\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r2')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r2')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"\r\n\r\n\r\n--changesetresponse_7d8d1546-0848-442f-9284-7dc35897a6a4\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r3')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r3')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"\r\n\r\n\r\n--changesetresponse_7d8d1546-0848-442f-9284-7dc35897a6a4--\r\n--batchresponse_66ac1a09-28b5-474d-821f-d993ec447cac--\r\n", [ 'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'multipart/mixed; boundary=batchresponse_66ac1a09-28b5-474d-821f-d993ec447cac',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '31cc3a98-8002-0127-6e07-575da3000000',
+  'x-ms-client-request-id',
+  '801cfcef-beeb-4ddb-ae0f-08745153b408',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 01 Jun 2021 16:56:15 GMT' ]);
+
+nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .post('/$batch', "--batch_fakeId\r\ncontent-type: multipart/mixed; boundary=changeset_fakeId\r\n\r\n\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r4\",\"value\":\"4\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r5\",\"value\":\"5\"}\r\n--changeset_fakeId\r\ncontent-type: application/http\r\ncontent-transfer-encoding: binary\r\n\r\nPOST https://fakestorageaccount.table.core.windows.net/batchTableTestnode HTTP/1.1\r\ncontent-type: application/json;odata=nometadata\r\naccept: application/json;odata=minimalmetadata\r\ndataserviceversion: 3.0\r\nprefer: return-no-content\r\n\r\n\r\n{\"PartitionKey\":\"multiBatch1\",\"RowKey\":\"r6\",\"value\":\"6\"}\r\n--changeset_fakeId--\r\n--batch_fakeId\r\n")
+  .query(true)
+  .reply(202, "--batchresponse_7049d189-952f-4d8e-b1c7-3de49034e04d\r\nContent-Type: multipart/mixed; boundary=changesetresponse_6e0c0b9a-34a2-4588-a351-15a6d5081de6\r\n\r\n--changesetresponse_6e0c0b9a-34a2-4588-a351-15a6d5081de6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r4')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r4')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"\r\n\r\n\r\n--changesetresponse_6e0c0b9a-34a2-4588-a351-15a6d5081de6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r5')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r5')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"\r\n\r\n\r\n--changesetresponse_6e0c0b9a-34a2-4588-a351-15a6d5081de6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied: return-no-content\r\nDataServiceVersion: 3.0;\r\nLocation: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r6')\r\nDataServiceId: https://fakestorageaccount.table.core.windows.net/batchTableTestnode(PartitionKey='multiBatch1',RowKey='r6')\r\nETag: W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"\r\n\r\n\r\n--changesetresponse_6e0c0b9a-34a2-4588-a351-15a6d5081de6--\r\n--batchresponse_7049d189-952f-4d8e-b1c7-3de49034e04d--\r\n", [ 'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'multipart/mixed; boundary=batchresponse_7049d189-952f-4d8e-b1c7-3de49034e04d',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '31cc3aa1-8002-0127-7607-575da3000000',
+  'x-ms-client-request-id',
+  '12b685e5-8477-448f-a58c-e0f290f3ce63',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 01 Jun 2021 16:56:15 GMT' ]);
+
+nock('https://fakestorageaccount.table.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/batchTableTestnode()')
+  .query(true)
+  .reply(200, {"odata.metadata":"https://fakestorageaccount.table.core.windows.net/$metadata#batchTableTestnode","value":[{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"","PartitionKey":"multiBatch1","RowKey":"r1","Timestamp":"2021-06-01T16:56:15.9634213Z","value":"1"},{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"","PartitionKey":"multiBatch1","RowKey":"r2","Timestamp":"2021-06-01T16:56:15.9634213Z","value":"2"},{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A15.9634213Z'\"","PartitionKey":"multiBatch1","RowKey":"r3","Timestamp":"2021-06-01T16:56:15.9634213Z","value":"3"},{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"","PartitionKey":"multiBatch1","RowKey":"r4","Timestamp":"2021-06-01T16:56:16.0124566Z","value":"4"},{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"","PartitionKey":"multiBatch1","RowKey":"r5","Timestamp":"2021-06-01T16:56:16.0124566Z","value":"5"},{"odata.etag":"W/\"datetime'2021-06-01T16%3A56%3A16.0124566Z'\"","PartitionKey":"multiBatch1","RowKey":"r6","Timestamp":"2021-06-01T16:56:16.0124566Z","value":"6"}]}, [ 'Cache-Control',
+  'no-cache',
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json;odata=minimalmetadata;streaming=true;charset=utf-8',
+  'Server',
+  'Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '31cc3aac-8002-0127-0107-575da3000000',
+  'x-ms-client-request-id',
+  '8b307953-6478-46ba-b437-7f3324803d70',
+  'x-ms-version',
+  '2019-02-02',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Tue, 01 Jun 2021 16:56:15 GMT' ]);

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -23,11 +23,7 @@ import {
   GetAccessPolicyResponse,
   SetAccessPolicyResponse
 } from "./generatedModels";
-import {
-  GeneratedClientOptionalParams,
-  QueryOptions as GeneratedQueryOptions,
-  SignedIdentifier
-} from "./generated/models";
+import { QueryOptions as GeneratedQueryOptions, SignedIdentifier } from "./generated/models";
 import { getClientParamsFromConnectionString } from "./utils/connectionString";
 import {
   TablesSharedKeyCredential,
@@ -40,15 +36,19 @@ import { GeneratedClient, TableDeleteEntityOptionalParams } from "./generated";
 import { deserialize, deserializeObjectsArray, serialize } from "./serialization";
 import { Table } from "./generated/operations";
 import { LIB_INFO, TablesLoggingAllowedHeaderNames } from "./utils/constants";
-import { FullOperationResponse, OperationOptions } from "@azure/core-client";
+import {
+  FullOperationResponse,
+  InternalClientPipelineOptions,
+  OperationOptions
+} from "@azure/core-client";
 import { logger } from "./logger";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { InternalTableTransaction } from "./TableTransaction";
-import { InternalTransactionClientOptions, ListEntitiesResponse } from "./utils/internalModels";
+import { ListEntitiesResponse } from "./utils/internalModels";
 import { Uuid } from "./utils/uuid";
 import { parseXML, stringifyXML } from "@azure/core-xml";
-import { Pipeline, createEmptyPipeline } from "@azure/core-rest-pipeline";
+import { Pipeline } from "@azure/core-rest-pipeline";
 
 /**
  * A TableClient represents a Client to the Azure Tables service allowing you
@@ -151,32 +151,19 @@ export class TableClient {
       clientOptions.userAgentOptions.userAgentPrefix = LIB_INFO;
     }
 
-    let internalPipelineOptions: GeneratedClientOptionalParams = {
-      ...clientOptions
+    const internalPipelineOptions: InternalClientPipelineOptions = {
+      ...clientOptions,
+      loggingOptions: {
+        logger: logger.info,
+        additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
+      },
+      deserializationOptions: {
+        parseXML
+      },
+      serializationOptions: {
+        stringifyXML
+      }
     };
-
-    if (isInternalClientOptions(clientOptions)) {
-      // The client is meant to be an intercept client (for Transaction), so we need to create only the intercepting
-      // pipelines.
-      internalPipelineOptions.pipeline = createEmptyPipeline();
-    } else {
-      // The client is a regular client (non-transaction), pass the pipeline options to create a pipeline
-      internalPipelineOptions = {
-        ...internalPipelineOptions,
-        ...{
-          loggingOptions: {
-            logger: logger.info,
-            additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames]
-          },
-          deserializationOptions: {
-            parseXML
-          },
-          serializationOptions: {
-            stringifyXML
-          }
-        }
-      };
-    }
 
     this.tableName = tableName;
     this.credential = credential;
@@ -690,8 +677,4 @@ interface InternalListTableEntitiesOptions extends ListTableEntitiesOptions {
    * This option applies for all the properties
    */
   disableTypeConversion?: boolean;
-}
-
-function isInternalClientOptions(options: any): options is InternalTransactionClientOptions {
-  return Boolean(options.innerTransactionRequest);
 }

--- a/sdk/tables/data-tables/src/TablePolicies.ts
+++ b/sdk/tables/data-tables/src/TablePolicies.ts
@@ -9,8 +9,12 @@ import {
   createHttpHeaders,
   createPipelineRequest
 } from "@azure/core-rest-pipeline";
-import { HeaderConstants } from "./utils/constants";
-import { InnerTransactionRequest } from "./utils/internalModels";
+import {
+  HeaderConstants,
+  TRANSACTION_HTTP_LINE_ENDING,
+  TRANSACTION_HTTP_VERSION_1_1
+} from "./utils/constants";
+import { getChangeSetBoundary } from "./utils/transactionHelpers";
 
 export const transactionRequestAssemblePolicyName = "transactionRequestAssemblePolicy";
 
@@ -21,12 +25,14 @@ const dummyResponse: PipelineResponse = {
 };
 
 export function transactionRequestAssemblePolicy(
-  transactionRequest: InnerTransactionRequest
+  bodyParts: string[],
+  changesetId: string
 ): PipelinePolicy {
   return {
     name: transactionRequestAssemblePolicyName,
     async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
-      transactionRequest.appendSubRequestToBody(request);
+      const subRequest = getNextSubrequestBodyPart(request, changesetId);
+      bodyParts.push(subRequest);
       // Intercept request from going to wire
       return dummyResponse;
     }
@@ -44,4 +50,38 @@ export function transactionHeaderFilterPolicy(): PipelinePolicy {
       return next(request);
     }
   };
+}
+
+function getSubRequestUrl(url: string): string {
+  const sasTokenParts = ["sv", "ss", "srt", "sp", "se", "st", "spr", "sig"];
+  const urlParsed = new URL(url);
+  sasTokenParts.forEach((part) => urlParsed.searchParams.delete(part));
+  return urlParsed.toString();
+}
+
+function getNextSubrequestBodyPart(request: PipelineRequest, changesetId: string) {
+  const changesetBoundary = getChangeSetBoundary(changesetId);
+  const subRequestPrefix = `--${changesetBoundary}${TRANSACTION_HTTP_LINE_ENDING}${HeaderConstants.CONTENT_TYPE}: application/http${TRANSACTION_HTTP_LINE_ENDING}${HeaderConstants.CONTENT_TRANSFER_ENCODING}: binary`;
+
+  const subRequestUrl = getSubRequestUrl(request.url);
+  // Start to assemble sub request
+  const subRequest = [
+    subRequestPrefix, // sub request constant prefix
+    "", // empty line after sub request's content ID
+    `${request.method.toString()} ${subRequestUrl} ${TRANSACTION_HTTP_VERSION_1_1}` // sub request start line with method,
+  ];
+
+  // Add required headers
+  for (const [name, value] of request.headers) {
+    subRequest.push(`${name}: ${value}`);
+  }
+
+  // Append sub-request body
+  subRequest.push(`${TRANSACTION_HTTP_LINE_ENDING}`); // sub request's headers need end with an empty line
+  if (request.body) {
+    subRequest.push(String(request.body));
+  }
+
+  // Add subrequest to transaction body
+  return subRequest.join(TRANSACTION_HTTP_LINE_ENDING);
 }

--- a/sdk/tables/data-tables/src/utils/constants.ts
+++ b/sdk/tables/data-tables/src/utils/constants.ts
@@ -4,6 +4,9 @@
 export const SDK_VERSION: string = "12.0.0-beta.3";
 export const LIB_INFO = `azsdk-js-data-tables/${SDK_VERSION}`;
 
+export const TRANSACTION_HTTP_VERSION_1_1 = "HTTP/1.1";
+export const TRANSACTION_HTTP_LINE_ENDING = "\r\n";
+
 export const HeaderConstants = {
   AUTHORIZATION: "authorization",
   CONTENT_LENGTH: "content-length",

--- a/sdk/tables/data-tables/src/utils/internalModels.ts
+++ b/sdk/tables/data-tables/src/utils/internalModels.ts
@@ -93,6 +93,10 @@ export interface InternalTransactionClientOptions extends TableServiceClientOpti
  */
 export interface TableClientLike {
   /**
+   * Represents a pipeline for making a HTTP request to a URL.
+   */
+  pipeline: Pipeline;
+  /**
    * Name of the table to perform operations on.
    */
   readonly tableName: string;

--- a/sdk/tables/data-tables/src/utils/transactionHelpers.ts
+++ b/sdk/tables/data-tables/src/utils/transactionHelpers.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HeaderConstants, TRANSACTION_HTTP_LINE_ENDING } from "./constants";
+import { Pipeline } from "@azure/core-rest-pipeline";
+import { serializationPolicy } from "@azure/core-client";
+import { transactionHeaderFilterPolicy, transactionRequestAssemblePolicy } from "../TablePolicies";
+
+/**
+ * Builds a transaction change set boundary to be added to the transaction request body
+ * @param changesetId - Id of the transaction changeset
+ */
+export function getChangeSetBoundary(changesetId: string): string {
+  return `changeset_${changesetId}`;
+}
+
+/**
+ * Builds a transaction boundary to be added to the transaction request body
+ * @param transactionId - Id of the transaction
+ */
+export function getTransactionBoundary(transactionId: string): string {
+  return `batch_${transactionId}`;
+}
+
+/**
+ * Returns an initial representation of the Transaction body.
+ * @param transactionId - Id of the transaction
+ * @param changesetId - Id of the transaction changeset
+ */
+export function getInitialTransactionBody(transactionId: string, changesetId: string): string[] {
+  const transactionBoundary = `batch_${transactionId}`;
+  return [
+    `--${transactionBoundary}${TRANSACTION_HTTP_LINE_ENDING}${HeaderConstants.CONTENT_TYPE}: multipart/mixed; boundary=changeset_${changesetId}${TRANSACTION_HTTP_LINE_ENDING}${TRANSACTION_HTTP_LINE_ENDING}`
+  ];
+}
+
+/**
+ * Build the Transaction http request body to send to the service.
+ * @param bodyParts - Parts of the transaction body, containing information about the actions to be included in the transaction request
+ * @param transactionId - Id of the transaction
+ * @param changesetId - Id of the transaction changeset
+ */
+export function getTransactionHttpRequestBody(
+  bodyParts: string[],
+  transactionId: string,
+  changesetId: string
+): string {
+  const transactionBoundary = getTransactionBoundary(transactionId);
+  const changesetBoundary = getChangeSetBoundary(changesetId);
+  const changesetEnding = `--${changesetBoundary}--`;
+  const transactionEnding = `--${transactionBoundary}`;
+  const bodyContent = bodyParts.join(TRANSACTION_HTTP_LINE_ENDING);
+  return `${bodyContent}${TRANSACTION_HTTP_LINE_ENDING}${changesetEnding}${TRANSACTION_HTTP_LINE_ENDING}${transactionEnding}${TRANSACTION_HTTP_LINE_ENDING}`;
+}
+
+/**
+ * Removes all the policies on a pipeline.
+ * @param pipeline - Client pipeline
+ */
+export function clearTransactionPipeline(pipeline: Pipeline): void {
+  const policies = pipeline.getOrderedPolicies();
+
+  for (const policy of policies) {
+    pipeline.removePolicy({ name: policy.name });
+  }
+}
+
+/**
+ * Adds required pipeline policies for preparing a Transaction request.
+ */
+export function addTransactionPipelinePolicies(
+  pipeline: Pipeline,
+  bodyParts: string[],
+  changesetId: string
+): void {
+  // Use transaction assemble policy to assemble request and intercept request from going to wire
+
+  pipeline.addPolicy(serializationPolicy(), { phase: "Serialize" });
+  pipeline.addPolicy(transactionHeaderFilterPolicy());
+  pipeline.addPolicy(transactionRequestAssemblePolicy(bodyParts, changesetId));
+}

--- a/sdk/tables/data-tables/src/utils/transactionHelpers.ts
+++ b/sdk/tables/data-tables/src/utils/transactionHelpers.ts
@@ -54,25 +54,24 @@ export function getTransactionHttpRequestBody(
 }
 
 /**
- * Removes all the policies on a pipeline.
+ * Prepares the transaction pipeline to intercept operations
  * @param pipeline - Client pipeline
  */
-export function clearTransactionPipeline(pipeline: Pipeline): void {
-  const policies = pipeline.getOrderedPolicies();
-
-  for (const policy of policies) {
-    pipeline.removePolicy({ name: policy.name });
-  }
-}
-
-/**
- * Adds required pipeline policies for preparing a Transaction request.
- */
-export function addTransactionPipelinePolicies(
+export function prepateTransactionPipeline(
   pipeline: Pipeline,
   bodyParts: string[],
   changesetId: string
 ): void {
+  // Fist, we need to clear all the existing policies to make sure we start
+  // with a fresh state.
+  const policies = pipeline.getOrderedPolicies();
+  for (const policy of policies) {
+    pipeline.removePolicy({
+      name: policy.name
+    });
+  }
+
+  // With the clear state we now initialize the pipelines required for intercepting the requests.
   // Use transaction assemble policy to assemble request and intercept request from going to wire
 
   pipeline.addPolicy(serializationPolicy(), { phase: "Serialize" });

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -176,4 +176,40 @@ describe("batch operations", () => {
       assert.isString(error.message);
     }
   });
+
+  it("should send multiple transactions with the same partition key", async () => {
+    const partitionKey = "multiBatch1";
+    const actions1: TransactionAction[] = [
+      ["create", { partitionKey, rowKey: "r1", value: "1" }],
+      ["create", { partitionKey, rowKey: "r2", value: "2" }],
+      ["create", { partitionKey, rowKey: "r3", value: "3" }]
+    ];
+
+    await client.submitTransaction(actions1);
+
+    const actions2: TransactionAction[] = [
+      ["create", { partitionKey, rowKey: "r4", value: "4" }],
+      ["create", { partitionKey, rowKey: "r5", value: "5" }],
+      ["create", { partitionKey, rowKey: "r6", value: "6" }]
+    ];
+
+    await client.submitTransaction(actions2);
+
+    const entities = client.listEntities<{ name: string }>({
+      queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
+    });
+
+    let entityCount = 0;
+    for await (const entity of entities) {
+      if (entity.partitionKey !== partitionKey) {
+        throw new Error(
+          `Expected all entities to have the same partition key: ${partitionKey} but found ${entity.partitionKey}`
+        );
+      }
+
+      entityCount++;
+    }
+
+    assert.equal(entityCount, 6);
+  });
 });

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -178,32 +178,32 @@ describe("batch operations", () => {
   });
 
   it("should send multiple transactions with the same partition key", async () => {
-    const partitionKey = "multiBatch1";
+    const multiBatchPartitionKey = "multiBatch1";
     const actions1: TransactionAction[] = [
-      ["create", { partitionKey, rowKey: "r1", value: "1" }],
-      ["create", { partitionKey, rowKey: "r2", value: "2" }],
-      ["create", { partitionKey, rowKey: "r3", value: "3" }]
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r1", value: "1" }],
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r2", value: "2" }],
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r3", value: "3" }]
     ];
 
     await client.submitTransaction(actions1);
 
     const actions2: TransactionAction[] = [
-      ["create", { partitionKey, rowKey: "r4", value: "4" }],
-      ["create", { partitionKey, rowKey: "r5", value: "5" }],
-      ["create", { partitionKey, rowKey: "r6", value: "6" }]
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r4", value: "4" }],
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r5", value: "5" }],
+      ["create", { partitionKey: multiBatchPartitionKey, rowKey: "r6", value: "6" }]
     ];
 
     await client.submitTransaction(actions2);
 
     const entities = client.listEntities<{ name: string }>({
-      queryOptions: { filter: odata`PartitionKey eq ${partitionKey}` }
+      queryOptions: { filter: odata`PartitionKey eq ${multiBatchPartitionKey}` }
     });
 
     let entityCount = 0;
     for await (const entity of entities) {
-      if (entity.partitionKey !== partitionKey) {
+      if (entity.partitionKey !== multiBatchPartitionKey) {
         throw new Error(
-          `Expected all entities to have the same partition key: ${partitionKey} but found ${entity.partitionKey}`
+          `Expected all entities to have the same partition key: ${multiBatchPartitionKey} but found ${entity.partitionKey}`
         );
       }
 


### PR DESCRIPTION
Fixes #15403

Sending more than one transaction had an unexpected behavior, sending empty transaction bodies after the first request.

This PR refactors the way we build the transaction request so that there is less state to keep track of and make sure we reset the remaining state and pipeline policies before starting to build a new Transaction Request