### PR TITLE
Add SDK_VERSION to package.json 

### DIFF
--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -132,5 +132,13 @@
     ],
     "requiredResources": {},
     "apiRefLink": "https://docs.microsoft.com/javascript/api/"
+  },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/utils/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
   }
 }

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
@@ -8,7 +8,7 @@ import {
   DEPENDENCY_MODE_DISABLED,
   DEPENDENCY_MODE_ENABLED,
   DEPENDENCY_MODE_TRY_FROM_EXPANDED
-} from "./constants";
+} from "./utils/constants";
 import { createClientPipeline, InternalClientPipelineOptions } from "@azure/core-client";
 import { Fetcher } from "./fetcherAbstract";
 import { URL } from "./utils/url";

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryServiceClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ServiceClientOptions, ServiceClient } from "@azure/core-client";
-import { DEFAULT_API_VERSION } from "./constants";
+import { DEFAULT_API_VERSION } from "./utils/constants";
 
 interface IoTModelsRepositoryServiceClientOptions extends ServiceClientOptions {
   // API Version to be used during HTTP Calls.

--- a/sdk/iot/iot-modelsrepository/src/utils/constants.ts
+++ b/sdk/iot/iot-modelsrepository/src/utils/constants.ts
@@ -5,7 +5,7 @@ import { isNode } from "@azure/core-util";
 
 const currentPlatform = isNode ? "node" : "browser";
 
-export const SDK_VERSION = "1.0.0-beta.2";
+export const SDK_VERSION: string = "1.0.0-beta.2";
 export const DEFAULT_USER_AGENT = `azsdk-node-modelsrepository/${SDK_VERSION} (${currentPlatform})`;
 export const DEFAULT_REPOSITORY_LOCATION = "https://devicemodels.azure.com";
 export const DEFAULT_API_VERSION = "2021-02-11";

--- a/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/node/unit/constants.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as cnst from "../../../src/constants";
+import * as cnst from "../../../src/utils/constants";
 import { readFileSync } from "fs";
 import { expect } from "chai";
 describe("constants", function() {


### PR DESCRIPTION
Per convos with @ramya-rao-a, following the style of data-tables to have the SDK_VERSION inserted in the package.json. I am not positive but I assume this somehow ensures the constants.ts file is also updated during version bumps.