### PR TITLE
Bump the code generator version used for management-plane packages

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -6,7 +6,7 @@
       "typescript": "",
       "license-header": "MICROSOFT_MIT_NO_VERSION",
       "sdkrel:typescript-sdks-folder": ".",
-      "use": "@microsoft.azure/autorest.typescript@4.6.0"
+      "use": "@microsoft.azure/autorest.typescript@4.7.0"
     },
     "advanced_options": {
       "clone_dir": "./azure-sdk-for-js",


### PR DESCRIPTION
v4.7 is the most recent one that generated readmes with [our updated node support policy](https://github.com/Azure/azure-sdk-for-js/blob/master/SUPPORT.md#microsoft-support-policy): https://www.npmjs.com/package/@microsoft.azure/autorest.typescript/v/4.7.0