### PR TITLE
Add note on dropping support for non LTS versions of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ Libraries which enable you to provision specific resources. They are responsible
 - For detailed documentation visit our [Azure SDK for JavaScript documentation](https://aka.ms/js-docs)
 - File an issue via [GitHub Issues](https://github.com/Azure/azure-sdk-for-js/issues)
 - Check [previous questions](https://stackoverflow.com/questions/tagged/azure-sdk-js) or ask new ones on StackOverflow using `azure-sdk-js` tag.
+- Read our [Support documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/SUPPORT.md).
 
 ### Community
 
-* Chat with other community members [![Join the chat at https://gitter.im/azure/azure-sdk-for-js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/azure/azure-sdk-for-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Try our [community resources](https://github.com/Azure/azure-sdk-for-js/blob/master/SUPPORT.md#community-resources).
 
 ### Reporting security issues and security bugs
 
 Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
 
 ## Contributing
+
 For details on contributing to this repository, see the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md).
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,4 +31,8 @@ Further information, including the MSRC PGP key, can be found in the [Security T
 
 ## Microsoft Support Policy
 
-Please refer to [Azure SDK Support and Lifecycle information](https://azure.github.io/azure-sdk/policies_support.html)
+The JavaScript Azure SDK libraries will not be guaranteed to work on Node.js versions that have reached their end of life. Dropping support for such Node.js versions may be done without increasing the major version of the Azure SDK libraries.
+
+We strongly recommend migration to [LTS versions of Node.js](https://nodejs.org/about/releases/) to be eligible for technical support. In terms of browsers, we support latest versions of Safari, Chrome, Edge and Firefox. We will make reasonable efforts to support the Azure SDK libraries on Node.js that have reached their end of life less than six months prior, unless security or other considerations require otherwise.
+
+Please refer to [Azure SDK Support and Lifecycle information](https://azure.github.io/azure-sdk/policies_support.html) for more on our support policy.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,7 +31,7 @@ Further information, including the MSRC PGP key, can be found in the [Security T
 
 ## Microsoft Support Policy
 
-The JavaScript Azure SDK libraries will not be guaranteed to work on Node.js versions that have reached their end of life. Dropping support for such Node.js versions may be done without increasing the major version of the Azure SDK libraries.
+The Azure SDK libraries for JavaScript will not be guaranteed to work on Node.js versions that have reached their end of life. Dropping support for such Node.js versions may be done without increasing the major version of the Azure SDK libraries.
 
 We strongly recommend migration to [LTS versions of Node.js](https://nodejs.org/about/releases/) to be eligible for technical support. In terms of browsers, we support latest versions of Safari, Chrome, Edge and Firefox. We will make reasonable efforts to support the Azure SDK libraries on Node.js that have reached their end of life less than six months prior, unless security or other considerations require otherwise.
 


### PR DESCRIPTION
This PR updates our support policy regarding dropping support for non LTS versions of Node.js