### PR TITLE
[monitor-query] Prepping monitor-query for first beta release.

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2021-06-08)
 
 - Initial release of the monitor-query library, allowing you to query Log Analytics Workspaces
   for logs and metrics.

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -9,7 +9,19 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/generated/generatedClientContext.ts",
+        "path": "src/generated/logquery/src/azureLogAnalyticsContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/generated/metrics/src/monitorManagementClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/generated/metricsdefinitions/src/metricsDefinitionsClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/generated/metricsnamespaces/src/metricsNamespacesClientContext.ts",
         "prefix": "packageVersion"
       },
       {

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { AzureLogAnalyticsOptionalParams } from "./models";
 
 const packageName = "monitor-log-query";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.0-beta.1";
 
 /** @hidden */
 export class AzureLogAnalyticsContext extends coreHttp.ServiceClient {

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "monitor-metrics";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.0-beta.1";
 
 /** @hidden */
 export class MonitorManagementClientContext extends coreHttp.ServiceClient {

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/metricsDefinitionsClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/metricsDefinitionsClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "monitor-metrics-definitions";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.0-beta.1";
 
 /** @hidden */
 export class MetricsDefinitionsClientContext extends coreHttp.ServiceClient {

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/metricsNamespacesClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/metricsNamespacesClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "monitor-metrics-namespaces";
-const packageVersion = "1.0.0";
+const packageVersion = "1.0.0-beta.1";
 
 /** @hidden */
 export class MetricsNamespacesClientContext extends coreHttp.ServiceClient {


### PR DESCRIPTION
Normal release updates - changelog date and adjusting package.json metadata so the generated file's user agent version are also updated.