### PR TITLE
[Attestation] Prepare for release v1.0.0-beta.4

### DIFF
--- a/sdk/attestation/attestation/CHANGELOG.md
+++ b/sdk/attestation/attestation/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.0.0-beta.4 (Unreleased)
+## 1.0.0-beta.4 (2021-06-15)
 
 ### Features Added
 
-### Breaking Changes
+- The package now contains type definitions compatible with TypeScript versions earlier than v3.6.
 
 ### Key Bugs Fixed
 
-### Fixed
+- Fixes the location of types definition in package.json
 
 
 ## 1.0.0-beta.3 (2021-06-08)


### PR DESCRIPTION
After https://github.com/Azure/azure-sdk-for-js/issues/15727 has been fixed.

If you think there is no need for this release, feel free to close the PR.

More info about the problem: The typescript compiler will not be able to find the type definitions. See this doc for the resolution algorithm: https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html#editing-the-packagejson

In the currently released package, the `types` key in package.json points to types/latest/attestation.d.ts but the file actually exists in types/attestation.d.ts.