### PR TITLE
[service-bus] Fix autoCompleteMessages help to indicate that it'll both completeMessage() and abandonMessage()

### DIFF
--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -154,10 +154,10 @@ export interface SubscribeOptions extends OperationOptionsBase {
    * user provided `processMessage` callback. 
    * 
    * - If an error is thrown from the `processMessage` callback the message will be abandoned 
-   *   using `receiver.abandon()`. Doing so will make the message available again from the 
+   *   using `receiver.abandonMessage()`. Doing so will make the message available again from the 
    *   queue/subscription and the delivery count will be incremented.
    * - If NO error is thrown from `processMessage` the message will be completed 
-   *   using `receiver.complete()`. Doing so removes the message from the queue/subscription.
+   *   using `receiver.completeMessage()`. Doing so removes the message from the queue/subscription.
    *
    * This option is ignored if messages are received in the `receiveAndDelete` receive mode or if
    * the message is already settled in the user provided message callback.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -150,9 +150,14 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {}
  */
 export interface SubscribeOptions extends OperationOptionsBase {
   /**
-   * Indicates whether the message should be settled using the `completeMessage()`
-   * method on the receiver automatically after it executes the user provided message callback.
-   * Doing so removes the message from the queue/subscription.
+   * Indicates whether the message should be settled automatically based on the result from the 
+   * user provided `processMessage` callback. 
+   * 
+   * - If an error is thrown from the `processMessage` callback the message will be abandoned 
+   *   using `receiver.abandon()`. Doing so will make the message available again from the 
+   *   queue/subscription and the delivery count will be incremented.
+   * - If NO error is thrown from `processMessage` the message will be completed 
+   *   using `receiver.complete()`. Doing so removes the message from the queue/subscription.
    *
    * This option is ignored if messages are received in the `receiveAndDelete` receive mode or if
    * the message is already settled in the user provided message callback.

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -150,13 +150,13 @@ export interface GetMessageIteratorOptions extends OperationOptionsBase {}
  */
 export interface SubscribeOptions extends OperationOptionsBase {
   /**
-   * Indicates whether the message should be settled automatically based on the result from the 
-   * user provided `processMessage` callback. 
-   * 
-   * - If an error is thrown from the `processMessage` callback the message will be abandoned 
-   *   using `receiver.abandonMessage()`. Doing so will make the message available again from the 
+   * Indicates whether the message should be settled automatically based on the result from the
+   * user provided `processMessage` callback.
+   *
+   * - If an error is thrown from the `processMessage` callback the message will be abandoned
+   *   using `receiver.abandonMessage()`. Doing so will make the message available again from the
    *   queue/subscription and the delivery count will be incremented.
-   * - If NO error is thrown from `processMessage` the message will be completed 
+   * - If NO error is thrown from `processMessage` the message will be completed
    *   using `receiver.completeMessage()`. Doing so removes the message from the queue/subscription.
    *
    * This option is ignored if messages are received in the `receiveAndDelete` receive mode or if


### PR DESCRIPTION
Updating doc comment for autoComplete, indicating that it will abandon() if an error is thrown.

The prior text made it sound like it would call completeMessage() no matter what happened, which was confusing.

Fixes #15519