### PR TITLE
Update Version in Search Documents SDK

### DIFF
--- a/sdk/search/perf-tests/search-documents/package.json
+++ b/sdk/search/perf-tests/search-documents/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/search-documents": "11.2.0-beta.3",
+    "@azure/search-documents": "11.3.0-beta.1",
     "@azure/identity": "^1.1.0",
     "@azure/test-utils-perfstress": "^1.0.0",
     "dotenv": "^8.2.0"

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,7 +1,22 @@
 # Release History
 
-## 11.2.0-beta.3 (Unreleased)
+## 11.3.0-beta.1 (Unreleased)
 
+## 11.2.0 (2021-06-08)
+
+The list of changes in 11.2.0 since 11.1.0 & 11.2.0-beta.2 are provided below:
+
+**Changes since 11.1.0**
+
+- Added support for Knowledge Store feature through the new `SearchIndexerKnowledgeStore` in the `SearchIndexerSkillset` object.
+- The `skillsetCounter` property in `ServiceCounters` object has been made optional.
+- Added Support for new datasource `adlsgen2`. Please refer [#14620](https://github.com/Azure/azure-sdk-for-js/pull/14620) for further details.
+- Added Support for new skills such as `CustomEntityLookupSkill`, `DocumentExtractionSkill`, etc. Please refer [#14620](https://github.com/Azure/azure-sdk-for-js/pull/14620) for further details.
+
+**Changes since 11.2.0-beta.2**
+
+- Removed Support for Semantic Search and introduced new properties in `SearchOptions`, `SearchRequest`, `SearchResult` and `SearchDocumentsResult` objects.
+- Removed Support for normalizers `LexicalNormalizer` & `CustomNormalizer`. Please refer [#14620](https://github.com/Azure/azure-sdk-for-js/pull/14620) for further details.
 
 ## 11.2.0-beta.2 (2021-05-11)
 

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "11.2.0-beta.3",
+  "version": "11.3.0-beta.1",
   "description": "Azure client library to use Cognitive Search for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/search/search-documents/src/constants.ts
+++ b/sdk/search/search-documents/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "11.2.0-beta.3";
+export const SDK_VERSION: string = "11.3.0-beta.1";

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "11.2.0-beta.3";
+const packageVersion = "11.3.0-beta.1";
 
 /** @internal */
 export class SearchClientContext extends coreHttp.ServiceClient {

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "11.2.0-beta.3";
+const packageVersion = "11.3.0-beta.1";
 
 /** @internal */
 export class SearchServiceClientContext extends coreHttp.ServiceClient {


### PR DESCRIPTION
Today (06/08/2021), We have released [`@azure/search-documents - 11.2.0` ](https://www.npmjs.com/package/@azure/search-documents/v/11.2.0) from the [feature](https://github.com/Azure/azure-sdk-for-js/tree/release/azure-search-documents_11.2.0) branch.

After the release, this PR is to update the version of the SDK (and Changelog) in the master branch. The next release would be `11.3.0-beta.1`.

@xirzec Please review and approve.

@ramya-rao-a FYI....
 