### PR TITLE
Update tsconfig to target es2017

### DIFF
--- a/common/tools/dev-tool/tsconfig.json
+++ b/common/tools/dev-tool/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,

--- a/common/tools/eslint-plugin-azure-sdk/tsconfig.json
+++ b/common/tools/eslint-plugin-azure-sdk/tsconfig.json
@@ -13,7 +13,7 @@
     "pretty": true,
     "removeComments": true,
     "strict": true,
-    "target": "es2016",
+    "target": "es2017",
     "types": ["node"],
     "sourceMap": true,
     "resolveJsonModule": true

--- a/sdk/appconfiguration/app-configuration/sample-react/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/sample-react/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +15,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/sdk/core/core-amqp/tsconfig.json
+++ b/sdk/core/core-amqp/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
-    "target": "es6",
     "outDir": "./dist-esm",
     "declarationDir": "./types",
     "resolveJsonModule": true

--- a/sdk/digitaltwins/digital-twins-core/tsconfig.json
+++ b/sdk/digitaltwins/digital-twins-core/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
     "strict": true,
-    "target": "es5",
     "sourceMap": true,
     "lib": ["es6", "dom"],
     "declaration": true,

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
-    "target": "es6",
     "lib": ["DOM"],
     "declarationDir": "./types",
     "outDir": "./dist-esm",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2017",
     "module": "commonjs",
     "lib": [],
     "declaration": true,


### PR DESCRIPTION
This will greatly simplify TS codegen by avoiding the need to polyfill async/await. Async functions are supported all the way down to Node 8, so this isn't a compat concern except for IE11.

This PR leaves in place existing downlevel targets for storage, cosmos, and core. If this change is merged, I will track getting those packages updated in an issue.