### PR TITLE
[Add Identity Script] node.js -> Node.js

### DIFF
--- a/common/tools/add-identity-mgmt-lib.js
+++ b/common/tools/add-identity-mgmt-lib.js
@@ -55,7 +55,7 @@ function updateREADME(mainModule, relativePath, namespace) {
 
     return `## Azure ${clientName} SDK for JavaScript
 
-This package contains an isomorphic SDK (runs both in node.js and in browsers) for ${clientName}.
+This package contains an isomorphic SDK (runs both in Node.js and in browsers) for ${clientName}.
 
 ### Currently supported environments
 


### PR DESCRIPTION
Fix the capitalization of the word `Node.js` in the script that adds identity language to management-plane readmes.