### PR TITLE
Use engines not engine in package.json files

### DIFF
--- a/eng/tools/dependency-testing/templates/package.json
+++ b/eng/tools/dependency-testing/templates/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "Azure client library tests for TypeScript",
-  "engine": {
+  "engines": {
     "node": ">=8.0.0"
   },
   "scripts": {

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -45,9 +45,6 @@
       ]
     }
   },
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "files": [
     "dist/",
     "dist-esm/src/",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -41,9 +41,6 @@
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },
   "types": "./types/logger.d.ts",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "files": [
     "dist/",
     "dist-esm/src/",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -74,9 +74,6 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity/README.md",
   "sideEffects": false,
   "dependencies": {

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -26,9 +26,6 @@
   "main": "./dist/index.js",
   "module": "dist-esm/keyvault-admin/src/index.js",
   "types": "./types/keyvault-admin.d.ts",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -22,9 +22,6 @@
   "main": "./dist/index.js",
   "module": "dist-esm/keyvault-secrets/src/index.js",
   "types": "./types/keyvault-secrets.d.ts",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -21,9 +21,6 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -25,9 +25,6 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -21,9 +21,6 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -20,9 +20,6 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -20,9 +20,6 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/sdk/test-utils/perfstress/package.json
+++ b/sdk/test-utils/perfstress/package.json
@@ -56,9 +56,6 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/test-utils/perfstress/README.md",
   "sideEffects": false,
   "private": true,

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -52,9 +52,6 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "engine": {
-    "node": ">=8.0.0"
-  },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/test-utils/test-utils/README.md",
   "sideEffects": false,
   "private": true,


### PR DESCRIPTION
The right field to use is `engines` not `engine`. See https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines

All of the files updated in this PR except 1 listed both engines and engine