### PR TITLE
[Cosmos] Adds REQUEST_SEND_ERROR exception to failover codes

### DIFF
--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -82,6 +82,7 @@ export async function execute({
     const headers = err.headers || {};
     if (
       err.code === StatusCodes.ENOTFOUND ||
+      err.code === "REQUEST_SEND_ERROR" ||
       (err.code === StatusCodes.Forbidden &&
         (err.substatus === SubStatusCodes.DatabaseAccountNotFound ||
           err.substatus === SubStatusCodes.WriteForbidden))


### PR DESCRIPTION
`core-rest-pipeline` has an `ENOTFOUND` message but throws with `REQUEST_SEND_ERROR` code. Fetch throws with `ENOTFOUND` code.