### PR TITLE
[storage-file-share]Fixed bug where ShareFileClient.download may corrupt data when source is changing.

### DIFF
--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.6.0 (2021-06-09)
 
 - Updated Azure Storage Service API version to 2020-08-04.
+- Fixed bug where ShareFileClient.download, ShareFileClient.downloadToBuffer or ShareFileClient.downloadToFile could corrupt data if source is modified when retrying.
 
 ## 12.5.0 (2021-03-10)
 

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -3579,14 +3579,17 @@ export class ShareFileClient extends StorageClient {
           //   }, options: ${JSON.stringify(updatedOptions)}`
           // );
 
-          return (
-            await this.context.download({
-              abortSignal: options.abortSignal,
-              leaseAccessConditions: options.leaseAccessConditions,
-              ...updatedOptions,
-              ...convertTracingToRequestOptionsBase(updatedOptions)
-            })
-          ).readableStreamBody!;
+          const downloadRes = await this.context.download({
+            abortSignal: options.abortSignal,
+            leaseAccessConditions: options.leaseAccessConditions,
+            ...updatedOptions,
+            ...convertTracingToRequestOptionsBase(updatedOptions)
+          });
+
+          if (!(downloadRes.etag === res.etag)) {
+            throw new Error("File has been modified concurrently");
+          }
+          return downloadRes.readableStreamBody!;
         },
         offset,
         res.contentLength!,


### PR DESCRIPTION
Fixed bug where ShareFileClient.download may corrupt data when source is changing.