### PR TITLE
[KeyVault] - Make role definition permission fields required on output

### DIFF
--- a/sdk/keyvault/keyvault-admin/recordings/node/keyvaultaccesscontrolclient_role_definitions/recording_can_create_update_and_delete_a_role_definition_happy_path.js
+++ b/sdk/keyvault/keyvault-admin/recordings/node/keyvaultaccesscontrolclient_role_definitions/recording_can_create_update_and_delete_a_role_definition_happy_path.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.hash = "1c491ac4038e6f302d3f0c8847514f15";
+module.exports.hash = "c303472bc813961b576a55e576d83554";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
@@ -21,7 +21,7 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'content-length',
   '0',
   'x-ms-request-id',
-  'af435282-a866-11eb-b4be-000d3aab33d0',
+  'ffce21b4-c54e-11eb-a977-000d3ae55bfc',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -49,19 +49,19 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'dc0e24fc-fb7e-42df-bcbc-12dc02952602',
+  '80648425-51d4-4844-a3ae-9ac4d78e5700',
   'x-ms-ests-server',
-  '2.1.11654.16 - EUS ProdSlices',
+  '2.1.11787.14 - SCUS ProdSlices',
   'Set-Cookie',
-  'fpc=Ajp62JUxeNNDt0Ku6Phhnl6nSoKIBQAAAB_HG9gOAAAA; expires=Fri, 28-May-2021 21:14:14 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ApTfAtXYzPFCrJoh6qfkHhk; expires=Sun, 04-Jul-2021 16:07:45 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr3qNGM6bWzeHQaUD3QPN2PopDjFjTF4UAvpMkqANqjQgcEndPmu9sZ3rggKBAu_EQ0LGrVtE_4j8m5CrV-o_1tFWynhZfu02sYidOrUgdK7Da0pmSF3DYeGxCv3zCFVOyb7RqEt7Kw9ShACBEZFed8lcwnVUovB-pklbBeHY5f-4gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevr_YPSl4vYY5-OVwlIInsfKva1B1NDxQ58rcUsm6-reNwC_IKYnjTXo33Go4UJhT_HO4Mop_4uIDkQ7OsVD5VEHcZ5oKJpeoIM9hsW1MguWOCSzkLFyoodvs89vBavr1ncf9BktkvaXuO8vYBKx9sgc62UD5cbD043uzo7iM86aL8gAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 21:14:13 GMT',
+  'Fri, 04 Jun 2021 16:07:45 GMT',
   'Content-Length',
   '980'
 ]);
@@ -84,28 +84,25 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '43a56a9e-d342-4db6-b75a-60f688dfb001',
+  '0b5b2258-a981-4b9f-8277-114c6c065500',
   'x-ms-ests-server',
-  '2.1.11654.16 - WUS2 ProdSlices',
+  '2.1.11787.14 - SCUS ProdSlices',
   'Set-Cookie',
-  'fpc=Ajp62JUxeNNDt0Ku6Phhnl6nSoKIBQAAAB_HG9gOAAAA; expires=Fri, 28-May-2021 21:14:15 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ApTfAtXYzPFCrJoh6qfkHhk; expires=Sun, 04-Jul-2021 16:07:45 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
-  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7WevrRVjG8D4QOkFkDXroalNFrFLr7Xy59X4ZYVci5uWYwvT9vvpQCrDD3FPNVmeNapNdniGpMw7VQckFHl-uqe4unbTTo0qJ6RddOzqdQPyhNIDezPh0VitkVuBRyriJ7a4CAA_CwGGncxnRy6q4_Rj5yyf77D82jeNX_YzywYyKn5wgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
+  'esctx=AQABAAAAAAD--DLA3VO7QrddgJg7Wevrco_QzyJpB4-QzzmNTKTiinBiFqDyF3HDOq6g9WERBKwoMUvf2CC94-m4-HMZp9GGbkgboTUO6t7LNj3WYeE9SRk9AEd6x9tQmyJtLxlEZwNEwVmbKRwDNLdE5TcCtSxr_WAiOKYFtT7EmvkEePR7mDJ2ZFY9ZTFRefqJKNQQhFAgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 21:14:14 GMT',
+  'Fri, 04 Jun 2021 16:07:45 GMT',
   'Content-Length',
   '1651'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .filteringRequestBody(function (body) {
-            return body.replace(/client-request-id=[^&]*/g, "client-request-id=client-request-id");
-        })
-  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fmanagedhsm.azure.net%2F.default%20openid%20profile%20offline_access&grant_type=client_credentials&client-request-id=client-request-id&client_secret=azure_client_secret")
+  .post('/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token', "client_id=azure_client_id&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=6716b11c-6f01-4cc5-956e-90812dc8474b&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -122,43 +119,43 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '8e30eed8-6132-4ee7-b258-30e22aeeec00',
+  'cfa4964c-ca49-4dbf-a7a0-dad94d494f00',
   'x-ms-ests-server',
-  '2.1.11654.16 - WUS2 ProdSlices',
+  '2.1.11787.14 - WUS2 ProdSlices',
   'x-ms-clitelem',
   '1,0,0,,',
   'Set-Cookie',
-  'fpc=Ajp62JUxeNNDt0Ku6Phhnl6nSoKIBgAAAB_HG9gOAAAA; expires=Fri, 28-May-2021 21:14:15 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=ApTfAtXYzPFCrJoh6qfkHhm1p1ZhAQAAANFGTNgOAAAA; expires=Sun, 04-Jul-2021 16:07:45 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Wed, 28 Apr 2021 21:14:14 GMT',
+  'Fri, 04 Jun 2021 16:07:45 GMT',
   'Content-Length',
   '1322'
 ]);
 
 nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .put('///providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27', {"properties":{"roleName":"custom role definition name","description":"custom role description","type":"CustomRole","permissions":[{"actions":[],"notActions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action"],"notDataActions":[]}],"assignableScopes":["/"]}})
+  .put('///providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27', {"properties":{"roleName":"custom role definition name","description":"custom role description","type":"CustomRole","permissions":[{"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"]}],"assignableScopes":["/"]}})
   .query(true)
-  .reply(201, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action"],"notActions":[],"notDataActions":[]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
+  .reply(201, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"],"notActions":[],"notDataActions":[]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '547',
+  '485',
   'x-ms-request-id',
-  'afcec592-a866-11eb-b4be-000d3aab33d0',
+  '00012c76-c54f-11eb-a977-000d3ae55bfc',
   'x-ms-keyvault-region',
-  'westeurope',
+  'eastus2',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
   "default-src 'self'",
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=72.68.182.20;act_addr_fam=Ipv4;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
   'x-ms-server-latency',
   '47',
   'cache-control',
@@ -168,27 +165,27 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
 ]);
 
 nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
-  .put('///providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27', {"properties":{"roleName":"custom role definition name","description":"custom role description","type":"CustomRole","permissions":[{"actions":[],"notActions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action"],"notDataActions":[]},{"actions":[],"notActions":[],"dataActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"assignableScopes":["/"]}})
+  .put('///providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27', {"properties":{"roleName":"custom role definition name","description":"custom role description","type":"CustomRole","permissions":[{"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"assignableScopes":["/"]}})
   .query(true)
-  .reply(201, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action"],"notActions":[],"notDataActions":[]},{"actions":[],"dataActions":[],"notActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
+  .reply(201, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"],"notActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '666',
+  '536',
   'x-ms-request-id',
-  'afe51b58-a866-11eb-b4be-000d3aab33d0',
+  '00146a84-c54f-11eb-a977-000d3ae55bfc',
   'x-ms-keyvault-region',
-  'westeurope',
+  'eastus2',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
   "default-src 'self'",
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=72.68.182.20;act_addr_fam=Ipv4;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
   'x-ms-server-latency',
-  '44',
+  '43',
   'cache-control',
   'no-cache',
   'x-frame-options',
@@ -198,23 +195,23 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
 nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
   .delete('///providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27')
   .query(true)
-  .reply(200, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action"],"notActions":[],"notDataActions":[]},{"actions":[],"dataActions":[],"notActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
+  .reply(200, {"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b36b00af-89c6-435f-a43d-9a3087015c27","name":"b36b00af-89c6-435f-a43d-9a3087015c27","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"],"notActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}, [
   'content-type',
   'application/json; charset=utf-8',
   'x-content-type-options',
   'nosniff',
   'content-length',
-  '666',
+  '536',
   'x-ms-request-id',
-  'affa2fca-a866-11eb-b4be-000d3aab33d0',
+  '0026df8e-c54f-11eb-a977-000d3ae55bfc',
   'x-ms-keyvault-region',
-  'westeurope',
+  'eastus2',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
   "default-src 'self'",
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=72.68.182.20;act_addr_fam=Ipv4;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
   'x-ms-server-latency',
   '44',
   'cache-control',
@@ -226,17 +223,17 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
 nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":true})
   .get('///providers/Microsoft.Authorization/roleDefinitions')
   .query(true)
-  .reply(200, {"value":[{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8","name":"7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action","Microsoft.KeyVault/managedHsm/keys/backup/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Backup","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/33413926-3206-4cdd-b39a-83574fe37a17","name":"33413926-3206-4cdd-b39a-83574fe37a17","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/wrap/action","Microsoft.KeyVault/managedHsm/keys/unwrap/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Service Encryption","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625c","name":"21dbd100-6940-42c2-9190-5d6cb909625c","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/keys/release/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Service Release","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/2c18b078-7c48-4d3a-af88-5a3a1b3f82b3","name":"2c18b078-7c48-4d3a-af88-5a3a1b3f82b3","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Auditor","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/4bd23610-cdcf-4971-bdee-bdc562cc28e4","name":"4bd23610-cdcf-4971-bdee-bdc562cc28e4","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleAssignments/delete/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Policy Administrator","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b","name":"21dbd100-6940-42c2-9190-5d6cb909625b","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/write/action","Microsoft.KeyVault/managedHsm/keys/delete","Microsoft.KeyVault/managedHsm/keys/create","Microsoft.KeyVault/managedHsm/keys/import/action","Microsoft.KeyVault/managedHsm/keys/release/action","Microsoft.KeyVault/managedHsm/keys/backup/action","Microsoft.KeyVault/managedHsm/keys/restore/action","Microsoft.KeyVault/managedHsm/keys/encrypt/action","Microsoft.KeyVault/managedHsm/keys/decrypt/action","Microsoft.KeyVault/managedHsm/keys/wrap/action","Microsoft.KeyVault/managedHsm/keys/unwrap/action","Microsoft.KeyVault/managedHsm/keys/sign/action","Microsoft.KeyVault/managedHsm/keys/verify/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto User","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778","name":"515eb02d-2335-4d2d-92f2-b1cbdf9c3778","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete","Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action","Microsoft.KeyVault/managedHsm/keys/export/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Officer","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/a290e904-7015-4bba-90c8-60543313cdb4","name":"a290e904-7015-4bba-90c8-60543313cdb4","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/securitydomain/download/action","Microsoft.KeyVault/managedHsm/securitydomain/download/read","Microsoft.KeyVault/managedHsm/securitydomain/upload/action","Microsoft.KeyVault/managedHsm/securitydomain/upload/read","Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read","Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/restore/start/action","Microsoft.KeyVault/managedHsm/backup/status/action","Microsoft.KeyVault/managedHsm/restore/status/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Administrator","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"}]}, [
+  .reply(200, {"value":[{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8","name":"7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/backup/status/action","Microsoft.KeyVault/managedHsm/keys/backup/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Backup User","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/33413926-3206-4cdd-b39a-83574fe37a17","name":"33413926-3206-4cdd-b39a-83574fe37a17","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/wrap/action","Microsoft.KeyVault/managedHsm/keys/unwrap/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Service Encryption User","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625c","name":"21dbd100-6940-42c2-9190-5d6cb909625c","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/keys/release/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Service Release User","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/2c18b078-7c48-4d3a-af88-5a3a1b3f82b3","name":"2c18b078-7c48-4d3a-af88-5a3a1b3f82b3","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Auditor","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/4bd23610-cdcf-4971-bdee-bdc562cc28e4","name":"4bd23610-cdcf-4971-bdee-bdc562cc28e4","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleAssignments/delete/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Policy Administrator","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b","name":"21dbd100-6940-42c2-9190-5d6cb909625b","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/keys/read/action","Microsoft.KeyVault/managedHsm/keys/write/action","Microsoft.KeyVault/managedHsm/keys/delete","Microsoft.KeyVault/managedHsm/keys/create","Microsoft.KeyVault/managedHsm/keys/import/action","Microsoft.KeyVault/managedHsm/keys/release/action","Microsoft.KeyVault/managedHsm/keys/backup/action","Microsoft.KeyVault/managedHsm/keys/restore/action","Microsoft.KeyVault/managedHsm/keys/encrypt/action","Microsoft.KeyVault/managedHsm/keys/decrypt/action","Microsoft.KeyVault/managedHsm/keys/wrap/action","Microsoft.KeyVault/managedHsm/keys/unwrap/action","Microsoft.KeyVault/managedHsm/keys/sign/action","Microsoft.KeyVault/managedHsm/keys/verify/action","Microsoft.KeyVault/managedHsm/rng/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto User","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778","name":"515eb02d-2335-4d2d-92f2-b1cbdf9c3778","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action","Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete","Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action","Microsoft.KeyVault/managedHsm/keys/export/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Crypto Officer","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/a290e904-7015-4bba-90c8-60543313cdb4","name":"a290e904-7015-4bba-90c8-60543313cdb4","properties":{"assignableScopes":["/"],"description":"","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/roleAssignments/delete/action","Microsoft.KeyVault/managedHsm/roleAssignments/read/action","Microsoft.KeyVault/managedHsm/roleAssignments/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/read/action","Microsoft.KeyVault/managedHsm/roleDefinitions/write/action","Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action","Microsoft.KeyVault/managedHsm/securitydomain/download/action","Microsoft.KeyVault/managedHsm/securitydomain/download/read","Microsoft.KeyVault/managedHsm/securitydomain/upload/action","Microsoft.KeyVault/managedHsm/securitydomain/upload/read","Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read","Microsoft.KeyVault/managedHsm/backup/start/action","Microsoft.KeyVault/managedHsm/restore/start/action","Microsoft.KeyVault/managedHsm/backup/status/action","Microsoft.KeyVault/managedHsm/restore/status/action"],"notActions":[],"notDataActions":[]}],"roleName":"Managed HSM Administrator","type":"AKVBuiltInRole"},"type":"Microsoft.Authorization/roleDefinitions"},{"id":"Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/3e5ae8ce-0845-4eab-a869-9da65cd0dc58","name":"3e5ae8ce-0845-4eab-a869-9da65cd0dc58","properties":{"assignableScopes":["/"],"description":"custom role description","permissions":[{"actions":[],"dataActions":["Microsoft.KeyVault/managedHsm/backup/start/action"],"notActions":[],"notDataActions":["Microsoft.KeyVault/managedHsm/keys/encrypt/action"]}],"roleName":"custom role definition name","type":"CustomRole"},"type":"Microsoft.Authorization/roleDefinitions"}]}, [
   'x-frame-options',
   'SAMEORIGIN',
   'x-ms-request-id',
-  'b00efa5e-a866-11eb-b4be-000d3aab33d0',
+  '003952ea-c54f-11eb-a977-000d3ae55bfc',
   'content-type',
   'application/json; charset=utf-8',
   'x-ms-keyvault-region',
-  'westeurope',
+  'eastus2',
   'content-length',
-  '6590',
+  '7185',
   'strict-transport-security',
   'max-age=31536000; includeSubDomains',
   'content-security-policy',
@@ -246,9 +243,9 @@ nock('https://azure_managedhsm.managedhsm.azure.net:443', {"encodedQueryParams":
   'x-content-type-options',
   'nosniff',
   'x-ms-build-version',
-  '1.0.20210407-3-27236ed1-develop',
+  '1.0.20210520-1-d6634624-develop',
   'x-ms-keyvault-network-info',
-  'conn_type=Ipv4;addr=72.68.182.20;act_addr_fam=Ipv4;',
+  'conn_type=Ipv4;addr=50.35.231.105;act_addr_fam=Ipv4;',
   'x-ms-server-latency',
-  '0'
+  '1'
 ]);

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -105,10 +105,10 @@ export type KeyVaultDataAction = string;
 
 // @public
 export interface KeyVaultPermission {
-    actions?: string[];
-    dataActions?: KeyVaultDataAction[];
-    notActions?: string[];
-    notDataActions?: KeyVaultDataAction[];
+    actions: string[];
+    dataActions: KeyVaultDataAction[];
+    notActions: string[];
+    notDataActions: KeyVaultDataAction[];
 }
 
 // @public
@@ -228,7 +228,7 @@ export const SDK_VERSION: string;
 export interface SetRoleDefinitionOptions extends coreHttp.OperationOptions {
     assignableScopes?: KeyVaultRoleScope[];
     description?: string;
-    permissions?: KeyVaultPermission[];
+    permissions?: Partial<KeyVaultPermission>[];
     roleDefinitionName?: string;
     roleName?: string;
 }

--- a/sdk/keyvault/keyvault-admin/samples-dev/accessControlHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples-dev/accessControlHelloWorld.ts
@@ -7,7 +7,6 @@
 
 import {
   KeyVaultAccessControlClient,
-  KeyVaultPermission,
   KnownKeyVaultDataAction,
   KnownKeyVaultRoleScope
 } from "@azure/keyvault-admin";
@@ -36,15 +35,17 @@ export async function main(): Promise<void> {
 
   const globalScope = KnownKeyVaultRoleScope.Global;
   const roleDefinitionName = uuid.v4();
-  const permissions: KeyVaultPermission[] = [
-    {
-      dataActions: [KnownKeyVaultDataAction.StartHsmBackup, KnownKeyVaultDataAction.StartHsmRestore]
-    }
-  ];
   let roleDefinition = await client.setRoleDefinition(globalScope, {
     roleDefinitionName,
     roleName: "Backup Manager",
-    permissions,
+    permissions: [
+      {
+        dataActions: [
+          KnownKeyVaultDataAction.StartHsmBackup,
+          KnownKeyVaultDataAction.StartHsmRestore
+        ]
+      }
+    ],
     description: "Allow backup actions"
   });
   console.log(roleDefinition);

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/accessControlHelloWorld.js
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/accessControlHelloWorld.js
@@ -35,15 +35,17 @@ async function main() {
 
   const globalScope = KnownKeyVaultRoleScope.Global;
   const roleDefinitionName = uuid.v4();
-  const permissions = [
-    {
-      dataActions: [KnownKeyVaultDataAction.StartHsmBackup, KnownKeyVaultDataAction.StartHsmRestore]
-    }
-  ];
   let roleDefinition = await client.setRoleDefinition(globalScope, {
     roleDefinitionName,
     roleName: "Backup Manager",
-    permissions,
+    permissions: [
+      {
+        dataActions: [
+          KnownKeyVaultDataAction.StartHsmBackup,
+          KnownKeyVaultDataAction.StartHsmRestore
+        ]
+      }
+    ],
     description: "Allow backup actions"
   });
   console.log(roleDefinition);

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/accessControlHelloWorld.ts
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/src/accessControlHelloWorld.ts
@@ -7,7 +7,6 @@
 
 import {
   KeyVaultAccessControlClient,
-  KeyVaultPermission,
   KnownKeyVaultDataAction,
   KnownKeyVaultRoleScope
 } from "@azure/keyvault-admin";
@@ -36,15 +35,17 @@ export async function main(): Promise<void> {
 
   const globalScope = KnownKeyVaultRoleScope.Global;
   const roleDefinitionName = uuid.v4();
-  const permissions: KeyVaultPermission[] = [
-    {
-      dataActions: [KnownKeyVaultDataAction.StartHsmBackup, KnownKeyVaultDataAction.StartHsmRestore]
-    }
-  ];
   let roleDefinition = await client.setRoleDefinition(globalScope, {
     roleDefinitionName,
     roleName: "Backup Manager",
-    permissions,
+    permissions: [
+      {
+        dataActions: [
+          KnownKeyVaultDataAction.StartHsmBackup,
+          KnownKeyVaultDataAction.StartHsmRestore
+        ]
+      }
+    ],
     description: "Allow backup actions"
   });
   console.log(roleDefinition);

--- a/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/accessControlModels.ts
@@ -51,19 +51,19 @@ export interface KeyVaultPermission {
   /**
    * Allowed actions.
    */
-  actions?: string[];
+  actions: string[];
   /**
    * Actions that are excluded but not denied. They may be granted by other role definitions assigned to a principal.
    */
-  notActions?: string[];
+  notActions: string[];
   /**
    * Allowed Data actions.
    */
-  dataActions?: KeyVaultDataAction[];
+  dataActions: KeyVaultDataAction[];
   /**
    * Data actions that are excluded but not denied. They may be granted by other role definitions assigned to a principal.
    */
-  notDataActions?: KeyVaultDataAction[];
+  notDataActions: KeyVaultDataAction[];
 }
 
 /**
@@ -174,7 +174,7 @@ export interface SetRoleDefinitionOptions extends coreHttp.OperationOptions {
   /**
    * List of Key Vault permissions
    */
-  permissions?: KeyVaultPermission[];
+  permissions?: Partial<KeyVaultPermission>[];
   /**
    * List of assignable Key Vault role scopes
    */

--- a/sdk/keyvault/keyvault-admin/src/mappings.ts
+++ b/sdk/keyvault/keyvault-admin/src/mappings.ts
@@ -44,7 +44,14 @@ export const mappings = {
         roleName: roleName!,
         description: description!,
         roleType: roleType!,
-        permissions: permissions!,
+        permissions: permissions!.map((p) => {
+          return {
+            actions: p.actions || [],
+            notActions: p.notActions || [],
+            dataActions: p.dataActions || [],
+            notDataActions: p.notDataActions || []
+          };
+        })!,
         assignableScopes: assignableScopes!
       };
     }


### PR DESCRIPTION
## What

- Make `KeyVaultPermission` fields required when deserializing server responses
- Allow `KeyVaultPermission` fields to be optional when building a request

## Why

This came up in a recent architecture review. Suggestion was to make these required. Because these are both input and output
types we want to allow omitting various permissions on the way in, but ensure they are populated on the way out.

## Callouts

I wasn't sure if this required separate types for the input and output so figured I can start here and open a discussion in the PR.