### PR TITLE
[core] Allow password-less proxySettings

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed an issue where `proxySettings` does not work when there is username but no password [Issue 15720](https://github.com/Azure/azure-sdk-for-js/issues/15720)
 
 ## 1.2.6 (2021-06-14)
 

--- a/sdk/core/core-http/src/proxyAgent.ts
+++ b/sdk/core/core-http/src/proxyAgent.ts
@@ -32,6 +32,8 @@ export function createProxyAgent(
 
   if (proxySettings.username && proxySettings.password) {
     tunnelOptions.proxy!.proxyAuth = `${proxySettings.username}:${proxySettings.password}`;
+  } else if (proxySettings.username) {
+    tunnelOptions.proxy!.proxyAuth = `${proxySettings.username}`;
   }
 
   const isRequestHttps = isUrlHttps(requestUrl);

--- a/sdk/core/core-http/test/proxyAgent.node.ts
+++ b/sdk/core/core-http/test/proxyAgent.node.ts
@@ -6,7 +6,7 @@ import { should } from "chai";
 import Tunnel from "tunnel";
 import https from "https";
 
-import { HttpHeaders } from "../src/coreHttp";
+import { HttpHeaders, ProxySettings } from "../src/coreHttp";
 import { createProxyAgent, createTunnel } from "../src/proxyAgent";
 
 describe("proxyAgent", () => {
@@ -61,6 +61,37 @@ describe("proxyAgent", () => {
       const agent = proxyAgent.agent as HttpsAgent;
       should().exist(agent.proxyOptions.headers);
       agent.proxyOptions.headers!.should.contain({ "user-agent": "Node.js" });
+      done();
+    });
+
+    it("should set agent proxyAuth correctly", function(done) {
+      const proxySettings: ProxySettings = {
+        host: "http://proxy.microsoft.com",
+        port: 8080,
+        username: "username",
+        password: "pass123"
+      };
+
+      const proxyAgent = createProxyAgent("http://example.com", proxySettings);
+
+      const agent = proxyAgent.agent as HttpsAgent;
+      should().exist(agent.options.proxy.proxyAuth);
+      agent.options.proxy.proxyAuth!.should.equal("username:pass123");
+      done();
+    });
+
+    it("should set agent proxyAuth correctly when password is not specified", function(done) {
+      const proxySettings: ProxySettings = {
+        host: "http://proxy.microsoft.com",
+        port: 8080,
+        username: "username"
+      };
+
+      const proxyAgent = createProxyAgent("http://example.com", proxySettings);
+
+      const agent = proxyAgent.agent as HttpsAgent;
+      should().exist(agent.options.proxy.proxyAuth);
+      agent.options.proxy.proxyAuth!.should.equal("username");
       done();
     });
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0-beta.4 (Unreleased)
 
+### Fixed
+
+- Fixed an issue where `proxySettings` does not work when there is username but no password [Issue 15720](https://github.com/Azure/azure-sdk-for-js/issues/15720)
 
 ## 1.1.0-beta.3 (2021-06-03)
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.4 (Unreleased)
 
 ### Fixed
+
 - Fixed an issue where `proxySettings` does not work when there is username but no password [Issue 15720](https://github.com/Azure/azure-sdk-for-js/issues/15720)
 
 ## 1.1.0-beta.3 (2021-06-03)

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.1.0-beta.4 (Unreleased)
 
 ### Fixed
-
 - Fixed an issue where `proxySettings` does not work when there is username but no password [Issue 15720](https://github.com/Azure/azure-sdk-for-js/issues/15720)
 
 ## 1.1.0-beta.3 (2021-06-03)

--- a/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.ts
@@ -122,7 +122,10 @@ export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | unde
   };
 }
 
-function getProxyAgentOptions(
+/**
+ * @internal
+ */
+export function getProxyAgentOptions(
   proxySettings: ProxySettings,
   requestHeaders: HttpHeaders
 ): HttpProxyAgentOptions {
@@ -143,6 +146,8 @@ function getProxyAgentOptions(
   };
   if (proxySettings.username && proxySettings.password) {
     proxyAgentOptions.auth = `${proxySettings.username}:${proxySettings.password}`;
+  } else if (proxySettings.username) {
+    proxyAgentOptions.auth = `${proxySettings.username}`;
   }
   return proxyAgentOptions;
 }

--- a/sdk/core/core-rest-pipeline/test/node/proxyPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/proxyPolicy.spec.ts
@@ -8,9 +8,10 @@ import {
   createPipelineRequest,
   SendRequest,
   ProxySettings,
-  getDefaultProxySettings
+  getDefaultProxySettings,
+  createHttpHeaders
 } from "../../src";
-import { noProxyList, loadNoProxy } from "../../src/policies/proxyPolicy";
+import { noProxyList, loadNoProxy, getProxyAgentOptions } from "../../src/policies/proxyPolicy";
 
 describe("proxyPolicy (node)", function() {
   it("Sets proxy settings on the request", function() {
@@ -114,6 +115,27 @@ describe("proxyPolicy (node)", function() {
       noProxyList.splice(0, noProxyList.length);
       noProxyList.push(...loadNoProxy());
     }
+  });
+
+  it("getProxyAgentOptions from proxy settings having both username and password", function() {
+    const proxySettings: ProxySettings = {
+      host: "https://proxy.example.com",
+      port: 8080,
+      username: "user",
+      password: "pass"
+    };
+    const options = getProxyAgentOptions(proxySettings, createHttpHeaders());
+    assert.strictEqual(options.auth, "user:pass");
+  });
+
+  it("getProxyAgentOptions from proxy settings having username but no password", function() {
+    const proxySettings: ProxySettings = {
+      host: "https://proxy.example.com",
+      port: 8080,
+      username: "user"
+    };
+    const options = getProxyAgentOptions(proxySettings, createHttpHeaders());
+    assert.strictEqual(options.auth, "user");
   });
 
   describe("getDefaultProxySettings", function() {


### PR DESCRIPTION
It turns out that in some enterprise customer the proxy auth settings include a
username, but not a password: https://github.com/microsoft/AzureStorageExplorer/issues/4430

This change allows password-less auth settings to be passed to the underlying agent.

It's unclear whether it's a real scenario when a proxy auth has a password, but not username so 
this PR doesn't consider this scenario.

Resolves #15720.