### PR TITLE
fix bug in 15436

### DIFF
--- a/.scripts/common.ts
+++ b/.scripts/common.ts
@@ -107,6 +107,10 @@ function isPackageFolderPath(folderPath: string, packagesToIgnore: string[]): bo
   const packageJsonFilePath: string = joinPath(folderPath, "package.json");
   if (fileExistsSync(packageJsonFilePath)) {
     const packageJson: PackageJson = readPackageJsonFileSync(packageJsonFilePath);
+    // Skip all perf framework projects from gulp pack
+    if (packageJson?.name?.startsWith("@azure-tests/")) {
+      return false;
+    }
     result = !contains(packagesToIgnore, packageJson.name!);
   }
   return result;

--- a/.scripts/common.ts
+++ b/.scripts/common.ts
@@ -107,10 +107,6 @@ function isPackageFolderPath(folderPath: string, packagesToIgnore: string[]): bo
   const packageJsonFilePath: string = joinPath(folderPath, "package.json");
   if (fileExistsSync(packageJsonFilePath)) {
     const packageJson: PackageJson = readPackageJsonFileSync(packageJsonFilePath);
-    // Skip all perf framework projects from gulp pack
-    if (packageJson.name.startsWith("@azure-tests/")) {
-      return false;
-    }
     result = !contains(packagesToIgnore, packageJson.name!);
   }
   return result;


### PR DESCRIPTION
Fix Azure/azure-sdk-for-js#15436 because it leads to all pipeline runs failed, and it has a bug:
```
.scripts/common.ts(111,9): error TS2532: Object is possibly 'undefined'.
```