### PR TITLE
[Cosmos] Implements regional failover for ENOTFOUND responses

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 3.11.4 (Unreleased)
+## 3.11.4 (2021-06-10)
 
+- BUGFIX: Correctly failover to new regions when regional DNS has gone offline.
 
 ## 3.11.3 (2021-05-21)
 

--- a/sdk/cosmosdb/cosmos/src/common/statusCodes.ts
+++ b/sdk/cosmosdb/cosmos/src/common/statusCodes.ts
@@ -30,6 +30,9 @@ export interface StatusCodesType {
   InternalServerError: 500;
   ServiceUnavailable: 503;
 
+  // System codes
+  ENOTFOUND: "ENOTFOUND";
+
   // Operation pause and cancel. These are FAKE status codes for QOS logging purpose only.
   OperationPaused: 1200;
   OperationCancelled: 1201;
@@ -63,6 +66,9 @@ export const StatusCodes: StatusCodesType = {
   // Server Error
   InternalServerError: 500,
   ServiceUnavailable: 503,
+
+  // System codes
+  ENOTFOUND: "ENOTFOUND",
 
   // Operation pause and cancel. These are FAKE status codes for QOS logging purpose only.
   OperationPaused: 1200,

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -81,9 +81,10 @@ export async function execute({
     let retryPolicy: RetryPolicy = null;
     const headers = err.headers || {};
     if (
-      err.code === StatusCodes.Forbidden &&
-      (err.substatus === SubStatusCodes.DatabaseAccountNotFound ||
-        err.substatus === SubStatusCodes.WriteForbidden)
+      err.code === StatusCodes.ENOTFOUND ||
+      (err.code === StatusCodes.Forbidden &&
+        (err.substatus === SubStatusCodes.DatabaseAccountNotFound ||
+          err.substatus === SubStatusCodes.WriteForbidden))
     ) {
       retryPolicy = retryPolicies.endpointDiscoveryRetryPolicy;
     } else if (err.code === StatusCodes.TooManyRequests) {


### PR DESCRIPTION
Regional failover was only happening for Forbidden codes, but if DNS goes offline for a region before a new request we can see `ENOTFOUND` codes. This correctly handles them