### PR TITLE
[Attestation] Fix types path

### DIFF
--- a/sdk/attestation/attestation/api-extractor.json
+++ b/sdk/attestation/attestation/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/attestation.d.ts"
+    "publicTrimmedFilePath": "./types/latest/attestation.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -61,7 +61,8 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/latest/attestation.d.ts",
+    "types/latest/",
+    "types/3.1/",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -61,7 +61,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/attestation.d.ts",
+    "types/latest/attestation.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/15727. The declaration file should be created under `types/latest`.