### PR TITLE
Standardize constantPaths for updating package version in automated PRs

### DIFF
--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -8,7 +8,7 @@
   "types": "types/communication-chat.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --version=3.0.6267 --v3 --package-version=1.1.0-beta.1 && rushx format",
+    "build:autorest": "autorest ./swagger/README.md --typescript --version=3.0.6267 --v3 && rushx format",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "echo Obsolete.",
@@ -123,6 +123,22 @@
     "typescript": "~4.2.0",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
+  },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/src/chatApiClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
   },
   "//sampleConfiguration": {
     "productName": "Azure Communication Services - Chat",

--- a/sdk/communication/communication-chat/swagger/README.md
+++ b/sdk/communication/communication-chat/swagger/README.md
@@ -21,6 +21,7 @@ use-extension:
 azure-arm: false
 add-credentials: false
 disable-async-iterators: true
+package-version: 1.1.0-beta.1
 ```
 
 ### Rename CommunicationError to ChatError

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -12,7 +12,7 @@
   "types": "types/communication-sms.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --v3 --package-version=1.0.1 && rushx format",
+    "build:autorest": "autorest ./swagger/README.md --typescript --v3 && rushx format",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "dev-tool samples publish --force",
@@ -121,6 +121,22 @@
     "typescript": "~4.2.0",
     "util": "^0.12.1",
     "typedoc": "0.15.2"
+  },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/src/smsApiClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
   },
   "//sampleConfiguration": {
     "productName": "Azure Communication Services - SMS",

--- a/sdk/communication/communication-sms/swagger/README.md
+++ b/sdk/communication/communication-sms/swagger/README.md
@@ -19,4 +19,5 @@ use-extension:
   "@autorest/typescript": "6.0.0-dev.20200623.2"
 azure-arm: false
 add-credentials: false
+package-version: 1.0.1
 ```

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -19,6 +19,10 @@
       {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/containerregistry/container-registry/swagger/README.md
+++ b/sdk/containerregistry/container-registry/swagger/README.md
@@ -22,4 +22,5 @@ hide-clients: true
 use-core-v2: true
 use-extension:
   "@autorest/typescript": "C:/github/autorest.typescript"
+package-version: 1.0.0-beta.4
 ```

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -123,6 +123,22 @@
     "@types/uuid": "^8.0.0"
   },
   "sideEffects": false,
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/azureDigitalTwinsAPIContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/digitalTwinsClient.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
+  },
   "//sampleConfiguration": {
     "productName": "Azure Digital Twins",
     "productSlugs": [

--- a/sdk/digitaltwins/digital-twins-core/swagger/README.md
+++ b/sdk/digitaltwins/digital-twins-core/swagger/README.md
@@ -15,6 +15,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/master/specification/digitaltwins/data-plane/Microsoft.DigitalTwins/stable/2020-10-31/digitaltwins.json
 output-folder: ../
 source-code-folder-path: ./src/generated
+package-version: 1.0.4
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -71,6 +71,22 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "typedoc --excludePrivate --excludeNotExported --excludeExternals --stripInternal --mode file --out ./dist/docs ./src"
   },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/keyVaultClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
+  },
   "//sampleConfiguration": {
     "productName": "Azure Key Vault Administration",
     "productSlugs": [

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -17,6 +17,7 @@ input-file:
   - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/backuprestore.json
 output-folder: ../
 source-code-folder-path: ./src/generated
+package-version: 4.0.0-beta.4
 ```
 
 ### Hide LROs

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -79,6 +79,10 @@
       {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -18,4 +18,5 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
+package-version: 4.2.0-beta.4
 ```

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -82,6 +82,10 @@
       {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -18,6 +18,7 @@ disable-async-iterators: true
 api-version-parameter: choice
 v3: true
 hide-clients: true
+package-version: 4.2.0-beta.6
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -79,6 +79,10 @@
       {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -18,4 +18,5 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
+package-version: 4.2.0-beta.5
 ```

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -42,6 +42,10 @@
       {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -21,6 +21,7 @@ use-extension:
   "@autorest/typescript": "6.0.0-dev.20210223.1"
 disable-async-iterators: true
 hide-clients: true
+package-version: 1.0.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/mixedreality/mixedreality-authentication/package.json
+++ b/sdk/mixedreality/mixedreality-authentication/package.json
@@ -111,6 +111,22 @@
     "util": "^0.12.1",
     "typedoc": "0.15.2"
   },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/mixedRealityStsRestClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
+  },
   "//sampleConfiguration": {
     "disableDocsMs": false,
     "apiRefLink": "https://docs.microsoft.com/javascript/api/",

--- a/sdk/mixedreality/mixedreality-authentication/swagger/README.md
+++ b/sdk/mixedreality/mixedreality-authentication/swagger/README.md
@@ -19,6 +19,7 @@ add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.2"
 hide-clients: true
+package-version: 1.0.0-beta.1
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -59,8 +59,16 @@
   "//metadata": {
     "constantPaths": [
       {
+        "path": "src/generated/applicationInsightsClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
         "path": "src/utils/constants/applicationinsights.ts",
         "prefix": "packageVersion"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/monitor/monitor-opentelemetry-exporter/swagger/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/swagger/README.md
@@ -25,4 +25,5 @@ input-file: https://github.com/Azure/azure-rest-api-specs/blob/e47988f3ccaa90681
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210121.1"
+package-version: 1.0.0-beta.4
 ```

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.6.0",
+    "build:autorest": "autorest ./swagger/README.md --typescript",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:nodebrowser": "rollup -c 2>&1",
@@ -96,8 +96,16 @@
   "//metadata": {
     "constantPaths": [
       {
+        "path": "src/generated/src/storageClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
         "path": "src/utils/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -20,6 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
+package-version: 12.6.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -92,8 +92,16 @@
   "//metadata": {
     "constantPaths": [
       {
+        "path": "src/generated/src/storageClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
         "path": "src/utils/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -20,6 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210223.1"
+package-version: 12.5.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.6.0",
+    "build:autorest": "autorest ./swagger/README.md --typescript",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:nodebrowser": "rollup -c 2>&1",
@@ -95,6 +95,10 @@
       {
         "path": "src/utils/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -20,6 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
+package-version: 12.6.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.5.0",
+    "build:autorest": "autorest ./swagger/README.md --typescript",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -91,6 +91,10 @@
       {
         "path": "src/utils/constants.ts",
         "prefix": "SDK_VERSION"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
       }
     ]
   },

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -20,6 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
+package-version: 12.5.0
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/synapse/synapse-artifacts/swagger/README.md
+++ b/sdk/synapse/synapse-artifacts/swagger/README.md
@@ -20,7 +20,7 @@ modelerfour:
 batch:
   - package-artifacts: true
     package-name: "@azure/synapse-artifacts"
-    pacage-version: "1.0.0-beta.4"
+    package-version: "1.0.0-beta.4"
     add-credentials: true
     license-header: MICROSOFT_MIT_NO_VERSION
     credential-scopes: https://dev.azuresynapse.net/.default


### PR DESCRIPTION
When a package update is released, we have automation that creates [PRs to increment the package version](https://github.com/Azure/azure-sdk-for-js/pulls?q=is%3Apr+%22increment+version+for%22+in%3Atitle+is%3Aopen) in the source code. This is done by looking at the `constantPaths` declared in the package.json file under `//metadata`.

Some of our packages have the `build:autorest` npm script to regenerate the package and mention the package version. This is getting missed by our automation and so #15599 was logged.

Turns out the solution is to move the package version to the swagger/README.md file and ensure that file is included in the `constantPaths`. This PR does exactly that.

While working on this PR, I noticed a few other places where we have the package version in code that should also be updated by automation. So this PR takes care of those as well.

Fixes #15599