### PR TITLE
[Communication][Test] Update client secret replacement to common one

### DIFF
--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_gets_a_token_in_a_single_request.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_gets_a_token_in_a_single_request.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_token.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_token.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_deletes_a_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_deletes_a_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_multiple_scopes.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_multiple_scopes.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_single_scope.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_single_scope.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_revokes_tokens_issued_for_a_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad/recording_successfully_revokes_tokens_issued_for_a_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_delete_an_invalid_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_delete_an_invalid_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_for_an_invalid_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_for_an_invalid_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_without_any_scopes.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_without_any_scopes.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_revoke_a_token_from_an_invalid_user.json
+++ b/sdk/communication/communication-identity/recordings/browsers/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_revoke_a_token_from_an_invalid_user.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_gets_a_token_in_a_single_request.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_gets_a_token_in_a_single_request.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_token.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_creates_a_user_and_token.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_deletes_a_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_deletes_a_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_multiple_scopes.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_multiple_scopes.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_single_scope.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_gets_a_token_for_a_user_single_scope.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_revokes_tokens_issued_for_a_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad/recording_successfully_revokes_tokens_issued_for_a_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_delete_an_invalid_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_delete_an_invalid_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_for_an_invalid_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_for_an_invalid_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_without_any_scopes.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_issue_a_token_without_any_scopes.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_revoke_a_token_from_an_invalid_user.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclient_playbacklive_aad_error_cases_/recording_throws_an_error_when_attempting_to_revoke_a_token_from_an_invalid_user.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclientwithtoken_playbacklive/recording_successfully_gets_a_token_for_a_user_multiple_scopes.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclientwithtoken_playbacklive/recording_successfully_gets_a_token_for_a_user_multiple_scopes.js
@@ -5,7 +5,7 @@ module.exports.hash = "a91f3fcca9a24a85e7fd284bad6a1005";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/recordings/node/communicationidentityclientwithtoken_playbacklive/recording_successfully_gets_a_token_for_a_user_single_scope.js
+++ b/sdk/communication/communication-identity/recordings/node/communicationidentityclientwithtoken_playbacklive/recording_successfully_gets_a_token_for_a_user_single_scope.js
@@ -5,7 +5,7 @@ module.exports.hash = "4b71805393b6313134537016202f37a1";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
@@ -37,7 +37,7 @@ const replaceableVariables: { [k: string]: string } = {
   INCLUDE_PHONENUMBER_LIVE_TESTS: "false",
   COMMUNICATION_ENDPOINT: "https://endpoint/",
   AZURE_CLIENT_ID: "SomeClientId",
-  AZURE_CLIENT_SECRET: "SomeClientSecret",
+  AZURE_CLIENT_SECRET: "azure_client_secret",
   AZURE_TENANT_ID: "SomeTenantId",
   COMMUNICATION_MSAL_USERNAME: "MSALUsername",
   COMMUNICATION_MSAL_PASSWORD: "MSALPassword",

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
+++ b/sdk/communication/communication-sms/recordings/browsers/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=4d10d2e3-9740-4d46-a770-933d9b60d8f7&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=4d10d2e3-9740-4d46-a770-933d9b60d8f7&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=e5401dcb-275e-4fd4-a8bb-f85e67cb0b40&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=e5401dcb-275e-4fd4-a8bb-f85e67cb0b40&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=aeabd791-df32-414b-8db4-6c98bf24d150&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=aeabd791-df32-414b-8db4-6c98bf24d150&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=0e6c9a53-e879-423a-a78f-319c80caa605&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=0e6c9a53-e879-423a-a78f-319c80caa605&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=10eda0f7-ca0b-4f68-a814-abcb1d979b71&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=10eda0f7-ca0b-4f68-a814-abcb1d979b71&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_playbackrecord_aad_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=4830c82c-d7ff-4e21-90f9-f1aee8c0f8bf&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=4830c82c-d7ff-4e21-90f9-f1aee8c0f8bf&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message.js
@@ -5,7 +5,7 @@ module.exports.hash = "40a36a477f7f16678261c29cc32a4387";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_to_multiple_recipients.js
@@ -5,7 +5,7 @@ module.exports.hash = "c9d3b30b09556d605a1814b7cc66c2ba";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_can_send_an_sms_message_with_options_passed_in.js
@@ -5,7 +5,7 @@ module.exports.hash = "e63a7c0807966575ec1513c6eb0a2b17";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_sends_a_new_message_each_time_send_is_called.js
@@ -5,7 +5,7 @@ module.exports.hash = "ead77ee45b60a585c7ffd2d2bad4b030";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_a_number_you_dont_own.js
@@ -5,7 +5,7 @@ module.exports.hash = "eeff82b8ae33893e424efcce27438830";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.js
+++ b/sdk/communication/communication-sms/recordings/node/smsclient_using_token_based_authentication_playbackrecord_when_sending_sms/recording_throws_an_exception_when_sending_from_an_invalid_number.js
@@ -5,7 +5,7 @@ module.exports.hash = "e40572f5ed6d1f0cd7c4a5809ef38226";
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
+  .post('/SomeTenantId/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fcommunication.azure.com%2F%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-sms/test/public/utils/recordedClient.ts
@@ -18,7 +18,7 @@ export const recorderConfiguration: RecorderEnvironmentSetup = {
     COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
     AZURE_PHONE_NUMBER: "+14255550123",
     AZURE_CLIENT_ID: "SomeClientId",
-    AZURE_CLIENT_SECRET: "SomeClientSecret",
+    AZURE_CLIENT_SECRET: "azure_client_secret",
     AZURE_TENANT_ID: "SomeTenantId",
     COMMUNICATION_SKIP_INT_SMS_TEST: "false"
   },


### PR DESCRIPTION
So that we can suppress CredScan errors using one common value from eng/CredScanSuppression.json.