### PR TITLE
[KeyVault] - Fix JavaScript samples and poller circular references

### DIFF
--- a/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/operation.ts
@@ -15,7 +15,12 @@ import {
   KeyVaultAdminPollOperation,
   KeyVaultAdminPollOperationState
 } from "../keyVaultAdminPoller";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src/tracingHelpers";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultBackupPoller");
 
 /**
  * An interface representing the publicly available properties of the state of a backup Key Vault's poll operation.

--- a/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/backup/poller.ts
@@ -8,17 +8,11 @@ import {
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
 import { KeyVaultBackupResult } from "../../backupClientModels";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface KeyVaultBackupPollerOptions extends KeyVaultAdminPollerOptions {
   blobStorageUri: string;
   sasToken: string;
 }
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultBackupPoller");
 
 /**
  * Class that creates a poller that waits until the backup of a Key Vault ends up being generated.

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/operation.ts
@@ -15,7 +15,12 @@ import {
   KeyVaultAdminPollOperationState
 } from "../keyVaultAdminPoller";
 import { KeyVaultRestoreResult } from "../../backupClientModels";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultRestorePoller");
 
 /**
  * An interface representing the publicly available properties of the state of a restore Key Vault's poll operation.

--- a/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/restore/poller.ts
@@ -8,18 +8,12 @@ import {
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
 import { KeyVaultRestoreResult } from "../../backupClientModels";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface KeyVaultRestorePollerOptions extends KeyVaultAdminPollerOptions {
   folderUri: string;
   sasToken: string;
   folderName: string;
 }
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultRestorePoller");
 
 /**
  * Class that creates a poller that waits until a Key Vault ends up being restored.

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/operation.ts
@@ -15,7 +15,12 @@ import {
   KeyVaultAdminPollOperationState
 } from "../keyVaultAdminPoller";
 import { KeyVaultSelectiveKeyRestoreResult } from "../../backupClientModels";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Admin.KeyVaultSelectiveKeyRestorePoller");
 
 /**
  * An interface representing the publicly available properties of the state of a restore Key Vault's poll operation.

--- a/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/selectiveKeyRestore/poller.ts
@@ -8,7 +8,6 @@ import {
 } from "./operation";
 import { KeyVaultAdminPollerOptions, KeyVaultAdminPoller } from "../keyVaultAdminPoller";
 import { KeyVaultSelectiveKeyRestoreResult } from "../../backupClientModels";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface KeyVaultSelectiveKeyRestorePollerOptions extends KeyVaultAdminPollerOptions {
   keyName: string;
@@ -16,13 +15,6 @@ export interface KeyVaultSelectiveKeyRestorePollerOptions extends KeyVaultAdminP
   sasToken: string;
   folderName: string;
 }
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction(
-  "Azure.KeyVault.Admin.KeyVaultSelectiveKeyRestorePoller"
-);
 
 /**
  * Class that creates a poller that waits until a key of a Key Vault backup ends up being restored.

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/operation.ts
@@ -23,7 +23,12 @@ import {
   toCoreAttributes,
   toCorePolicy
 } from "../../transformations";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Certificates.CreateCertificatePoller");
 
 /**
  * The public representation of the CreateCertificatePoller operation state.

--- a/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/create/poller.ts
@@ -11,17 +11,11 @@ import {
   KeyVaultCertificatePoller,
   KeyVaultCertificatePollerOptions
 } from "../keyVaultCertificatePoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface CreateCertificatePollerOptions extends KeyVaultCertificatePollerOptions {
   certificatePolicy?: CertificatePolicy;
   createCertificateOptions: CreateCertificateOptions;
 }
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Certificates.CreateCertificatePoller");
 
 /**
  * Class that deletes a poller that waits until a certificate finishes being deleted

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/operation.ts
@@ -14,7 +14,12 @@ import {
 } from "../keyVaultCertificatePoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { getDeletedCertificateFromDeletedCertificateBundle } from "../../transformations";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Certificates.DeleteCertificatePoller");
 
 /**
  * The public representation of the DeleteCertificatePoller operation state.

--- a/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/delete/poller.ts
@@ -7,14 +7,8 @@ import {
   KeyVaultCertificatePoller,
   KeyVaultCertificatePollerOptions
 } from "../keyVaultCertificatePoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface DeleteCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Certificates.DeleteCertificatePoller");
 
 /**
  * Class that deletes a poller that waits until a certificate finishes being deleted

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
@@ -20,7 +20,14 @@ import {
   getCertificateOperationFromCoreOperation,
   getCertificateWithPolicyFromCertificateBundle
 } from "../../transformations";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+export const withTrace = createTraceFunction(
+  "Azure.KeyVault.Certificates.CertificateOperationPoller"
+);
 
 /**
  * An interface representing the publicly available properties of the state of the CertificateOperationPoller.

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
@@ -25,9 +25,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 /**
  * @internal
  */
-const withTrace = createTraceFunction(
-  "Azure.KeyVault.Certificates.CertificateOperationPoller"
-);
+const withTrace = createTraceFunction("Azure.KeyVault.Certificates.CertificateOperationPoller");
 
 /**
  * An interface representing the publicly available properties of the state of the CertificateOperationPoller.

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/operation.ts
@@ -25,7 +25,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 /**
  * @internal
  */
-export const withTrace = createTraceFunction(
+const withTrace = createTraceFunction(
   "Azure.KeyVault.Certificates.CertificateOperationPoller"
 );
 

--- a/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/operation/poller.ts
@@ -8,16 +8,8 @@ import {
   KeyVaultCertificatePollerOptions,
   cleanState
 } from "../keyVaultCertificatePoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface CertificateOperationPollerOptions extends KeyVaultCertificatePollerOptions {}
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction(
-  "Azure.KeyVault.Certificates.CertificateOperationPoller"
-);
 
 /**
  * Class that creates a poller that waits until a certificate finishes being created

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/operation.ts
@@ -3,6 +3,7 @@
 
 import { AbortSignalLike } from "@azure/abort-controller";
 import { OperationOptions } from "@azure/core-http";
+import { createTraceFunction } from "../../../../keyvault-common/src";
 import {
   GetCertificateOptions,
   KeyVaultCertificateWithPolicy,
@@ -14,7 +15,13 @@ import {
   KeyVaultCertificatePollOperation,
   KeyVaultCertificatePollOperationState
 } from "../keyVaultCertificatePoller";
-import { withTrace } from "./poller";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction(
+  "Azure.KeyVault.Certificates.RecoverDeletedCertificatePoller"
+);
 
 /**
  * Deprecated: Public representation of the recovery of a deleted certificate poll operation

--- a/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-certificates/src/lro/recover/poller.ts
@@ -10,16 +10,8 @@ import {
   KeyVaultCertificatePoller,
   KeyVaultCertificatePollerOptions
 } from "../keyVaultCertificatePoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
 
 export interface RecoverDeletedCertificatePollerOptions extends KeyVaultCertificatePollerOptions {}
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction(
-  "Azure.KeyVault.Certificates.RecoverDeletedCertificatePoller"
-);
 
 /**
  * Class that creates a poller that waits until a deleted certificate is fully recovered.

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
@@ -7,7 +7,12 @@ import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { DeletedKey, DeleteKeyOptions, GetDeletedKeyOptions } from "../../keysModels";
 import { getKeyFromKeyBundle } from "../../transformations";
 import { KeyVaultKeyPollOperation, KeyVaultKeyPollOperationState } from "../keyVaultKeyPoller";
-import { withTrace } from "./poller";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Keys.DeleteKeyPoller");
 
 /**
  * An interface representing the state of a delete key's poll operation

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/poller.ts
@@ -4,12 +4,6 @@
 import { DeleteKeyPollOperation, DeleteKeyPollOperationState } from "./operation";
 import { DeletedKey } from "../../keysModels";
 import { KeyVaultKeyPoller, KeyVaultKeyPollerOptions } from "../keyVaultKeyPoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Keys.DeleteKeyPoller");
 
 /**
  * Class that creates a poller that waits until a key finishes being deleted.

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -7,7 +7,13 @@ import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { KeyVaultKey, GetKeyOptions, RecoverDeletedKeyOptions } from "../../keysModels";
 import { getKeyFromKeyBundle } from "../../transformations";
 import { KeyVaultKeyPollOperation, KeyVaultKeyPollOperationState } from "../keyVaultKeyPoller";
-import { withTrace } from "./poller";
+
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+export const withTrace = createTraceFunction("Azure.KeyVault.Keys.RecoverDeletedKeyPoller");
 
 /**
  * An interface representing the state of a delete key's poll operation

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -13,7 +13,7 @@ import { createTraceFunction } from "../../../../keyvault-common/src";
 /**
  * @internal
  */
-export const withTrace = createTraceFunction("Azure.KeyVault.Keys.RecoverDeletedKeyPoller");
+const withTrace = createTraceFunction("Azure.KeyVault.Keys.RecoverDeletedKeyPoller");
 
 /**
  * An interface representing the state of a delete key's poll operation

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
@@ -4,12 +4,6 @@
 import { RecoverDeletedKeyPollOperation, RecoverDeletedKeyPollOperationState } from "./operation";
 import { KeyVaultKey } from "../../keysModels";
 import { KeyVaultKeyPoller, KeyVaultKeyPollerOptions } from "../keyVaultKeyPoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Keys.RecoverDeletedKeyPoller");
 
 /**
  * Class that deletes a poller that waits until a key finishes being deleted

--- a/sdk/keyvault/keyvault-secrets/samples-dev/backupAndRestore.ts
+++ b/sdk/keyvault/keyvault-secrets/samples-dev/backupAndRestore.ts
@@ -32,7 +32,7 @@ function readFile(filename: string): Promise<Uint8Array> {
   });
 }
 
-export function delay<T>(t: number, value?: T): Promise<T | void> {
+function delay<T>(t: number, value?: T): Promise<T | void> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/samples-dev/deleteAndRecover.ts
+++ b/sdk/keyvault/keyvault-secrets/samples-dev/deleteAndRecover.ts
@@ -12,7 +12,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-export function delay<T>(t: number, value?: T): Promise<T | void> {
+function delay<T>(t: number, value?: T): Promise<T | void> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/backupAndRestore.js
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/backupAndRestore.js
@@ -32,7 +32,7 @@ function readFile(filename) {
   });
 }
 
-export function delay(t, value) {
+function delay(t, value) {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/deleteAndRecover.js
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/deleteAndRecover.js
@@ -12,7 +12,7 @@ const { DefaultAzureCredential } = require("@azure/identity");
 const dotenv = require("dotenv");
 dotenv.config();
 
-export function delay(t, value) {
+function delay(t, value) {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for JavaScript",
-  "engine": {
+  "engines": {
     "node": ">=12.0.0"
   },
   "repository": {
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets",
   "dependencies": {
-    "@azure/keyvault-secrets": "next",
+    "@azure/keyvault-secrets": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.3"
   }
 }

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for TypeScript",
-  "engine": {
+  "engines": {
     "node": ">=12.0.0"
   },
   "scripts": {
@@ -31,9 +31,9 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets",
   "dependencies": {
-    "@azure/keyvault-secrets": "next",
+    "@azure/keyvault-secrets": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^1.1.0"
+    "@azure/identity": "2.0.0-beta.3"
   },
   "devDependencies": {
     "typescript": "~4.2.0",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/backupAndRestore.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/backupAndRestore.ts
@@ -32,7 +32,7 @@ function readFile(filename: string): Promise<Uint8Array> {
   });
 }
 
-export function delay<T>(t: number, value?: T): Promise<T | void> {
+function delay<T>(t: number, value?: T): Promise<T | void> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/deleteAndRecover.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/deleteAndRecover.ts
@@ -12,7 +12,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-export function delay<T>(t: number, value?: T): Promise<T | void> {
+function delay<T>(t: number, value?: T): Promise<T | void> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
@@ -9,8 +9,13 @@ import {
 } from "../keyVaultSecretPoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { getSecretFromSecretBundle } from "../../transformations";
-import { withTrace } from "./poller";
 import { OperationOptions } from "@azure/core-http";
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Secrets.DeleteSecretPoller");
 
 /**
  * An interface representing the state of a delete secret's poll operation

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/poller.ts
@@ -4,12 +4,6 @@
 import { DeleteSecretPollOperation, DeleteSecretPollOperationState } from "./operation";
 import { DeletedSecret } from "../../secretsModels";
 import { KeyVaultSecretPoller, KeyVaultSecretPollerOptions } from "../keyVaultSecretPoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Secrets.DeleteSecretPoller");
 
 /**
  * Class that creates a poller that waits until a secret finishes being deleted.

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
@@ -14,8 +14,14 @@ import {
 } from "../keyVaultSecretPoller";
 import { KeyVaultClient } from "../../generated/keyVaultClient";
 import { getSecretFromSecretBundle } from "../../transformations";
-import { withTrace } from "./poller";
 import { OperationOptions } from "@azure/core-http";
+
+import { createTraceFunction } from "../../../../keyvault-common/src";
+
+/**
+ * @internal
+ */
+const withTrace = createTraceFunction("Azure.KeyVault.Secrets.RecoverDeletedSecretPoller");
 
 /**
  * An interface representing the state of a delete secret's poll operation

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/poller.ts
@@ -7,12 +7,6 @@ import {
 } from "./operation";
 import { SecretProperties } from "../../secretsModels";
 import { KeyVaultSecretPoller, KeyVaultSecretPollerOptions } from "../keyVaultSecretPoller";
-import { createTraceFunction } from "../../../../keyvault-common/src";
-
-/**
- * @internal
- */
-export const withTrace = createTraceFunction("Azure.KeyVault.Secrets.RecoverDeletedSecretPoller");
 
 /**
  * Class that deletes a poller that waits until a secret finishes being deleted


### PR DESCRIPTION
## What

- Remove unnecessary `export` from KV samples
- Fix circular dependency in KV pollers

## Why

I noticed today that the keyvault-secrets samples were failing to run due to 

```
SyntaxError: Unexpected token 'export'
```

There's an existing bug against dev-tool (#15724) which when fixed will address this, but in order to make sure
our samples are working it's perfectly fine not to export these functions.

Fixing the circular dependencies is a good thing to do before we go out.