### PR TITLE
[KeyVault] - Avoid `const enum` for extensible enums

### DIFF
--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -162,7 +162,7 @@ export interface KeyVaultSelectiveKeyRestoreResult {
 }
 
 // @public
-export const enum KnownKeyVaultDataAction {
+export enum KnownKeyVaultDataAction {
     BackupHsmKeys = "Microsoft.KeyVault/managedHsm/keys/backup/action",
     CreateHsmKey = "Microsoft.KeyVault/managedHsm/keys/create",
     DecryptHsmKey = "Microsoft.KeyVault/managedHsm/keys/decrypt/action",
@@ -195,7 +195,7 @@ export const enum KnownKeyVaultDataAction {
 }
 
 // @public
-export const enum KnownKeyVaultRoleScope {
+export enum KnownKeyVaultRoleScope {
     Global = "/",
     Keys = "/keys"
 }

--- a/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
@@ -298,7 +298,9 @@ export const enum KnownRoleType {
 export type RoleType = string;
 
 /** Known values of {@link DataAction} that the service accepts. */
-export const enum KnownDataAction {
+// Note: `const` keyword removed manually while we discuss the generated code
+// in https://github.com/Azure/autorest.typescript/issues/1013
+export enum KnownDataAction {
   /** Read HSM key metadata. */
   ReadHsmKey = "Microsoft.KeyVault/managedHsm/keys/read/action",
   /** Update an HSM key. */
@@ -397,7 +399,9 @@ export const enum KnownDataAction {
 export type DataAction = string;
 
 /** Known values of {@link RoleScope} that the service accepts. */
-export const enum KnownRoleScope {
+// Note: `const` keyword removed manually while we discuss the generated code
+// in https://github.com/Azure/autorest.typescript/issues/1013
+export enum KnownRoleScope {
   /** Global scope */
   Global = "/",
   /** Keys scope */


### PR DESCRIPTION
## What

- Use a plain enum instead of a const enum

## Why

- const enums should not be used as they are removed at compilation. While this works well for TypeScript users it leaves JavaScript users with a type that can be understood by IntelliSense but not actually exist at runtime. 
- Since our guidelines prefer regular enums instead I changed this in the generated code and filed an issue in https://github.com/Azure/autorest.typescript/issues/1013 to discuss longer term changes.