### PR TITLE
[Text Analytics] Makes LROs state properties required

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -19,9 +19,9 @@ export interface AnalysisPollOperationState<TResult> extends PollOperationState<
 
 // @public
 export interface AnalyzeActionsOperationMetadata extends OperationMetadata {
-    actionsFailedCount?: number;
-    actionsInProgressCount?: number;
-    actionsSucceededCount?: number;
+    actionsFailedCount: number;
+    actionsInProgressCount: number;
+    actionsSucceededCount: number;
     displayName?: string;
 }
 
@@ -328,11 +328,11 @@ export interface Match {
 
 // @public
 export interface OperationMetadata {
-    createdOn?: Date;
+    createdOn: Date;
     expiresOn?: Date;
-    lastModifiedOn?: Date;
-    operationId?: string;
-    status?: TextAnalyticsOperationStatus;
+    lastModifiedOn: Date;
+    operationId: string;
+    status: TextAnalyticsOperationStatus;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -45,15 +45,15 @@ export interface AnalyzeActionsOperationMetadata extends OperationMetadata {
   /**
    * Number of successfully completed actions.
    */
-  actionsSucceededCount?: number;
+  actionsSucceededCount: number;
   /**
    * Number of failed actions.
    */
-  actionsFailedCount?: number;
+  actionsFailedCount: number;
   /**
    * Number of actions still in progress.
    */
-  actionsInProgressCount?: number;
+  actionsInProgressCount: number;
   /**
    * The operation's display name.
    */
@@ -71,7 +71,7 @@ interface AnalyzeActionsOperationStatus {
    * in the client call.
    */
   statistics?: TextDocumentBatchStatistics;
-  operationMetdata?: AnalyzeActionsOperationMetadata;
+  operationMetdata: Omit<AnalyzeActionsOperationMetadata, "operationId">;
 }
 
 /**
@@ -113,7 +113,7 @@ export interface AnalyzeActionsOperationState
 /**
  * @internal
  */
-function getMetaInfoFromResponse(response: AnalyzeJobState): AnalyzeActionsOperationMetadata {
+function getMetaInfoFromResponse(response: AnalyzeJobState): Omit<AnalyzeActionsOperationMetadata, "operationId"> {
   return {
     createdOn: response.createdDateTime,
     lastModifiedOn: response.lastUpdateDateTime,
@@ -320,13 +320,13 @@ export class BeginAnalyzeActionsPollerOperation extends AnalysisPollOperation<
       tracingOptions: this.options.tracingOptions
     });
 
-    state.createdOn = operationStatus.operationMetdata?.createdOn;
-    state.expiresOn = operationStatus.operationMetdata?.expiresOn;
-    state.lastModifiedOn = operationStatus.operationMetdata?.lastModifiedOn;
-    state.status = operationStatus.operationMetdata?.status;
-    state.actionsSucceededCount = operationStatus.operationMetdata?.actionsSucceededCount;
-    state.actionsFailedCount = operationStatus.operationMetdata?.actionsFailedCount;
-    state.actionsInProgressCount = operationStatus.operationMetdata?.actionsInProgressCount;
+    state.createdOn = operationStatus.operationMetdata.createdOn;
+    state.expiresOn = operationStatus.operationMetdata.expiresOn;
+    state.lastModifiedOn = operationStatus.operationMetdata.lastModifiedOn;
+    state.status = operationStatus.operationMetdata.status;
+    state.actionsSucceededCount = operationStatus.operationMetdata.actionsSucceededCount;
+    state.actionsFailedCount = operationStatus.operationMetdata.actionsFailedCount;
+    state.actionsInProgressCount = operationStatus.operationMetdata.actionsInProgressCount;
     state.displayName = operationStatus.operationMetdata?.displayName;
 
     if (!state.isCompleted && operationStatus.done) {

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/operation.ts
@@ -113,7 +113,9 @@ export interface AnalyzeActionsOperationState
 /**
  * @internal
  */
-function getMetaInfoFromResponse(response: AnalyzeJobState): Omit<AnalyzeActionsOperationMetadata, "operationId"> {
+function getMetaInfoFromResponse(
+  response: AnalyzeJobState
+): Omit<AnalyzeActionsOperationMetadata, "operationId"> {
   return {
     createdOn: response.createdDateTime,
     lastModifiedOn: response.lastUpdateDateTime,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/analyze/poller.ts
@@ -54,7 +54,7 @@ export class BeginAnalyzeActionsPoller extends AnalysisPoller<
       state = JSON.parse(resumeFrom).state;
     }
     const operation = new BeginAnalyzeActionsPollerOperation(
-      state || {},
+      (state || {}) as any,
       client,
       documents,
       actions,

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/operation.ts
@@ -65,7 +65,7 @@ interface HealthcareJobStatus {
    * batch of input documents.
    */
   modelVersion?: string;
-  operationMetdata?: AnalyzeHealthcareEntitiesOperationMetadata;
+  operationMetdata: Omit<AnalyzeHealthcareEntitiesOperationMetadata, "operationId">;
 }
 
 /**
@@ -122,7 +122,7 @@ export interface AnalyzeHealthcareOperationState
  */
 function getMetaInfoFromResponse(
   response: HealthcareJobState
-): AnalyzeHealthcareEntitiesOperationMetadata {
+): Omit<AnalyzeHealthcareEntitiesOperationMetadata, "operationId"> {
   return {
     createdOn: response.createdDateTime,
     lastModifiedOn: response.lastUpdateDateTime,
@@ -348,10 +348,10 @@ export class BeginAnalyzeHealthcarePollerOperation extends AnalysisPollOperation
       serializerOptions: this.options.serializerOptions
     });
 
-    state.createdOn = operationStatus.operationMetdata?.createdOn;
-    state.expiresOn = operationStatus.operationMetdata?.expiresOn;
-    state.lastModifiedOn = operationStatus.operationMetdata?.lastModifiedOn;
-    state.status = operationStatus.operationMetdata?.status;
+    state.createdOn = operationStatus.operationMetdata.createdOn;
+    state.expiresOn = operationStatus.operationMetdata.expiresOn;
+    state.lastModifiedOn = operationStatus.operationMetdata.lastModifiedOn;
+    state.status = operationStatus.operationMetdata.status;
 
     if (!state.isCompleted && operationStatus.done) {
       const pagedIterator = this.listHealthcareEntitiesByPage(state.operationId!, {

--- a/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/health/poller.ts
@@ -45,7 +45,7 @@ export class BeginAnalyzeHealthcarePoller extends AnalysisPoller<
       state = JSON.parse(resumeFrom).state;
     }
     const operation = new BeginAnalyzeHealthcarePollerOperation(
-      state || {},
+      (state || {}) as any,
       client,
       documents,
       options

--- a/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/lro/poller.ts
@@ -24,7 +24,7 @@ export interface OperationMetadata {
   /**
    * The date and time the operation was created.
    */
-  createdOn?: Date;
+  createdOn: Date;
   /**
    * The date and time when the operation results will expire on the server.
    */
@@ -32,15 +32,15 @@ export interface OperationMetadata {
   /**
    * The operation id.
    */
-  operationId?: string;
+  operationId: string;
   /**
    * The time the operation status was last updated.
    */
-  lastModifiedOn?: Date;
+  lastModifiedOn: Date;
   /**
    * The current status of the operation.
    */
-  status?: State;
+  status: State;
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -5,8 +5,6 @@
 ## Configuration
 
 ```yaml
-use: /home/dealmaha/corev2-v6
-use-core-v2: true
 package-name: "@azure/ai-text-analytics"
 title: GeneratedClient
 description: TextAnalytics Client


### PR DESCRIPTION
Makes some of the LRO state properties required to exactly follow the swagger.

The only one that is not at the moment is the `expiresOn` one according to the swagger. @suhas92 do you know why it is not required?