### PR TITLE
[monitor-query] Allowing for passing a custom endpoint and custom authorization scopes.

### DIFF
--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -96,6 +96,7 @@ export class LogsQueryClient {
 // @public
 export interface LogsQueryClientOptions extends PipelineOptions {
     endpoint?: string;
+    scopes?: string | string[];
 }
 
 // @public

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -32,8 +32,6 @@ const defaultMonitorScope = "https://api.loganalytics.io/.default";
 export interface LogsQueryClientOptions extends PipelineOptions {
   /**
    * The host to connect to.
-   *
-   * Defaults to 'https://api.loganalytics.io/v1'.
    */
   endpoint?: string;
 

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -36,6 +36,13 @@ export interface LogsQueryClientOptions extends PipelineOptions {
    * Defaults to 'https://api.loganalytics.io/v1'.
    */
   endpoint?: string;
+
+  /**
+   * The authentication scopes to use when getting authentication tokens.
+   *
+   * Defaults to 'https://api.loganalytics.io/.default'
+   */
+  scopes?: string | string[];
 }
 
 /**
@@ -51,7 +58,10 @@ export class LogsQueryClient {
    * @param options - Options for the LogsClient.
    */
   constructor(tokenCredential: TokenCredential, options?: LogsQueryClientOptions) {
-    const authPolicy = bearerTokenAuthenticationPolicy(tokenCredential, defaultMonitorScope);
+    const authPolicy = bearerTokenAuthenticationPolicy(
+      tokenCredential,
+      options?.scopes ?? defaultMonitorScope
+    );
 
     // This client defaults to using 'https://api.loganalytics.io/v1' as the
     // host.
@@ -59,7 +69,8 @@ export class LogsQueryClient {
 
     this._logAnalytics = new AzureLogAnalytics({
       ...serviceClientOptions,
-      $host: options?.endpoint
+      $host: options?.endpoint,
+      endpoint: options?.endpoint
     });
   }
 

--- a/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Durations, LogsQueryClient } from "../../../src";
+import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { assert } from "chai";
+
+describe("LogsQueryClient unit tests", () => {
+  /**
+   * Custom scopes and endpoints are needed if you're connecting to
+   * a government cloud, for instance.
+   */
+  it("using custom scopes and endpoints", async () => {
+    const scopesPassed: string[] = [];
+
+    const tokenCredential: TokenCredential = {
+      async getToken(
+        scopes: string | string[],
+        _options?: GetTokenOptions
+      ): Promise<AccessToken | null> {
+        if (Array.isArray(scopes)) {
+          scopesPassed.push(...scopes);
+        } else {
+          scopesPassed.push(scopes);
+        }
+
+        throw new Error("Shortcircuit auth exception");
+      }
+    };
+
+    const client = new LogsQueryClient(tokenCredential, {
+      endpoint: "customEndpoint1",
+      scopes: "customScopes1"
+    });
+
+    assert.equal(client["_logAnalytics"].$host, "customEndpoint1");
+    assert.equal(client["_logAnalytics"]["baseUri"], "customEndpoint1");
+
+    try {
+      await client.queryLogs("workspaceId", "query", Durations.last5Minutes);
+      assert.fail("Should have thrown");
+    } catch (err) {
+      assert.deepNestedInclude(err, {
+        message: "Shortcircuit auth exception"
+      });
+    }
+
+    assert.deepEqual(scopesPassed, ["customScopes1"]);
+  });
+});


### PR DESCRIPTION
This PR makes it so you can pass in a custom endpoint and custom scopes for authentication. Without these you can't properly connect to government-based clouds.

Example usage:

```typescript
  const dac = new DefaultAzureCredential({
    authorityHost: AzureAuthorityHosts.AzureGovernment
  });

  const client = new LogsQueryClient(dac, {
    endpoint: "https://api.loganalytics.us/v1",
    scopes: "https://api.loganalytics.us/.default"
  });
```

Fixes #15663