### PR TITLE
Use engines not engine in generated package.json file for samples

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -76,7 +76,7 @@ function createPackageJson(info: SampleGenerationInfo, outputKind: OutputKind): 
     private: true,
     version: "1.0.0",
     description: `${info.productName} client library samples for ${fullOutputKind}`,
-    engine: {
+    engines: {
       node: `>=${MIN_SUPPORTED_NODE_VERSION}`
     },
     ...(outputKind === OutputKind.TypeScript


### PR DESCRIPTION
Fixes #15575

The `dev-tool samples publish` command generates the JS and TS projects based on samples in the samples-dev folder as described in https://github.com/Azure/azure-sdk-for-js/wiki/Samples-v2-Migration-Guide. In the generated package.json files we use the `engine` field instead of `engines` which is what this PR fixes.

See https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines