### PR TITLE
Remove Node v8 from run matrix

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -52,12 +52,6 @@ jobs:
       condition: and(succeeded(), eq(dependencies.smoke_test_eligibility.outputs['check_smoke_tests.RunSmokeTests'], true))
     strategy:
       matrix:
-        Linux Node8 (AzureCloud):
-          Pool: Azure Pipelines
-          OSVmImage: "macOS-10.14"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "8.x"
         Mac Node10 (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "macOS-10.14"
@@ -192,14 +186,8 @@ jobs:
         displayName: List packages installed from the feed
 
       - script: npm run smoke-test -- --devops-logging
-        condition: and(succeeded(), ne(variables.NodeTestVersion, '8.x'))
         workingDirectory: common/smoke-test/
         displayName: Run smoke tests
-
-      - script: npm run smoke-test-node8 -- --devops-logging
-        condition: and(succeeded(), eq(variables.NodeTestVersion, '8.x'))
-        workingDirectory: common/smoke-test/
-        displayName: Run smoke tests (Node 8)
 
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -8,7 +8,7 @@
       "ubuntu-18.04": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
-    "NodeTestVersion": [ "8.x", "10.x", "12.x", "14.x", "16.x" ],
+    "NodeTestVersion": [ "10.x", "12.x", "14.x", "16.x" ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },


### PR DESCRIPTION
As stated in https://github.com/Azure/azure-sdk-for-js/issues/7022#issuecomment-857281424, we are dropping support for Node.js 8 in our JS SDK libraries.

This PR removes v8.x from our build pipeline run matrix.