### PR TITLE
Run rush update --full

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -613,22 +613,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-INOR23hOISEe2OgwlNhM/BA5+uJmLfx5jqE21wLkQBHNzusdn7P65LT3Zu/AX84ofJO0Z0q+QjY6XOhpFLW90w==
-  /@azure/storage-blob/12.5.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-http': 1.2.5
-      '@azure/core-lro': 1.0.5
-      '@azure/core-paging': 1.1.3
-      '@azure/core-tracing': 1.0.0-preview.10
-      '@azure/logger': 1.0.2
-      '@opentelemetry/api': 0.10.2
-      events: 3.3.0
-      tslib: 2.2.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-DgoefgODst2IPkkQsNdhtYdyJgSsAZC1pEujO6aD5y7uFy5GnzhYliobSrp204jYRyK5XeJ9iiePmy/SPtTbLA==
   /@babel/code-frame/7.12.11:
     dependencies:
       '@babel/highlight': 7.14.0
@@ -827,12 +811,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==
-  /@eslint/eslintrc/0.4.1:
+  /@eslint/eslintrc/0.4.2:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.1
       espree: 7.3.1
-      globals: 12.4.0
+      globals: 13.9.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
@@ -842,7 +826,7 @@ packages:
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
-      integrity: sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==
+      integrity: sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
   /@istanbuljs/schema/0.1.3:
     dev: false
     engines:
@@ -1320,19 +1304,19 @@ packages:
       integrity: sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
   /@types/eslint/7.2.13:
     dependencies:
-      '@types/estree': 0.0.47
+      '@types/estree': 0.0.48
       '@types/json-schema': 7.0.7
     dev: false
     resolution:
-      integrity: sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==
+      integrity: sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==
   /@types/estree/0.0.39:
     dev: false
     resolution:
       integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-  /@types/estree/0.0.47:
+  /@types/estree/0.0.48:
     dev: false
     resolution:
-      integrity: sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+      integrity: sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==
   /@types/express-serve-static-core/4.17.21:
     dependencies:
       '@types/node': 8.10.66
@@ -1390,10 +1374,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rNAPdomlIUX0i0cg2+I+Q1wOUr531zHBQ+cV/28PJ39bSPKjahatZZ2LMuhiguETkCgLVzfruw/ZvNMNkKoSzw==
-  /@types/jsrsasign/8.0.12:
-    dev: false
-    resolution:
-      integrity: sha512-FLXKbwbB+4fsJECYOpIiYX2GSqSHYnkO/UnrFqlZn6crpyyOtk4LRab+G1HC7dTbT1NB7spkHecZRQGXoCWiJQ==
   /@types/jws/3.2.3:
     dependencies:
       '@types/node': 8.10.66
@@ -1559,13 +1539,13 @@ packages:
     optional: true
     resolution:
       integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
-  /@typescript-eslint/eslint-plugin/4.19.0_2e65eb0819c7f7c9d1c3c68a57a6d466:
+  /@typescript-eslint/eslint-plugin/4.19.0_579c993deb6b0313d5d0f5c428bab62d:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.27.0+typescript@4.2.4
-      '@typescript-eslint/parser': 4.19.0_eslint@7.27.0+typescript@4.2.4
+      '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.28.0+typescript@4.2.4
+      '@typescript-eslint/parser': 4.19.0_eslint@7.28.0+typescript@4.2.4
       '@typescript-eslint/scope-manager': 4.19.0
       debug: 4.3.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       functional-red-black-tree: 1.0.1
       lodash: 4.17.21
       regexpp: 3.1.0
@@ -1584,13 +1564,13 @@ packages:
         optional: true
     resolution:
       integrity: sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==
-  /@typescript-eslint/experimental-utils/4.19.0_eslint@7.27.0+typescript@4.2.4:
+  /@typescript-eslint/experimental-utils/4.19.0_eslint@7.28.0+typescript@4.2.4:
     dependencies:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/scope-manager': 4.19.0
       '@typescript-eslint/types': 4.19.0
       '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.4
-      eslint: 7.27.0
+      eslint: 7.28.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
@@ -1601,13 +1581,13 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==
-  /@typescript-eslint/parser/4.19.0_eslint@7.27.0+typescript@4.2.4:
+  /@typescript-eslint/parser/4.19.0_eslint@7.28.0+typescript@4.2.4:
     dependencies:
       '@typescript-eslint/scope-manager': 4.19.0
       '@typescript-eslint/types': 4.19.0
       '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.4
       debug: 4.3.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       typescript: 4.2.4
     dev: false
     engines:
@@ -1751,7 +1731,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  /ajv/8.5.0:
+  /ajv/8.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1759,7 +1739,7 @@ packages:
       uri-js: 4.4.1
     dev: false
     resolution:
-      integrity: sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==
+      integrity: sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
   /ansi-colors/3.2.3:
     dev: false
     engines:
@@ -2182,11 +2162,11 @@ packages:
       integrity: sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=
   /browserslist/4.16.6:
     dependencies:
-      caniuse-lite: 1.0.30001234
+      caniuse-lite: 1.0.30001235
       colorette: 1.2.2
-      electron-to-chromium: 1.3.748
+      electron-to-chromium: 1.3.749
       escalade: 3.1.1
-      node-releases: 1.1.72
+      node-releases: 1.1.73
     dev: false
     engines:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
@@ -2266,10 +2246,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30001234:
+  /caniuse-lite/1.0.30001235:
     dev: false
     resolution:
-      integrity: sha512-a3gjUVKkmwLdNysa1xkUAwN2VfJUJyVW47rsi3aCbkRCtbHAfo+rOsCqVw29G6coQ8gzAPb5XBXwiGHwme3isA==
+      integrity: sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -2554,11 +2534,11 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-  /core-js/3.13.1:
+  /core-js/3.14.0:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==
+      integrity: sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==
   /core-util-is/1.0.2:
     dev: false
     resolution:
@@ -2924,10 +2904,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.748:
+  /electron-to-chromium/1.3.749:
     dev: false
     resolution:
-      integrity: sha512-fmIKfYALVeEybk/L2ucdgt7jN3JsbGtg3K9pmF/MRWgkeADBI1VSAa5IzdG2gZwTxsnsrFtdMpOTSM5mrBRKVQ==
+      integrity: sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==
   /emoji-regex/7.0.3:
     dev: false
     resolution:
@@ -3071,9 +3051,9 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  /eslint-config-prettier/7.2.0_eslint@7.27.0:
+  /eslint-config-prettier/7.2.0_eslint@7.28.0:
     dependencies:
-      eslint: 7.27.0
+      eslint: 7.28.0
     dev: false
     hasBin: true
     peerDependencies:
@@ -3096,9 +3076,9 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==
-  /eslint-plugin-es/3.0.1_eslint@7.27.0:
+  /eslint-plugin-es/3.0.1_eslint@7.28.0:
     dependencies:
-      eslint: 7.27.0
+      eslint: 7.28.0
       eslint-utils: 2.1.0
       regexpp: 3.1.0
     dev: false
@@ -3108,13 +3088,13 @@ packages:
       eslint: '>=4.19.1'
     resolution:
       integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
-  /eslint-plugin-import/2.23.4_eslint@7.27.0:
+  /eslint-plugin-import/2.23.4_eslint@7.28.0:
     dependencies:
       array-includes: 3.1.3
       array.prototype.flat: 1.2.4
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       eslint-import-resolver-node: 0.3.4
       eslint-module-utils: 2.6.1
       find-up: 2.1.0
@@ -3139,10 +3119,10 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
-  /eslint-plugin-node/11.1.0_eslint@7.27.0:
+  /eslint-plugin-node/11.1.0_eslint@7.28.0:
     dependencies:
-      eslint: 7.27.0
-      eslint-plugin-es: 3.0.1_eslint@7.27.0
+      eslint: 7.28.0
+      eslint-plugin-es: 3.0.1_eslint@7.28.0
       eslint-utils: 2.1.0
       ignore: 5.1.8
       minimatch: 3.0.4
@@ -3197,10 +3177,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-  /eslint/7.27.0:
+  /eslint/7.28.0:
     dependencies:
       '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.1
+      '@eslint/eslintrc': 0.4.2
       ajv: 6.12.6
       chalk: 4.1.1
       cross-spawn: 7.0.3
@@ -3243,7 +3223,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     resolution:
-      integrity: sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==
+      integrity: sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==
   /esm/3.2.25:
     dev: false
     engines:
@@ -3468,7 +3448,7 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/runtime': 7.14.0
-      core-js: 3.13.1
+      core-js: 3.14.0
       debug: 4.3.1
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
@@ -3884,14 +3864,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-  /globals/12.4.0:
-    dependencies:
-      type-fest: 0.8.1
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   /globals/13.9.0:
     dependencies:
       type-fest: 0.20.2
@@ -3938,7 +3910,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     resolution:
       integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   /har-schema/2.0.0:
@@ -4387,7 +4359,7 @@ packages:
       integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
   /is-reference/1.2.1:
     dependencies:
-      '@types/estree': 0.0.47
+      '@types/estree': 0.0.48
     dev: false
     resolution:
       integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -5529,10 +5501,10 @@ packages:
       node: 4.x || >=6.0.0
     resolution:
       integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-  /node-releases/1.1.72:
+  /node-releases/1.1.73:
     dev: false
     resolution:
-      integrity: sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
+      integrity: sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -6593,7 +6565,7 @@ packages:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/1.32.1:
     dependencies:
-      '@types/estree': 0.0.47
+      '@types/estree': 0.0.48
       '@types/node': 8.10.66
       acorn: 7.4.1
     dev: false
@@ -7232,7 +7204,7 @@ packages:
       integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   /table/6.7.1:
     dependencies:
-      ajv: 8.5.0
+      ajv: 8.6.0
       lodash.clonedeep: 4.5.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
@@ -7450,12 +7422,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-  /type-fest/0.8.1:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
   /type-is/1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -7527,13 +7493,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
-  /uglify-js/3.13.8:
+  /uglify-js/3.13.9:
     dev: false
     engines:
       node: '>=0.8.0'
     hasBin: true
     resolution:
-      integrity: sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==
+      integrity: sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==
   /unbox-primitive/1.0.1:
     dependencies:
       function-bind: 1.1.1
@@ -7985,7 +7951,7 @@ packages:
       cross-env: 7.0.3
       delay: 4.4.1
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8026,7 +7992,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8075,7 +8041,7 @@ packages:
       cross-env: 7.0.3
       csv-parse: 4.15.4
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -8119,7 +8085,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8163,7 +8129,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8207,7 +8173,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8254,7 +8220,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8307,7 +8273,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -8335,7 +8301,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
@@ -8344,12 +8310,12 @@ packages:
     version: 0.0.0
   file:projects/attestation.tgz:
     dependencies:
+      '@azure/core-rest-pipeline': 1.0.4
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/identity': 1.3.0
       '@microsoft/api-extractor': 7.7.11
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
-      '@types/jsrsasign': 8.0.12
       '@types/mocha': 7.0.2
       '@types/node': 8.10.66
       buffer: 5.7.1
@@ -8358,11 +8324,11 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       inherits: 2.0.4
       jsrsasign: 10.3.0
-      karma: 6.3.2
+      karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
       karma-edge-launcher: 0.4.2_karma@6.3.3
@@ -8416,7 +8382,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -8472,7 +8438,7 @@ packages:
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       jwt-decode: 2.2.0
@@ -8525,7 +8491,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -8580,7 +8546,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -8634,7 +8600,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -8688,7 +8654,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -8734,7 +8700,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -8779,7 +8745,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -8837,7 +8803,7 @@ packages:
       debug: 4.3.1
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       jssha: 3.2.0
       karma: 6.3.3_debug@4.3.1
@@ -8873,7 +8839,7 @@ packages:
   file:projects/core-asynciterator-polyfill.tgz:
     dependencies:
       '@types/node': 8.10.66
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       typedoc: 0.15.2
       typescript: 4.2.4
@@ -8896,7 +8862,7 @@ packages:
       assert: 1.5.0
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -8934,7 +8900,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -8975,7 +8941,7 @@ packages:
       '@types/node': 8.10.66
       chai: 4.3.4
       cross-env: 7.0.3
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9020,7 +8986,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -9074,7 +9040,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       express: 4.17.1
       fetch-mock: 9.11.0_node-fetch@2.6.1
       form-data: 3.0.1
@@ -9108,7 +9074,7 @@ packages:
       tunnel: 0.0.6
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
       uuid: 8.3.2
       xhr-mock: 2.5.1
       xml2js: 0.4.23
@@ -9132,7 +9098,7 @@ packages:
       assert: 1.5.0
       chai: 4.3.4
       cross-env: 7.0.3
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9160,7 +9126,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
@@ -9170,7 +9136,7 @@ packages:
   file:projects/core-paging.tgz:
     dependencies:
       '@types/node': 8.10.66
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       typedoc: 0.15.2
@@ -9198,7 +9164,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       form-data: 3.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.0
@@ -9250,7 +9216,7 @@ packages:
       '@types/sinon': 9.0.11
       assert: 1.5.0
       cross-env: 7.0.3
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -9286,7 +9252,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9334,7 +9300,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9388,7 +9354,7 @@ packages:
       debug: 4.3.1
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       execa: 3.4.0
       fast-json-stable-stringify: 2.1.0
@@ -9440,7 +9406,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9473,7 +9439,7 @@ packages:
     dev: false
     name: '@rush-temp/data-tables'
     resolution:
-      integrity: sha512-ZXPV9NiS8N/zpxKgkPZeZG/vVAbdr/JhtucYUkONi0tTz8x0Q3vgmbRK6Jsmoam0BK4XEboGUzDJS1w8kn3gIQ==
+      integrity: sha512-KL62Sl5k6LlY0mOLf7ptXw/UbRG7ahQoHaTTLp3+dQOg17xaXCbOQIYNvfTpNcmojSWmYWlNAwuxscmDyI1P+A==
       tarball: file:projects/data-tables.tgz
     version: 0.0.0
   file:projects/dev-tool.tgz:
@@ -9494,7 +9460,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       chalk: 4.1.1
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       fs-extra: 8.1.0
       minimist: 1.2.5
       mocha: 7.2.0
@@ -9532,7 +9498,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -9573,19 +9539,19 @@ packages:
     dependencies:
       '@types/chai': 4.2.18
       '@types/eslint': 7.2.13
-      '@types/estree': 0.0.47
+      '@types/estree': 0.0.48
       '@types/glob': 7.1.3
       '@types/json-schema': 7.0.7
       '@types/mocha': 7.0.2
       '@types/node': 10.17.60
-      '@typescript-eslint/eslint-plugin': 4.19.0_2e65eb0819c7f7c9d1c3c68a57a6d466
-      '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.27.0+typescript@4.2.4
-      '@typescript-eslint/parser': 4.19.0_eslint@7.27.0+typescript@4.2.4
+      '@typescript-eslint/eslint-plugin': 4.19.0_579c993deb6b0313d5d0f5c428bab62d
+      '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.28.0+typescript@4.2.4
+      '@typescript-eslint/parser': 4.19.0_eslint@7.28.0+typescript@4.2.4
       '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.4
       chai: 4.3.4
-      eslint: 7.27.0
-      eslint-config-prettier: 7.2.0_eslint@7.27.0
-      eslint-plugin-import: 2.23.4_eslint@7.27.0
+      eslint: 7.28.0
+      eslint-config-prettier: 7.2.0_eslint@7.28.0
+      eslint-plugin-import: 2.23.4_eslint@7.28.0
       eslint-plugin-no-only-tests: 2.6.0
       eslint-plugin-promise: 4.3.1
       eslint-plugin-tsdoc: 0.2.14
@@ -9636,7 +9602,7 @@ packages:
       debug: 4.3.1
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       https-proxy-agent: 5.0.0
       is-buffer: 2.0.5
@@ -9705,7 +9671,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       https-proxy-agent: 5.0.0
       mocha: 7.2.0
@@ -9749,7 +9715,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -9788,7 +9754,6 @@ packages:
     version: 0.0.0
   file:projects/eventhubs-checkpointstore-blob.tgz:
     dependencies:
-      '@azure/storage-blob': 12.5.0
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
@@ -9809,7 +9774,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.1
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       guid-typescript: 1.0.9
@@ -9843,7 +9808,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-+IkU2ATSSMXaGRwCmLYsC6zjHzXJdbyPHp2Hj9r90C/odBUHvsffC0Pr0Z6VKqb9V1DZfFDoLlQTUdjwkS2NHg==
+      integrity: sha512-HVGnI1U0A0SyBMpjRlQDZINX71Kaae+cfNmQRcgmRhnDtt0J4K5sUbUJRuSEUje7LX/cZrKB7JyYzH+U9bXmLQ==
       tarball: file:projects/eventhubs-checkpointstore-blob.tgz
     version: 0.0.0
   file:projects/identity.tgz:
@@ -9863,7 +9828,7 @@ packages:
       assert: 1.5.0
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       jws: 4.0.0
@@ -9877,7 +9842,6 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
-      mock-fs: 4.14.0
       open: 7.4.2
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -9894,7 +9858,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-WBDiw99pS183MgGmJf7Ety38qx9pB8H8lJ+bcOhgLCD0EQsG+yPKjUIuQjicVG8XIpEWCcb6NjftPkfjLCkVkw==
+      integrity: sha512-hO5FxDWanVtC8MNG7Zei9b4RKxEQwXzJCyrrDZ6cXVKCHKVGy2Odte0Lup8Boj3mztVzw57LqEfX3TkMzNVUzg==
       tarball: file:projects/identity.tgz
     version: 0.0.0
   file:projects/iot-device-update.tgz:
@@ -9906,7 +9870,7 @@ packages:
       '@types/uuid': 8.3.0
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       mkdirp: 1.0.4
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -9917,7 +9881,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/iot-device-update'
@@ -9941,7 +9905,7 @@ packages:
       '@types/sinon': 9.0.11
       chai: 4.3.4
       cross-env: 7.0.3
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -9998,7 +9962,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
@@ -10041,7 +10005,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -10083,7 +10047,7 @@ packages:
   file:projects/keyvault-common.tgz:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.11
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       tslib: 2.2.0
@@ -10115,7 +10079,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -10173,7 +10137,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -10228,7 +10192,7 @@ packages:
       cross-env: 7.0.3
       delay: 4.4.1
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -10272,7 +10236,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       inherits: 2.0.4
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -10307,7 +10271,7 @@ packages:
     dependencies:
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rhea: 1.0.24
       rimraf: 3.0.2
@@ -10329,8 +10293,8 @@ packages:
       '@opentelemetry/tracing': 0.18.2
       '@types/mocha': 7.0.2
       '@types/node': 10.17.60
-      eslint: 7.27.0
-      eslint-plugin-node: 11.1.0_eslint@7.27.0
+      eslint: 7.28.0
+      eslint-plugin-node: 11.1.0_eslint@7.28.0
       execa: 3.4.0
       mocha: 7.2.0
       nock: 12.0.3
@@ -10366,7 +10330,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.3
@@ -10404,7 +10368,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10421,7 +10385,7 @@ packages:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10438,7 +10402,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10454,7 +10418,7 @@ packages:
     dependencies:
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10470,7 +10434,7 @@ packages:
     dependencies:
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10487,7 +10451,7 @@ packages:
       '@azure/identity': 2.0.0-beta.3
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10504,7 +10468,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10522,7 +10486,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10540,7 +10504,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10558,7 +10522,7 @@ packages:
       '@azure/identity': 1.3.0
       '@types/node': 8.10.66
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10577,7 +10541,7 @@ packages:
       '@types/node-fetch': 2.5.10
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       node-fetch: 2.6.1
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -10596,7 +10560,7 @@ packages:
       '@types/node': 8.10.66
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10614,7 +10578,7 @@ packages:
       '@types/node': 8.10.66
       '@types/uuid': 8.3.0
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       prettier: 1.19.1
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.2.4
@@ -10638,7 +10602,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -10681,7 +10645,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -10730,7 +10694,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -10788,7 +10752,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -10841,7 +10805,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -10891,7 +10855,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -10960,7 +10924,7 @@ packages:
       delay: 4.4.1
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       glob: 7.1.7
@@ -11022,7 +10986,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -11082,7 +11046,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -11141,7 +11105,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       execa: 3.4.0
@@ -11198,7 +11162,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -11251,7 +11215,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.3
@@ -11305,7 +11269,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.3
@@ -11349,7 +11313,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.11
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11357,7 +11321,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/synapse-access-control'
     resolution:
@@ -11379,7 +11343,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -11408,7 +11372,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/synapse-artifacts'
     resolution:
@@ -11420,7 +11384,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.11
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11428,7 +11392,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/synapse-managed-private-endpoints'
     resolution:
@@ -11440,7 +11404,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.11
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11448,7 +11412,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/synapse-monitoring'
     resolution:
@@ -11460,7 +11424,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.11
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      eslint: 7.27.0
+      eslint: 7.28.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-node-resolve: 3.4.0
@@ -11468,7 +11432,7 @@ packages:
       tslib: 2.2.0
       typedoc: 0.15.2
       typescript: 4.2.4
-      uglify-js: 3.13.8
+      uglify-js: 3.13.9
     dev: false
     name: '@rush-temp/synapse-spark'
     resolution:
@@ -11489,7 +11453,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.4.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.3.3
@@ -11526,7 +11490,7 @@ packages:
       '@types/minimist': 1.2.1
       '@types/node': 8.10.66
       '@types/node-fetch': 2.5.10
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -11560,7 +11524,7 @@ packages:
       '@types/node': 8.10.66
       chai: 4.3.4
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       fs-extra: 8.1.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
@@ -11609,7 +11573,7 @@ packages:
       '@types/sinon': 9.0.11
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
-      eslint: 7.27.0
+      eslint: 7.28.0
       karma: 6.3.3
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.3
@@ -11641,7 +11605,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.3.3
@@ -11694,7 +11658,7 @@ packages:
       cloudevents: 4.0.2
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       jsonwebtoken: 8.5.1
       karma: 6.3.3
@@ -11752,7 +11716,7 @@ packages:
       chai: 4.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 7.27.0
+      eslint: 7.28.0
       esm: 3.2.25
       jsonwebtoken: 8.5.1
       karma: 6.3.3

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
@@ -116,7 +116,7 @@ export const getLocalExports = (context: Rule.RuleContext): TSSymbol[] | undefin
 };
 
 export const getPublicMethods = (node: ClassDeclaration): MethodDefinition[] =>
-  node.body.body.filter((method: MethodDefinition): boolean => {
+  node.body.body.filter((method): method is MethodDefinition => {
     const TSMethod = method as TSESTree.MethodDefinition;
     return method.type === "MethodDefinition" && TSMethod.accessibility !== "private";
   });


### PR DESCRIPTION
This updates our deps and fixes a type error in `eslint-plugin-azure-sdk` that was causing it to fail to build with some newer types.