### PR TITLE
[KeyVault] - Use error object for LRO errors

### DIFF
--- a/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginbackup/recording_returns_the_correct_backup_result_when_fails_to_authenticate.js
+++ b/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginbackup/recording_returns_the_correct_backup_result_when_fails_to_authenticate.js
@@ -1,0 +1,173 @@
+let nock = require('nock');
+
+module.exports.hash = "a0fc93163e063f255b997efc58521fc4";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/backup')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '68789f98-c313-11eb-845c-000d3ae55bfc',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '9ad04278-4a68-4667-84ea-b33348784900',
+  'x-ms-ests-server',
+  '2.1.11722.21 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=ApF0-YapxXhOqaRqxf0iTrA; expires=Thu, 01-Jul-2021 19:56:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrx_UkFWrmlW-bZkmOo4J3PXc2NlyLY70aO-ar9KvN-SzZGfhlNQj3AdRN1frbfygX1y84XNgIzLBH6eNcPJ4C3CQ2Cg_3c3ec_QOYlOWSVMlKVgmICZV9BFcHqVYp14v0hh9PYozWui3nzrlX9dwlC3sJ7FARjccowIqTvBw48NwgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 19:56:08 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Length',
+  '1651',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '916f3131-ce61-4904-88d3-4d91bf187900',
+  'x-ms-ests-server',
+  '2.1.11722.26 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=ApF0-YapxXhOqaRqxf0iTrA; expires=Thu, 01-Jul-2021 19:56:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrg7FF5SIWzvHsa8saDwETvM278UviI-AMS3u12h7qDIIDXZiO36kgJPWtVXik2m6W9ajASVcz7m7ouDu45CsKjAVPgVoTAa1630DQPMbSNecyqc6r8VsDy44XeQyPFQo8wI10cJAZq_nD_x9AWeS4oFM2VyY_4WY_CweDe5TTi1kgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 19:56:08 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=a55fd54b-3764-459d-b287-e3d0631d36a2&client_secret=azure_client_secret")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'e45f4d10-c207-407a-b1e7-c8bf791c8400',
+  'x-ms-ests-server',
+  '2.1.11722.26 - SCUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=ApF0-YapxXhOqaRqxf0iTrDn3_GsAQAAANiHSNgOAAAA; expires=Thu, 01-Jul-2021 19:56:09 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 19:56:08 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/backup', {"storageResourceUri":"https://uri.blob.core.windows.net/uri","token":"invalid_sas_token"})
+  .query(true)
+  .reply(202, {"status":"InProgress","statusDetails":null,"error":null,"startTime":1622577372,"endTime":null,"jobId":"7df407b8dc124424aa96976fec0f6ba7","azureStorageBlobContainerUri":null}, [
+  'server',
+  'Kestrel',
+  'date',
+  'Tue, 01 Jun 2021 19:56:11 GMT',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'azure-asyncoperation',
+  'https://azure_managedhsm.managedhsm.azure.net/backup/7df407b8dc124424aa96976fec0f6ba7/pending',
+  'x-ms-keyvault-region',
+  'eastus2',
+  'retry-after',
+  '10',
+  'x-ms-request-id',
+  '68b94854-c313-11eb-845c-000d3ae55bfc',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
+  'x-ms-server-latency',
+  '2806',
+  'content-length',
+  '174',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'"
+]);

--- a/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginbackup/recording_throws_when_polling_errors.js
+++ b/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginbackup/recording_throws_when_polling_errors.js
@@ -1,0 +1,207 @@
+let nock = require('nock');
+
+module.exports.hash = "40dccd6bcc532afe69e7bcf11e8925e2";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/backup')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '0',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  '9e74958c-c315-11eb-b644-000d3aded99f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '8cb41f22-4aa1-4220-890a-53b42b66c500',
+  'x-ms-ests-server',
+  '2.1.11722.26 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pko; expires=Thu, 01-Jul-2021 20:11:58 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr4K4o7I--5A0inino15Y5BEHcqP0jGmG3dTbACNRQpRvxsDdBRz9QgaPcQ3d3zCEpzNz35Rdrb7mlH0ZrVkRI28JiuQBsncknwlJIlksf-1apTanb7cgH1nqgke3v3sCJJe5WOaNBwvsmebrt5LT8UAm1aHqKnt7sxBVv1-1AvvUgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:11:58 GMT',
+  'Content-Length',
+  '980'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ed26eee1-354e-4546-93c3-d88ffb107f00',
+  'x-ms-ests-server',
+  '2.1.11722.26 - SCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pko; expires=Thu, 01-Jul-2021 20:11:58 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrD_qE7-ehdTNJ09wp5M9Ei94gDR9JhODId3lSI9rBM6oW_DHaQfHQRAqJ4jxivaaTpYOh8PG4-mSq5eL4J8eIWGzELNCg_MuMWBy7FX1z-KyQA-Sc9ZwFqUxXkve7AKtuABZJhC5hy-xtdcD2nJ1KgO7g2EbKfbBAPBc6V71TncEgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:11:58 GMT',
+  'Content-Length',
+  '1651'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=285a1de3-9482-4b88-9bb7-c9ab1428b824&client_secret=azure_client_secret")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '1322',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'f3e3a3d2-f88b-4bb8-a10d-c234ad45a900',
+  'x-ms-ests-server',
+  '2.1.11722.26 - EUS ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pkrn3_GsAQAAAI6LSNgOAAAA; expires=Thu, 01-Jul-2021 20:11:59 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:11:58 GMT'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .post('/backup', {"storageResourceUri":"https://uri.blob.core.windows.net/uri","token":"invalid_sas_token"})
+  .query(true)
+  .reply(202, {"status":"InProgress","statusDetails":null,"error":null,"startTime":1622578321,"endTime":null,"jobId":"6d1d80e7cd084061ad37edbd731b4880","azureStorageBlobContainerUri":null}, [
+  'server',
+  'Kestrel',
+  'date',
+  'Tue, 01 Jun 2021 20:12:01 GMT',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'azure-asyncoperation',
+  'https://azure_managedhsm.managedhsm.azure.net/backup/6d1d80e7cd084061ad37edbd731b4880/pending',
+  'x-ms-keyvault-region',
+  'eastus2',
+  'retry-after',
+  '10',
+  'x-ms-request-id',
+  '9ed046fc-c315-11eb-b644-000d3aded99f',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
+  'x-ms-server-latency',
+  '2625',
+  'content-length',
+  '174',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'"
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/backup/6d1d80e7cd084061ad37edbd731b4880/pending')
+  .query(true)
+  .reply(400, {"error":{"code":"BadRequest","innererror":null,"message":"The customer provided SAS token is malformed. The SAS token does not contain the expiry field"}}, [
+  'server',
+  'Kestrel',
+  'x-ms-build-version',
+  '1.0.20210407-3-27236ed1-develop',
+  'date',
+  'Tue, 01 Jun 2021 20:12:05 GMT',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-keyvault-region',
+  'eastus2',
+  'x-ms-request-id',
+  'a06d0bd0-c315-11eb-b644-000d3aded99f',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '155',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
+  'x-ms-server-latency',
+  '3759',
+  'content-security-policy',
+  "default-src 'self'"
+]);

--- a/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginrestore/recording_throws_when_polling_errors.js
+++ b/sdk/keyvault/keyvault-admin/recordings/node/keyvaultbackupclient_beginrestore/recording_throws_when_polling_errors.js
@@ -1,0 +1,207 @@
+let nock = require('nock');
+
+module.exports.hash = "9435ab74eb768ce5ec87b6b7f320d2d4";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .put('/restore')
+  .query(true)
+  .reply(401, "", [
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-ms-server-latency',
+  '1',
+  'x-content-type-options',
+  'nosniff',
+  'www-authenticate',
+  'Bearer authorization="https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012", resource="https://managedhsm.azure.net"',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '0',
+  'x-ms-request-id',
+  'a2b7f850-c315-11eb-b644-000d3aded99f',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'",
+  'cache-control',
+  'no-cache'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/common/discovery/instance')
+  .query(true)
+  .reply(200, {"tenant_discovery_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Length',
+  '980',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  'ffb963d0-7e04-4d52-a8d1-eef5d4a08004',
+  'x-ms-ests-server',
+  '2.1.11722.21 - NCUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pkrn3_GsAQAAAI6LSNgOAAAA; expires=Thu, 01-Jul-2021 20:12:05 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrjcg--20MKYHZTpTUTJplpJ91f9E4ti2IzsNBuikSKRFxjkHC8lePKiTyC5ZMAAzJaAparxMki5-QvgqkAFGEoiWgdKzrOj4e_EzTKFHcnyP06zLoOJby6TnzQbfXcRjEkoO3dVSb3CMFp1kS8NuC1XuI6_gyDdgGBnBPeC9_fcEgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:12:05 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .get('/12345678-1234-1234-1234-123456789012/v2.0/.well-known/openid-configuration')
+  .reply(200, {"token_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}, [
+  'Cache-Control',
+  'max-age=86400, private',
+  'Content-Length',
+  '1651',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Methods',
+  'GET, OPTIONS',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '794d6802-7852-4389-bdad-8e3bbd3cad00',
+  'x-ms-ests-server',
+  '2.1.11722.26 - EUS ProdSlices',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pkrn3_GsAQAAAI6LSNgOAAAA; expires=Thu, 01-Jul-2021 20:12:05 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr5tFB9sP49utMpQUaQxtzymxm7wEX7VJHuWt0XE2ONQ1aDPtg6kVM6VwIJZWHsqcRtEuOUbd1_fg6SaPpWbA-dlwuiy2MFDH1GLsk0wgqyYYhBqHCMInjpGbhs-BJIFermapdFplZX0zy6onliiuK5bsYZ0FjDEEyn_4WWJAErqAgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:12:05 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=0e623e90-9342-46f3-a61f-88536a65585d&client_secret=azure_client_secret")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-store, no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'x-ms-request-id',
+  '0f3a8296-c88a-48bf-af92-8a14e54e9300',
+  'x-ms-ests-server',
+  '2.1.11722.26 - WUS2 ProdSlices',
+  'x-ms-clitelem',
+  '1,0,0,,',
+  'Set-Cookie',
+  'fpc=AoRx8shS4OZDtNBWPQq9pkrn3_GsAgAAAI6LSNgOAAAA; expires=Thu, 01-Jul-2021 20:12:06 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
+  'Date',
+  'Tue, 01 Jun 2021 20:12:05 GMT',
+  'Content-Length',
+  '1322'
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .put('/restore', {"sasTokenParameters":{"storageResourceUri":"https://uri.blob.core.windows.net","token":"bad_token"},"folderToRestore":"uri"})
+  .query(true)
+  .reply(202, {"endTime":null,"error":null,"jobId":"dfc8e8272b084556bfe33ef615017d34","startTime":1622578328,"status":"InProgress","statusDetails":null}, [
+  'server',
+  'Kestrel',
+  'date',
+  'Tue, 01 Jun 2021 20:12:08 GMT',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'azure-asyncoperation',
+  'https://azure_managedhsm.managedhsm.azure.net/restore/dfc8e8272b084556bfe33ef615017d34/pending',
+  'x-ms-keyvault-region',
+  'eastus2',
+  'retry-after',
+  '10',
+  'x-ms-request-id',
+  'a2fe3cc0-c315-11eb-b644-000d3aded99f',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
+  'x-ms-server-latency',
+  '2694',
+  'content-length',
+  '138',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'content-security-policy',
+  "default-src 'self'"
+]);
+
+nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
+  .get('/restore/dfc8e8272b084556bfe33ef615017d34/pending')
+  .query(true)
+  .reply(400, {"error":{"code":"BadRequest","innererror":null,"message":"The customer provided SAS token is malformed. The SAS token does not contain the expiry field"}}, [
+  'server',
+  'Kestrel',
+  'x-ms-build-version',
+  '1.0.20210407-3-27236ed1-develop',
+  'date',
+  'Tue, 01 Jun 2021 20:12:11 GMT',
+  'cache-control',
+  'no-cache',
+  'x-content-type-options',
+  'nosniff',
+  'x-ms-keyvault-region',
+  'eastus2',
+  'x-ms-request-id',
+  'a4a5933e-c315-11eb-b644-000d3aded99f',
+  'content-type',
+  'application/json; charset=utf-8',
+  'x-frame-options',
+  'SAMEORIGIN',
+  'content-length',
+  '155',
+  'strict-transport-security',
+  'max-age=31536000; includeSubDomains',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
+  'x-ms-server-latency',
+  '2518',
+  'content-security-policy',
+  "default-src 'self'"
+]);

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -136,12 +136,11 @@ export class KeyVaultBackupPollOperation extends KeyVaultAdminPollOperation<
     state.startTime = startTime;
     state.status = status;
     state.statusDetails = statusDetails;
+    state.isCompleted = !!endTime;
 
-    if (status?.toLowerCase() === "failed") {
+    if (state.isCompleted && error?.code) {
       throw new Error(error?.message || statusDetails);
     }
-
-    state.isCompleted = !!endTime;
 
     if (state.isCompleted) {
       state.result = {

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -143,7 +143,7 @@ export class KeyVaultRestorePollOperation extends KeyVaultAdminPollOperation<
 
     state.isCompleted = !!endTime;
 
-    if (status?.toLowerCase() === "failed") {
+    if (state.isCompleted && error?.code) {
       throw new Error(error?.message || statusDetails);
     }
 

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/operation.ts
@@ -139,12 +139,11 @@ export class KeyVaultSelectiveKeyRestorePollOperation extends KeyVaultAdminPollO
     state.startTime = startTime;
     state.status = status;
     state.statusDetails = statusDetails;
+    state.isCompleted = !!endTime;
 
-    if (status?.toLowerCase() === "failed") {
+    if (state.isCompleted && error?.code) {
       throw new Error(error?.message || statusDetails);
     }
-
-    state.isCompleted = !!endTime;
 
     if (state.isCompleted) {
       state.result = {

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -62,15 +62,13 @@ describe("KeyVaultBackupClient", () => {
       assert.match(backupResult.folderUri!, new RegExp(blobStorageUri));
     });
 
-    // There is a service issue that prevents errors from showing up in the
-    // error field. Pending until it's resolved. ADO 8750375
-    it.skip("returns the correct backup result when fails to authenticate", async function() {
+    it("throws when polling errors", async function() {
       const backupPoller = await client.beginBackup(
         blobStorageUri,
         "invalid_sas_token",
         testPollerProperties
       );
-      assert.isRejected(backupPoller.pollUntilDone());
+      await assert.isRejected(backupPoller.pollUntilDone(), /SAS token is malformed/);
     });
   });
 
@@ -167,15 +165,13 @@ describe("KeyVaultBackupClient", () => {
       await keyClient.getKey(keyName);
     });
 
-    // There is a service issue that prevents errors from showing up in the
-    // error field. Pending until it's resolved. ADO 8750375
-    it.skip("contains an error when fails to authenticate", async function() {
+    it("throws when polling errors", async function() {
       const restorePoller = await client.beginRestore(
         blobStorageUri,
         "bad_token",
         testPollerProperties
       );
-      await assert.isRejected(restorePoller.pollUntilDone());
+      await assert.isRejected(restorePoller.pollUntilDone(), /SAS token is malformed/);
     });
   });
 });


### PR DESCRIPTION
## What

- Use `error.code` to check if there's an error (not just the presence of error)
- Unpend the Admin LRO tests

## Why

- Consistency with other languages
- We used to require using StatusDetails or status because the AAD errors were not populated in the error object, now that this is fixed we can use the error object.
- Even on a successful response `error` will still get sent over the wire, so we need to check the presence of `code` as well. This service-side issue will be fixed, but for now all languages will guard against this.

Fixes #15448