### PR TITLE
[MetricsAdvisor] Generated code and latest swagger

### DIFF
--- a/sdk/metricsadvisor/ai-metrics-advisor/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/README.md
@@ -462,7 +462,7 @@ async function queryAnomaliesByAlert(client, alert) {
   console.log(
     `Listing anomalies for alert configuration '${alert.alertConfigId}' and alert '${alert.id}'`
   );
-  const iterator = client.listAnomalies(alert);
+  const iterator = client.listAnomaliesForAlert(alert);
   for await (const anomaly of iterator) {
     console.log(
       `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/aad_metricsadvisoradministrationclient_datafeed_datafeed/recording_creates_eventhubs_data_feed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/aad_metricsadvisoradministrationclient_datafeed_datafeed/recording_creates_eventhubs_data_feed.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "20a42b7c23b773a1da152bf8cfd1872b";
+module.exports.hash = "b305b062177574b168150bc47bb53ffe";
 
-module.exports.testInfo = {"uniqueName":{"js-test-datafeed-":"js-test-datafeed-162286538972802836","js-test-appInsightsFeed-":"js-test-appInsightsFeed-162286538972803864","js-test-sqlServerFeed-":"js-test-sqlServerFeed-162286538972807760","js-test-cosmosFeed-":"js-test-cosmosFeed-162286538972800952","js-test-dataExplorerFeed-":"js-test-dataExplorerFeed-162286538972805442","js-test-tableFeed-":"js-test-tableFeed-162286538972800856","js-test-httpRequestFeed-":"js-test-httpRequestFeed-162286538972809899","js-test-logAnalyticsFeed-":"js-test-logAnalyticsFeed-162286538972803497","js-test-influxdbFeed-":"js-test-influxdbFeed-162286538972805329","js-test-mongoDbFeed-":"js-test-mongoDbFeed-162286538972808553","js-test-mySqlFeed-":"js-test-mySqlFeed-162286538972808287","js-test-postgreSqlFeed-":"js-test-postgreSqlFeed-162286538972809007","js-test-dataLakeGenFeed-":"js-test-dataLakeGenFeed-162286538972803708"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"js-test-datafeed-":"js-test-datafeed-162456611703607360","js-test-appInsightsFeed-":"js-test-appInsightsFeed-162456611703602601","js-test-sqlServerFeed-":"js-test-sqlServerFeed-162456611703605931","js-test-cosmosFeed-":"js-test-cosmosFeed-162456611703606158","js-test-dataExplorerFeed-":"js-test-dataExplorerFeed-162456611703605594","js-test-tableFeed-":"js-test-tableFeed-162456611703601948","js-test-httpRequestFeed-":"js-test-httpRequestFeed-162456611703601598","js-test-logAnalyticsFeed-":"js-test-logAnalyticsFeed-162456611703605729","js-test-influxdbFeed-":"js-test-influxdbFeed-162456611703608797","js-test-mongoDbFeed-":"js-test-mongoDbFeed-162456611703608062","js-test-mySqlFeed-":"js-test-mySqlFeed-162456611703601892","js-test-postgreSqlFeed-":"js-test-postgreSqlFeed-162456611703605513","js-test-dataLakeGenFeed-":"js-test-dataLakeGenFeed-162456611703602792"},"newDate":{}}
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F")
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -22,59 +22,59 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  '8555f162-6194-490d-98e9-74574bef5400',
+  '0825421b-0412-4892-9d10-18085d133a00',
   'x-ms-ests-server',
-  '2.1.11787.14 - WUS2 ProdSlices',
+  '2.1.11829.9 - SCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AmLQSFzZ3NtIncXgUaZsx9HGLH8mAQAAAO3sTNgOAAAA; expires=Mon, 05-Jul-2021 03:56:30 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ap4NeeLKqOpIlcTRHUTrwPfGLH8mAQAAAGXgZtgOAAAA; expires=Sat, 24-Jul-2021 20:21:57 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Sat, 05 Jun 2021 03:56:30 GMT',
+  'Thu, 24 Jun 2021 20:21:56 GMT',
   'Content-Length',
   '1331'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .post('/metricsadvisor/v1.0/dataFeeds', {"dataSourceType":"AzureEventHubs","dataFeedName":"js-test-httpRequestFeed-162286538972809899","dataFeedDescription":"Data feed description","granularityName":"Daily","metrics":[{"metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2020-08-21T00:00:00.000Z","startOffsetInSeconds":0,"maxConcurrency":-1,"minRetryIntervalInSeconds":-1,"stopRetryAfterInSeconds":-1,"needRollup":"NeedRollup","rollUpMethod":"Sum","allUpIdentification":"__CUSTOM_SUM__","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"viewMode":"Private","authenticationType":"Basic","dataSourceParameter":{"connectionString":"eventhub-connection-string","consumerGroup":"consumer-group"}})
+  .post('/metricsadvisor/v1.0/dataFeeds', {"dataSourceType":"AzureEventHubs","dataFeedName":"js-test-httpRequestFeed-162456611703601598","dataFeedDescription":"Data feed description","granularityName":"Daily","metrics":[{"metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2020-08-21T00:00:00.000Z","startOffsetInSeconds":0,"maxConcurrency":-1,"minRetryIntervalInSeconds":-1,"stopRetryAfterInSeconds":-1,"needRollup":"NeedRollup","rollUpMethod":"Sum","allUpIdentification":"__CUSTOM_SUM__","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"viewMode":"Private","authenticationType":"Basic","dataSourceParameter":{"connectionString":"eventhub-connection-string","consumerGroup":"consumer-group"}})
   .reply(201, "", [
   'Content-Length',
   '0',
   'Location',
-  'https://endpoint/metricsadvisor/v1.0/dataFeeds/d14eb6dc-6761-491d-bf79-d3279080f70d',
+  'https://endpoint/metricsadvisor/v1.0/dataFeeds/1409ab03-d455-465e-9df0-ef5db2cdb961',
   'x-request-id',
-  '5720d423-b94c-4644-a50a-cf33d5498f8f',
+  'bf8ce3d4-e4ca-4825-9222-40ab47422d30',
   'x-envoy-upstream-service-time',
-  '6108',
+  '7340',
   'apim-request-id',
-  '5720d423-b94c-4644-a50a-cf33d5498f8f',
+  'bf8ce3d4-e4ca-4825-9222-40ab47422d30',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:36 GMT'
+  'Thu, 24 Jun 2021 20:22:04 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/dataFeeds/d14eb6dc-6761-491d-bf79-d3279080f70d')
-  .reply(200, {"dataFeedId":"d14eb6dc-6761-491d-bf79-d3279080f70d","dataFeedName":"js-test-httpRequestFeed-162286538972809899","metrics":[{"metricId":"da49548d-fb10-44ef-8f9f-472b7e257bbe","metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricId":"cbea5d2b-c4af-4d97-bae0-6b21d92dfb67","metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2021-06-05T00:00:00Z","dataSourceType":"AzureEventHubs","timestampColumn":"","startOffsetInSeconds":0,"maxQueryPerMinute":30,"granularityName":"Daily","allUpIdentification":"__CUSTOM_SUM__","needRollup":"NeedRollup","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"rollUpMethod":"Sum","dataFeedDescription":"Data feed description","stopRetryAfterInSeconds":-1,"minRetryIntervalInSeconds":-1,"maxConcurrency":-1,"viewMode":"Private","admins":["azure_client_id"],"viewers":[],"creator":"azure_client_id","status":"Active","createdTime":"2021-06-05T03:56:36Z","isAdmin":true,"actionLinkTemplate":"","dataSourceParameter":{"consumerGroup":"consumer-group"},"authenticationType":"Basic"}, [
+  .get('/metricsadvisor/v1.0/dataFeeds/1409ab03-d455-465e-9df0-ef5db2cdb961')
+  .reply(200, {"dataFeedId":"1409ab03-d455-465e-9df0-ef5db2cdb961","dataFeedName":"js-test-httpRequestFeed-162456611703601598","metrics":[{"metricId":"5b7c65ed-5f79-4281-a53d-631edc294f9a","metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricId":"6e9f6865-afa0-4524-831d-ed620e6fa5a9","metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2021-06-24T00:00:00Z","dataSourceType":"AzureEventHubs","timestampColumn":"","startOffsetInSeconds":0,"maxQueryPerMinute":30,"granularityName":"Daily","allUpIdentification":"__CUSTOM_SUM__","needRollup":"NeedRollup","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"rollUpMethod":"Sum","dataFeedDescription":"Data feed description","stopRetryAfterInSeconds":-1,"minRetryIntervalInSeconds":-1,"maxConcurrency":-1,"viewMode":"Private","admins":["azure_client_id"],"viewers":[],"creator":"azure_client_id","status":"Active","createdTime":"2021-06-24T20:22:04Z","isAdmin":true,"actionLinkTemplate":"","dataSourceParameter":{"consumerGroup":"consumer-group"},"authenticationType":"Basic"}, [
   'Content-Length',
   '1263',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'd55c046c-e32c-43ea-a89e-77cf47bb875e',
+  '9af44072-c58d-46ca-86a7-bab9d1e12f52',
   'x-envoy-upstream-service-time',
-  '183',
+  '5334',
   'apim-request-id',
-  'd55c046c-e32c-43ea-a89e-77cf47bb875e',
+  '9af44072-c58d-46ca-86a7-bab9d1e12f52',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:36 GMT'
+  'Thu, 24 Jun 2021 20:22:10 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/aad_metricsadvisoradministrationclient_datafeed_datafeed/recording_deletes_eventhubs_data_feed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/aad_metricsadvisoradministrationclient_datafeed_datafeed/recording_deletes_eventhubs_data_feed.js
@@ -1,11 +1,11 @@
 let nock = require('nock');
 
-module.exports.hash = "8db789c5a43bf8d7e9c8ff57f96724c2";
+module.exports.hash = "3b26ef694bf46025b536723153ef1756";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
-  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F")
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',
@@ -22,57 +22,57 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'x-ms-request-id',
-  'b1e3b71e-7805-4038-a226-cc8e7c6f6500',
+  'e26d6036-8ed7-4299-8775-58c73aa43600',
   'x-ms-ests-server',
-  '2.1.11787.14 - WUS2 ProdSlices',
+  '2.1.11829.9 - NCUS ProdSlices',
   'Set-Cookie',
-  'fpc=AmLQSFzZ3NtIncXgUaZsx9HGLH8mAgAAAO3sTNgOAAAA; expires=Mon, 05-Jul-2021 03:56:37 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=Ap4NeeLKqOpIlcTRHUTrwPfGLH8mAgAAAGXgZtgOAAAA; expires=Sat, 24-Jul-2021 20:22:11 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; secure; samesite=none; httponly',
   'Date',
-  'Sat, 05 Jun 2021 03:56:37 GMT',
+  'Thu, 24 Jun 2021 20:22:10 GMT',
   'Content-Length',
   '1331'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .delete('/metricsadvisor/v1.0/dataFeeds/d14eb6dc-6761-491d-bf79-d3279080f70d')
+  .delete('/metricsadvisor/v1.0/dataFeeds/1409ab03-d455-465e-9df0-ef5db2cdb961')
   .reply(204, "", [
   'Content-Length',
   '0',
   'x-request-id',
-  '293c7964-b109-4123-86cc-ea20f39e3ef4',
+  '4666cc14-a826-4061-947a-085483e932ac',
   'x-envoy-upstream-service-time',
-  '5590',
+  '5984',
   'apim-request-id',
-  '293c7964-b109-4123-86cc-ea20f39e3ef4',
+  '4666cc14-a826-4061-947a-085483e932ac',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:42 GMT'
+  'Thu, 24 Jun 2021 20:22:16 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/dataFeeds/d14eb6dc-6761-491d-bf79-d3279080f70d')
+  .get('/metricsadvisor/v1.0/dataFeeds/1409ab03-d455-465e-9df0-ef5db2cdb961')
   .reply(404, {"code":"404 NOT_FOUND","message":"datafeedId is invalid."}, [
   'Content-Length',
   '59',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'fee8363d-582a-4c16-9f94-fd67d7db5423',
+  'c3d92522-51c4-4c5b-8b5a-30f3808a3793',
   'x-envoy-upstream-service-time',
-  '5138',
+  '5314',
   'apim-request-id',
-  'fee8363d-582a-4c16-9f94-fd67d7db5423',
+  'c3d92522-51c4-4c5b-8b5a-30f3808a3793',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:47 GMT'
+  'Thu, 24 Jun 2021 20:22:22 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisoradministrationclient_datafeed_datafeed/recording_creates_eventhubs_data_feed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisoradministrationclient_datafeed_datafeed/recording_creates_eventhubs_data_feed.js
@@ -1,47 +1,47 @@
 let nock = require('nock');
 
-module.exports.hash = "20a42b7c23b773a1da152bf8cfd1872b";
+module.exports.hash = "b305b062177574b168150bc47bb53ffe";
 
-module.exports.testInfo = {"uniqueName":{"js-test-datafeed-":"js-test-datafeed-162286540825106897","js-test-appInsightsFeed-":"js-test-appInsightsFeed-162286540825103508","js-test-sqlServerFeed-":"js-test-sqlServerFeed-162286540825102841","js-test-cosmosFeed-":"js-test-cosmosFeed-162286540825109497","js-test-dataExplorerFeed-":"js-test-dataExplorerFeed-162286540825100498","js-test-tableFeed-":"js-test-tableFeed-162286540825106607","js-test-httpRequestFeed-":"js-test-httpRequestFeed-162286540825107845","js-test-logAnalyticsFeed-":"js-test-logAnalyticsFeed-162286540825103590","js-test-influxdbFeed-":"js-test-influxdbFeed-162286540825109243","js-test-mongoDbFeed-":"js-test-mongoDbFeed-162286540825106090","js-test-mySqlFeed-":"js-test-mySqlFeed-162286540825102842","js-test-postgreSqlFeed-":"js-test-postgreSqlFeed-162286540825106280","js-test-dataLakeGenFeed-":"js-test-dataLakeGenFeed-162286540825100711"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"js-test-datafeed-":"js-test-datafeed-162456614300300139","js-test-appInsightsFeed-":"js-test-appInsightsFeed-162456614300408925","js-test-sqlServerFeed-":"js-test-sqlServerFeed-162456614300402561","js-test-cosmosFeed-":"js-test-cosmosFeed-162456614300400836","js-test-dataExplorerFeed-":"js-test-dataExplorerFeed-162456614300402514","js-test-tableFeed-":"js-test-tableFeed-162456614300409086","js-test-httpRequestFeed-":"js-test-httpRequestFeed-162456614300408284","js-test-logAnalyticsFeed-":"js-test-logAnalyticsFeed-162456614300401025","js-test-influxdbFeed-":"js-test-influxdbFeed-162456614300401958","js-test-mongoDbFeed-":"js-test-mongoDbFeed-162456614300402402","js-test-mySqlFeed-":"js-test-mySqlFeed-162456614300400971","js-test-postgreSqlFeed-":"js-test-postgreSqlFeed-162456614300408445","js-test-dataLakeGenFeed-":"js-test-dataLakeGenFeed-162456614300400179"},"newDate":{}}
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .post('/metricsadvisor/v1.0/dataFeeds', {"dataSourceType":"AzureEventHubs","dataFeedName":"js-test-httpRequestFeed-162286540825107845","dataFeedDescription":"Data feed description","granularityName":"Daily","metrics":[{"metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2020-08-21T00:00:00.000Z","startOffsetInSeconds":0,"maxConcurrency":-1,"minRetryIntervalInSeconds":-1,"stopRetryAfterInSeconds":-1,"needRollup":"NeedRollup","rollUpMethod":"Sum","allUpIdentification":"__CUSTOM_SUM__","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"viewMode":"Private","authenticationType":"Basic","dataSourceParameter":{"connectionString":"eventhub-connection-string","consumerGroup":"consumer-group"}})
+  .post('/metricsadvisor/v1.0/dataFeeds', {"dataSourceType":"AzureEventHubs","dataFeedName":"js-test-httpRequestFeed-162456614300408284","dataFeedDescription":"Data feed description","granularityName":"Daily","metrics":[{"metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2020-08-21T00:00:00.000Z","startOffsetInSeconds":0,"maxConcurrency":-1,"minRetryIntervalInSeconds":-1,"stopRetryAfterInSeconds":-1,"needRollup":"NeedRollup","rollUpMethod":"Sum","allUpIdentification":"__CUSTOM_SUM__","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"viewMode":"Private","authenticationType":"Basic","dataSourceParameter":{"connectionString":"eventhub-connection-string","consumerGroup":"consumer-group"}})
   .reply(201, "", [
   'Content-Length',
   '0',
   'Location',
-  'https://endpoint/metricsadvisor/v1.0/dataFeeds/f6e5a8cb-398a-4d5a-89e7-56d1307d72c5',
+  'https://endpoint/metricsadvisor/v1.0/dataFeeds/49afdaec-205b-4211-8020-56a7458063c2',
   'x-request-id',
-  '386f4c2e-85ca-46e5-a265-388c1387d4de',
+  'fb26ee74-d492-4354-ae45-99e8253fdfb7',
   'x-envoy-upstream-service-time',
-  '749',
+  '2233',
   'apim-request-id',
-  '386f4c2e-85ca-46e5-a265-388c1387d4de',
+  'fb26ee74-d492-4354-ae45-99e8253fdfb7',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:48 GMT'
+  'Thu, 24 Jun 2021 20:22:24 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/dataFeeds/f6e5a8cb-398a-4d5a-89e7-56d1307d72c5')
-  .reply(200, {"dataFeedId":"f6e5a8cb-398a-4d5a-89e7-56d1307d72c5","dataFeedName":"js-test-httpRequestFeed-162286540825107845","metrics":[{"metricId":"15512319-f95c-48ae-aeca-f775497fbc35","metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricId":"395ca396-b5d4-45a3-96fa-d0adc40873f8","metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2021-06-05T00:00:00Z","dataSourceType":"AzureEventHubs","timestampColumn":"","startOffsetInSeconds":0,"maxQueryPerMinute":30,"granularityName":"Daily","allUpIdentification":"__CUSTOM_SUM__","needRollup":"NeedRollup","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"rollUpMethod":"Sum","dataFeedDescription":"Data feed description","stopRetryAfterInSeconds":-1,"minRetryIntervalInSeconds":-1,"maxConcurrency":-1,"viewMode":"Private","admins":["kaghiya@microsoft.com"],"viewers":[],"creator":"kaghiya@microsoft.com","status":"Active","createdTime":"2021-06-05T03:56:48Z","isAdmin":true,"actionLinkTemplate":"","dataSourceParameter":{"consumerGroup":"consumer-group"},"authenticationType":"Basic"}, [
+  .get('/metricsadvisor/v1.0/dataFeeds/49afdaec-205b-4211-8020-56a7458063c2')
+  .reply(200, {"dataFeedId":"49afdaec-205b-4211-8020-56a7458063c2","dataFeedName":"js-test-httpRequestFeed-162456614300408284","metrics":[{"metricId":"f0d89260-9d15-438f-865c-877a65558832","metricName":"cost","metricDisplayName":"cost","metricDescription":""},{"metricId":"05627ee3-091c-4d8c-8263-819e6d689193","metricName":"revenue","metricDisplayName":"revenue","metricDescription":""}],"dimension":[{"dimensionName":"category","dimensionDisplayName":"category"},{"dimensionName":"city","dimensionDisplayName":"city"}],"dataStartFrom":"2021-06-24T00:00:00Z","dataSourceType":"AzureEventHubs","timestampColumn":"","startOffsetInSeconds":0,"maxQueryPerMinute":30,"granularityName":"Daily","allUpIdentification":"__CUSTOM_SUM__","needRollup":"NeedRollup","fillMissingPointType":"CustomValue","fillMissingPointValue":555,"rollUpMethod":"Sum","dataFeedDescription":"Data feed description","stopRetryAfterInSeconds":-1,"minRetryIntervalInSeconds":-1,"maxConcurrency":-1,"viewMode":"Private","admins":["kaghiya@microsoft.com"],"viewers":[],"creator":"kaghiya@microsoft.com","status":"Active","createdTime":"2021-06-24T20:22:24Z","isAdmin":true,"actionLinkTemplate":"","dataSourceParameter":{"consumerGroup":"consumer-group"},"authenticationType":"Basic"}, [
   'Content-Length',
   '1233',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'a44fa8ca-54d1-48e6-b609-a38894c2d09d',
+  'b8689547-dcd2-4a12-8cfd-7ebf3cf2e8d5',
   'x-envoy-upstream-service-time',
-  '175',
+  '500',
   'apim-request-id',
-  'a44fa8ca-54d1-48e6-b609-a38894c2d09d',
+  'b8689547-dcd2-4a12-8cfd-7ebf3cf2e8d5',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:48 GMT'
+  'Thu, 24 Jun 2021 20:22:25 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisoradministrationclient_datafeed_datafeed/recording_deletes_eventhubs_data_feed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/recordings/node/api_key_metricsadvisoradministrationclient_datafeed_datafeed/recording_deletes_eventhubs_data_feed.js
@@ -1,45 +1,45 @@
 let nock = require('nock');
 
-module.exports.hash = "8db789c5a43bf8d7e9c8ff57f96724c2";
+module.exports.hash = "3b26ef694bf46025b536723153ef1756";
 
 module.exports.testInfo = {"uniqueName":{},"newDate":{}}
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .delete('/metricsadvisor/v1.0/dataFeeds/f6e5a8cb-398a-4d5a-89e7-56d1307d72c5')
+  .delete('/metricsadvisor/v1.0/dataFeeds/49afdaec-205b-4211-8020-56a7458063c2')
   .reply(204, "", [
   'Content-Length',
   '0',
   'x-request-id',
-  'bdbfaac7-2008-4713-866a-abbb8a6787c2',
+  '24dfcbc6-ba4c-45b4-9f19-98c141b9c83a',
   'x-envoy-upstream-service-time',
-  '431',
+  '6082',
   'apim-request-id',
-  'bdbfaac7-2008-4713-866a-abbb8a6787c2',
+  '24dfcbc6-ba4c-45b4-9f19-98c141b9c83a',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:48 GMT'
+  'Thu, 24 Jun 2021 20:22:31 GMT'
 ]);
 
 nock('https://endpoint:443', {"encodedQueryParams":true})
-  .get('/metricsadvisor/v1.0/dataFeeds/f6e5a8cb-398a-4d5a-89e7-56d1307d72c5')
+  .get('/metricsadvisor/v1.0/dataFeeds/49afdaec-205b-4211-8020-56a7458063c2')
   .reply(404, {"code":"404 NOT_FOUND","message":"datafeedId is invalid."}, [
   'Content-Length',
   '59',
   'Content-Type',
   'application/json; charset=utf-8',
   'x-request-id',
-  'fce9dd4e-f02f-47b4-a626-c5afd5251b74',
+  'b53ca28c-fbaf-4a8c-b738-d26533679f90',
   'x-envoy-upstream-service-time',
-  '139',
+  '192',
   'apim-request-id',
-  'fce9dd4e-f02f-47b4-a626-c5afd5251b74',
+  'b53ca28c-fbaf-4a8c-b738-d26533679f90',
   'Strict-Transport-Security',
   'max-age=31536000; includeSubDomains; preload',
   'x-content-type-options',
   'nosniff',
   'Date',
-  'Sat, 05 Jun 2021 03:56:49 GMT'
+  'Thu, 24 Jun 2021 20:22:31 GMT'
 ]);

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -1037,8 +1037,8 @@ export class MetricsAdvisorClient {
     listAnomaliesForDetectionConfiguration(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listAnomalyDimensionValues(detectionConfigId: string, startTime: Date | string, endTime: Date | string, dimensionName: string, options?: ListAnomalyDimensionValuesOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listFeedback(metricId: string, options?: ListFeedbackOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse>;
-    listIncidents(alert: AnomalyAlert, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
-    listIncidents(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
+    listIncidentsForAlert(alert: AnomalyAlert, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
+    listIncidentsForDetectionConfiguration(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListIncidentsForDetectionConfigurationOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
     listMetricDimensionValues(metricId: string, dimensionName: string, options?: ListMetricDimensionValuesOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listMetricEnrichmentStatus(metricId: string, startTime: Date | string, endTime: Date | string, options?: ListMetricEnrichmentStatusOptions): PagedAsyncIterableIterator<EnrichmentStatus, MetricEnrichmentStatusPageResponse>;
     listMetricSeriesDefinitions(metricId: string, activeSince: Date | string, options?: ListMetricSeriesDefinitionsOptions): PagedAsyncIterableIterator<MetricSeriesDefinition, MetricSeriesPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -450,9 +450,12 @@ export type DatasourceCredentialUnion = SqlServerConnectionStringDatasourceCrede
 export type DataSourceType = "AzureApplicationInsights" | "AzureBlob" | "AzureCosmosDB" | "AzureDataExplorer" | "AzureDataLakeStorageGen2" | "AzureEventHubs" | "AzureLogAnalytics" | "AzureTable" | "InfluxDB" | "MongoDB" | "MySql" | "PostgreSql" | "SqlServer";
 
 // @public
+export type DetectionConditionOperator = "AND" | "OR";
+
+// @public
 export interface DetectionConditionsCommon {
     changeThresholdCondition?: ChangeThresholdConditionUnion;
-    conditionOperator?: DetectionConditionsOperator;
+    conditionOperator?: DetectionConditionOperator;
     hardThresholdCondition?: HardThresholdConditionUnion;
     smartDetectionCondition?: SmartDetectionCondition;
 }
@@ -460,13 +463,10 @@ export interface DetectionConditionsCommon {
 // @public
 export interface DetectionConditionsCommonPatch {
     changeThresholdCondition?: Partial<ChangeThresholdConditionUnion>;
-    conditionOperator?: DetectionConditionsOperator;
+    conditionOperator?: DetectionConditionOperator;
     hardThresholdCondition?: Partial<HardThresholdConditionUnion>;
     smartDetectionCondition?: Partial<SmartDetectionCondition>;
 }
-
-// @public
-export type DetectionConditionsOperator = "AND" | "OR";
 
 // @public
 export interface DetectionConfigurationsPageResponse extends Array<AnomalyDetectionConfiguration> {
@@ -974,8 +974,8 @@ export class MetricsAdvisorClient {
     readonly endpointUrl: string;
     getFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
-    getMetricEnrichedSeriesData(detectionConfigId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
-    getMetricSeriesData(metricId: string, startTime: Date | string, endTime: Date | string, seriesToFilter: DimensionKey[], options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
+    getMetricEnrichedSeriesData(detectionConfigId: string, seriesKey: DimensionKey[], startTime: Date | string, endTime: Date | string, options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
+    getMetricSeriesData(metricId: string, seriesKey: DimensionKey[], startTime: Date | string, endTime: Date | string, options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
     listAlerts(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
     listAnomalies(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listAnomalies(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -230,7 +230,7 @@ export interface CreateDataFeedOptions extends OperationOptions {
 }
 
 // @public
-export interface CredentialsPageResponse extends Array<DataSourceCredentialUnion> {
+export interface CredentialsPageResponse extends Array<DataSourceCredentialEntityUnion> {
     continuationToken?: string;
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
@@ -376,20 +376,6 @@ export interface DataFeedsPageResponse extends Array<DataFeed> {
 export type DataFeedStatus = "Paused" | "Active";
 
 // @public
-export interface DataLakeGen2SharedKeyDataSourceCredential extends DataSourceCredential {
-    accountKey?: string;
-    type: "DataLakeGen2SharedKey";
-}
-
-// @public
-export interface DataLakeGen2SharedKeyDataSourceCredentialPatch {
-    accountKey?: string;
-    description?: string;
-    name?: string;
-    type: "DataLakeGen2SharedKey";
-}
-
-// @public
 export type DataLakeStorageGen2AuthBasic = {
     authenticationType: "Basic";
     accountKey: string;
@@ -434,17 +420,87 @@ export interface DataPointAnomaly {
 }
 
 // @public
-export interface DataSourceCredential {
+export interface DataSourceCredentialEntity {
     description?: string;
     readonly id?: string;
     name: string;
 }
 
-// @public
-export type DataSourceCredentialPatch = SqlServerConnectionStringDataSourceCredentialPatch | DataLakeGen2SharedKeyDataSourceCredentialPatch | ServicePrincipalDataSourceCredentialPatch | ServicePrincipalInKeyVaultDataSourceCredentialPatch;
-
 // @public (undocumented)
-export type DataSourceCredentialUnion = SqlServerConnectionStringDataSourceCredential | DataLakeGen2SharedKeyDataSourceCredential | ServicePrincipalDataSourceCredential | ServicePrincipalInKeyVaultDataSourceCredential;
+export type DataSourceCredentialEntityUnion = DataSourceSqlConnectionString | DataSourceDataLakeGen2SharedKey | DataSourceServicePrincipal | DataSourceServicePrincipalInKeyVault;
+
+// @public
+export type DataSourceCredentialPatch = DataSourceSqlServerConnectionStringPatch | DataSourceDataLakeGen2SharedKeyPatch | DataSourceServicePrincipalPatch | DataSourceServicePrincipalInKeyVaultPatch;
+
+// @public
+export interface DataSourceDataLakeGen2SharedKey extends DataSourceCredentialEntity {
+    accountKey?: string;
+    type: "DataLakeGen2SharedKey";
+}
+
+// @public
+export interface DataSourceDataLakeGen2SharedKeyPatch {
+    accountKey?: string;
+    description?: string;
+    name?: string;
+    type: "DataLakeGen2SharedKey";
+}
+
+// @public
+export interface DataSourceServicePrincipal extends DataSourceCredentialEntity {
+    clientId: string;
+    clientSecret?: string;
+    tenantId: string;
+    type: "ServicePrincipal";
+}
+
+// @public
+export interface DataSourceServicePrincipalInKeyVault extends DataSourceCredentialEntity {
+    keyVaultClientId: string;
+    keyVaultClientSecret?: string;
+    keyVaultEndpoint: string;
+    servicePrincipalIdNameInKV: string;
+    servicePrincipalSecretNameInKV: string;
+    tenantId: string;
+    type: "ServicePrincipalInKV";
+}
+
+// @public
+export interface DataSourceServicePrincipalInKeyVaultPatch {
+    description?: string;
+    keyVaultClientId?: string;
+    keyVaultClientSecret?: string;
+    keyVaultEndpoint?: string;
+    name?: string;
+    servicePrincipalIdNameInKV?: string;
+    servicePrincipalSecretNameInKV?: string;
+    tenantId?: string;
+    type: "ServicePrincipalInKV";
+}
+
+// @public
+export interface DataSourceServicePrincipalPatch {
+    clientId?: string;
+    clientSecret?: string;
+    description?: string;
+    name?: string;
+    tenantId?: string;
+    type: "ServicePrincipal";
+}
+
+// @public
+export interface DataSourceSqlConnectionString extends DataSourceCredentialEntity {
+    connectionString?: string;
+    type: "AzureSQLConnectionString";
+}
+
+// @public
+export interface DataSourceSqlServerConnectionStringPatch {
+    connectionString?: string;
+    description?: string;
+    name?: string;
+    type: "AzureSQLConnectionString";
+}
 
 // @public
 export type DataSourceType = "AzureApplicationInsights" | "AzureBlob" | "AzureCosmosDB" | "AzureDataExplorer" | "AzureDataLakeStorageGen2" | "AzureEventHubs" | "AzureLogAnalytics" | "AzureTable" | "InfluxDB" | "MongoDB" | "MySql" | "PostgreSql" | "SqlServer";
@@ -535,7 +591,7 @@ export type GetDataFeedResponse = DataFeed & {
 };
 
 // @public
-export type GetDataSourceCredentialEntityResponse = DataSourceCredentialUnion & {
+export type GetDataSourceCredentialEntityResponse = DataSourceCredentialEntityUnion & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
         parsedBody: any;
@@ -934,7 +990,7 @@ export class MetricsAdvisorAdministrationClient {
     constructor(endpointUrl: string, credential: TokenCredential | MetricsAdvisorKeyCredential, options?: MetricsAdvisorAdministrationClientOptions);
     createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     createDataFeed(feed: DataFeedDescriptor, operationOptions?: CreateDataFeedOptions): Promise<GetDataFeedResponse>;
-    createDataSourceCredential(dataSourceCredential: DataSourceCredentialUnion, options?: OperationOptions): Promise<GetDataSourceCredentialEntityResponse>;
+    createDataSourceCredential(dataSourceCredential: DataSourceCredentialEntityUnion, options?: OperationOptions): Promise<GetDataSourceCredentialEntityResponse>;
     createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<GetHookResponse>;
     deleteAlertConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
@@ -952,7 +1008,7 @@ export class MetricsAdvisorAdministrationClient {
     listAlertConfigs(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;
     listDataFeedIngestionStatus(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: ListDataFeedIngestionStatusOptions): PagedAsyncIterableIterator<IngestionStatus, IngestionStatusPageResponse>;
     listDataFeeds(options?: ListDataFeedsOptions): PagedAsyncIterableIterator<DataFeed, DataFeedsPageResponse>;
-    listDataSourceCredential(options?: ListDataSourceCredentialsOptions): PagedAsyncIterableIterator<DataSourceCredentialUnion, CredentialsPageResponse>;
+    listDataSourceCredential(options?: ListDataSourceCredentialsOptions): PagedAsyncIterableIterator<DataSourceCredentialEntityUnion, CredentialsPageResponse>;
     listDetectionConfigs(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, DetectionConfigurationsPageResponse, undefined>;
     listHooks(options?: ListHooksOptions): PagedAsyncIterableIterator<NotificationHookUnion, HooksPageResponse>;
     refreshDataFeedIngestion(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: OperationOptions): Promise<RestResponse>;
@@ -1083,48 +1139,6 @@ export type PostgreSqlDataFeedSource = {
 };
 
 // @public
-export interface ServicePrincipalDataSourceCredential extends DataSourceCredential {
-    clientId: string;
-    clientSecret?: string;
-    tenantId: string;
-    type: "ServicePrincipal";
-}
-
-// @public
-export interface ServicePrincipalDataSourceCredentialPatch {
-    clientId?: string;
-    clientSecret?: string;
-    description?: string;
-    name?: string;
-    tenantId?: string;
-    type: "ServicePrincipal";
-}
-
-// @public
-export interface ServicePrincipalInKeyVaultDataSourceCredential extends DataSourceCredential {
-    keyVaultClientId: string;
-    keyVaultClientSecret?: string;
-    keyVaultEndpoint: string;
-    servicePrincipalIdNameInKV: string;
-    servicePrincipalSecretNameInKV: string;
-    tenantId: string;
-    type: "ServicePrincipalInKV";
-}
-
-// @public
-export interface ServicePrincipalInKeyVaultDataSourceCredentialPatch {
-    description?: string;
-    keyVaultClientId?: string;
-    keyVaultClientSecret?: string;
-    keyVaultEndpoint?: string;
-    name?: string;
-    servicePrincipalIdNameInKV?: string;
-    servicePrincipalSecretNameInKV?: string;
-    tenantId?: string;
-    type: "ServicePrincipalInKV";
-}
-
-// @public
 export type Severity = "Low" | "Medium" | "High";
 
 // @public (undocumented)
@@ -1184,20 +1198,6 @@ export interface SqlServerAuthServicePrincipalInKeyVault {
 
 // @public
 export type SqlServerAuthTypes = SqlServerAuthBasic | SqlServerAuthManagedIdentity | SqlServerAuthConnectionString | SqlServerAuthServicePrincipal | SqlServerAuthServicePrincipalInKeyVault;
-
-// @public
-export interface SqlServerConnectionStringDataSourceCredential extends DataSourceCredential {
-    connectionString?: string;
-    type: "AzureSQLConnectionString";
-}
-
-// @public
-export interface SqlServerConnectionStringDataSourceCredentialPatch {
-    connectionString?: string;
-    description?: string;
-    name?: string;
-    type: "AzureSQLConnectionString";
-}
 
 // @public
 export type SqlServerDataFeedSource = {

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -264,6 +264,9 @@ export type DataFeed = {
 export type DataFeedAccessMode = "Private" | "Public";
 
 // @public
+export type DataFeedAutoRollupMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
+
+// @public
 export type DataFeedDescriptor = Omit<DataFeed, "id" | "metricIds" | "isAdmin" | "status" | "creator" | "createdOn">;
 
 // @public
@@ -333,9 +336,6 @@ export type DataFeedPatch = {
 };
 
 // @public
-export type DataFeedRollupMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
-
-// @public
 export type DataFeedRollupSettings = {
     rollupType: "NoRollup";
 } | {
@@ -344,7 +344,7 @@ export type DataFeedRollupSettings = {
 } | {
     rollupType: "AutoRollup";
     autoRollupGroupByColumnNames?: string[];
-    rollupMethod?: DataFeedRollupMethod;
+    rollupMethod?: DataFeedAutoRollupMethod;
     rollupIdentificationValue?: string;
 };
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -230,7 +230,7 @@ export interface CreateDataFeedOptions extends OperationOptions {
 }
 
 // @public
-export interface CredentialsPageResponse extends Array<DatasourceCredentialUnion> {
+export interface CredentialsPageResponse extends Array<DataSourceCredentialUnion> {
     continuationToken?: string;
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
@@ -376,13 +376,13 @@ export interface DataFeedsPageResponse extends Array<DataFeed> {
 export type DataFeedStatus = "Paused" | "Active";
 
 // @public
-export interface DataLakeGen2SharedKeyDatasourceCredential extends DatasourceCredential {
+export interface DataLakeGen2SharedKeyDataSourceCredential extends DataSourceCredential {
     accountKey?: string;
     type: "DataLakeGen2SharedKey";
 }
 
 // @public
-export interface DataLakeGen2SharedKeyDatasourceCredentialPatch {
+export interface DataLakeGen2SharedKeyDataSourceCredentialPatch {
     accountKey?: string;
     description?: string;
     name?: string;
@@ -434,17 +434,17 @@ export interface DataPointAnomaly {
 }
 
 // @public
-export interface DatasourceCredential {
+export interface DataSourceCredential {
     description?: string;
     readonly id?: string;
     name: string;
 }
 
 // @public
-export type DatasourceCredentialPatch = SqlServerConnectionStringDatasourceCredentialPatch | DataLakeGen2SharedKeyDatasourceCredentialPatch | ServicePrincipalDatasourceCredentialPatch | ServicePrincipalInKeyVaultDatasourceCredentialPatch;
+export type DataSourceCredentialPatch = SqlServerConnectionStringDataSourceCredentialPatch | DataLakeGen2SharedKeyDataSourceCredentialPatch | ServicePrincipalDataSourceCredentialPatch | ServicePrincipalInKeyVaultDataSourceCredentialPatch;
 
 // @public (undocumented)
-export type DatasourceCredentialUnion = SqlServerConnectionStringDatasourceCredential | DataLakeGen2SharedKeyDatasourceCredential | ServicePrincipalDatasourceCredential | ServicePrincipalInKeyVaultDatasourceCredential;
+export type DataSourceCredentialUnion = SqlServerConnectionStringDataSourceCredential | DataLakeGen2SharedKeyDataSourceCredential | ServicePrincipalDataSourceCredential | ServicePrincipalInKeyVaultDataSourceCredential;
 
 // @public
 export type DataSourceType = "AzureApplicationInsights" | "AzureBlob" | "AzureCosmosDB" | "AzureDataExplorer" | "AzureDataLakeStorageGen2" | "AzureEventHubs" | "AzureLogAnalytics" | "AzureTable" | "InfluxDB" | "MongoDB" | "MySql" | "PostgreSql" | "SqlServer";
@@ -527,7 +527,7 @@ export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
 };
 
 // @public
-export type GetCredentialEntityResponse = DatasourceCredentialUnion & {
+export type GetDataFeedResponse = DataFeed & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
         parsedBody: any;
@@ -535,7 +535,7 @@ export type GetCredentialEntityResponse = DatasourceCredentialUnion & {
 };
 
 // @public
-export type GetDataFeedResponse = DataFeed & {
+export type GetDataSourceCredentialEntityResponse = DataSourceCredentialUnion & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
         parsedBody: any;
@@ -725,7 +725,7 @@ export interface ListDataFeedsOptions extends OperationOptions {
 }
 
 // @public
-export interface ListDatasourceCredentialsOptions extends OperationOptions {
+export interface ListDataSourceCredentialsOptions extends OperationOptions {
     skip?: number;
 }
 
@@ -934,31 +934,31 @@ export class MetricsAdvisorAdministrationClient {
     constructor(endpointUrl: string, credential: TokenCredential | MetricsAdvisorKeyCredential, options?: MetricsAdvisorAdministrationClientOptions);
     createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     createDataFeed(feed: DataFeedDescriptor, operationOptions?: CreateDataFeedOptions): Promise<GetDataFeedResponse>;
-    createDatasourceCredential(datasourceCredential: DatasourceCredentialUnion, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
+    createDataSourceCredential(dataSourceCredential: DataSourceCredentialUnion, options?: OperationOptions): Promise<GetDataSourceCredentialEntityResponse>;
     createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<GetHookResponse>;
     deleteAlertConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDataFeed(id: string, options?: OperationOptions): Promise<RestResponse>;
-    deleteDatasourceCredential(id: string, options?: OperationOptions): Promise<RestResponse>;
+    deleteDataSourceCredential(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDetectionConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteHook(id: string, options?: OperationOptions): Promise<RestResponse>;
     readonly endpointUrl: string;
     getAlertConfig(id: string, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     getDataFeed(id: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
     getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GetIngestionProgressResponse>;
-    getDatasourceCredential(id: string, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
+    getDataSourceCredential(id: string, options?: OperationOptions): Promise<GetDataSourceCredentialEntityResponse>;
     getDetectionConfig(id: string, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     getHook(id: string, options?: OperationOptions): Promise<GetHookResponse>;
     listAlertConfigs(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;
     listDataFeedIngestionStatus(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: ListDataFeedIngestionStatusOptions): PagedAsyncIterableIterator<IngestionStatus, IngestionStatusPageResponse>;
     listDataFeeds(options?: ListDataFeedsOptions): PagedAsyncIterableIterator<DataFeed, DataFeedsPageResponse>;
-    listDatasourceCredential(options?: ListDatasourceCredentialsOptions): PagedAsyncIterableIterator<DatasourceCredentialUnion, CredentialsPageResponse>;
+    listDataSourceCredential(options?: ListDataSourceCredentialsOptions): PagedAsyncIterableIterator<DataSourceCredentialUnion, CredentialsPageResponse>;
     listDetectionConfigs(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, DetectionConfigurationsPageResponse, undefined>;
     listHooks(options?: ListHooksOptions): PagedAsyncIterableIterator<NotificationHookUnion, HooksPageResponse>;
     refreshDataFeedIngestion(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: OperationOptions): Promise<RestResponse>;
     updateAlertConfig(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     updateDataFeed(dataFeedId: string, patch: DataFeedPatch, options?: OperationOptions): Promise<GetDataFeedResponse>;
-    updateDatasourceCredential(id: string, patch: DatasourceCredentialPatch, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
+    updateDataSourceCredential(id: string, patch: DataSourceCredentialPatch, options?: OperationOptions): Promise<GetDataSourceCredentialEntityResponse>;
     updateDetectionConfig(id: string, patch: AnomalyDetectionConfigurationPatch, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     updateHook(id: string, patch: EmailNotificationHookPatch | WebNotificationHookPatch, options?: OperationOptions): Promise<GetHookResponse>;
 }
@@ -1083,7 +1083,7 @@ export type PostgreSqlDataFeedSource = {
 };
 
 // @public
-export interface ServicePrincipalDatasourceCredential extends DatasourceCredential {
+export interface ServicePrincipalDataSourceCredential extends DataSourceCredential {
     clientId: string;
     clientSecret?: string;
     tenantId: string;
@@ -1091,7 +1091,7 @@ export interface ServicePrincipalDatasourceCredential extends DatasourceCredenti
 }
 
 // @public
-export interface ServicePrincipalDatasourceCredentialPatch {
+export interface ServicePrincipalDataSourceCredentialPatch {
     clientId?: string;
     clientSecret?: string;
     description?: string;
@@ -1101,7 +1101,7 @@ export interface ServicePrincipalDatasourceCredentialPatch {
 }
 
 // @public
-export interface ServicePrincipalInKeyVaultDatasourceCredential extends DatasourceCredential {
+export interface ServicePrincipalInKeyVaultDataSourceCredential extends DataSourceCredential {
     keyVaultClientId: string;
     keyVaultClientSecret?: string;
     keyVaultEndpoint: string;
@@ -1112,7 +1112,7 @@ export interface ServicePrincipalInKeyVaultDatasourceCredential extends Datasour
 }
 
 // @public
-export interface ServicePrincipalInKeyVaultDatasourceCredentialPatch {
+export interface ServicePrincipalInKeyVaultDataSourceCredentialPatch {
     description?: string;
     keyVaultClientId?: string;
     keyVaultClientSecret?: string;
@@ -1186,13 +1186,13 @@ export interface SqlServerAuthServicePrincipalInKeyVault {
 export type SqlServerAuthTypes = SqlServerAuthBasic | SqlServerAuthManagedIdentity | SqlServerAuthConnectionString | SqlServerAuthServicePrincipal | SqlServerAuthServicePrincipalInKeyVault;
 
 // @public
-export interface SqlServerConnectionStringDatasourceCredential extends DatasourceCredential {
+export interface SqlServerConnectionStringDataSourceCredential extends DataSourceCredential {
     connectionString?: string;
     type: "AzureSQLConnectionString";
 }
 
 // @public
-export interface SqlServerConnectionStringDatasourceCredentialPatch {
+export interface SqlServerConnectionStringDataSourceCredentialPatch {
     connectionString?: string;
     description?: string;
     name?: string;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -53,11 +53,11 @@ export interface AnomalyAlert {
 export interface AnomalyAlertConfiguration {
     crossMetricsOperator?: MetricAnomalyAlertConfigurationsOperator;
     description?: string;
+    dimensionsToSplitAlert?: string[];
     hookIds: string[];
     id: string;
     metricAlertConfigurations: MetricAlertConfiguration[];
     name: string;
-    splitAlertByDimensions?: string[];
 }
 
 // @public

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -1033,8 +1033,8 @@ export class MetricsAdvisorClient {
     getMetricEnrichedSeriesData(detectionConfigId: string, seriesKey: DimensionKey[], startTime: Date | string, endTime: Date | string, options?: GetMetricEnrichedSeriesDataOptions): Promise<GetMetricEnrichedSeriesDataResponse>;
     getMetricSeriesData(metricId: string, seriesKey: DimensionKey[], startTime: Date | string, endTime: Date | string, options?: GetMetricSeriesDataOptions): Promise<GetMetricSeriesDataResponse>;
     listAlerts(alertConfigId: string, startTime: Date | string, endTime: Date | string, timeMode: AlertQueryTimeMode, options?: ListAlertsOptions): PagedAsyncIterableIterator<AnomalyAlert, AlertsPageResponse>;
-    listAnomalies(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
-    listAnomalies(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
+    listAnomaliesForAlert(alert: AnomalyAlert, options?: ListAnomaliesForAlertConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
+    listAnomaliesForDetectionConfiguration(detectionConfigId: string, startTime: Date | string, endTime: Date | string, options?: ListAnomaliesForDetectionConfigurationOptions): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
     listAnomalyDimensionValues(detectionConfigId: string, startTime: Date | string, endTime: Date | string, dimensionName: string, options?: ListAnomalyDimensionValuesOptions): PagedAsyncIterableIterator<string, DimensionValuesPageResponse>;
     listFeedback(metricId: string, options?: ListFeedbackOptions): PagedAsyncIterableIterator<MetricFeedbackUnion, MetricFeedbackPageResponse>;
     listIncidents(alert: AnomalyAlert, options?: ListIncidentsForAlertOptions): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -264,7 +264,7 @@ export type DataFeedGranularity = {
     customGranularityValue: number;
 };
 
-// @public (undocumented)
+// @public
 export interface DataFeedIngestionProgress {
     readonly latestActiveTimestamp?: Date;
     readonly latestSuccessTimestamp?: Date;
@@ -404,7 +404,7 @@ export interface DataSourceCredentialEntity {
     name: string;
 }
 
-// @public (undocumented)
+// @public
 export type DataSourceCredentialEntityUnion = DataSourceSqlConnectionString | DataSourceDataLakeGen2SharedKey | DataSourceServicePrincipal | DataSourceServicePrincipalInKeyVault;
 
 // @public
@@ -522,7 +522,7 @@ export interface DimensionValuesPageResponse extends Array<string> {
     };
 }
 
-// @public (undocumented)
+// @public
 export interface EmailHookParameter {
     toList: string[];
 }
@@ -539,7 +539,7 @@ export type EmailNotificationHookPatch = {
     hookParameter?: Partial<EmailHookParameter>;
 } & NotificationHookPatch;
 
-// @public (undocumented)
+// @public
 export interface EnrichmentStatus {
     readonly message?: string;
     readonly status?: string;
@@ -736,7 +736,6 @@ export interface ListAnomaliesForDetectionConfigurationOptions extends Operation
 
 // @public
 export interface ListAnomalyDimensionValuesOptions extends OperationOptions {
-    // (undocumented)
     seriesGroupKey?: DimensionKey;
     skip?: number;
 }
@@ -825,7 +824,7 @@ export type LogAnalyticsAuthServicePrincipalInKeyVault = {
     credentialId: string;
 };
 
-// @public (undocumented)
+// @public
 export interface MetricAlertConfiguration {
     alertConditions?: MetricAnomalyAlertConditions;
     alertScope: MetricAnomalyAlertScope;
@@ -834,7 +833,7 @@ export interface MetricAlertConfiguration {
     snoozeCondition?: MetricAnomalyAlertSnoozeCondition;
 }
 
-// @public (undocumented)
+// @public
 export interface MetricAnomalyAlertConditions {
     metricBoundaryCondition?: MetricBoundaryCondition;
     severityCondition?: SeverityCondition;
@@ -854,7 +853,7 @@ export type MetricAnomalyAlertScope = {
     topNAnomalyScope: TopNGroupScope;
 };
 
-// @public (undocumented)
+// @public
 export interface MetricAnomalyAlertSnoozeCondition {
     autoSnooze: number;
     onlyForSuccessive: boolean;
@@ -1141,23 +1140,22 @@ export type PostgreSqlDataFeedSource = {
 // @public
 export type Severity = "Low" | "Medium" | "High";
 
-// @public (undocumented)
+// @public
 export interface SeverityCondition {
     maxAlertSeverity: Severity;
     minAlertSeverity: Severity;
 }
 
-// @public (undocumented)
+// @public
 export interface SeverityFilterCondition {
     max: Severity;
     min: Severity;
 }
 
-// @public (undocumented)
+// @public
 export interface SmartDetectionCondition {
     anomalyDetectorDirection: AnomalyDetectorDirection;
     sensitivity: number;
-    // (undocumented)
     suppressCondition: SuppressCondition;
 }
 
@@ -1205,13 +1203,13 @@ export type SqlServerDataFeedSource = {
     query: string;
 } & SqlServerAuthTypes;
 
-// @public (undocumented)
+// @public
 export interface SuppressCondition {
     minNumber: number;
     minRatio: number;
 }
 
-// @public (undocumented)
+// @public
 export interface TopNGroupScope {
     minTopCount: number;
     period: number;

--- a/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/review/ai-metrics-advisor.api.md
@@ -277,7 +277,7 @@ export interface DataFeedDimension {
 
 // @public
 export type DataFeedGranularity = {
-    granularityType: "Yearly" | "Monthly" | "Weekly" | "Daily" | "Hourly" | "PerMinute" | "PerSecond";
+    granularityType: "Yearly" | "Monthly" | "Weekly" | "Daily" | "Hourly" | "PerMinute";
 } | {
     granularityType: "Custom";
     customGranularityValue: number;
@@ -377,7 +377,7 @@ export type DataFeedStatus = "Paused" | "Active";
 
 // @public
 export interface DataLakeGen2SharedKeyDatasourceCredential extends DatasourceCredential {
-    accountKey: string;
+    accountKey?: string;
     type: "DataLakeGen2SharedKey";
 }
 
@@ -527,14 +527,6 @@ export type GetAnomalyAlertConfigurationResponse = AnomalyAlertConfiguration & {
 };
 
 // @public
-export type GetAnomalyDetectionConfigurationResponse = AnomalyDetectionConfiguration & {
-    _response: coreHttp.HttpResponse & {
-        bodyAsText: string;
-        parsedBody: any;
-    };
-};
-
-// @public
 export type GetCredentialEntityResponse = DatasourceCredentialUnion & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
@@ -544,6 +536,14 @@ export type GetCredentialEntityResponse = DatasourceCredentialUnion & {
 
 // @public
 export type GetDataFeedResponse = DataFeed & {
+    _response: coreHttp.HttpResponse & {
+        bodyAsText: string;
+        parsedBody: any;
+    };
+};
+
+// @public
+export type GetDetectionConfigResponse = AnomalyDetectionConfiguration & {
     _response: coreHttp.HttpResponse & {
         bodyAsText: string;
         parsedBody: any;
@@ -935,7 +935,7 @@ export class MetricsAdvisorAdministrationClient {
     createAlertConfig(config: Omit<AnomalyAlertConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
     createDataFeed(feed: DataFeedDescriptor, operationOptions?: CreateDataFeedOptions): Promise<GetDataFeedResponse>;
     createDatasourceCredential(datasourceCredential: DatasourceCredentialUnion, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
-    createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    createDetectionConfig(config: Omit<AnomalyDetectionConfiguration, "id">, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     createHook(hookInfo: EmailNotificationHook | WebNotificationHook, options?: OperationOptions): Promise<GetHookResponse>;
     deleteAlertConfig(id: string, options?: OperationOptions): Promise<RestResponse>;
     deleteDataFeed(id: string, options?: OperationOptions): Promise<RestResponse>;
@@ -947,7 +947,7 @@ export class MetricsAdvisorAdministrationClient {
     getDataFeed(id: string, options?: OperationOptions): Promise<GetDataFeedResponse>;
     getDataFeedIngestionProgress(dataFeedId: string, options?: {}): Promise<GetIngestionProgressResponse>;
     getDatasourceCredential(id: string, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
-    getDetectionConfig(id: string, options?: OperationOptions): Promise<GetAnomalyDetectionConfigurationResponse>;
+    getDetectionConfig(id: string, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
     getHook(id: string, options?: OperationOptions): Promise<GetHookResponse>;
     listAlertConfigs(detectionConfigId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyAlertConfiguration, AlertConfigurationsPageResponse, undefined>;
     listDataFeedIngestionStatus(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: ListDataFeedIngestionStatusOptions): PagedAsyncIterableIterator<IngestionStatus, IngestionStatusPageResponse>;
@@ -956,11 +956,11 @@ export class MetricsAdvisorAdministrationClient {
     listDetectionConfigs(metricId: string, options?: OperationOptions): PagedAsyncIterableIterator<AnomalyDetectionConfiguration, DetectionConfigurationsPageResponse, undefined>;
     listHooks(options?: ListHooksOptions): PagedAsyncIterableIterator<NotificationHookUnion, HooksPageResponse>;
     refreshDataFeedIngestion(dataFeedId: string, startTime: Date | string, endTime: Date | string, options?: OperationOptions): Promise<RestResponse>;
-    updateAlertConfig(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<RestResponse>;
-    updateDataFeed(dataFeedId: string, patch: DataFeedPatch, options?: OperationOptions): Promise<RestResponse>;
-    updateDatasourceCredential(id: string, patch: DatasourceCredentialPatch, options?: OperationOptions): Promise<RestResponse>;
-    updateDetectionConfig(id: string, patch: AnomalyDetectionConfigurationPatch, options?: OperationOptions): Promise<RestResponse>;
-    updateHook(id: string, patch: EmailNotificationHookPatch | WebNotificationHookPatch, options?: OperationOptions): Promise<RestResponse>;
+    updateAlertConfig(id: string, patch: Partial<Omit<AnomalyAlertConfiguration, "id">>, options?: OperationOptions): Promise<GetAnomalyAlertConfigurationResponse>;
+    updateDataFeed(dataFeedId: string, patch: DataFeedPatch, options?: OperationOptions): Promise<GetDataFeedResponse>;
+    updateDatasourceCredential(id: string, patch: DatasourceCredentialPatch, options?: OperationOptions): Promise<GetCredentialEntityResponse>;
+    updateDetectionConfig(id: string, patch: AnomalyDetectionConfigurationPatch, options?: OperationOptions): Promise<GetDetectionConfigResponse>;
+    updateHook(id: string, patch: EmailNotificationHookPatch | WebNotificationHookPatch, options?: OperationOptions): Promise<GetHookResponse>;
 }
 
 // @public
@@ -970,7 +970,7 @@ export interface MetricsAdvisorAdministrationClientOptions extends PipelineOptio
 // @public
 export class MetricsAdvisorClient {
     constructor(endpointUrl: string, credential: TokenCredential | MetricsAdvisorKeyCredential, options?: MetricsAdvisorClientOptions);
-    createFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
+    addFeedback(feedback: MetricFeedbackUnion, options?: OperationOptions): Promise<GetFeedbackResponse>;
     readonly endpointUrl: string;
     getFeedback(id: string, options?: OperationOptions): Promise<GetFeedbackResponse>;
     getIncidentRootCauses(detectionConfigId: string, incidentId: string, options?: OperationOptions): Promise<GetIncidentRootCauseResponse>;
@@ -1085,7 +1085,7 @@ export type PostgreSqlDataFeedSource = {
 // @public
 export interface ServicePrincipalDatasourceCredential extends DatasourceCredential {
     clientId: string;
-    clientSecret: string;
+    clientSecret?: string;
     tenantId: string;
     type: "ServicePrincipal";
 }
@@ -1103,7 +1103,7 @@ export interface ServicePrincipalDatasourceCredentialPatch {
 // @public
 export interface ServicePrincipalInKeyVaultDatasourceCredential extends DatasourceCredential {
     keyVaultClientId: string;
-    keyVaultClientSecret: string;
+    keyVaultClientSecret?: string;
     keyVaultEndpoint: string;
     servicePrincipalIdNameInKV: string;
     servicePrincipalSecretNameInKV: string;
@@ -1187,7 +1187,7 @@ export type SqlServerAuthTypes = SqlServerAuthBasic | SqlServerAuthManagedIdenti
 
 // @public
 export interface SqlServerConnectionStringDatasourceCredential extends DatasourceCredential {
-    connectionString: string;
+    connectionString?: string;
     type: "AzureSQLConnectionString";
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/alertingConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/alertingConfig.ts
@@ -110,8 +110,7 @@ async function updateAlertConfig(
     ]
   };
   console.log(`Updating alerting configuration ${detectionConfigId}`);
-  await adminClient.updateAlertConfig(alertConfigId, patch);
-  const updated = await adminClient.getAlertConfig(alertConfigId);
+  const updated = await adminClient.updateAlertConfig(alertConfigId, patch);
   return updated;
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataFeed.ts
@@ -164,8 +164,7 @@ async function updateDataFeed(client: MetricsAdvisorAdministrationClient, dataFe
 
   try {
     console.log(`Updating datafeed ${dataFeedId}...`);
-    await client.updateDataFeed(dataFeedId, patch);
-    const updated = await client.getDataFeed(dataFeedId);
+    const updated = await client.updateDataFeed(dataFeedId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating data feed");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
@@ -13,9 +13,9 @@ dotenv.config();
 import {
   MetricsAdvisorKeyCredential,
   MetricsAdvisorAdministrationClient,
-  GetCredentialEntityResponse,
-  DatasourceCredentialPatch,
-  SqlServerConnectionStringDatasourceCredential
+  GetDataSourceCredentialEntityResponse,
+  DataSourceCredentialPatch,
+  SqlServerConnectionStringDataSourceCredential
 } from "@azure/ai-metrics-advisor";
 
 export async function main() {
@@ -27,19 +27,19 @@ export async function main() {
 
   const adminClient = new MetricsAdvisorAdministrationClient(endpoint, credential);
 
-  const created = await createDatasourceCredential(adminClient);
+  const created = await createDataSourceCredential(adminClient);
   if (created.id) {
-    await getDatasourceCredential(adminClient, created.id);
-    await updateDatasourceCredential(adminClient, created.id);
-    await listDatasourceCredentials(adminClient);
-    await deleteDatasourceCredential(adminClient, created.id);
+    await getDataSourceCredential(adminClient, created.id);
+    await updateDataSourceCredential(adminClient, created.id);
+    await listDataSourceCredentials(adminClient);
+    await deleteDataSourceCredential(adminClient, created.id);
   }
 }
 
-async function listDatasourceCredentials(client: MetricsAdvisorAdministrationClient) {
-  console.log("Listing Datasource credentials ...");
+async function listDataSourceCredentials(client: MetricsAdvisorAdministrationClient) {
+  console.log("Listing DataSource credentials ...");
   console.log("  using while loop");
-  const iter = client.listDatasourceCredential();
+  const iter = client.listDataSourceCredential();
   let result = await iter.next();
   while (!result.done) {
     console.log(`id :${result.value.id}, name: ${result.value.name}`);
@@ -48,7 +48,7 @@ async function listDatasourceCredentials(client: MetricsAdvisorAdministrationCli
 
   // second approach
   console.log("  using for-await-of loop");
-  const iterator = client.listDatasourceCredential();
+  const iterator = client.listDataSourceCredential();
   for await (const datasourceCredential of iterator) {
     console.log(
       `id :${datasourceCredential.id}, name: ${datasourceCredential.name}, type: ${datasourceCredential.type}`
@@ -57,7 +57,7 @@ async function listDatasourceCredentials(client: MetricsAdvisorAdministrationCli
 
   // by pages
   console.log("  by pages");
-  const pages = client.listDatasourceCredential().byPage({ maxPageSize: 1 });
+  const pages = client.listDataSourceCredential().byPage({ maxPageSize: 1 });
   let page = await pages.next();
   let i = 1;
   while (!page.done) {
@@ -71,34 +71,34 @@ async function listDatasourceCredentials(client: MetricsAdvisorAdministrationCli
   }
 }
 
-async function createDatasourceCredential(
+async function createDataSourceCredential(
   client: MetricsAdvisorAdministrationClient
-): Promise<GetCredentialEntityResponse> {
-  console.log("Creating Datasource credential...");
-  const datasourceCredential: SqlServerConnectionStringDatasourceCredential = {
+): Promise<GetDataSourceCredentialEntityResponse> {
+  console.log("Creating DataSource credential...");
+  const datasourceCredential: SqlServerConnectionStringDataSourceCredential = {
     name: "Sql-server-cred",
     description: "an example sql server credential",
     type: "AzureSQLConnectionString",
     connectionString: "connection-string"
   };
-  const result = await client.createDatasourceCredential(datasourceCredential);
+  const result = await client.createDataSourceCredential(datasourceCredential);
   console.dir(result);
   return result;
 }
 
-async function getDatasourceCredential(
+async function getDataSourceCredential(
   client: MetricsAdvisorAdministrationClient,
   datasourceCredentialId: string
 ) {
   console.log("Retrieving datasourceCredential by id...");
-  const result = await client.getDatasourceCredential(datasourceCredentialId);
+  const result = await client.getDataSourceCredential(datasourceCredentialId);
   console.log("datasource credential result is as follows - ");
   console.log(`  id: ${result.id}`);
   console.log(`  datasource credential type: ${result.type}`);
   console.log(`  name: ${result.name}`);
 }
 
-async function updateDatasourceCredential(
+async function updateDataSourceCredential(
   client: MetricsAdvisorAdministrationClient,
   credentialId: string
 ) {
@@ -107,11 +107,11 @@ async function updateDatasourceCredential(
     description: "updated-description",
     type: "AzureSQLConnectionString",
     connectionString: "connection-string"
-  } as DatasourceCredentialPatch;
+  } as DataSourceCredentialPatch;
 
   try {
     console.log(`Updating credential ${credentialId}...`);
-    const updated = await client.updateDatasourceCredential(credentialId, patch);
+    const updated = await client.updateDataSourceCredential(credentialId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating credential");
@@ -119,12 +119,12 @@ async function updateDatasourceCredential(
   }
 }
 
-async function deleteDatasourceCredential(
+async function deleteDataSourceCredential(
   client: MetricsAdvisorAdministrationClient,
   credentialId: string
 ) {
   console.log(`Deleting datasource credential ${credentialId}...`);
-  await client.deleteDatasourceCredential(credentialId);
+  await client.deleteDataSourceCredential(credentialId);
 }
 
 main()

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
@@ -111,8 +111,7 @@ async function updateDatasourceCredential(
 
   try {
     console.log(`Updating credential ${credentialId}...`);
-    await client.updateDatasourceCredential(credentialId, patch);
-    const updated = await client.getDataFeed(credentialId);
+    const updated = await client.updateDatasourceCredential(credentialId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating credential");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/dataSourceCredential.ts
@@ -15,7 +15,7 @@ import {
   MetricsAdvisorAdministrationClient,
   GetDataSourceCredentialEntityResponse,
   DataSourceCredentialPatch,
-  SqlServerConnectionStringDataSourceCredential
+  DataSourceSqlConnectionString
 } from "@azure/ai-metrics-advisor";
 
 export async function main() {
@@ -75,7 +75,7 @@ async function createDataSourceCredential(
   client: MetricsAdvisorAdministrationClient
 ): Promise<GetDataSourceCredentialEntityResponse> {
   console.log("Creating DataSource credential...");
-  const datasourceCredential: SqlServerConnectionStringDataSourceCredential = {
+  const datasourceCredential: DataSourceSqlConnectionString = {
     name: "Sql-server-cred",
     description: "an example sql server credential",
     type: "AzureSQLConnectionString",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/detectionConfig.ts
@@ -176,8 +176,7 @@ async function updateDetectionConfig(
     ]
   };
   console.log(`Updating existing detection configuration '${configId}'`);
-  await adminClient.updateDetectionConfig(configId, patch);
-  const result = adminClient.getDetectionConfig(configId);
+  const result = await adminClient.updateDetectionConfig(configId, patch);
   console.log(result);
   return result;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/hooks.ts
@@ -93,8 +93,7 @@ async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookI
       toList: ["test2@example.com", "test3@example.com"]
     }
   };
-  await client.updateHook(hookId, emailPatch);
-  const response = await client.getHook(hookId);
+  const response = await client.updateHook(hookId, emailPatch);
   console.log(response);
   return response;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/incidentsAndAlerts.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/incidentsAndAlerts.ts
@@ -76,7 +76,7 @@ async function listIncidentsForDetectionConfig(
 ) {
   console.log(`Listing incidents for detection config '${detectionConfigId}'`);
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents(
+  const listIterator = client.listIncidentsForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -97,7 +97,11 @@ async function listIncidentsForDetectionConfig(
 
   console.log(`  by pages`);
   const iterator = client
-    .listIncidents(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"))
+    .listIncidentsForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020")
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -228,7 +232,7 @@ async function listIncidentsForAlert(
     `Listing incidents for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents({ alertConfigId, id: alertId });
+  const listIterator = client.listIncidentsForAlert({ alertConfigId, id: alertId });
   for await (const incident of listIterator) {
     console.log("    Incident");
     console.log(`      id: ${incident.id}`);
@@ -241,7 +245,9 @@ async function listIncidentsForAlert(
   }
 
   console.log(`  by pages`);
-  const iterator = client.listIncidents({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listIncidentsForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/incidentsAndAlerts.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/incidentsAndAlerts.ts
@@ -121,7 +121,7 @@ async function listAnomaliesForDetectionConfig(
   detectionConfigId: string
 ) {
   console.log(`Listing anomalies for detection config '${detectionConfigId}'`);
-  const listIterator = client.listAnomalies(
+  const listIterator = client.listAnomaliesForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -143,9 +143,14 @@ async function listAnomaliesForDetectionConfig(
 
   console.log(`  by pages`);
   const iterator = client
-    .listAnomalies(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"), {
-      severityFilter: { min: "Medium", max: "High" }
-    })
+    .listAnomaliesForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020"),
+      {
+        severityFilter: { min: "Medium", max: "High" }
+      }
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -263,7 +268,7 @@ async function listAnomaliesForAlert(
     `Listing anomalies for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listAnomalies({ alertConfigId, id: alertId });
+  const listIterator = client.listAnomaliesForAlert({ alertConfigId, id: alertId });
   for await (const anomaly of listIterator) {
     console.log("    Anomaly");
     console.log(`      timestamp: ${anomaly.timestamp}`);
@@ -272,7 +277,9 @@ async function listAnomaliesForAlert(
   }
 
   console.log(`  by pages`);
-  const iterator = client.listAnomalies({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listAnomaliesForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/metricFeedback.ts
@@ -48,7 +48,7 @@ async function provideAnomalyFeedback(client: MetricsAdvisorClient, metricId: st
     value: "NotAnomaly",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(anomalyFeedback);
+  return await client.addFeedback(anomalyFeedback);
 }
 
 async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -60,7 +60,7 @@ async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: str
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(periodFeedback);
+  return await client.addFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -72,7 +72,7 @@ async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(changePointFeedback);
+  return await client.addFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -83,7 +83,7 @@ async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: st
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  return await client.createFeedback(commendFeedback);
+  return await client.addFeedback(commendFeedback);
 }
 
 async function getFeedback(client: MetricsAdvisorClient, feedbackId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/quickstart.ts
@@ -277,7 +277,7 @@ async function queryAnomaliesByAlert(client: MetricsAdvisorClient, alert: Anomal
   console.log(
     `Listing anomalies for alert configuration '${alert.alertConfigId}' and alert '${alert.id}'`
   );
-  const listIterator = client.listAnomalies(alert);
+  const listIterator = client.listAnomaliesForAlert(alert);
   for await (const anomaly of listIterator) {
     console.log(
       `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples-dev/seriesData.ts
@@ -36,12 +36,12 @@ async function getEnrichedSeriesData(client: MetricsAdvisorClient, detectionConf
   try {
     const result = await client.getMetricEnrichedSeriesData(
       detectionConfigId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const enriched of result) {
@@ -71,12 +71,12 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
   try {
     const result = await client.getMetricSeriesData(
       metricId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const series of result) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/alertingConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/alertingConfig.js
@@ -100,8 +100,7 @@ async function updateAlertConfig(adminClient, alertConfigId, detectionConfigId, 
     ]
   };
   console.log(`Updating alerting configuration ${detectionConfigId}`);
-  await adminClient.updateAlertConfig(alertConfigId, patch);
-  const updated = await adminClient.getAlertConfig(alertConfigId);
+  const updated = await adminClient.updateAlertConfig(alertConfigId, patch);
   return updated;
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/dataFeed.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/dataFeed.js
@@ -158,8 +158,7 @@ async function updateDataFeed(client, dataFeedId) {
 
   try {
     console.log(`Updating datafeed ${dataFeedId}...`);
-    await client.updateDataFeed(dataFeedId, patch);
-    const updated = await client.getDataFeed(dataFeedId);
+    const updated = await client.updateDataFeed(dataFeedId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating data feed");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/dataSourceCredential.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/dataSourceCredential.js
@@ -99,8 +99,7 @@ async function updateDatasourceCredential(client, credentialId) {
 
   try {
     console.log(`Updating credential ${credentialId}...`);
-    await client.updateDatasourceCredential(credentialId, patch);
-    const updated = await client.getDataFeed(credentialId);
+    const updated = await client.updateDatasourceCredential(credentialId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating credential");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/detectionConfig.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/detectionConfig.js
@@ -162,8 +162,7 @@ async function updateDetectionConfig(adminClient, configId) {
     ]
   };
   console.log(`Updating existing detection configuration '${configId}'`);
-  await adminClient.updateDetectionConfig(configId, patch);
-  const result = adminClient.getDetectionConfig(configId);
+  const result = await adminClient.updateDetectionConfig(configId, patch);
   console.log(result);
   return result;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/hooks.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/hooks.js
@@ -89,8 +89,7 @@ async function updateEmailHook(client, hookId) {
       toList: ["test2@example.com", "test3@example.com"]
     }
   };
-  await client.updateHook(hookId, emailPatch);
-  const response = await client.getHook(hookId);
+  const response = await client.updateHook(hookId, emailPatch);
   console.log(response);
   return response;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/incidentsAndAlerts.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/incidentsAndAlerts.js
@@ -72,7 +72,7 @@ async function listAnomalyDimensionValues(client, detectionConfigId) {
 async function listIncidentsForDetectionConfig(client, detectionConfigId) {
   console.log(`Listing incidents for detection config '${detectionConfigId}'`);
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents(
+  const listIterator = client.listIncidentsForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -93,7 +93,11 @@ async function listIncidentsForDetectionConfig(client, detectionConfigId) {
 
   console.log(`  by pages`);
   const iterator = client
-    .listIncidents(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"))
+    .listIncidentsForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020")
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -114,7 +118,7 @@ async function listIncidentsForDetectionConfig(client, detectionConfigId) {
 
 async function listAnomaliesForDetectionConfig(client, detectionConfigId) {
   console.log(`Listing anomalies for detection config '${detectionConfigId}'`);
-  const listIterator = client.listAnomalies(
+  const listIterator = client.listAnomaliesForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -136,9 +140,14 @@ async function listAnomaliesForDetectionConfig(client, detectionConfigId) {
 
   console.log(`  by pages`);
   const iterator = client
-    .listAnomalies(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"), {
-      severityFilter: { min: "Medium", max: "High" }
-    })
+    .listAnomaliesForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020"),
+      {
+        severityFilter: { min: "Medium", max: "High" }
+      }
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -208,7 +217,7 @@ async function listIncidentsForAlert(client, alertConfigId, alertId) {
     `Listing incidents for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents({ alertConfigId, id: alertId });
+  const listIterator = client.listIncidentsForAlert({ alertConfigId, id: alertId });
   for await (const incident of listIterator) {
     console.log("    Incident");
     console.log(`      id: ${incident.id}`);
@@ -221,7 +230,9 @@ async function listIncidentsForAlert(client, alertConfigId, alertId) {
   }
 
   console.log(`  by pages`);
-  const iterator = client.listIncidents({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listIncidentsForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {
@@ -244,7 +255,7 @@ async function listAnomaliesForAlert(client, alertConfigId, alertId) {
     `Listing anomalies for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listAnomalies({ alertConfigId, id: alertId });
+  const listIterator = client.listAnomaliesForAlert({ alertConfigId, id: alertId });
   for await (const anomaly of listIterator) {
     console.log("    Anomaly");
     console.log(`      timestamp: ${anomaly.timestamp}`);
@@ -253,7 +264,9 @@ async function listAnomaliesForAlert(client, alertConfigId, alertId) {
   }
 
   console.log(`  by pages`);
-  const iterator = client.listAnomalies({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listAnomaliesForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/metricFeedback.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/metricFeedback.js
@@ -40,7 +40,7 @@ async function provideAnomalyFeedback(client, metricId) {
     value: "NotAnomaly",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(anomalyFeedback);
+  return await client.addFeedback(anomalyFeedback);
 }
 
 async function providePeriodFeedback(client, metricId) {
@@ -52,7 +52,7 @@ async function providePeriodFeedback(client, metricId) {
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(periodFeedback);
+  return await client.addFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client, metricId) {
@@ -64,7 +64,7 @@ async function provideChangePointFeedback(client, metricId) {
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(changePointFeedback);
+  return await client.addFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client, metricId) {
@@ -75,7 +75,7 @@ async function provideCommentFeedback(client, metricId) {
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  return await client.createFeedback(commendFeedback);
+  return await client.addFeedback(commendFeedback);
 }
 
 async function getFeedback(client, feedbackId) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/metricsadvisor/ai-metrics-advisor",
   "dependencies": {
-    "@azure/ai-metrics-advisor": "next",
+    "@azure/ai-metrics-advisor": "latest",
     "dotenv": "latest"
   }
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/quickstart.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/quickstart.js
@@ -249,7 +249,7 @@ async function queryAnomaliesByAlert(client, alert) {
   console.log(
     `Listing anomalies for alert configuration '${alert.alertConfigId}' and alert '${alert.id}'`
   );
-  const listIterator = client.listAnomalies(alert);
+  const listIterator = client.listAnomaliesForAlert(alert);
   for await (const anomaly of listIterator) {
     console.log(
       `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/sample.env
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/sample.env
@@ -3,6 +3,13 @@
 METRICS_ADVISOR_ENDPOINT=https://<resource name>.cognitiveservices.azure.com/
 METRICS_ADVISOR_SUBSCRIPTION_KEY=<subscription key>
 METRICS_ADVISOR_API_KEY=<api key>
+# METRICS_ADVISOR_METRIC_ID=
+# METRICS_ADVISOR_DETECTION_CONFIG_ID=
+# METRICS_ADVISOR_HOOK_ID=
+# METRICS_ADVISOR_DATAFEED_ID=
+# METRICS_ADVISOR_INCIDENT_ID=
+# METRICS_ADVISOR_SQL_SERVER_CONNECTION_STRING=
+# METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY=
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/seriesData.js
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/seriesData.js
@@ -35,12 +35,12 @@ async function getEnrichedSeriesData(client, detectionConfigId) {
   try {
     const result = await client.getMetricEnrichedSeriesData(
       detectionConfigId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const enriched of result) {
@@ -70,12 +70,12 @@ async function getMetricSeriesData(client, metricId) {
   try {
     const result = await client.getMetricSeriesData(
       metricId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const series of result) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/metricsadvisor/ai-metrics-advisor",
   "dependencies": {
-    "@azure/ai-metrics-advisor": "next",
+    "@azure/ai-metrics-advisor": "latest",
     "dotenv": "latest"
   },
   "devDependencies": {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/sample.env
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/sample.env
@@ -3,6 +3,13 @@
 METRICS_ADVISOR_ENDPOINT=https://<resource name>.cognitiveservices.azure.com/
 METRICS_ADVISOR_SUBSCRIPTION_KEY=<subscription key>
 METRICS_ADVISOR_API_KEY=<api key>
+# METRICS_ADVISOR_METRIC_ID=
+# METRICS_ADVISOR_DETECTION_CONFIG_ID=
+# METRICS_ADVISOR_HOOK_ID=
+# METRICS_ADVISOR_DATAFEED_ID=
+# METRICS_ADVISOR_INCIDENT_ID=
+# METRICS_ADVISOR_SQL_SERVER_CONNECTION_STRING=
+# METRICS_ADVISOR_AZURE_SQL_SERVER_QUERY=
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/alertingConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/alertingConfig.ts
@@ -109,8 +109,7 @@ async function updateAlertConfig(
     ]
   };
   console.log(`Updating alerting configuration ${detectionConfigId}`);
-  await adminClient.updateAlertConfig(alertConfigId, patch);
-  const updated = await adminClient.getAlertConfig(alertConfigId);
+  const updated = await adminClient.updateAlertConfig(alertConfigId, patch);
   return updated;
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/dataFeed.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/dataFeed.ts
@@ -163,8 +163,7 @@ async function updateDataFeed(client: MetricsAdvisorAdministrationClient, dataFe
 
   try {
     console.log(`Updating datafeed ${dataFeedId}...`);
-    await client.updateDataFeed(dataFeedId, patch);
-    const updated = await client.getDataFeed(dataFeedId);
+    const updated = await client.updateDataFeed(dataFeedId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating data feed");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/dataSourceCredential.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/dataSourceCredential.ts
@@ -110,8 +110,7 @@ async function updateDatasourceCredential(
 
   try {
     console.log(`Updating credential ${credentialId}...`);
-    await client.updateDatasourceCredential(credentialId, patch);
-    const updated = await client.getDataFeed(credentialId);
+    const updated = await client.updateDatasourceCredential(credentialId, patch);
     console.dir(updated);
   } catch (err) {
     console.log("Error occurred when updating credential");

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/detectionConfig.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/detectionConfig.ts
@@ -175,8 +175,7 @@ async function updateDetectionConfig(
     ]
   };
   console.log(`Updating existing detection configuration '${configId}'`);
-  await adminClient.updateDetectionConfig(configId, patch);
-  const result = adminClient.getDetectionConfig(configId);
+  const result = await adminClient.updateDetectionConfig(configId, patch);
   console.log(result);
   return result;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/hooks.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/hooks.ts
@@ -92,8 +92,7 @@ async function updateEmailHook(client: MetricsAdvisorAdministrationClient, hookI
       toList: ["test2@example.com", "test3@example.com"]
     }
   };
-  await client.updateHook(hookId, emailPatch);
-  const response = await client.getHook(hookId);
+  const response = await client.updateHook(hookId, emailPatch);
   console.log(response);
   return response;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/incidentsAndAlerts.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/incidentsAndAlerts.ts
@@ -75,7 +75,7 @@ async function listIncidentsForDetectionConfig(
 ) {
   console.log(`Listing incidents for detection config '${detectionConfigId}'`);
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents(
+  const listIterator = client.listIncidentsForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -96,7 +96,11 @@ async function listIncidentsForDetectionConfig(
 
   console.log(`  by pages`);
   const iterator = client
-    .listIncidents(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"))
+    .listIncidentsForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020")
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -120,7 +124,7 @@ async function listAnomaliesForDetectionConfig(
   detectionConfigId: string
 ) {
   console.log(`Listing anomalies for detection config '${detectionConfigId}'`);
-  const listIterator = client.listAnomalies(
+  const listIterator = client.listAnomaliesForDetectionConfiguration(
     detectionConfigId,
     new Date("10/22/2020"),
     new Date("10/24/2020"),
@@ -142,9 +146,14 @@ async function listAnomaliesForDetectionConfig(
 
   console.log(`  by pages`);
   const iterator = client
-    .listAnomalies(detectionConfigId, new Date("10/22/2020"), new Date("10/24/2020"), {
-      severityFilter: { min: "Medium", max: "High" }
-    })
+    .listAnomaliesForDetectionConfiguration(
+      detectionConfigId,
+      new Date("10/22/2020"),
+      new Date("10/24/2020"),
+      {
+        severityFilter: { min: "Medium", max: "High" }
+      }
+    )
     .byPage({ maxPageSize: 20 });
   let result = await iterator.next();
 
@@ -222,7 +231,7 @@ async function listIncidentsForAlert(
     `Listing incidents for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listIncidents({ alertConfigId, id: alertId });
+  const listIterator = client.listIncidentsForAlert({ alertConfigId, id: alertId });
   for await (const incident of listIterator) {
     console.log("    Incident");
     console.log(`      id: ${incident.id}`);
@@ -235,7 +244,9 @@ async function listIncidentsForAlert(
   }
 
   console.log(`  by pages`);
-  const iterator = client.listIncidents({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listIncidentsForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {
@@ -262,7 +273,7 @@ async function listAnomaliesForAlert(
     `Listing anomalies for alert configuration '${alertConfigId}' and alert '${alertId}'`
   );
   console.log("  using for-await-of syntax");
-  const listIterator = client.listAnomalies({ alertConfigId, id: alertId });
+  const listIterator = client.listAnomaliesForAlert({ alertConfigId, id: alertId });
   for await (const anomaly of listIterator) {
     console.log("    Anomaly");
     console.log(`      timestamp: ${anomaly.timestamp}`);
@@ -271,7 +282,9 @@ async function listAnomaliesForAlert(
   }
 
   console.log(`  by pages`);
-  const iterator = client.listAnomalies({ alertConfigId, id: alertId }).byPage({ maxPageSize: 20 });
+  const iterator = client
+    .listAnomaliesForAlert({ alertConfigId, id: alertId })
+    .byPage({ maxPageSize: 20 });
 
   let result = await iterator.next();
   while (!result.done) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/metricFeedback.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/metricFeedback.ts
@@ -47,7 +47,7 @@ async function provideAnomalyFeedback(client: MetricsAdvisorClient, metricId: st
     value: "NotAnomaly",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(anomalyFeedback);
+  return await client.addFeedback(anomalyFeedback);
 }
 
 async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -59,7 +59,7 @@ async function providePeriodFeedback(client: MetricsAdvisorClient, metricId: str
     periodValue: 4,
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(periodFeedback);
+  return await client.addFeedback(periodFeedback);
 }
 
 async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -71,7 +71,7 @@ async function provideChangePointFeedback(client: MetricsAdvisorClient, metricId
     value: "ChangePoint",
     dimensionKey: { city: "Manila", category: "Handmade" }
   };
-  return await client.createFeedback(changePointFeedback);
+  return await client.addFeedback(changePointFeedback);
 }
 
 async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: string) {
@@ -82,7 +82,7 @@ async function provideCommentFeedback(client: MetricsAdvisorClient, metricId: st
     dimensionKey: { city: "Manila", category: "Handmade" },
     comment: "This is a comment"
   };
-  return await client.createFeedback(commendFeedback);
+  return await client.addFeedback(commendFeedback);
 }
 
 async function getFeedback(client: MetricsAdvisorClient, feedbackId: string) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/quickstart.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/quickstart.ts
@@ -276,7 +276,7 @@ async function queryAnomaliesByAlert(client: MetricsAdvisorClient, alert: Anomal
   console.log(
     `Listing anomalies for alert configuration '${alert.alertConfigId}' and alert '${alert.id}'`
   );
-  const listIterator = client.listAnomalies(alert);
+  const listIterator = client.listAnomaliesForAlert(alert);
   for await (const anomaly of listIterator) {
     console.log(
       `  Anomaly ${anomaly.severity} ${anomaly.status} ${anomaly.seriesKey.dimension} ${anomaly.timestamp}`

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/seriesData.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/src/seriesData.ts
@@ -35,12 +35,12 @@ async function getEnrichedSeriesData(client: MetricsAdvisorClient, detectionConf
   try {
     const result = await client.getMetricEnrichedSeriesData(
       detectionConfigId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const enriched of result) {
@@ -70,12 +70,12 @@ async function getMetricSeriesData(client: MetricsAdvisorClient, metricId: strin
   try {
     const result = await client.getMetricSeriesData(
       metricId,
-      new Date("09/01/2020"),
-      new Date("09/12/2020"),
       [
         { city: "Manila", category: "Handmade" },
         { city: "Shanghai", category: "Shoes Handbags & Sunglasses" }
-      ]
+      ],
+      new Date("09/01/2020"),
+      new Date("09/12/2020")
     );
 
     for (const series of result) {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
@@ -57,10 +57,7 @@ export type MetricFeedbackUnion =
   | CommentFeedback
   | PeriodFeedback;
 export type HookInfoUnion = HookInfo | EmailHookInfo | WebhookHookInfo;
-export type HookInfoPatchUnion =
-  | HookInfoPatch
-  | EmailHookInfoPatch
-  | WebhookHookInfoPatch;
+export type HookInfoPatchUnion = HookInfoPatch | EmailHookInfoPatch | WebhookHookInfoPatch;
 
 export interface UsageStats {
   /**
@@ -409,16 +406,19 @@ export interface WholeMetricConfiguration {
    * should be specified when combining multiple detection conditions
    */
   conditionOperator?: AnomalyDetectionConfigurationLogicType;
+  /** Represents Smart Condition */
   smartDetectionCondition?: SmartDetectionCondition;
   hardThresholdCondition?: HardThresholdCondition;
   changeThresholdCondition?: ChangeThresholdCondition;
 }
 
+/** Represents Smart Condition */
 export interface SmartDetectionCondition {
   /** sensitivity, value range : (0, 100] */
   sensitivity: number;
   /** detection direction */
   anomalyDetectorDirection: AnomalyDetectorDirection;
+  /** suppress condition */
   suppressCondition: SuppressCondition;
 }
 
@@ -470,6 +470,7 @@ export interface DimensionGroupConfiguration {
    * should be specified when combining multiple detection conditions
    */
   conditionOperator?: AnomalyDetectionConfigurationLogicType;
+  /** Represents Smart Condition */
   smartDetectionCondition?: SmartDetectionCondition;
   hardThresholdCondition?: HardThresholdCondition;
   changeThresholdCondition?: ChangeThresholdCondition;
@@ -483,6 +484,7 @@ export interface SeriesConfiguration {
    * should be specified when combining multiple detection conditions
    */
   conditionOperator?: AnomalyDetectionConfigurationLogicType;
+  /** Represents Smart Condition */
   smartDetectionCondition?: SmartDetectionCondition;
   hardThresholdCondition?: HardThresholdCondition;
   changeThresholdCondition?: ChangeThresholdCondition;
@@ -1824,11 +1826,7 @@ export type NeedRollupEnum = "NoRollup" | "NeedRollup" | "AlreadyRollup";
 /** Defines values for RollUpMethod. */
 export type RollUpMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
 /** Defines values for FillMissingPointType. */
-export type FillMissingPointType =
-  | "SmartFilling"
-  | "PreviousValue"
-  | "CustomValue"
-  | "NoFilling";
+export type FillMissingPointType = "SmartFilling" | "PreviousValue" | "CustomValue" | "NoFilling";
 /** Defines values for ViewMode. */
 export type ViewMode = "Private" | "Public";
 /** Defines values for AuthenticationTypeEnum. */
@@ -2140,8 +2138,7 @@ export type GeneratedClientCreateCredentialResponse = GeneratedClientCreateCrede
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListCredentialsOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientListCredentialsOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2185,8 +2182,7 @@ export type GeneratedClientGetCredentialResponse = DataSourceCredentialUnion & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListDataFeedsOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientListDataFeedsOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2291,8 +2287,7 @@ export type GeneratedClientCreateMetricFeedbackResponse = GeneratedClientCreateM
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListHooksOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientListHooksOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2392,8 +2387,7 @@ export type GeneratedClientGetMetricDataResponse = MetricDataList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientGetMetricSeriesOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientGetMetricSeriesOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2413,8 +2407,7 @@ export type GeneratedClientGetMetricSeriesResponse = MetricSeriesList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientGetMetricDimensionOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientGetMetricDimensionOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2696,8 +2689,7 @@ export type GeneratedClientListCredentialsNextResponse = DataSourceCredentialLis
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListDataFeedsNextOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientListDataFeedsNextOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2727,8 +2719,7 @@ export type GeneratedClientListDataFeedsNextResponse = DataFeedList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListHooksNextOptionalParams
-  extends coreHttp.OperationOptions {
+export interface GeneratedClientListHooksNextOptionalParams extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2771,8 +2762,7 @@ export type GeneratedClientGetAnomalyDetectionConfigurationsByMetricNextResponse
 };
 
 /** Optional parameters. */
-export interface GeneratedClientOptionalParams
-  extends coreHttp.ServiceClientOptions {
+export interface GeneratedClientOptionalParams extends coreHttp.ServiceClientOptions {
   /** Overrides client endpoint. */
   endpoint?: string;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
@@ -57,7 +57,10 @@ export type MetricFeedbackUnion =
   | CommentFeedback
   | PeriodFeedback;
 export type HookInfoUnion = HookInfo | EmailHookInfo | WebhookHookInfo;
-export type HookInfoPatchUnion = HookInfoPatch | EmailHookInfoPatch | WebhookHookInfoPatch;
+export type HookInfoPatchUnion =
+  | HookInfoPatch
+  | EmailHookInfoPatch
+  | WebhookHookInfoPatch;
 
 export interface UsageStats {
   /**
@@ -124,8 +127,11 @@ export interface MetricAlertingConfiguration {
   /** Negation operation */
   negationOperation?: boolean;
   dimensionAnomalyScope?: DimensionGroupIdentity;
+  /** Group Scope for Top N values */
   topNAnomalyScope?: TopNGroupScope;
+  /** Alert Severity Condition */
   severityFilter?: SeverityCondition;
+  /** Represents Conditions to snooze Alerts */
   snoozeFilter?: AlertSnoozeCondition;
   valueFilter?: ValueCondition;
 }
@@ -135,6 +141,7 @@ export interface DimensionGroupIdentity {
   dimension: { [propertyName: string]: string };
 }
 
+/** Group Scope for Top N values */
 export interface TopNGroupScope {
   /** top N, value range : [1, +∞) */
   top: number;
@@ -148,6 +155,7 @@ export interface TopNGroupScope {
   minTopCount: number;
 }
 
+/** Alert Severity Condition */
 export interface SeverityCondition {
   /** min alert severity */
   minAlertSeverity: Severity;
@@ -155,6 +163,7 @@ export interface SeverityCondition {
   maxAlertSeverity: Severity;
 }
 
+/** Represents Conditions to snooze Alerts */
 export interface AlertSnoozeCondition {
   /** snooze point count, value range : [0, +∞) */
   autoSnooze: number;
@@ -418,10 +427,11 @@ export interface SmartDetectionCondition {
   sensitivity: number;
   /** detection direction */
   anomalyDetectorDirection: AnomalyDetectorDirection;
-  /** suppress condition */
+  /** Represents Suppress Condition */
   suppressCondition: SuppressCondition;
 }
 
+/** Represents Suppress Condition */
 export interface SuppressCondition {
   /** min point number, value range : [1, +∞) */
   minNumber: number;
@@ -444,6 +454,7 @@ export interface HardThresholdCondition {
   upperBound?: number;
   /** detection direction */
   anomalyDetectorDirection: AnomalyDetectorDirection;
+  /** Represents Suppress Condition */
   suppressCondition: SuppressCondition;
 }
 
@@ -459,6 +470,7 @@ export interface ChangeThresholdCondition {
   withinRange: boolean;
   /** detection direction */
   anomalyDetectorDirection: AnomalyDetectorDirection;
+  /** Represents Suppress Condition */
   suppressCondition: SuppressCondition;
 }
 
@@ -611,9 +623,11 @@ export interface DetectionAnomalyResultQuery {
 export interface DetectionAnomalyFilterCondition {
   /** dimension filter */
   dimensionFilter?: DimensionGroupIdentity[];
+  /** Represents Conditions to filter severity */
   severityFilter?: SeverityFilterCondition;
 }
 
+/** Represents Conditions to filter severity */
 export interface SeverityFilterCondition {
   /** min severity */
   min: Severity;
@@ -984,6 +998,7 @@ export interface IngestionStatusList {
   readonly value?: IngestionStatus[];
 }
 
+/** Ingestion Status */
 export interface IngestionStatus {
   /**
    * data slice timestamp.
@@ -1009,6 +1024,7 @@ export interface IngestionProgressResetOptions {
   endTime: Date;
 }
 
+/** Track the progress for Datafeed Ingestion */
 export interface DataFeedIngestionProgress {
   /**
    * the timestamp of latest success ingestion job.
@@ -1424,6 +1440,7 @@ export interface PeriodFeedbackValue {
   periodValue: number;
 }
 
+/** Parameters for Email Hook */
 export interface EmailHookParameter {
   /** Email TO: list. */
   toList: string[];
@@ -1710,6 +1727,7 @@ export type PeriodFeedback = MetricFeedback & {
 export type EmailHookInfo = HookInfo & {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   hookType: "Email";
+  /** Parameters for Email Hook */
   hookParameter: EmailHookParameter;
 };
 
@@ -1826,7 +1844,11 @@ export type NeedRollupEnum = "NoRollup" | "NeedRollup" | "AlreadyRollup";
 /** Defines values for RollUpMethod. */
 export type RollUpMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
 /** Defines values for FillMissingPointType. */
-export type FillMissingPointType = "SmartFilling" | "PreviousValue" | "CustomValue" | "NoFilling";
+export type FillMissingPointType =
+  | "SmartFilling"
+  | "PreviousValue"
+  | "CustomValue"
+  | "NoFilling";
 /** Defines values for ViewMode. */
 export type ViewMode = "Private" | "Public";
 /** Defines values for AuthenticationTypeEnum. */
@@ -2138,7 +2160,8 @@ export type GeneratedClientCreateCredentialResponse = GeneratedClientCreateCrede
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListCredentialsOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientListCredentialsOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2182,7 +2205,8 @@ export type GeneratedClientGetCredentialResponse = DataSourceCredentialUnion & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListDataFeedsOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientListDataFeedsOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2287,7 +2311,8 @@ export type GeneratedClientCreateMetricFeedbackResponse = GeneratedClientCreateM
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListHooksOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientListHooksOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2387,7 +2412,8 @@ export type GeneratedClientGetMetricDataResponse = MetricDataList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientGetMetricSeriesOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientGetMetricSeriesOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2407,7 +2433,8 @@ export type GeneratedClientGetMetricSeriesResponse = MetricSeriesList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientGetMetricDimensionOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientGetMetricDimensionOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2689,7 +2716,8 @@ export type GeneratedClientListCredentialsNextResponse = DataSourceCredentialLis
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListDataFeedsNextOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientListDataFeedsNextOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2719,7 +2747,8 @@ export type GeneratedClientListDataFeedsNextResponse = DataFeedList & {
 };
 
 /** Optional parameters. */
-export interface GeneratedClientListHooksNextOptionalParams extends coreHttp.OperationOptions {
+export interface GeneratedClientListHooksNextOptionalParams
+  extends coreHttp.OperationOptions {
   /** for paging, skipped number */
   skip?: number;
   /** the maximum number of items in one page */
@@ -2762,7 +2791,8 @@ export type GeneratedClientGetAnomalyDetectionConfigurationsByMetricNextResponse
 };
 
 /** Optional parameters. */
-export interface GeneratedClientOptionalParams extends coreHttp.ServiceClientOptions {
+export interface GeneratedClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
   /** Overrides client endpoint. */
   endpoint?: string;
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/index.ts
@@ -1132,19 +1132,19 @@ export interface EnrichmentStatus {
 
 export interface AzureSQLConnectionStringParam {
   /** The connection string to access the Azure SQL. */
-  connectionString: string;
+  connectionString?: string;
 }
 
 export interface DataLakeGen2SharedKeyParam {
   /** The account key to access the Azure Data Lake Storage Gen2. */
-  accountKey: string;
+  accountKey?: string;
 }
 
 export interface ServicePrincipalParam {
   /** The client id of the service principal. */
   clientId: string;
   /** The client secret of the service principal. */
-  clientSecret: string;
+  clientSecret?: string;
   /** The tenant id of the service principal. */
   tenantId: string;
 }
@@ -1155,7 +1155,7 @@ export interface ServicePrincipalInKVParam {
   /** The Client Id to access the Key Vault. */
   keyVaultClientId: string;
   /** The Client Secret to access the Key Vault. */
-  keyVaultClientSecret: string;
+  keyVaultClientSecret?: string;
   /** The secret name of the service principal's client Id in the Key Vault. */
   servicePrincipalIdNameInKV: string;
   /** The secret name of the service principal's client secret in the Key Vault. */
@@ -1816,7 +1816,6 @@ export type Granularity =
   | "Daily"
   | "Hourly"
   | "Minutely"
-  | "Secondly"
   | "Custom";
 /** Defines values for EntityStatus. */
 export type EntityStatus = "Active" | "Paused";

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/mappers.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/mappers.ts
@@ -2047,7 +2047,6 @@ export const DataFeedDetail: coreHttp.CompositeMapper = {
             "Daily",
             "Hourly",
             "Minutely",
-            "Secondly",
             "Custom"
           ]
         }
@@ -3327,7 +3326,6 @@ export const AzureSQLConnectionStringParam: coreHttp.CompositeMapper = {
     modelProperties: {
       connectionString: {
         serializedName: "connectionString",
-        required: true,
         type: {
           name: "String"
         }
@@ -3343,7 +3341,6 @@ export const DataLakeGen2SharedKeyParam: coreHttp.CompositeMapper = {
     modelProperties: {
       accountKey: {
         serializedName: "accountKey",
-        required: true,
         type: {
           name: "String"
         }
@@ -3366,7 +3363,6 @@ export const ServicePrincipalParam: coreHttp.CompositeMapper = {
       },
       clientSecret: {
         serializedName: "clientSecret",
-        required: true,
         type: {
           name: "String"
         }
@@ -3403,7 +3399,6 @@ export const ServicePrincipalInKVParam: coreHttp.CompositeMapper = {
       },
       keyVaultClientSecret: {
         serializedName: "keyVaultClientSecret",
-        required: true,
         type: {
           name: "String"
         }

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/parameters.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/generated/models/parameters.ts
@@ -262,7 +262,6 @@ export const granularityName: OperationQueryParameter = {
         "Daily",
         "Hourly",
         "Minutely",
-        "Secondly",
         "Custom"
       ]
     }

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -36,7 +36,7 @@ import {
   GetAnomalyAlertConfigurationResponse as GetAlertConfigResponse,
   GetHookResponse,
   NotificationHookUnion,
-  DataFeedRollupMethod,
+  DataFeedAutoRollupMethod,
   DataFeedsPageResponse,
   IngestionStatusPageResponse,
   AlertConfigurationsPageResponse,
@@ -239,7 +239,7 @@ export class MetricsAdvisorAdministrationClient {
       rollupSettings?.rollupType === "AutoRollup" || rollupSettings?.rollupType === "AlreadyRollup"
         ? rollupSettings.rollupIdentificationValue
         : undefined;
-    const rollUpMethod: DataFeedRollupMethod | undefined =
+    const rollUpMethod: DataFeedAutoRollupMethod | undefined =
       rollupSettings?.rollupType === "AutoRollup" ? rollupSettings.rollupMethod : undefined;
     const fillMissingPointType = missingDataPointFillSettings?.fillType;
     const fillMissingPointValue =

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -32,8 +32,8 @@ import {
   AnomalyDetectionConfiguration,
   AnomalyDetectionConfigurationPatch,
   GetDataFeedResponse,
-  GetAnomalyDetectionConfigurationResponse,
-  GetAnomalyAlertConfigurationResponse,
+  GetDetectionConfigResponse,
+  GetAnomalyAlertConfigurationResponse as GetAlertConfigResponse,
   GetHookResponse,
   NotificationHookUnion,
   DataFeedRollupMethod,
@@ -48,7 +48,7 @@ import {
   DatasourceCredentialUnion,
   DatasourceCredentialPatch,
   CredentialsPageResponse,
-  GetCredentialEntityResponse
+  GetCredentialEntityResponse as GetDatasourceCredentialEntityResponse
 } from "./models";
 import { DataSourceType, HookInfoUnion, NeedRollupEnum } from "./generated/models";
 import {
@@ -472,7 +472,7 @@ export class MetricsAdvisorAdministrationClient {
     dataFeedId: string,
     patch: DataFeedPatch,
     options: OperationOptions = {}
-  ): Promise<RestResponse> {
+  ): Promise<GetDataFeedResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateDataFeed",
       options
@@ -511,7 +511,9 @@ export class MetricsAdvisorAdministrationClient {
         status: patch.status,
         actionLinkTemplate: patch.actionLinkTemplate
       };
-      return await this.client.updateDataFeed(dataFeedId, patchBody, requestOptions);
+      const result = await this.client.updateDataFeed(dataFeedId, patchBody, requestOptions);
+      const resultDataFeed: DataFeed = fromServiceDataFeedDetailUnion(result);
+      return { ...resultDataFeed, _response: result._response };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
@@ -558,7 +560,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createDetectionConfig(
     config: Omit<AnomalyDetectionConfiguration, "id">,
     options: OperationOptions = {}
-  ): Promise<GetAnomalyDetectionConfigurationResponse> {
+  ): Promise<GetDetectionConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createDetectionConfig",
       options
@@ -596,7 +598,7 @@ export class MetricsAdvisorAdministrationClient {
   public async getDetectionConfig(
     id: string,
     options: OperationOptions = {}
-  ): Promise<GetAnomalyDetectionConfigurationResponse> {
+  ): Promise<GetDetectionConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-getDetectionConfig",
       options
@@ -631,7 +633,7 @@ export class MetricsAdvisorAdministrationClient {
     id: string,
     patch: AnomalyDetectionConfigurationPatch,
     options: OperationOptions = {}
-  ): Promise<RestResponse> {
+  ): Promise<GetDetectionConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateDetectionConfig",
       options
@@ -640,7 +642,15 @@ export class MetricsAdvisorAdministrationClient {
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       const transformed = toServiceAnomalyDetectionConfigurationPatch(patch);
-      return await this.client.updateAnomalyDetectionConfiguration(id, transformed, requestOptions);
+      const result = await this.client.updateAnomalyDetectionConfiguration(
+        id,
+        transformed,
+        requestOptions
+      );
+      return {
+        ...fromServiceAnomalyDetectionConfiguration(result),
+        _response: result._response
+      };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
@@ -689,7 +699,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createAlertConfig(
     config: Omit<AnomalyAlertConfiguration, "id">,
     options: OperationOptions = {}
-  ): Promise<GetAnomalyAlertConfigurationResponse> {
+  ): Promise<GetAlertConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createAlertConfig",
       options
@@ -728,7 +738,7 @@ export class MetricsAdvisorAdministrationClient {
     id: string,
     patch: Partial<Omit<AnomalyAlertConfiguration, "id">>,
     options: OperationOptions = {}
-  ): Promise<RestResponse> {
+  ): Promise<GetAlertConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateAlertConfig",
       options
@@ -737,7 +747,12 @@ export class MetricsAdvisorAdministrationClient {
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       const transformed = toServiceAlertConfigurationPatch(patch);
-      return await this.client.updateAnomalyAlertingConfiguration(id, transformed, requestOptions);
+      const result = await this.client.updateAnomalyAlertingConfiguration(
+        id,
+        transformed,
+        requestOptions
+      );
+      return { ...fromServiceAlertConfiguration(result), _response: result._response };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
@@ -758,7 +773,7 @@ export class MetricsAdvisorAdministrationClient {
   public async getAlertConfig(
     id: string,
     options: OperationOptions = {}
-  ): Promise<GetAnomalyAlertConfigurationResponse> {
+  ): Promise<GetAlertConfigResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-getAlertConfig",
       options
@@ -1132,14 +1147,18 @@ export class MetricsAdvisorAdministrationClient {
     id: string,
     patch: EmailNotificationHookPatch | WebNotificationHookPatch,
     options: OperationOptions = {}
-  ): Promise<RestResponse> {
+  ): Promise<GetHookResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateHook",
       options
     );
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-      return await this.client.updateHook(id, patch, requestOptions);
+      const result = await this.client.updateHook(id, patch, requestOptions);
+      const resultHookResponse: NotificationHookUnion = fromServiceHookInfoUnion(
+        result._response.parsedBody
+      );
+      return { ...resultHookResponse, _response: result._response };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
@@ -1567,7 +1586,7 @@ export class MetricsAdvisorAdministrationClient {
   public async createDatasourceCredential(
     datasourceCredential: DatasourceCredentialUnion,
     options: OperationOptions = {}
-  ): Promise<GetCredentialEntityResponse> {
+  ): Promise<GetDatasourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-createDatasourceCredential",
       options
@@ -1603,7 +1622,7 @@ export class MetricsAdvisorAdministrationClient {
   public async getDatasourceCredential(
     id: string,
     options: OperationOptions = {}
-  ): Promise<GetCredentialEntityResponse> {
+  ): Promise<GetDatasourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-getDatasourceCredential",
       options
@@ -1767,18 +1786,20 @@ export class MetricsAdvisorAdministrationClient {
     id: string,
     patch: DatasourceCredentialPatch,
     options: OperationOptions = {}
-  ): Promise<RestResponse> {
+  ): Promise<GetDatasourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateDataSourceCredential",
       options
     );
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
-      return await this.client.updateCredential(
+      const result = await this.client.updateCredential(
         id,
         toServiceCredentialPatch(patch),
         requestOptions
       );
+      const resultCred = fromServiceCredential(result);
+      return { ...resultCred, _response: result._response };
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -45,10 +45,10 @@ import {
   DataFeedStatus,
   GetIngestionProgressResponse,
   AnomalyAlertConfiguration,
-  DatasourceCredentialUnion,
-  DatasourceCredentialPatch,
+  DataSourceCredentialUnion,
+  DataSourceCredentialPatch,
   CredentialsPageResponse,
-  GetCredentialEntityResponse as GetDatasourceCredentialEntityResponse
+  GetDataSourceCredentialEntityResponse
 } from "./models";
 import { DataSourceType, HookInfoUnion, NeedRollupEnum } from "./generated/models";
 import {
@@ -97,7 +97,7 @@ export interface ListHooksOptions extends OperationOptions {
 /**
  * Options for listing data source credentials
  */
-export interface ListDatasourceCredentialsOptions extends OperationOptions {
+export interface ListDataSourceCredentialsOptions extends OperationOptions {
   /** Number of items to skip */
   skip?: number;
 }
@@ -1579,29 +1579,29 @@ export class MetricsAdvisorAdministrationClient {
 
   /**
    * Creates data source credential for the given id
-   * @param datasourceCredential - the credential entity object to create
+   * @param dataSourceCredential - the credential entity object to create
    * @param options - The options parameter
    */
 
-  public async createDatasourceCredential(
-    datasourceCredential: DatasourceCredentialUnion,
+  public async createDataSourceCredential(
+    dataSourceCredential: DataSourceCredentialUnion,
     options: OperationOptions = {}
-  ): Promise<GetDatasourceCredentialEntityResponse> {
+  ): Promise<GetDataSourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-createDatasourceCredential",
+      "MetricsAdvisorAdministrationClient-createDataSourceCredential",
       options
     );
     try {
       const requestOptions = operationOptionsToRequestOptionsBase(finalOptions);
       // transformation
-      const transformedCred = toServiceCredential(datasourceCredential);
+      const transformedCred = toServiceCredential(dataSourceCredential);
       const result = await this.client.createCredential(transformedCred, requestOptions);
       if (!result.location) {
         throw new Error("Expected a valid location to retrieve the created credential entity");
       }
       const lastSlashIndex = result.location.lastIndexOf("/");
       const credEntityId = result.location.substring(lastSlashIndex + 1);
-      return this.getDatasourceCredential(credEntityId);
+      return this.getDataSourceCredential(credEntityId);
     } catch (e) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
@@ -1619,12 +1619,12 @@ export class MetricsAdvisorAdministrationClient {
    * @param options - The options parameter
    */
 
-  public async getDatasourceCredential(
+  public async getDataSourceCredential(
     id: string,
     options: OperationOptions = {}
-  ): Promise<GetDatasourceCredentialEntityResponse> {
+  ): Promise<GetDataSourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-getDatasourceCredential",
+      "MetricsAdvisorAdministrationClient-getDataSourceCredential",
       options
     );
     try {
@@ -1653,18 +1653,18 @@ export class MetricsAdvisorAdministrationClient {
    * ```js
    * const client = new MetricsAdvisorAdministrationClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const datasourceCredentialList = client.listDatasourceCredential();
+   * const dataSourceCredentialList = client.listDataSourceCredential();
    * let i = 1;
-   * for await (const datasourceCredential of datasourceCredentialList){
-   *  console.log(`datasourceCredential ${i++}:`);
-   *  console.log(datasourceCredential);
+   * for await (const dataSourceCredential of dataSourceCredentialList){
+   *  console.log(`dataSourceCredential ${i++}:`);
+   *  console.log(dataSourceCredential);
    * }
    * ```
    *
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listDatasourceCredential();
+   * let iter = client.listDataSourceCredential();
    * let result = await iter.next();
    * while (!result.done) {
    *   console.dir(result);
@@ -1675,14 +1675,14 @@ export class MetricsAdvisorAdministrationClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listDatasourceCredential().byPage({ maxPageSize: 2 });
+   * const pages = client.listDataSourceCredential().byPage({ maxPageSize: 2 });
    * let page = await pages.next();
    * let i = 1;
    * while (!page.done) {
    *  if (page.value) {
    *    console.log(`-- page ${i++}`);
    *    for (const credential of page.value) {
-   *      console.log("datasource credential-");
+   *      console.log("dataSource credential-");
    *      console.dir(credential);
    *    }
    *  }
@@ -1690,10 +1690,10 @@ export class MetricsAdvisorAdministrationClient {
    * }
    * ```
    */
-  public listDatasourceCredential(
-    options: ListDatasourceCredentialsOptions = {}
-  ): PagedAsyncIterableIterator<DatasourceCredentialUnion, CredentialsPageResponse> {
-    const iter = this.listItemsOfDatasourceCredentials(options);
+  public listDataSourceCredential(
+    options: ListDataSourceCredentialsOptions = {}
+  ): PagedAsyncIterableIterator<DataSourceCredentialUnion, CredentialsPageResponse> {
+    const iter = this.listItemsOfDataSourceCredentials(options);
     return {
       /**
        * The next method, part of the iteration protocol
@@ -1719,9 +1719,9 @@ export class MetricsAdvisorAdministrationClient {
     };
   }
 
-  private async *listItemsOfDatasourceCredentials(
-    options: ListDatasourceCredentialsOptions
-  ): AsyncIterableIterator<DatasourceCredentialUnion> {
+  private async *listItemsOfDataSourceCredentials(
+    options: ListDataSourceCredentialsOptions
+  ): AsyncIterableIterator<DataSourceCredentialUnion> {
     for await (const segment of this.listSegmentsOfCredentialEntities(options)) {
       if (segment) {
         yield* segment;
@@ -1730,7 +1730,7 @@ export class MetricsAdvisorAdministrationClient {
   }
 
   private async *listSegmentsOfCredentialEntities(
-    options: ListDatasourceCredentialsOptions & { maxPageSize?: number },
+    options: ListDataSourceCredentialsOptions & { maxPageSize?: number },
     continuationToken?: string
   ): AsyncIterableIterator<CredentialsPageResponse> {
     let segmentResponse;
@@ -1782,11 +1782,11 @@ export class MetricsAdvisorAdministrationClient {
    * @param patch -  Input to the update credential entity operation {@link DataSourceCredentialPatch}
    * @param options - The options parameter
    */
-  public async updateDatasourceCredential(
+  public async updateDataSourceCredential(
     id: string,
-    patch: DatasourceCredentialPatch,
+    patch: DataSourceCredentialPatch,
     options: OperationOptions = {}
-  ): Promise<GetDatasourceCredentialEntityResponse> {
+  ): Promise<GetDataSourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
       "MetricsAdvisorAdministrationClient-updateDataSourceCredential",
       options
@@ -1816,7 +1816,7 @@ export class MetricsAdvisorAdministrationClient {
    * @param id - id of the credential entity to delete
    * @param options - The options parameter
    */
-  public async deleteDatasourceCredential(
+  public async deleteDataSourceCredential(
     id: string,
     options: OperationOptions = {}
   ): Promise<RestResponse> {

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -45,7 +45,7 @@ import {
   DataFeedStatus,
   GetIngestionProgressResponse,
   AnomalyAlertConfiguration,
-  DataSourceCredentialUnion,
+  DataSourceCredentialEntityUnion,
   DataSourceCredentialPatch,
   CredentialsPageResponse,
   GetDataSourceCredentialEntityResponse
@@ -1584,7 +1584,7 @@ export class MetricsAdvisorAdministrationClient {
    */
 
   public async createDataSourceCredential(
-    dataSourceCredential: DataSourceCredentialUnion,
+    dataSourceCredential: DataSourceCredentialEntityUnion,
     options: OperationOptions = {}
   ): Promise<GetDataSourceCredentialEntityResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -1692,7 +1692,7 @@ export class MetricsAdvisorAdministrationClient {
    */
   public listDataSourceCredential(
     options: ListDataSourceCredentialsOptions = {}
-  ): PagedAsyncIterableIterator<DataSourceCredentialUnion, CredentialsPageResponse> {
+  ): PagedAsyncIterableIterator<DataSourceCredentialEntityUnion, CredentialsPageResponse> {
     const iter = this.listItemsOfDataSourceCredentials(options);
     return {
       /**
@@ -1721,7 +1721,7 @@ export class MetricsAdvisorAdministrationClient {
 
   private async *listItemsOfDataSourceCredentials(
     options: ListDataSourceCredentialsOptions
-  ): AsyncIterableIterator<DataSourceCredentialUnion> {
+  ): AsyncIterableIterator<DataSourceCredentialEntityUnion> {
     for await (const segment of this.listSegmentsOfCredentialEntities(options)) {
       if (segment) {
         yield* segment;

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorAdministrationClient.ts
@@ -1582,7 +1582,6 @@ export class MetricsAdvisorAdministrationClient {
    * @param dataSourceCredential - the credential entity object to create
    * @param options - The options parameter
    */
-
   public async createDataSourceCredential(
     dataSourceCredential: DataSourceCredentialEntityUnion,
     options: OperationOptions = {}

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -93,6 +93,7 @@ export interface ListIncidentsForAlertOptions extends OperationOptions {
 export interface ListAnomalyDimensionValuesOptions extends OperationOptions {
   /** Number of items to skip */
   skip?: number;
+  /** Specify series group to filter results */
   seriesGroupKey?: DimensionKey;
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -711,7 +711,7 @@ export class MetricsAdvisorClient {
    * ```js
    * const client = new MetricsAdvisorClient(endpoint,
    *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const incidentList = client.listIncidents(anomalyAlert);
+   * const incidentList = client.listIncidentsForAlert(anomalyAlert);
    * let i = 1;
    * for await (const incident of incidentList){
    *   console.log(`incident ${i++}:`);
@@ -722,7 +722,7 @@ export class MetricsAdvisorClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * let iter = client.listIncidents(anomalyAlert);
+   * let iter = client.listIncidentsForAlert(anomalyAlert);
    * let result = await iter.next();
    * while (!result.done) {
    *   console.log(` incident - ${result.value.id}`);
@@ -734,7 +734,7 @@ export class MetricsAdvisorClient {
    * Example using `byPage()`:
    *
    * ```js
-   * const pages = client.listIncidents(anomalyAlert).byPage({ maxPageSize: 10 });
+   * const pages = client.listIncidentsForAlert(anomalyAlert).byPage({ maxPageSize: 10 });
    * let page = await pages.next();
    * let i = 1;
    * while (!page.done) {
@@ -750,100 +750,7 @@ export class MetricsAdvisorClient {
    * @param alert - Anomaly alert containing alertConfigId and id
    * @param options - The options parameter.
    */
-  public listIncidents(
-    alert: AnomalyAlert,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListIncidentsForAlertOptions
-  ): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
-  /**
-   * Returns an async iterable iterator to list incidents for an anomaly detection configuration.
-   *
-   * `.byPage()` returns an async iterable iterator to list the incidents in pages.
-   *
-   * Example using `for await` syntax:
-   *
-   * ```js
-   * const client = new MetricsAdvisorClient(endpoint,
-   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const incidentList = client
-   *   .listIncidents(detectionConfigId, startTime, endTime);
-   * let i = 1;
-   * for await (const incident of incidentList){
-   *  console.log(`incident ${i++}:`);
-   *  console.log(incident);
-   * }
-   * ```
-   *
-   * Example using `iter.next()`:
-   *
-   * ```js
-   * let iter = client.listIncidents(detectionConfigId, startTime, endTime);
-   * let result = await iter.next();
-   * while (!result.done) {
-   *   console.log(` incident - ${result.value.id}`);
-   *   console.dir(result.value);
-   *   result = await iter.next();
-   * }
-   * ```
-   *
-   * Example using `byPage()`:
-   *
-   * ```js
-   * const pages = client.listIncidents(detectionConfigId, startTime, endTime)
-   *   .byPage({ maxPageSize: 10 });
-   * let page = await pages.next();
-   * let i = 1;
-   * while (!page.done) {
-   *  if (page.value) {
-   *    console.log(`-- page ${i++}`);
-   *    for (const incident of page.value) {
-   *      console.dir(incident);
-   *    }
-   *  }
-   *  page = await pages.next();
-   * }
-   * ```
-   * @param detectionConfigId - Anomaly detection configuration id
-   * @param startTime - The start of time range to query for incidents
-   * @param endTime - The end of time range to query for incidents
-   * @param options - The options parameter.
-   */
-  public listIncidents(
-    detectionConfigId: string,
-    startTime: Date | string,
-    endTime: Date | string,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListIncidentsForDetectionConfigurationOptions
-  ): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse>;
-
-  public listIncidents(
-    alertOrDetectionConfigId: AnomalyAlert | string,
-    optionsOrStartTime?: ListIncidentsForAlertOptions | Date | string,
-    endTime?: Date | string,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListIncidentsForDetectionConfigurationOptions
-  ): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse> {
-    if (typeof alertOrDetectionConfigId === "string") {
-      if (!optionsOrStartTime || !endTime) {
-        throw new Error("Invalid startTime or endTime");
-      }
-      return this.listIncidentsForDetectionConfiguration(
-        alertOrDetectionConfigId,
-        typeof optionsOrStartTime === "string"
-          ? new Date(optionsOrStartTime)
-          : (optionsOrStartTime as Date),
-        typeof endTime === "string" ? new Date(endTime) : endTime,
-        options || {}
-      );
-    } else {
-      return this.listIncidentsForAlert(
-        alertOrDetectionConfigId as AnomalyAlert,
-        (optionsOrStartTime || {}) as ListIncidentsForAlertOptions
-      );
-    }
-  }
-
-  private listIncidentsForAlert(
+  public listIncidentsForAlert(
     alert: AnomalyAlert,
     options: ListIncidentsForAlertOptions = {}
   ): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse> {
@@ -1424,16 +1331,71 @@ export class MetricsAdvisorClient {
     }
   }
 
-  private listIncidentsForDetectionConfiguration(
+  /**
+   * Returns an async iterable iterator to list incidents for an anomaly detection configuration.
+   *
+   * `.byPage()` returns an async iterable iterator to list the incidents in pages.
+   *
+   * Example using `for await` syntax:
+   *
+   * ```js
+   * const client = new MetricsAdvisorClient(endpoint,
+   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
+   * const incidentList = client
+   *   .listIncidentsForDetectionConfiguration(detectionConfigId, startTime, endTime);
+   * let i = 1;
+   * for await (const incident of incidentList){
+   *  console.log(`incident ${i++}:`);
+   *  console.log(incident);
+   * }
+   * ```
+   *
+   * Example using `iter.next()`:
+   *
+   * ```js
+   * let iter = client.listIncidentsForDetectionConfiguration(detectionConfigId, startTime, endTime);
+   * let result = await iter.next();
+   * while (!result.done) {
+   *   console.log(` incident - ${result.value.id}`);
+   *   console.dir(result.value);
+   *   result = await iter.next();
+   * }
+   * ```
+   *
+   * Example using `byPage()`:
+   *
+   * ```js
+   * const pages = client.listIncidentsForDetectionConfiguration(detectionConfigId, startTime, endTime)
+   *   .byPage({ maxPageSize: 10 });
+   * let page = await pages.next();
+   * let i = 1;
+   * while (!page.done) {
+   *  if (page.value) {
+   *    console.log(`-- page ${i++}`);
+   *    for (const incident of page.value) {
+   *      console.dir(incident);
+   *    }
+   *  }
+   *  page = await pages.next();
+   * }
+   * ```
+   * @param detectionConfigId - Anomaly detection configuration id
+   * @param startTime - The start of time range to query for incidents
+   * @param endTime - The end of time range to query for incidents
+   * @param options - The options parameter.
+   */
+  public listIncidentsForDetectionConfiguration(
     detectionConfigId: string,
-    startTime: Date,
-    endTime: Date,
+    startTime: Date | string,
+    endTime: Date | string,
     options: ListIncidentsForDetectionConfigurationOptions = {}
   ): PagedAsyncIterableIterator<AnomalyIncident, IncidentsPageResponse> {
+    const start: Date = typeof startTime === "string" ? new Date(startTime) : startTime;
+    const end: Date = typeof endTime === "string" ? new Date(endTime) : endTime;
     const iter = this.listItemsOfIncidentsForDetectionConfig(
       detectionConfigId,
-      startTime,
-      endTime,
+      start,
+      end,
       options
     );
     return {
@@ -1455,8 +1417,8 @@ export class MetricsAdvisorClient {
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfIncidentsForDetectionConfig(
           detectionConfigId,
-          startTime,
-          endTime,
+          start,
+          end,
           settings.continuationToken,
           settings.maxPageSize,
           options

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -832,20 +832,20 @@ export class MetricsAdvisorClient {
    * @param detectionConfigId - Anomaly detection configuration id
    * @param startTime - The start of time range to query metric enriched series data
    * @param endTime - The end of time range to query metric enriched series data
-   * @param seriesToFilter - Series to retrieve their data
+   * @param seriesKey - Series to retrieve their data
    * @param options - The options parameter.
    */
   public async getMetricEnrichedSeriesData(
     detectionConfigId: string,
+    seriesKey: DimensionKey[],
     startTime: Date | string,
     endTime: Date | string,
-    seriesToFilter: DimensionKey[],
     options: GetMetricEnrichedSeriesDataOptions = {}
   ): Promise<GetMetricEnrichedSeriesDataResponse> {
     const optionsBody = {
       startTime: typeof startTime === "string" ? new Date(startTime) : startTime,
       endTime: typeof endTime === "string" ? new Date(endTime) : endTime,
-      series: seriesToFilter.map((s) => {
+      series: seriesKey.map((s) => {
         return { dimension: s };
       })
     };
@@ -1790,20 +1790,20 @@ export class MetricsAdvisorClient {
    * @param metricId - Metric id
    * @param startTime - The start of the time range to retrieve series data
    * @param endTime - The end of the time range to retrieve series data
-   * @param seriesToFilter - A list of time series to retrieve their data
+   * @param seriesKey - A list of time series to retrieve their data
    * @param options - The options parameter
    */
   public async getMetricSeriesData(
     metricId: string,
+    seriesKey: DimensionKey[],
     startTime: Date | string,
     endTime: Date | string,
-    seriesToFilter: DimensionKey[],
     options: GetMetricSeriesDataOptions = {}
   ): Promise<GetMetricSeriesDataResponse> {
     const optionsBody = {
       startTime: typeof startTime === "string" ? new Date(startTime) : startTime,
       endTime: typeof endTime === "string" ? new Date(endTime) : endTime,
-      series: seriesToFilter
+      series: seriesKey
     };
     const result = await this.client.getMetricData(metricId, optionsBody, options);
     const resultArray =

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -517,7 +517,57 @@ export class MetricsAdvisorClient {
     }
   }
 
-  private listAnomaliesForAlert(
+  /**
+   * Returns an async iterable iterator to list anamolies associated with an alert
+   *
+   * `.byPage()` returns an async iterable iterator to list the anomalies in pages.
+   *
+   * Example using `for await` syntax:
+   *
+   * ```js
+   * const client = new MetricsAdvisorClient(endpoint,
+   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
+   * const anamolyList = client.listAnomaliesForAlert({alertConfigId, id: alertId});
+   * let i = 1;
+   * for await (const anamoly of anamolyList){
+   *  console.log(`anamoly ${i++}:`);
+   *  console.log(anamoly);
+   * }
+   * ```
+   *
+   * Example using `iter.next()`:
+   *
+   * ```js
+   * let iter = client.listAnomaliesForAlert({alertConfigId, id: alertId});
+   * let result = await iter.next();
+   * while (!result.done) {
+   *   console.log(` anamoly - ${result.value.metricId}, ${result.value.detectionConfigurationId} `);
+   *   result = await iter.next();
+   * }
+   * ```
+   *
+   * Example using `byPage()`:
+   *
+   * ```js
+   * const pages = client.listAnomaliesForAlert({alertConfigId, id: alertId}).byPage({ maxPageSize: 10 });
+   * let page = await pages.next();
+   * let i = 1;
+   * while (!page.done) {
+   *  if (page.value) {
+   *    console.log(`-- page ${i++}`);
+   *    for (const anomaly of page.value) {
+   *      console.log(`${anomaly}`);
+   *    }
+   *  }
+   *  page = await pages.next();
+   * }
+   *
+   * ```
+   * @param alert - Anomaly alert containing alertConfigId and id
+   * @param options - The options parameter.
+   */
+
+  public listAnomaliesForAlert(
     alert: AnomalyAlert,
     options: ListAnomaliesForAlertConfigurationOptions = {}
   ): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse> {
@@ -985,16 +1035,71 @@ export class MetricsAdvisorClient {
     }
   }
 
-  private listAnomaliesForDetectionConfiguration(
+  /**
+   * Returns an async iterable iterator to list anomalies for a detection configuration.
+   *
+   * `.byPage()` returns an async iterable iterator to list the anomalies in pages.
+   *
+   * Example using `for await` syntax:
+   *
+   * ```js
+   * const client = new MetricsAdvisorClient(endpoint,
+   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
+   * const anomalies = client.listAnomaliesForDetectionConfiguration(detectionConfigId, startTime, endTime);
+   * let i = 1;
+   * for await (const anomaly of anomalies) {
+   *   console.log(`anomaly ${i++}:`);
+   *   console.log(anomaly);
+   * }
+   * ```
+   *
+   * Example using `iter.next()`:
+   *
+   * ```js
+   * let iter = client.listAnomaliesForDetectionConfiguration(detectionConfigId, startTime, endTime);
+   * let result = await iter.next();
+   * while (!result.done) {
+   *   console.log(` anomaly - ${result.value.severity} ${result.value.status}`);
+   *   console.dir(result.value);
+   *   result = await iter.next();
+   * }
+   * ```
+   *
+   * Example using `byPage()`:
+   *
+   * ```js
+   * const pages = client.listAnomaliesForDetectionConfiguration(detectionConfigId, startTime, endTime)
+   *   .byPage({ maxPageSize: 10 });
+   * let page = await pages.next();
+   * let i = 1;
+   * while (!page.done) {
+   *  if (page.value) {
+   *    console.log(`-- page ${i++}`);
+   *    for (const anomaly of page.value) {
+   *      console.dir(anomaly);
+   *    }
+   *  }
+   *  page = await pages.next();
+   * }
+   *
+   * ```
+   * @param detectionConfigId - Anomaly detection configuration id
+   * @param startTime - The start of time range to query anomalies
+   * @param endTime - The end of time range to query anomalies
+   * @param options - The options parameter.
+   */
+  public listAnomaliesForDetectionConfiguration(
     detectionConfigId: string,
-    startTime: Date,
-    endTime: Date,
+    startTime: Date | string,
+    endTime: Date | string,
     options: ListAnomaliesForDetectionConfigurationOptions = {}
   ): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse> {
+    const start: Date = typeof startTime === "string" ? new Date(startTime) : startTime;
+    const end: Date = typeof endTime === "string" ? new Date(endTime) : endTime;
     const iter = this.listItemsOfAnomaliesForDetectionConfig(
       detectionConfigId,
-      startTime,
-      endTime,
+      start,
+      end,
       options
     );
     return {
@@ -1016,156 +1121,14 @@ export class MetricsAdvisorClient {
       byPage: (settings: PageSettings = {}) => {
         return this.listSegmentsOfAnomaliesForDetectionConfig(
           detectionConfigId,
-          startTime,
-          endTime,
+          start,
+          end,
           settings.maxPageSize,
           settings.continuationToken,
           options
         );
       }
     };
-  }
-
-  /**
-   * Returns an async iterable iterator to list anamolies associated with an alert
-   *
-   * `.byPage()` returns an async iterable iterator to list the anomalies in pages.
-   *
-   * Example using `for await` syntax:
-   *
-   * ```js
-   * const client = new MetricsAdvisorClient(endpoint,
-   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const anamolyList = client.listAnomalies({alertConfigId, id: alertId});
-   * let i = 1;
-   * for await (const anamoly of anamolyList){
-   *  console.log(`anamoly ${i++}:`);
-   *  console.log(anamoly);
-   * }
-   * ```
-   *
-   * Example using `iter.next()`:
-   *
-   * ```js
-   * let iter = client.listAnomalies({alertConfigId, id: alertId});
-   * let result = await iter.next();
-   * while (!result.done) {
-   *   console.log(` anamoly - ${result.value.metricId}, ${result.value.detectionConfigurationId} `);
-   *   result = await iter.next();
-   * }
-   * ```
-   *
-   * Example using `byPage()`:
-   *
-   * ```js
-   * const pages = client.listAnomalies({alertConfigId, id: alertId}).byPage({ maxPageSize: 10 });
-   * let page = await pages.next();
-   * let i = 1;
-   * while (!page.done) {
-   *  if (page.value) {
-   *    console.log(`-- page ${i++}`);
-   *    for (const anomaly of page.value) {
-   *      console.log(`${anomaly}`);
-   *    }
-   *  }
-   *  page = await pages.next();
-   * }
-   *
-   * ```
-   * @param alert - Anomaly alert containing alertConfigId and id
-   * @param options - The options parameter.
-   */
-  public listAnomalies(
-    alert: AnomalyAlert,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListAnomaliesForAlertConfigurationOptions
-  ): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
-
-  /**
-   * Returns an async iterable iterator to list anomalies for a detection configuration.
-   *
-   * `.byPage()` returns an async iterable iterator to list the anomalies in pages.
-   *
-   * Example using `for await` syntax:
-   *
-   * ```js
-   * const client = new MetricsAdvisorClient(endpoint,
-   *   new MetricsAdvisorKeyCredential(subscriptionKey, apiKey));
-   * const anomalies = client.listAnomalies(detectionConfigId, startTime, endTime);
-   * let i = 1;
-   * for await (const anomaly of anomalies) {
-   *   console.log(`anomaly ${i++}:`);
-   *   console.log(anomaly);
-   * }
-   * ```
-   *
-   * Example using `iter.next()`:
-   *
-   * ```js
-   * let iter = client.listAnomalies(detectionConfigId, startTime, endTime);
-   * let result = await iter.next();
-   * while (!result.done) {
-   *   console.log(` anomaly - ${result.value.severity} ${result.value.status}`);
-   *   console.dir(result.value);
-   *   result = await iter.next();
-   * }
-   * ```
-   *
-   * Example using `byPage()`:
-   *
-   * ```js
-   * const pages = client.listAnomalies(detectionConfigId, startTime, endTime)
-   *   .byPage({ maxPageSize: 10 });
-   * let page = await pages.next();
-   * let i = 1;
-   * while (!page.done) {
-   *  if (page.value) {
-   *    console.log(`-- page ${i++}`);
-   *    for (const anomaly of page.value) {
-   *      console.dir(anomaly);
-   *    }
-   *  }
-   *  page = await pages.next();
-   * }
-   *
-   * ```
-   * @param detectionConfigId - Anomaly detection configuration id
-   * @param startTime - The start of time range to query anomalies
-   * @param endTime - The end of time range to query anomalies
-   * @param options - The options parameter.
-   */
-  public listAnomalies(
-    detectionConfigId: string,
-    startTime: Date | string,
-    endTime: Date | string,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListAnomaliesForDetectionConfigurationOptions
-  ): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse>;
-  public listAnomalies(
-    alertOrDetectionConfigId: AnomalyAlert | string,
-    optionsOrStartTime?: ListAnomaliesForAlertConfigurationOptions | Date | string,
-    endTime?: Date | string,
-    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-    options?: ListAnomaliesForDetectionConfigurationOptions
-  ): PagedAsyncIterableIterator<DataPointAnomaly, AnomaliesPageResponse> {
-    if (typeof alertOrDetectionConfigId === "string") {
-      if (!optionsOrStartTime || !endTime) {
-        throw new Error("Invalid startTime or endTime");
-      }
-      return this.listAnomaliesForDetectionConfiguration(
-        alertOrDetectionConfigId,
-        typeof optionsOrStartTime === "string"
-          ? new Date(optionsOrStartTime)
-          : (optionsOrStartTime as Date),
-        typeof endTime === "string" ? new Date(endTime) : endTime,
-        options || {}
-      );
-    } else {
-      return this.listAnomaliesForAlert(
-        alertOrDetectionConfigId,
-        (optionsOrStartTime as ListAnomaliesForAlertConfigurationOptions) || {}
-      );
-    }
   }
 
   // ## list segments of dimension values of anomalies detected by a detection configuration

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/metricsAdvisorClient.ts
@@ -1556,12 +1556,12 @@ export class MetricsAdvisorClient {
    * @param options - The options parameter
    * @returns Response with Feedback object
    */
-  public async createFeedback(
+  public async addFeedback(
     feedback: MetricFeedbackUnion,
     options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-createFeedback",
+      "MetricsAdvisorClient-addFeedback",
       options
     );
 
@@ -1596,7 +1596,7 @@ export class MetricsAdvisorClient {
     options: OperationOptions = {}
   ): Promise<GetFeedbackResponse> {
     const { span, updatedOptions: finalOptions } = createSpan(
-      "MetricsAdvisorAdministrationClient-getFeedback",
+      "MetricsAdvisorClient-getFeedback",
       options
     );
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1496,7 +1496,7 @@ export interface AnomalyAlertConfiguration {
   /**
    * dimensions used to split alert
    */
-  splitAlertByDimensions?: string[];
+  dimensionsToSplitAlert?: string[];
 }
 
 /**

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1736,7 +1736,7 @@ export type GetHookResponse = NotificationHookUnion & {
 /**
  * Contains response data for the getCredentialEntity operation.
  */
-export type GetDataSourceCredentialEntityResponse = DataSourceCredentialUnion & {
+export type GetDataSourceCredentialEntityResponse = DataSourceCredentialEntityUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -2180,7 +2180,7 @@ export type GetIngestionProgressResponse = {
 /**
  * Data Source Credential
  */
-export interface DataSourceCredential {
+export interface DataSourceCredentialEntity {
   /**
    * Unique id of data source credential
    * NOTE: This property will not be serialized. It can only be populated by the server.
@@ -2195,7 +2195,7 @@ export interface DataSourceCredential {
 /**
  * SqlServer Data Source Credential
  */
-export interface SqlServerConnectionStringDataSourceCredential extends DataSourceCredential {
+export interface DataSourceSqlConnectionString extends DataSourceCredentialEntity {
   /** Azure Sql Connection String credential */
   type: "AzureSQLConnectionString";
   /** The connection string for SqlServer Data Source Credential */
@@ -2205,7 +2205,7 @@ export interface SqlServerConnectionStringDataSourceCredential extends DataSourc
 /**
  * DataLake Gen2 Shared Key DataSource Credential
  */
-export interface DataLakeGen2SharedKeyDataSourceCredential extends DataSourceCredential {
+export interface DataSourceDataLakeGen2SharedKey extends DataSourceCredentialEntity {
   /** DataLakeGen2 Shared Key DataSource credential */
   type: "DataLakeGen2SharedKey";
   /** The account key of the DataLake Gen2 Shared Key DataSource Credential  */
@@ -2215,7 +2215,7 @@ export interface DataLakeGen2SharedKeyDataSourceCredential extends DataSourceCre
 /**
  * Service Principal DataSource Credential
  */
-export interface ServicePrincipalDataSourceCredential extends DataSourceCredential {
+export interface DataSourceServicePrincipal extends DataSourceCredentialEntity {
   /** Service Principal DataSource Credential */
   type: "ServicePrincipal";
   /** The client id of the service principal. */
@@ -2229,7 +2229,7 @@ export interface ServicePrincipalDataSourceCredential extends DataSourceCredenti
 /**
  * Service Principal in KeyVault DataSource Credential
  */
-export interface ServicePrincipalInKeyVaultDataSourceCredential extends DataSourceCredential {
+export interface DataSourceServicePrincipalInKeyVault extends DataSourceCredentialEntity {
   /** Service Principal in KeyVault DataSource Credential */
   type: "ServicePrincipalInKV";
   /** The Key Vault endpoint that storing the service principal. */
@@ -2246,16 +2246,16 @@ export interface ServicePrincipalInKeyVaultDataSourceCredential extends DataSour
   tenantId: string;
 }
 
-export type DataSourceCredentialUnion =
-  | SqlServerConnectionStringDataSourceCredential
-  | DataLakeGen2SharedKeyDataSourceCredential
-  | ServicePrincipalDataSourceCredential
-  | ServicePrincipalInKeyVaultDataSourceCredential;
+export type DataSourceCredentialEntityUnion =
+  | DataSourceSqlConnectionString
+  | DataSourceDataLakeGen2SharedKey
+  | DataSourceServicePrincipal
+  | DataSourceServicePrincipalInKeyVault;
 
 /**
  * SqlServer Data Source Credential Patch
  */
-export interface SqlServerConnectionStringDataSourceCredentialPatch {
+export interface DataSourceSqlServerConnectionStringPatch {
   /** Azure Sql Connection String credential */
   type: "AzureSQLConnectionString";
   /** Name of data source credential */
@@ -2269,7 +2269,7 @@ export interface SqlServerConnectionStringDataSourceCredentialPatch {
 /**
  * DataLake Gen2 Shared Key DataSource Credential Patch
  */
-export interface DataLakeGen2SharedKeyDataSourceCredentialPatch {
+export interface DataSourceDataLakeGen2SharedKeyPatch {
   /** DataLakeGen2 Shared Key DataSource credential */
   type: "DataLakeGen2SharedKey";
   /** Name of data source credential */
@@ -2283,7 +2283,7 @@ export interface DataLakeGen2SharedKeyDataSourceCredentialPatch {
 /**
  *  Service Principal DataSource Credential Patch
  */
-export interface ServicePrincipalDataSourceCredentialPatch {
+export interface DataSourceServicePrincipalPatch {
   /** Service Principal DataSource Credential */
   type: "ServicePrincipal";
   /** Name of data source credential */
@@ -2301,7 +2301,7 @@ export interface ServicePrincipalDataSourceCredentialPatch {
 /**
  *  Service Principal in KeyVault DataSource Credential Patch
  */
-export interface ServicePrincipalInKeyVaultDataSourceCredentialPatch {
+export interface DataSourceServicePrincipalInKeyVaultPatch {
   /** Service Principal in KeyVault DataSource Credential */
   type: "ServicePrincipalInKV";
   /** Name of data source credential */
@@ -2326,15 +2326,15 @@ export interface ServicePrincipalInKeyVaultDataSourceCredentialPatch {
  * DataSource credential patch types
  */
 export type DataSourceCredentialPatch =
-  | SqlServerConnectionStringDataSourceCredentialPatch
-  | DataLakeGen2SharedKeyDataSourceCredentialPatch
-  | ServicePrincipalDataSourceCredentialPatch
-  | ServicePrincipalInKeyVaultDataSourceCredentialPatch;
+  | DataSourceSqlServerConnectionStringPatch
+  | DataSourceDataLakeGen2SharedKeyPatch
+  | DataSourceServicePrincipalPatch
+  | DataSourceServicePrincipalInKeyVaultPatch;
 
 /**
  * Contains response data for the listCredentials operation.
  */
-export interface CredentialsPageResponse extends Array<DataSourceCredentialUnion> {
+export interface CredentialsPageResponse extends Array<DataSourceCredentialEntityUnion> {
   /**
    * Continuation token to pass to `byPage()` to resume listing of more results if available.
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1676,7 +1676,7 @@ export type GetDataFeedResponse = DataFeed & {
 /**
  * Contains response data for the getAnomalyDetectionConfiguration operation.
  */
-export type GetAnomalyDetectionConfigurationResponse = AnomalyDetectionConfiguration & {
+export type GetDetectionConfigResponse = AnomalyDetectionConfiguration & {
   /**
    * The underlying HTTP response.
    */
@@ -2199,7 +2199,7 @@ export interface SqlServerConnectionStringDatasourceCredential extends Datasourc
   /** Azure Sql Connection String credential */
   type: "AzureSQLConnectionString";
   /** The connection string for SqlServer Data Source Credential */
-  connectionString: string;
+  connectionString?: string;
 }
 
 /**
@@ -2209,7 +2209,7 @@ export interface DataLakeGen2SharedKeyDatasourceCredential extends DatasourceCre
   /** DataLakeGen2 Shared Key Datasource credential */
   type: "DataLakeGen2SharedKey";
   /** The account key of the DataLake Gen2 Shared Key Datasource Credential  */
-  accountKey: string;
+  accountKey?: string;
 }
 
 /**
@@ -2221,7 +2221,7 @@ export interface ServicePrincipalDatasourceCredential extends DatasourceCredenti
   /** The client id of the service principal. */
   clientId: string;
   /** The client secret of the service principal. */
-  clientSecret: string;
+  clientSecret?: string;
   /** The tenant id of the service principal. */
   tenantId: string;
 }
@@ -2237,7 +2237,7 @@ export interface ServicePrincipalInKeyVaultDatasourceCredential extends Datasour
   /** The Client Id to access the Key Vault. */
   keyVaultClientId: string;
   /** The Client Secret to access the Key Vault. */
-  keyVaultClientSecret: string;
+  keyVaultClientSecret?: string;
   /** The secret name of the service principal's client Id in the Key Vault. */
   servicePrincipalIdNameInKV: string;
   /** The secret name of the service principal's client secret in the Key Vault. */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -330,7 +330,7 @@ export type AzureCosmosDbDataFeedSource = {
 export interface AzureDataExplorerAuthServicePrincipal {
   /** Authentication Type */
   authenticationType: "ServicePrincipal";
-  /** datasource credential id  */
+  /** dataSource credential id  */
   credentialId: string;
 }
 
@@ -340,7 +340,7 @@ export interface AzureDataExplorerAuthServicePrincipal {
 export interface AzureDataExplorerAuthServicePrincipalInKeyVault {
   /** Authentication Type */
   authenticationType: "ServicePrincipalInKV";
-  /** datasource credential id  */
+  /** dataSource credential id  */
   credentialId: string;
 }
 
@@ -639,7 +639,7 @@ export interface SqlServerAuthManagedIdentity {
 export interface SqlServerAuthConnectionString {
   /** Azure SQL Connection String Authentication */
   authenticationType: "AzureSQLConnectionString";
-  /** Datasource Credential Id for Sql Server datafeed authentication */
+  /** DataSource Credential Id for Sql Server datafeed authentication */
   credentialId: string;
 }
 
@@ -649,7 +649,7 @@ export interface SqlServerAuthConnectionString {
 export interface SqlServerAuthServicePrincipalInKeyVault {
   /** Service Principal in Keyvault Authentication */
   authenticationType: "ServicePrincipalInKV";
-  /** Datasource Credential Id for Sql Server datafeed authentication */
+  /** DataSource Credential Id for Sql Server datafeed authentication */
   credentialId: string;
   /** Connection string for Sql Server datafeed authentication */
   connectionString: string;
@@ -661,7 +661,7 @@ export interface SqlServerAuthServicePrincipalInKeyVault {
 export interface SqlServerAuthServicePrincipal {
   /** Service Principal Authentication */
   authenticationType: "ServicePrincipal";
-  /** Datasource Credential Id for Sql Server datafeed authentication */
+  /** DataSource Credential Id for Sql Server datafeed authentication */
   credentialId: string;
   /** Connection string for Sql Server datafeed authentication */
   connectionString: string;
@@ -778,7 +778,7 @@ export type DataFeedPatch = {
  * When changing to a different data source type, both dataSourceType and dataSourceParameter are required.
  */
 export type DataFeedSourcePatch = Partial<DataFeedSource> & {
-  /** datasource type for patch */
+  /** dataSource type for patch */
   dataSourceType: DataFeedSource["dataSourceType"];
 };
 
@@ -1736,7 +1736,7 @@ export type GetHookResponse = NotificationHookUnion & {
 /**
  * Contains response data for the getCredentialEntity operation.
  */
-export type GetCredentialEntityResponse = DatasourceCredentialUnion & {
+export type GetDataSourceCredentialEntityResponse = DataSourceCredentialUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -2180,7 +2180,7 @@ export type GetIngestionProgressResponse = {
 /**
  * Data Source Credential
  */
-export interface DatasourceCredential {
+export interface DataSourceCredential {
   /**
    * Unique id of data source credential
    * NOTE: This property will not be serialized. It can only be populated by the server.
@@ -2195,7 +2195,7 @@ export interface DatasourceCredential {
 /**
  * SqlServer Data Source Credential
  */
-export interface SqlServerConnectionStringDatasourceCredential extends DatasourceCredential {
+export interface SqlServerConnectionStringDataSourceCredential extends DataSourceCredential {
   /** Azure Sql Connection String credential */
   type: "AzureSQLConnectionString";
   /** The connection string for SqlServer Data Source Credential */
@@ -2203,20 +2203,20 @@ export interface SqlServerConnectionStringDatasourceCredential extends Datasourc
 }
 
 /**
- * DataLake Gen2 Shared Key Datasource Credential
+ * DataLake Gen2 Shared Key DataSource Credential
  */
-export interface DataLakeGen2SharedKeyDatasourceCredential extends DatasourceCredential {
-  /** DataLakeGen2 Shared Key Datasource credential */
+export interface DataLakeGen2SharedKeyDataSourceCredential extends DataSourceCredential {
+  /** DataLakeGen2 Shared Key DataSource credential */
   type: "DataLakeGen2SharedKey";
-  /** The account key of the DataLake Gen2 Shared Key Datasource Credential  */
+  /** The account key of the DataLake Gen2 Shared Key DataSource Credential  */
   accountKey?: string;
 }
 
 /**
- * Service Principal Datasource Credential
+ * Service Principal DataSource Credential
  */
-export interface ServicePrincipalDatasourceCredential extends DatasourceCredential {
-  /** Service Principal Datasource Credential */
+export interface ServicePrincipalDataSourceCredential extends DataSourceCredential {
+  /** Service Principal DataSource Credential */
   type: "ServicePrincipal";
   /** The client id of the service principal. */
   clientId: string;
@@ -2227,10 +2227,10 @@ export interface ServicePrincipalDatasourceCredential extends DatasourceCredenti
 }
 
 /**
- * Service Principal in KeyVault Datasource Credential
+ * Service Principal in KeyVault DataSource Credential
  */
-export interface ServicePrincipalInKeyVaultDatasourceCredential extends DatasourceCredential {
-  /** Service Principal in KeyVault Datasource Credential */
+export interface ServicePrincipalInKeyVaultDataSourceCredential extends DataSourceCredential {
+  /** Service Principal in KeyVault DataSource Credential */
   type: "ServicePrincipalInKV";
   /** The Key Vault endpoint that storing the service principal. */
   keyVaultEndpoint: string;
@@ -2246,16 +2246,16 @@ export interface ServicePrincipalInKeyVaultDatasourceCredential extends Datasour
   tenantId: string;
 }
 
-export type DatasourceCredentialUnion =
-  | SqlServerConnectionStringDatasourceCredential
-  | DataLakeGen2SharedKeyDatasourceCredential
-  | ServicePrincipalDatasourceCredential
-  | ServicePrincipalInKeyVaultDatasourceCredential;
+export type DataSourceCredentialUnion =
+  | SqlServerConnectionStringDataSourceCredential
+  | DataLakeGen2SharedKeyDataSourceCredential
+  | ServicePrincipalDataSourceCredential
+  | ServicePrincipalInKeyVaultDataSourceCredential;
 
 /**
  * SqlServer Data Source Credential Patch
  */
-export interface SqlServerConnectionStringDatasourceCredentialPatch {
+export interface SqlServerConnectionStringDataSourceCredentialPatch {
   /** Azure Sql Connection String credential */
   type: "AzureSQLConnectionString";
   /** Name of data source credential */
@@ -2267,24 +2267,24 @@ export interface SqlServerConnectionStringDatasourceCredentialPatch {
 }
 
 /**
- * DataLake Gen2 Shared Key Datasource Credential Patch
+ * DataLake Gen2 Shared Key DataSource Credential Patch
  */
-export interface DataLakeGen2SharedKeyDatasourceCredentialPatch {
-  /** DataLakeGen2 Shared Key Datasource credential */
+export interface DataLakeGen2SharedKeyDataSourceCredentialPatch {
+  /** DataLakeGen2 Shared Key DataSource credential */
   type: "DataLakeGen2SharedKey";
   /** Name of data source credential */
   name?: string;
   /** Description of data source credential */
   description?: string;
-  /** The account key of the DataLake Gen2 Shared Key Datasource Credential  */
+  /** The account key of the DataLake Gen2 Shared Key DataSource Credential  */
   accountKey?: string;
 }
 
 /**
- *  Service Principal Datasource Credential Patch
+ *  Service Principal DataSource Credential Patch
  */
-export interface ServicePrincipalDatasourceCredentialPatch {
-  /** Service Principal Datasource Credential */
+export interface ServicePrincipalDataSourceCredentialPatch {
+  /** Service Principal DataSource Credential */
   type: "ServicePrincipal";
   /** Name of data source credential */
   name?: string;
@@ -2299,10 +2299,10 @@ export interface ServicePrincipalDatasourceCredentialPatch {
 }
 
 /**
- *  Service Principal in KeyVault Datasource Credential Patch
+ *  Service Principal in KeyVault DataSource Credential Patch
  */
-export interface ServicePrincipalInKeyVaultDatasourceCredentialPatch {
-  /** Service Principal in KeyVault Datasource Credential */
+export interface ServicePrincipalInKeyVaultDataSourceCredentialPatch {
+  /** Service Principal in KeyVault DataSource Credential */
   type: "ServicePrincipalInKV";
   /** Name of data source credential */
   name?: string;
@@ -2323,18 +2323,18 @@ export interface ServicePrincipalInKeyVaultDatasourceCredentialPatch {
 }
 
 /**
- * Datasource credential patch types
+ * DataSource credential patch types
  */
-export type DatasourceCredentialPatch =
-  | SqlServerConnectionStringDatasourceCredentialPatch
-  | DataLakeGen2SharedKeyDatasourceCredentialPatch
-  | ServicePrincipalDatasourceCredentialPatch
-  | ServicePrincipalInKeyVaultDatasourceCredentialPatch;
+export type DataSourceCredentialPatch =
+  | SqlServerConnectionStringDataSourceCredentialPatch
+  | DataLakeGen2SharedKeyDataSourceCredentialPatch
+  | ServicePrincipalDataSourceCredentialPatch
+  | ServicePrincipalInKeyVaultDataSourceCredentialPatch;
 
 /**
  * Contains response data for the listCredentials operation.
  */
-export interface CredentialsPageResponse extends Array<DatasourceCredentialUnion> {
+export interface CredentialsPageResponse extends Array<DataSourceCredentialUnion> {
   /**
    * Continuation token to pass to `byPage()` to resume listing of more results if available.
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -181,14 +181,7 @@ export type DataFeedAccessMode = "Private" | "Public";
  */
 export type DataFeedGranularity =
   | {
-      granularityType:
-        | "Yearly"
-        | "Monthly"
-        | "Weekly"
-        | "Daily"
-        | "Hourly"
-        | "PerMinute"
-        | "PerSecond";
+      granularityType: "Yearly" | "Monthly" | "Weekly" | "Daily" | "Hourly" | "PerMinute";
     }
   | {
       granularityType: "Custom";

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -790,7 +790,7 @@ export type MetricAnomalyAlertConfigurationsOperator = "AND" | "OR" | "XOR";
 /**
  * The logical operator to apply across anomaly detection conditions.
  */
-export type DetectionConditionsOperator = "AND" | "OR";
+export type DetectionConditionOperator = "AND" | "OR";
 
 /**
  * Represents properties common to anomaly detection conditions.
@@ -799,7 +799,7 @@ export interface DetectionConditionsCommon {
   /**
    * Condition operator
    */
-  conditionOperator?: DetectionConditionsOperator;
+  conditionOperator?: DetectionConditionOperator;
   /**
    * Specifies the condition for Smart Detection
    */
@@ -821,7 +821,7 @@ export interface DetectionConditionsCommonPatch {
   /**
    * Condition operator
    */
-  conditionOperator?: DetectionConditionsOperator;
+  conditionOperator?: DetectionConditionOperator;
   /**
    * Specifies the condition for Smart Detection
    */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -122,9 +122,9 @@ export interface DataFeedIngestionSettings {
 }
 
 /**
- * Defines values for DataFeedRollupMethod.
+ * Defines values for DataFeedAutoRollupMethod.
  */
-export type DataFeedRollupMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
+export type DataFeedAutoRollupMethod = "None" | "Sum" | "Max" | "Min" | "Avg" | "Count";
 
 /**
  * Specifies the rollup settings for a data feed.
@@ -149,7 +149,7 @@ export type DataFeedRollupSettings =
       /**
        * roll up method
        */
-      rollupMethod?: DataFeedRollupMethod;
+      rollupMethod?: DataFeedAutoRollupMethod;
       /**
        * the identification value for the row of calculated all-up value.
        */

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/models.ts
@@ -1348,7 +1348,7 @@ export type MetricAnomalyAlertScope =
     };
 
 /**
- * Defines the
+ * Defines the Boundary Conditions for the Metric
  */
 export type MetricBoundaryCondition =
   | {
@@ -1428,6 +1428,10 @@ export type MetricBoundaryCondition =
       type?: "Value" | "Mean";
     };
 
+/**
+ * Defines conditions to decide whether the detected anomalies should be
+ * included in an alert or not.
+ */
 export interface MetricAnomalyAlertConditions {
   /**
    * severity condition to trigger alert
@@ -1439,6 +1443,10 @@ export interface MetricAnomalyAlertConditions {
   metricBoundaryCondition?: MetricBoundaryCondition;
 }
 
+/**
+ * Defines alerting settings for anomalies detected by a detection
+ * configuration.
+ */
 export interface MetricAlertConfiguration {
   /**
    * Anomaly detection configuration unique id
@@ -1934,6 +1942,9 @@ export interface MetricSeriesPageResponse extends Array<MetricSeriesDefinition> 
   };
 }
 
+/**
+ * Represents Enrichment Status
+ */
 export interface EnrichmentStatus {
   /**
    * data slice timestamp.
@@ -2246,6 +2257,9 @@ export interface DataSourceServicePrincipalInKeyVault extends DataSourceCredenti
   tenantId: string;
 }
 
+/**
+ * Data Source Credential Entity Union Type
+ */
 export type DataSourceCredentialEntityUnion =
   | DataSourceSqlConnectionString
   | DataSourceDataLakeGen2SharedKey

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -1314,7 +1314,7 @@ export function fromServiceAlertConfiguration(
         }
       };
     }),
-    splitAlertByDimensions: result.splitAlertByDimensions
+    dimensionsToSplitAlert: result.splitAlertByDimensions
   };
 }
 
@@ -1347,7 +1347,7 @@ export function toServiceAlertConfiguration(
         valueFilter: c.alertConditions?.metricBoundaryCondition
       };
     }),
-    splitAlertByDimensions: from.splitAlertByDimensions
+    splitAlertByDimensions: from.dimensionsToSplitAlert
   };
 }
 
@@ -1380,7 +1380,7 @@ export function toServiceAlertConfigurationPatch(
         valueFilter: c.alertConditions?.metricBoundaryCondition
       };
     }),
-    splitAlertByDimensions: from.splitAlertByDimensions
+    splitAlertByDimensions: from.dimensionsToSplitAlert
   };
 }
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -76,14 +76,14 @@ import {
   AzureDataLakeStorageGen2DataFeedSource,
   SqlServerAuthTypes,
   AnomalyDetectionConfigurationPatch,
-  DataSourceCredentialUnion,
-  DataSourceCredential,
+  DataSourceCredentialEntityUnion,
+  DataSourceCredentialEntity,
   DataFeedSource,
   DataFeedSourcePatch,
-  SqlServerConnectionStringDataSourceCredentialPatch,
-  DataLakeGen2SharedKeyDataSourceCredentialPatch,
-  ServicePrincipalDataSourceCredentialPatch,
-  ServicePrincipalInKeyVaultDataSourceCredentialPatch
+  DataSourceSqlServerConnectionStringPatch,
+  DataSourceDataLakeGen2SharedKeyPatch,
+  DataSourceServicePrincipalPatch,
+  DataSourceServicePrincipalInKeyVaultPatch
 } from "./models";
 
 // transform the protocol layer (codegen) service models into convenience layer models
@@ -1386,8 +1386,8 @@ export function toServiceAlertConfigurationPatch(
 
 export function fromServiceCredential(
   result: ServiceDataSourceCredentialUnion
-): DataSourceCredentialUnion {
-  const common: DataSourceCredential = {
+): DataSourceCredentialEntityUnion {
+  const common: DataSourceCredentialEntity = {
     description: result.dataSourceCredentialDescription,
     id: result.dataSourceCredentialId,
     name: result.dataSourceCredentialName
@@ -1429,7 +1429,7 @@ export function fromServiceCredential(
 }
 
 export function toServiceCredential(
-  from: DataSourceCredentialUnion
+  from: DataSourceCredentialEntityUnion
 ): ServiceDataSourceCredentialUnion {
   const common = {
     dataSourceCredentialName: from.name,
@@ -1496,7 +1496,7 @@ export function toServiceCredentialPatch(
   };
   switch (from.type) {
     case "AzureSQLConnectionString": {
-      const cred1 = from as SqlServerConnectionStringDataSourceCredentialPatch;
+      const cred1 = from as DataSourceSqlServerConnectionStringPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1506,7 +1506,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "DataLakeGen2SharedKey": {
-      const cred2 = from as DataLakeGen2SharedKeyDataSourceCredentialPatch;
+      const cred2 = from as DataSourceDataLakeGen2SharedKeyPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1516,7 +1516,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "ServicePrincipal": {
-      const cred3 = from as ServicePrincipalDataSourceCredentialPatch;
+      const cred3 = from as DataSourceServicePrincipalPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1528,7 +1528,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "ServicePrincipalInKV": {
-      const cred4 = from as ServicePrincipalInKeyVaultDataSourceCredentialPatch;
+      const cred4 = from as DataSourceServicePrincipalInKeyVaultPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -341,8 +341,6 @@ function fromServiceGranularity(original: ServiceGranularity, value?: number): D
   switch (original) {
     case "Minutely":
       return { granularityType: "PerMinute" };
-    case "Secondly":
-      return { granularityType: "PerSecond" };
     case "Custom":
       return { granularityType: "Custom", customGranularityValue: value! };
     default:
@@ -361,8 +359,6 @@ export function toServiceGranularity(
       return { granularityName: "Custom", granularityAmount: model.customGranularityValue };
     case "PerMinute":
       return { granularityName: "Minutely" };
-    case "PerSecond":
-      return { granularityName: "Secondly" };
     default:
       return { granularityName: model.granularityType };
   }

--- a/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/src/transforms.ts
@@ -70,20 +70,20 @@ import {
   HardThresholdConditionUnion,
   ChangeThresholdConditionUnion,
   DataFeedGranularity,
-  DatasourceCredentialPatch,
+  DataSourceCredentialPatch,
   AzureDataExplorerAuthTypes,
   AzureDataLakeStorageGen2AuthTypes,
   AzureDataLakeStorageGen2DataFeedSource,
   SqlServerAuthTypes,
   AnomalyDetectionConfigurationPatch,
-  DatasourceCredentialUnion,
-  DatasourceCredential,
+  DataSourceCredentialUnion,
+  DataSourceCredential,
   DataFeedSource,
   DataFeedSourcePatch,
-  SqlServerConnectionStringDatasourceCredentialPatch,
-  DataLakeGen2SharedKeyDatasourceCredentialPatch,
-  ServicePrincipalDatasourceCredentialPatch,
-  ServicePrincipalInKeyVaultDatasourceCredentialPatch
+  SqlServerConnectionStringDataSourceCredentialPatch,
+  DataLakeGen2SharedKeyDataSourceCredentialPatch,
+  ServicePrincipalDataSourceCredentialPatch,
+  ServicePrincipalInKeyVaultDataSourceCredentialPatch
 } from "./models";
 
 // transform the protocol layer (codegen) service models into convenience layer models
@@ -1386,8 +1386,8 @@ export function toServiceAlertConfigurationPatch(
 
 export function fromServiceCredential(
   result: ServiceDataSourceCredentialUnion
-): DatasourceCredentialUnion {
-  const common: DatasourceCredential = {
+): DataSourceCredentialUnion {
+  const common: DataSourceCredential = {
     description: result.dataSourceCredentialDescription,
     id: result.dataSourceCredentialId,
     name: result.dataSourceCredentialName
@@ -1429,7 +1429,7 @@ export function fromServiceCredential(
 }
 
 export function toServiceCredential(
-  from: DatasourceCredentialUnion
+  from: DataSourceCredentialUnion
 ): ServiceDataSourceCredentialUnion {
   const common = {
     dataSourceCredentialName: from.name,
@@ -1488,7 +1488,7 @@ export function toServiceCredential(
 }
 
 export function toServiceCredentialPatch(
-  from: DatasourceCredentialPatch
+  from: DataSourceCredentialPatch
 ): ServiceDataSourceCredentialPatch {
   const common = {
     dataSourceCredentialName: from.name,
@@ -1496,7 +1496,7 @@ export function toServiceCredentialPatch(
   };
   switch (from.type) {
     case "AzureSQLConnectionString": {
-      const cred1 = from as SqlServerConnectionStringDatasourceCredentialPatch;
+      const cred1 = from as SqlServerConnectionStringDataSourceCredentialPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1506,7 +1506,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "DataLakeGen2SharedKey": {
-      const cred2 = from as DataLakeGen2SharedKeyDatasourceCredentialPatch;
+      const cred2 = from as DataLakeGen2SharedKeyDataSourceCredentialPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1516,7 +1516,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "ServicePrincipal": {
-      const cred3 = from as ServicePrincipalDatasourceCredentialPatch;
+      const cred3 = from as ServicePrincipalDataSourceCredentialPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,
@@ -1528,7 +1528,7 @@ export function toServiceCredentialPatch(
       };
     }
     case "ServicePrincipalInKV": {
-      const cred4 = from as ServicePrincipalInKeyVaultDatasourceCredentialPatch;
+      const cred4 = from as ServicePrincipalInKeyVaultDataSourceCredentialPatch;
       return {
         ...common,
         dataSourceCredentialType: from.type,

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -14,7 +14,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
 # openapi v2 in PR
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7efe0ae6a89c93a915c85af1e2f871501adac0c9/specification/cognitiveservices/data-plane/MetricsAdvisor/preview/v1.0/MetricsAdvisor.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/08f5e391f2153a99580b458cc71ef88e45dd0531/specification/cognitiveservices/data-plane/MetricsAdvisor/preview/v1.0/MetricsAdvisor.json
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -689,3 +689,37 @@ directive:
           }
       }
 ```
+
+### Add description for `SmartDetectionCondition`
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.SmartDetectionCondition
+    transform: >
+      $.description = "Represents Smart Condition"
+  - from: swagger-document
+    where: $.definitions.SuppressCondition
+    transform: >
+      $.description = "Represents Suppress Condition"
+  - from: swagger-document
+    where: $.definitions.AlertSnoozeCondition
+    transform: >
+      $.description = "Represents Conditions to snooze Alerts"
+  - from: swagger-document
+    where: $.definitions.SeverityFilterCondition
+    transform: >
+      $.description = "Represents Conditions to filter severity"
+  - from: swagger-document
+    where: $.definitions.DataFeedIngestionProgress
+    transform: >
+      $.description = "Track the progress for Datafeed Ingestion"
+  - from: swagger-document
+    where: $.definitions.EmailHookParameter
+    transform: >
+      $.description = "Parameters for Email Hook"
+  - from: swagger-document
+    where: $.definitions.EmailHookParameter
+    transform: >
+      $.description = "Parameters for Email Hook"
+```

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -722,4 +722,20 @@ directive:
     where: $.definitions.EmailHookParameter
     transform: >
       $.description = "Parameters for Email Hook"
+  - from: swagger-document
+    where: $.definitions.WebHookParameter
+    transform: >
+      $.description = "Parameters for Web Hook"
+  - from: swagger-document
+    where: $.definitions.IngestionStatus
+    transform: >
+      $.description = "Ingestion Status"
+  - from: swagger-document
+    where: $.definitions.SeverityCondition
+    transform: >
+      $.description = "Alert Severity Condition"
+  - from: swagger-document
+    where: $.definitions.TopNGroupScope
+    transform: >
+      $.description = "Group Scope for Top N values"
 ```

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/internal/transforms.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/internal/transforms.spec.ts
@@ -217,7 +217,6 @@ describe("Transforms", () => {
   [
     { original: "Yearly", expected: "Yearly" },
     { original: "Daily", expected: "Daily" },
-    { original: "Secondly", expected: "PerSecond" },
     { original: "Minutely", expected: "PerMinute" }
   ].forEach((granularity) => {
     it(`fromServiceDataFeedDetailUnion() on granularity ${granularity.original}`, () => {
@@ -246,7 +245,6 @@ describe("Transforms", () => {
   [
     { original: "Yearly", expected: "Yearly" },
     { original: "Daily", expected: "Daily" },
-    { original: "PerSecond", expected: "Secondly" },
     { original: "PerMinute", expected: "Minutely" }
   ].forEach((granularity) => {
     it(`toServiceGranularity() on granularity ${granularity.original}`, () => {

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
@@ -276,7 +276,7 @@ matrix([[true, false]] as const, async (useAad) => {
             crossMetricsOperator: "AND",
             metricAlertConfigurations: [metricAlertConfig, metricAlertConfig],
             hookIds: [],
-            splitAlertByDimensions: []
+            dimensionsToSplitAlert: []
           };
 
           const actual = await client.createAlertConfig(expectedAlertConfig);
@@ -292,8 +292,8 @@ matrix([[true, false]] as const, async (useAad) => {
           );
           assert.deepStrictEqual(actual.hookIds, expectedAlertConfig.hookIds);
           assert.deepStrictEqual(
-            actual.splitAlertByDimensions,
-            expectedAlertConfig.splitAlertByDimensions
+            actual.dimensionsToSplitAlert,
+            expectedAlertConfig.dimensionsToSplitAlert
           );
         });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/adminclient.spec.ts
@@ -201,8 +201,7 @@ matrix([[true, false]] as const, async (useAad) => {
             ]
           };
 
-          await client.updateDetectionConfig(createdDetectionConfigId, expected);
-          const actual = await client.getDetectionConfig(createdDetectionConfigId);
+          const actual = await client.updateDetectionConfig(createdDetectionConfigId, expected);
           assert.ok(actual.id, "Expecting valid detection config");
           createdDetectionConfigId = actual.id!;
 
@@ -325,8 +324,7 @@ matrix([[true, false]] as const, async (useAad) => {
             metricAlertConfigurations: [metricAlertConfig, metricAlertConfig]
           };
 
-          await client.updateAlertConfig(createdAlertConfigId, patch);
-          const actual = await client.getAlertConfig(createdAlertConfigId);
+          const actual = await client.updateAlertConfig(createdAlertConfigId, patch);
           assert.ok(actual.id, "Expecting valid alerting config");
           assert.equal(actual.name, "new alert config name");
           assert.equal(actual.description, "new alert config description");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -84,7 +84,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("listIncidentsForDetectionConfiguration()", async function() {
-        const iterator = client.listIncidents(
+        const iterator = client.listIncidentsForDetectionConfiguration(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
           new Date(Date.UTC(2020, 0, 5)),
           new Date(Date.UTC(2020, 10, 5))
@@ -97,7 +97,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("listIncidentsForDetectionConfiguration() by page", async function() {
         const iterator = client
-          .listIncidents(
+          .listIncidentsForDetectionConfiguration(
             testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
             new Date(Date.UTC(2020, 0, 5)),
             new Date(Date.UTC(2020, 10, 5))
@@ -110,7 +110,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("listIncidentsForDetectionConfiguration() with datetime strings", async function() {
-        const iterator = client.listIncidents(
+        const iterator = client.listIncidentsForDetectionConfiguration(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
           "2020-01-05T00:00:00.000Z",
           "2020-11-05T00:00:00.000Z"
@@ -123,7 +123,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("listIncidentsForDetectionConfiguration() throws for invalid datetime string", async function() {
         try {
-          const iterator = client.listIncidents(
+          const iterator = client.listIncidentsForDetectionConfiguration(
             testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
             "startTime",
             "endTime"
@@ -242,7 +242,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("lists incidents for alert", async function() {
-        const iterator = client.listIncidents({
+        const iterator = client.listIncidentsForAlert({
           alertConfigId: testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
           id: testEnv.METRICS_ADVISOR_ALERT_ID
         });
@@ -254,7 +254,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("lists incidents for alert by page", async function() {
         const iterator = client
-          .listIncidents({
+          .listIncidentsForAlert({
             alertConfigId: testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
             id: testEnv.METRICS_ADVISOR_ALERT_ID
           })

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -324,12 +324,12 @@ matrix([[true, false]] as const, async (useAad) => {
       it("lists series data for a metric", async function() {
         const data = await client.getMetricSeriesData(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
-          new Date(Date.UTC(2020, 7, 5)),
-          new Date(Date.UTC(2020, 8, 5)),
           [
             { city: "Manila", category: "Shoes Handbags & Sunglasses" },
             { city: "Cairo", category: "Home & Garden" }
-          ]
+          ],
+          new Date(Date.UTC(2020, 7, 5)),
+          new Date(Date.UTC(2020, 8, 5))
         );
         assert.ok(data && data!.length === 2, "Expecting data for two time series");
         assert.equal(
@@ -370,12 +370,12 @@ matrix([[true, false]] as const, async (useAad) => {
       it("lists series data for a metric with datetime strings", async function() {
         const data = await client.getMetricSeriesData(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_METRIC_ID_1,
-          "2020-08-05T00:00:00.000Z",
-          "2020-09-05T00:00:00.000Z",
           [
             { city: "Cairo", category: "Home & Garden" },
             { city: "Manila", category: "Shoes Handbags & Sunglasses" }
-          ]
+          ],
+          "2020-08-05T00:00:00.000Z",
+          "2020-09-05T00:00:00.000Z"
         );
         assert.ok(data && data!.length === 2, "Expecting data for two time series");
         assert.equal(
@@ -399,12 +399,12 @@ matrix([[true, false]] as const, async (useAad) => {
       it("list enriched data for a detection configuration", async function() {
         const data = await client.getMetricEnrichedSeriesData(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
-          new Date(Date.UTC(2020, 7, 1)),
-          new Date(Date.UTC(2020, 7, 27)),
           [
             { city: "Manila", category: "Shoes Handbags & Sunglasses" },
             { city: "Cairo", category: "Home & Garden" }
-          ]
+          ],
+          new Date(Date.UTC(2020, 7, 1)),
+          new Date(Date.UTC(2020, 7, 27))
         );
         assert.ok(data && data!.length === 2, "Expecting data for two time series");
 
@@ -442,12 +442,12 @@ matrix([[true, false]] as const, async (useAad) => {
       it("list enriched data for a detection configuration with datetime strings", async function() {
         const data = await client.getMetricEnrichedSeriesData(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
-          "2020-08-01T00:00:00.000Z",
-          "2020-08-27T00:00:00.000Z",
           [
             { city: "Manila", category: "Shoes Handbags & Sunglasses" },
             { city: "Cairo", category: "Home & Garden" }
-          ]
+          ],
+          "2020-08-01T00:00:00.000Z",
+          "2020-08-27T00:00:00.000Z"
         );
         assert.ok(data && data!.length === 2, "Expecting data for two time series");
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -32,7 +32,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("listAnomaliesForDetectionConfiguration()", async function() {
-        const iterator = client.listAnomalies(
+        const iterator = client.listAnomaliesForDetectionConfiguration(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
           new Date(Date.UTC(2020, 0, 5)),
           new Date(Date.UTC(2020, 10, 5))
@@ -45,7 +45,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("listAnomaliesForDetectionConfiguration() by page", async function() {
         const iterator = client
-          .listAnomalies(
+          .listAnomaliesForDetectionConfiguration(
             testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
             new Date(Date.UTC(2020, 0, 5)),
             new Date(Date.UTC(2020, 10, 5))
@@ -58,7 +58,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("listAnomaliesForDetectionConfiguration() with datetime strings", async function() {
-        const iterator = client.listAnomalies(
+        const iterator = client.listAnomaliesForDetectionConfiguration(
           testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
           "2020-01-05T00:00:00.000Z",
           "2020-11-05T00:00:00.000Z"
@@ -71,7 +71,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("listAnomaliesForDetectionConfiguration() throws for invalid datetime strings", async function() {
         try {
-          const iterator = client.listAnomalies(
+          const iterator = client.listAnomaliesForDetectionConfiguration(
             testEnv.METRICS_ADVISOR_AZURE_SQLSERVER_DETECTION_CONFIG_ID,
             "startTime",
             "endTime"
@@ -218,7 +218,7 @@ matrix([[true, false]] as const, async (useAad) => {
       });
 
       it("lists anomalies for alert", async function() {
-        const iterator = client.listAnomalies({
+        const iterator = client.listAnomaliesForAlert({
           alertConfigId: testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
           id: testEnv.METRICS_ADVISOR_ALERT_ID
         });
@@ -230,7 +230,7 @@ matrix([[true, false]] as const, async (useAad) => {
 
       it("lists anomalies for alert by page", async function() {
         const iterator = client
-          .listAnomalies({
+          .listAnomaliesForAlert({
             alertConfigId: testEnv.METRICS_ADVISOR_ALERT_CONFIG_ID,
             id: testEnv.METRICS_ADVISOR_ALERT_ID
           })

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/advisorclient.spec.ts
@@ -525,7 +525,7 @@ matrix([[true, false]] as const, async (useAad) => {
             value: "NotAnomaly",
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const actual = await client.createFeedback(anomalyFeedback);
+          const actual = await client.addFeedback(anomalyFeedback);
 
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
@@ -543,7 +543,7 @@ matrix([[true, false]] as const, async (useAad) => {
             value: "ChangePoint",
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const actual = await client.createFeedback(changePointFeedback);
+          const actual = await client.addFeedback(changePointFeedback);
 
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
@@ -561,7 +561,7 @@ matrix([[true, false]] as const, async (useAad) => {
             periodValue: 4,
             dimensionKey: { city: "Cairo", category: "Home & Garden" }
           };
-          const actual = await client.createFeedback(periodFeedback);
+          const actual = await client.addFeedback(periodFeedback);
 
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;
@@ -580,7 +580,7 @@ matrix([[true, false]] as const, async (useAad) => {
             comment: "This is a comment"
           };
 
-          const actual = await client.createFeedback(expectedCommentFeedback);
+          const actual = await client.addFeedback(expectedCommentFeedback);
 
           assert.ok(actual.id, "Expecting valid feedback");
           createdFeedbackId = actual.id!;

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
@@ -4,15 +4,15 @@
 import { assert } from "chai";
 import { Context } from "mocha";
 import {
-  DataLakeGen2SharedKeyDatasourceCredential,
-  DataLakeGen2SharedKeyDatasourceCredentialPatch,
+  DataLakeGen2SharedKeyDataSourceCredential,
+  DataLakeGen2SharedKeyDataSourceCredentialPatch,
   MetricsAdvisorAdministrationClient,
-  ServicePrincipalDatasourceCredential,
-  ServicePrincipalDatasourceCredentialPatch,
-  ServicePrincipalInKeyVaultDatasourceCredential,
-  ServicePrincipalInKeyVaultDatasourceCredentialPatch,
-  SqlServerConnectionStringDatasourceCredential,
-  SqlServerConnectionStringDatasourceCredentialPatch
+  ServicePrincipalDataSourceCredential,
+  ServicePrincipalDataSourceCredentialPatch,
+  ServicePrincipalInKeyVaultDataSourceCredential,
+  ServicePrincipalInKeyVaultDataSourceCredentialPatch,
+  SqlServerConnectionStringDataSourceCredential,
+  SqlServerConnectionStringDataSourceCredentialPatch
 } from "../../src";
 import { createRecordedAdminClient, makeCredential } from "./util/recordedClients";
 import { Recorder } from "@azure/test-utils-recorder";
@@ -31,7 +31,7 @@ describe("DataSourceCredential", () => {
     }
   });
   describe("dataSource credential CRUD operations", async function() {
-    const datasourceCredential = {
+    const dataSourceCredential = {
       description: "used for testing purposes only"
     };
 
@@ -41,14 +41,14 @@ describe("DataSourceCredential", () => {
     let createdServicePrincipalInKVCredId: string;
 
     it("creates sql server connection string credential", async function() {
-      const sqlServerCredential: SqlServerConnectionStringDatasourceCredential = {
-        ...datasourceCredential,
+      const sqlServerCredential: SqlServerConnectionStringDataSourceCredential = {
+        ...dataSourceCredential,
         name: "ExampleSQLCredential",
         type: "AzureSQLConnectionString",
         connectionString: "sql-server-connection-string"
       };
-      const createdSqlServerCred = await client.createDatasourceCredential(sqlServerCredential);
-      assert.ok(createdSqlServerCred.id, "Expecting valid datasource credential");
+      const createdSqlServerCred = await client.createDataSourceCredential(sqlServerCredential);
+      assert.ok(createdSqlServerCred.id, "Expecting valid dataSource credential");
       createdSqlServerCredId = createdSqlServerCred.id!;
       assert.equal(createdSqlServerCred.name, sqlServerCredential.name);
       assert.equal(createdSqlServerCred.description, sqlServerCredential.description);
@@ -59,32 +59,32 @@ describe("DataSourceCredential", () => {
       if (!createdSqlServerCredId) {
         this.skip();
       }
-      const sqlServerCredentialPatch: SqlServerConnectionStringDatasourceCredentialPatch = {
+      const sqlServerCredentialPatch: SqlServerConnectionStringDataSourceCredentialPatch = {
         name: "UpdatedSqlCred",
         description: "updated description",
         connectionString: "updated-string",
         type: "AzureSQLConnectionString"
       };
-      const updated = await client.updateDatasourceCredential(
+      const updated = await client.updateDataSourceCredential(
         createdSqlServerCredId,
         sqlServerCredentialPatch
       );
-      assert.ok(updated.id, "Expecting valid datasource credential");
+      assert.ok(updated.id, "Expecting valid dataSource credential");
       assert.equal(updated.description, sqlServerCredentialPatch.description);
       assert.equal(updated.type, sqlServerCredentialPatch.type);
       assert.equal(updated.name, sqlServerCredentialPatch.name);
     });
 
     it("creates datalake gen2 shared key credential", async function() {
-      const datalakeCred: DataLakeGen2SharedKeyDatasourceCredential = {
-        ...datasourceCredential,
+      const datalakeCred: DataLakeGen2SharedKeyDataSourceCredential = {
+        ...dataSourceCredential,
         name: "ExampleDLCredential",
         type: "DataLakeGen2SharedKey",
         accountKey: "account-key"
       };
 
-      const createdDatalakeCred = await client.createDatasourceCredential(datalakeCred);
-      assert.ok(createdDatalakeCred.id, "Expecting valid datasource credential");
+      const createdDatalakeCred = await client.createDataSourceCredential(datalakeCred);
+      assert.ok(createdDatalakeCred.id, "Expecting valid dataSource credential");
       createdDatalakeCredId = createdDatalakeCred.id!;
       assert.equal(createdDatalakeCred.name, datalakeCred.name);
       assert.equal(createdDatalakeCred.description, datalakeCred.description);
@@ -95,25 +95,25 @@ describe("DataSourceCredential", () => {
       if (!createdDatalakeCredId) {
         this.skip();
       }
-      const dataLakeCredentialPatch: DataLakeGen2SharedKeyDatasourceCredentialPatch = {
+      const dataLakeCredentialPatch: DataLakeGen2SharedKeyDataSourceCredentialPatch = {
         name: "UpdatedDataLakeCred",
         description: "updated description",
         accountKey: "updated account key",
         type: "DataLakeGen2SharedKey"
       };
-      const updated = await client.updateDatasourceCredential(
+      const updated = await client.updateDataSourceCredential(
         createdDatalakeCredId,
         dataLakeCredentialPatch
       );
-      assert.ok(updated.id, "Expecting valid datasource credential");
+      assert.ok(updated.id, "Expecting valid dataSource credential");
       assert.equal(updated.description, dataLakeCredentialPatch.description);
       assert.equal(updated.type, dataLakeCredentialPatch.type);
       assert.equal(updated.name, dataLakeCredentialPatch.name);
     });
 
     it("creates service principal credential", async function() {
-      const servicePrincipalCred: ServicePrincipalDatasourceCredential = {
-        ...datasourceCredential,
+      const servicePrincipalCred: ServicePrincipalDataSourceCredential = {
+        ...dataSourceCredential,
         name: "ExampleSPCredential",
         type: "ServicePrincipal",
         clientId: "client-id",
@@ -121,10 +121,10 @@ describe("DataSourceCredential", () => {
         tenantId: "tenant-id"
       };
 
-      const createdServicePrincipalCred = await client.createDatasourceCredential(
+      const createdServicePrincipalCred = await client.createDataSourceCredential(
         servicePrincipalCred
       );
-      assert.ok(createdServicePrincipalCred.id, "Expecting valid sql server datasource credential");
+      assert.ok(createdServicePrincipalCred.id, "Expecting valid sql server dataSource credential");
       createdServicePrincipalCredId = createdServicePrincipalCred.id!;
       assert.equal(createdServicePrincipalCred.name, servicePrincipalCred.name);
       assert.equal(createdServicePrincipalCred.description, servicePrincipalCred.description);
@@ -135,7 +135,7 @@ describe("DataSourceCredential", () => {
       if (!createdServicePrincipalCredId) {
         this.skip();
       }
-      const servicePrincipalCredentialPatch: ServicePrincipalDatasourceCredentialPatch = {
+      const servicePrincipalCredentialPatch: ServicePrincipalDataSourceCredentialPatch = {
         name: "UpdatedSPCred",
         description: "updated description",
         clientId: "updated-client",
@@ -143,23 +143,23 @@ describe("DataSourceCredential", () => {
         tenantId: "updated-tenant",
         type: "ServicePrincipal"
       };
-      const updated = await client.updateDatasourceCredential(
+      const updated = await client.updateDataSourceCredential(
         createdServicePrincipalCredId,
         servicePrincipalCredentialPatch
       );
-      assert.ok(updated.id, "Expecting valid datasource credential");
+      assert.ok(updated.id, "Expecting valid dataSource credential");
       assert.equal(updated.description, servicePrincipalCredentialPatch.description);
       assert.equal(updated.type, servicePrincipalCredentialPatch.type);
       assert.equal(updated.name, servicePrincipalCredentialPatch.name);
       assert.equal(
-        (updated as ServicePrincipalDatasourceCredentialPatch).clientId,
+        (updated as ServicePrincipalDataSourceCredentialPatch).clientId,
         servicePrincipalCredentialPatch.clientId
       );
     });
 
     it("creates service principal in keyvault credential", async function() {
-      const servicePrincipalInKVCred: ServicePrincipalInKeyVaultDatasourceCredential = {
-        ...datasourceCredential,
+      const servicePrincipalInKVCred: ServicePrincipalInKeyVaultDataSourceCredential = {
+        ...dataSourceCredential,
         name: "ExampleSPinKVCredential",
         type: "ServicePrincipalInKV",
         tenantId: "tenant-id",
@@ -170,10 +170,10 @@ describe("DataSourceCredential", () => {
         servicePrincipalSecretNameInKV: "service-principal-secret-name-in-kv"
       };
 
-      const createdServicePrincipalInKVCred = await client.createDatasourceCredential(
+      const createdServicePrincipalInKVCred = await client.createDataSourceCredential(
         servicePrincipalInKVCred
       );
-      assert.ok(createdServicePrincipalInKVCred.id, "Expecting valid datasource credential");
+      assert.ok(createdServicePrincipalInKVCred.id, "Expecting valid dataSource credential");
       createdServicePrincipalInKVCredId = createdServicePrincipalInKVCred.id!;
       assert.equal(createdServicePrincipalInKVCred.name, servicePrincipalInKVCred.name);
       assert.equal(
@@ -187,7 +187,7 @@ describe("DataSourceCredential", () => {
       if (!createdServicePrincipalInKVCredId) {
         this.skip();
       }
-      const servicePrincipalInKVCredentialPatch: ServicePrincipalInKeyVaultDatasourceCredentialPatch = {
+      const servicePrincipalInKVCredentialPatch: ServicePrincipalInKeyVaultDataSourceCredentialPatch = {
         name: "UpdatedSPinKVCred",
         description: "updated description",
         keyVaultEndpoint: "updated-keyvault-endpoint",
@@ -199,86 +199,86 @@ describe("DataSourceCredential", () => {
         type: "ServicePrincipalInKV"
       };
 
-      const updated = await client.updateDatasourceCredential(
+      const updated = await client.updateDataSourceCredential(
         createdServicePrincipalInKVCredId,
         servicePrincipalInKVCredentialPatch
       );
-      assert.ok(updated.id, "Expecting valid datasource credential");
+      assert.ok(updated.id, "Expecting valid dataSource credential");
       assert.equal(updated.description, servicePrincipalInKVCredentialPatch.description);
       assert.equal(updated.type, servicePrincipalInKVCredentialPatch.type);
       assert.equal(updated.name, servicePrincipalInKVCredentialPatch.name);
       assert.equal(
-        (updated as ServicePrincipalDatasourceCredentialPatch).tenantId,
+        (updated as ServicePrincipalDataSourceCredentialPatch).tenantId,
         servicePrincipalInKVCredentialPatch.tenantId
       );
       assert.equal(
-        (updated as ServicePrincipalInKeyVaultDatasourceCredentialPatch).keyVaultClientId,
+        (updated as ServicePrincipalInKeyVaultDataSourceCredentialPatch).keyVaultClientId,
         servicePrincipalInKVCredentialPatch.keyVaultClientId
       );
       assert.equal(
-        (updated as ServicePrincipalInKeyVaultDatasourceCredentialPatch).servicePrincipalIdNameInKV,
+        (updated as ServicePrincipalInKeyVaultDataSourceCredentialPatch).servicePrincipalIdNameInKV,
         servicePrincipalInKVCredentialPatch.servicePrincipalIdNameInKV
       );
     });
 
-    it("lists datasource credentials one by one and by pages", async function() {
-      const iterator = client.listDatasourceCredential();
+    it("lists dataSource credentials one by one and by pages", async function() {
+      const iterator = client.listDataSourceCredential();
       let result = await iterator.next();
 
-      assert.ok(result.value.id, "Expecting first datasource credential");
+      assert.ok(result.value.id, "Expecting first dataSource credential");
       result = await iterator.next();
-      assert.ok(result.value.id, "Expecting second datasource credential");
+      assert.ok(result.value.id, "Expecting second dataSource credential");
 
-      const pageIterator = client.listDatasourceCredential().byPage({ maxPageSize: 2 });
+      const pageIterator = client.listDataSourceCredential().byPage({ maxPageSize: 2 });
       let pageResult = await pageIterator.next();
       assert.equal(pageResult.value.length, 2, "Expecting two entries in first page");
       pageResult = await pageIterator.next();
       assert.equal(pageResult.value.length, 2, "Expecting two entries in second page");
     });
 
-    it("deletes sqlserver datasource credential", async function(this: Context) {
+    it("deletes sqlserver dataSource credential", async function(this: Context) {
       if (!createdSqlServerCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(this, client, createdSqlServerCredId);
+      await verifyDataSourceCredentialDeletion(this, client, createdSqlServerCredId);
     });
 
-    it("deletes datalake gen2 shared key datasource credential", async function(this: Context) {
+    it("deletes datalake gen2 shared key dataSource credential", async function(this: Context) {
       if (!createdDatalakeCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(this, client, createdDatalakeCredId);
+      await verifyDataSourceCredentialDeletion(this, client, createdDatalakeCredId);
     });
 
-    it("deletes service principal datasource credential", async function(this: Context) {
+    it("deletes service principal dataSource credential", async function(this: Context) {
       if (!createdServicePrincipalCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(this, client, createdServicePrincipalCredId);
+      await verifyDataSourceCredentialDeletion(this, client, createdServicePrincipalCredId);
     });
 
-    it("deletes service principal in KeyVault datasource credential", async function(this: Context) {
+    it("deletes service principal in KeyVault dataSource credential", async function(this: Context) {
       if (!createdServicePrincipalInKVCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(this, client, createdServicePrincipalInKVCredId);
+      await verifyDataSourceCredentialDeletion(this, client, createdServicePrincipalInKVCredId);
     });
   });
 }).timeout(60000);
 
-export async function verifyDatasourceCredentialDeletion(
+export async function verifyDataSourceCredentialDeletion(
   context: Context,
   client: MetricsAdvisorAdministrationClient,
-  createdDatasourceCredentialId: string
+  createdDataSourceCredentialId: string
 ): Promise<void> {
-  if (!createdDatasourceCredentialId) {
+  if (!createdDataSourceCredentialId) {
     context.skip();
   }
 
-  await client.deleteDatasourceCredential(createdDatasourceCredentialId);
+  await client.deleteDataSourceCredential(createdDataSourceCredentialId);
   try {
-    await client.getDatasourceCredential(createdDatasourceCredentialId);
-    assert.fail("Expecting error getting datasource credential");
+    await client.getDataSourceCredential(createdDataSourceCredentialId);
+    assert.fail("Expecting error getting dataSource credential");
   } catch (error) {
     assert.equal((error as any).code, "404 NOT_FOUND");
     assert.equal((error as any).message, "credentialId is invalid.");

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
@@ -65,8 +65,10 @@ describe("DataSourceCredential", () => {
         connectionString: "updated-string",
         type: "AzureSQLConnectionString"
       };
-      await client.updateDatasourceCredential(createdSqlServerCredId, sqlServerCredentialPatch);
-      const updated = await client.getDatasourceCredential(createdSqlServerCredId);
+      const updated = await client.updateDatasourceCredential(
+        createdSqlServerCredId,
+        sqlServerCredentialPatch
+      );
       assert.ok(updated.id, "Expecting valid datasource credential");
       assert.equal(updated.description, sqlServerCredentialPatch.description);
       assert.equal(updated.type, sqlServerCredentialPatch.type);
@@ -99,8 +101,10 @@ describe("DataSourceCredential", () => {
         accountKey: "updated account key",
         type: "DataLakeGen2SharedKey"
       };
-      await client.updateDatasourceCredential(createdDatalakeCredId, dataLakeCredentialPatch);
-      const updated = await client.getDatasourceCredential(createdDatalakeCredId);
+      const updated = await client.updateDatasourceCredential(
+        createdDatalakeCredId,
+        dataLakeCredentialPatch
+      );
       assert.ok(updated.id, "Expecting valid datasource credential");
       assert.equal(updated.description, dataLakeCredentialPatch.description);
       assert.equal(updated.type, dataLakeCredentialPatch.type);
@@ -139,11 +143,10 @@ describe("DataSourceCredential", () => {
         tenantId: "updated-tenant",
         type: "ServicePrincipal"
       };
-      await client.updateDatasourceCredential(
+      const updated = await client.updateDatasourceCredential(
         createdServicePrincipalCredId,
         servicePrincipalCredentialPatch
       );
-      const updated = await client.getDatasourceCredential(createdServicePrincipalCredId);
       assert.ok(updated.id, "Expecting valid datasource credential");
       assert.equal(updated.description, servicePrincipalCredentialPatch.description);
       assert.equal(updated.type, servicePrincipalCredentialPatch.type);
@@ -196,11 +199,10 @@ describe("DataSourceCredential", () => {
         type: "ServicePrincipalInKV"
       };
 
-      await client.updateDatasourceCredential(
+      const updated = await client.updateDatasourceCredential(
         createdServicePrincipalInKVCredId,
         servicePrincipalInKVCredentialPatch
       );
-      const updated = await client.getDatasourceCredential(createdServicePrincipalInKVCredId);
       assert.ok(updated.id, "Expecting valid datasource credential");
       assert.equal(updated.description, servicePrincipalInKVCredentialPatch.description);
       assert.equal(updated.type, servicePrincipalInKVCredentialPatch.type);

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
@@ -267,7 +267,6 @@ describe("DataSourceCredential", () => {
 }).timeout(60000);
 
 export async function verifyDatasourceCredentialDeletion(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   context: Context,
   client: MetricsAdvisorAdministrationClient,
   createdDatasourceCredentialId: string

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
@@ -240,40 +240,40 @@ describe("DataSourceCredential", () => {
       if (!createdSqlServerCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(client, createdSqlServerCredId);
+      await verifyDatasourceCredentialDeletion(this, client, createdSqlServerCredId);
     });
 
     it("deletes datalake gen2 shared key datasource credential", async function(this: Context) {
       if (!createdDatalakeCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(client, createdDatalakeCredId);
+      await verifyDatasourceCredentialDeletion(this, client, createdDatalakeCredId);
     });
 
     it("deletes service principal datasource credential", async function(this: Context) {
       if (!createdServicePrincipalCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(client, createdServicePrincipalCredId);
+      await verifyDatasourceCredentialDeletion(this, client, createdServicePrincipalCredId);
     });
 
     it("deletes service principal in KeyVault datasource credential", async function(this: Context) {
       if (!createdServicePrincipalInKVCredId) {
         this.skip();
       }
-      await verifyDatasourceCredentialDeletion(client, createdServicePrincipalInKVCredId);
+      await verifyDatasourceCredentialDeletion(this, client, createdServicePrincipalInKVCredId);
     });
   });
 }).timeout(60000);
 
 export async function verifyDatasourceCredentialDeletion(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  this: any,
+  context: Context,
   client: MetricsAdvisorAdministrationClient,
   createdDatasourceCredentialId: string
 ): Promise<void> {
   if (!createdDatasourceCredentialId) {
-    this.skip();
+    context.skip();
   }
 
   await client.deleteDatasourceCredential(createdDatasourceCredentialId);

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/dataSourceCred.spec.ts
@@ -4,15 +4,15 @@
 import { assert } from "chai";
 import { Context } from "mocha";
 import {
-  DataLakeGen2SharedKeyDataSourceCredential,
-  DataLakeGen2SharedKeyDataSourceCredentialPatch,
+  DataSourceDataLakeGen2SharedKey,
+  DataSourceDataLakeGen2SharedKeyPatch,
   MetricsAdvisorAdministrationClient,
-  ServicePrincipalDataSourceCredential,
-  ServicePrincipalDataSourceCredentialPatch,
-  ServicePrincipalInKeyVaultDataSourceCredential,
-  ServicePrincipalInKeyVaultDataSourceCredentialPatch,
-  SqlServerConnectionStringDataSourceCredential,
-  SqlServerConnectionStringDataSourceCredentialPatch
+  DataSourceServicePrincipal,
+  DataSourceServicePrincipalPatch,
+  DataSourceServicePrincipalInKeyVault,
+  DataSourceServicePrincipalInKeyVaultPatch,
+  DataSourceSqlConnectionString,
+  DataSourceSqlServerConnectionStringPatch
 } from "../../src";
 import { createRecordedAdminClient, makeCredential } from "./util/recordedClients";
 import { Recorder } from "@azure/test-utils-recorder";
@@ -41,7 +41,7 @@ describe("DataSourceCredential", () => {
     let createdServicePrincipalInKVCredId: string;
 
     it("creates sql server connection string credential", async function() {
-      const sqlServerCredential: SqlServerConnectionStringDataSourceCredential = {
+      const sqlServerCredential: DataSourceSqlConnectionString = {
         ...dataSourceCredential,
         name: "ExampleSQLCredential",
         type: "AzureSQLConnectionString",
@@ -59,7 +59,7 @@ describe("DataSourceCredential", () => {
       if (!createdSqlServerCredId) {
         this.skip();
       }
-      const sqlServerCredentialPatch: SqlServerConnectionStringDataSourceCredentialPatch = {
+      const sqlServerCredentialPatch: DataSourceSqlServerConnectionStringPatch = {
         name: "UpdatedSqlCred",
         description: "updated description",
         connectionString: "updated-string",
@@ -76,7 +76,7 @@ describe("DataSourceCredential", () => {
     });
 
     it("creates datalake gen2 shared key credential", async function() {
-      const datalakeCred: DataLakeGen2SharedKeyDataSourceCredential = {
+      const datalakeCred: DataSourceDataLakeGen2SharedKey = {
         ...dataSourceCredential,
         name: "ExampleDLCredential",
         type: "DataLakeGen2SharedKey",
@@ -95,7 +95,7 @@ describe("DataSourceCredential", () => {
       if (!createdDatalakeCredId) {
         this.skip();
       }
-      const dataLakeCredentialPatch: DataLakeGen2SharedKeyDataSourceCredentialPatch = {
+      const dataLakeCredentialPatch: DataSourceDataLakeGen2SharedKeyPatch = {
         name: "UpdatedDataLakeCred",
         description: "updated description",
         accountKey: "updated account key",
@@ -112,7 +112,7 @@ describe("DataSourceCredential", () => {
     });
 
     it("creates service principal credential", async function() {
-      const servicePrincipalCred: ServicePrincipalDataSourceCredential = {
+      const servicePrincipalCred: DataSourceServicePrincipal = {
         ...dataSourceCredential,
         name: "ExampleSPCredential",
         type: "ServicePrincipal",
@@ -135,7 +135,7 @@ describe("DataSourceCredential", () => {
       if (!createdServicePrincipalCredId) {
         this.skip();
       }
-      const servicePrincipalCredentialPatch: ServicePrincipalDataSourceCredentialPatch = {
+      const servicePrincipalCredentialPatch: DataSourceServicePrincipalPatch = {
         name: "UpdatedSPCred",
         description: "updated description",
         clientId: "updated-client",
@@ -152,13 +152,13 @@ describe("DataSourceCredential", () => {
       assert.equal(updated.type, servicePrincipalCredentialPatch.type);
       assert.equal(updated.name, servicePrincipalCredentialPatch.name);
       assert.equal(
-        (updated as ServicePrincipalDataSourceCredentialPatch).clientId,
+        (updated as DataSourceServicePrincipalPatch).clientId,
         servicePrincipalCredentialPatch.clientId
       );
     });
 
     it("creates service principal in keyvault credential", async function() {
-      const servicePrincipalInKVCred: ServicePrincipalInKeyVaultDataSourceCredential = {
+      const servicePrincipalInKVCred: DataSourceServicePrincipalInKeyVault = {
         ...dataSourceCredential,
         name: "ExampleSPinKVCredential",
         type: "ServicePrincipalInKV",
@@ -187,7 +187,7 @@ describe("DataSourceCredential", () => {
       if (!createdServicePrincipalInKVCredId) {
         this.skip();
       }
-      const servicePrincipalInKVCredentialPatch: ServicePrincipalInKeyVaultDataSourceCredentialPatch = {
+      const servicePrincipalInKVCredentialPatch: DataSourceServicePrincipalInKeyVaultPatch = {
         name: "UpdatedSPinKVCred",
         description: "updated description",
         keyVaultEndpoint: "updated-keyvault-endpoint",
@@ -208,15 +208,15 @@ describe("DataSourceCredential", () => {
       assert.equal(updated.type, servicePrincipalInKVCredentialPatch.type);
       assert.equal(updated.name, servicePrincipalInKVCredentialPatch.name);
       assert.equal(
-        (updated as ServicePrincipalDataSourceCredentialPatch).tenantId,
+        (updated as DataSourceServicePrincipalPatch).tenantId,
         servicePrincipalInKVCredentialPatch.tenantId
       );
       assert.equal(
-        (updated as ServicePrincipalInKeyVaultDataSourceCredentialPatch).keyVaultClientId,
+        (updated as DataSourceServicePrincipalInKeyVaultPatch).keyVaultClientId,
         servicePrincipalInKVCredentialPatch.keyVaultClientId
       );
       assert.equal(
-        (updated as ServicePrincipalInKeyVaultDataSourceCredentialPatch).servicePrincipalIdNameInKV,
+        (updated as DataSourceServicePrincipalInKeyVaultPatch).servicePrincipalIdNameInKV,
         servicePrincipalInKVCredentialPatch.servicePrincipalIdNameInKV
       );
     });

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -460,16 +460,16 @@ matrix([[true, false]] as const, async (useAad) => {
           assert.equal(result.value.length, 1, "Expecting one entry in second page");
         });
 
-        it("deletes an Azure Blob datafeed", async function() {
-          await verifyDataFeedDeletion(client, createdAzureBlobDataFeedId);
+        it("deletes an Azure Blob datafeed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdAzureBlobDataFeedId);
         });
 
-        it("deletes an Azure Application Insights feed", async function() {
-          await verifyDataFeedDeletion(client, createdAppFeedId);
+        it("deletes an Azure Application Insights feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdAppFeedId);
         });
 
-        it("deletes an Azure SQL Server feed", async function() {
-          await verifyDataFeedDeletion(client, createdSqlServerFeedId);
+        it("deletes an Azure SQL Server feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdSqlServerFeedId);
         });
 
         it("creates an Azure Cosmos DB Feed", async () => {
@@ -505,8 +505,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes an Azure Cosmos DB", async function() {
-          await verifyDataFeedDeletion(client, createdCosmosFeedId);
+        it("deletes an Azure Cosmos DB", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdCosmosFeedId);
         });
 
         it("creates an Azure Data Explorer feed", async () => {
@@ -538,8 +538,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes an Azure Data Explorer feed", async function() {
-          await verifyDataFeedDeletion(client, createdAzureDataExplorerFeedId);
+        it("deletes an Azure Data Explorer feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdAzureDataExplorerFeedId);
         });
 
         it("creates an Azure Table feed", async () => {
@@ -570,8 +570,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes an Azure Table feed", async function() {
-          await verifyDataFeedDeletion(client, createdAzureTableFeedId);
+        it("deletes an Azure Table feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdAzureTableFeedId);
         });
 
         it("creates InfluxDB data feed", async () => {
@@ -605,8 +605,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes InfluxDB data feed", async function() {
-          await verifyDataFeedDeletion(client, createdInfluxFeedId);
+        it("deletes InfluxDB data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdInfluxFeedId);
         });
 
         it("creates MongoDB data feed", async () => {
@@ -640,8 +640,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes MongoDB data feed", async function() {
-          await verifyDataFeedDeletion(client, createdMongoDbFeedId);
+        it("deletes MongoDB data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdMongoDbFeedId);
         });
 
         it("creates MySQL data feed", async () => {
@@ -673,8 +673,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes MySQL data feed", async function() {
-          await verifyDataFeedDeletion(client, createdMySqlFeedId);
+        it("deletes MySQL data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdMySqlFeedId);
         });
 
         it("creates Datalake Gen 2 data feed", async () => {
@@ -708,8 +708,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes Datalake Gen 2 data feed", async function() {
-          await verifyDataFeedDeletion(client, createdDataLakeGenId);
+        it("deletes Datalake Gen 2 data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdDataLakeGenId);
         });
 
         it.skip("creates Eventhubs data feed", async () => {
@@ -739,7 +739,7 @@ matrix([[true, false]] as const, async (useAad) => {
         });
 
         it.skip("deletes Eventhubs data feed", async function() {
-          await verifyDataFeedDeletion(client, createdEventhubsId);
+          await verifyDataFeedDeletion(this, client, createdEventhubsId);
         });
 
         it("creates Log Analytics data feed", async () => {
@@ -774,8 +774,8 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it("deletes Log Analytics data feed", async function() {
-          await verifyDataFeedDeletion(client, createdLogAnalyticsId);
+        it("deletes Log Analytics data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdLogAnalyticsId);
         });
 
         it("creates PostgreSQL data feed", async () => {
@@ -836,8 +836,8 @@ matrix([[true, false]] as const, async (useAad) => {
           );
         });
 
-        it("deletes PostgreSQL data feed", async function() {
-          await verifyDataFeedDeletion(client, createdPostGreSqlId);
+        it("deletes PostgreSQL data feed", async function(this: Context) {
+          await verifyDataFeedDeletion(this, client, createdPostGreSqlId);
         });
 
         it("creates Unknown data feed", async () => {
@@ -888,12 +888,12 @@ matrix([[true, false]] as const, async (useAad) => {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function verifyDataFeedDeletion(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  this: any,
+  context: Context,
   client: MetricsAdvisorAdministrationClient,
   createdDataFeedId: string
 ): Promise<void> {
   if (!createdDataFeedId) {
-    this.skip();
+    context.skip();
   }
 
   await client.deleteDataFeed(createdDataFeedId);

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -346,8 +346,7 @@ matrix([[true, false]] as const, async (useAad) => {
             viewerEmails: ["viewer1@example.com"],
             actionLinkTemplate: "Updated Azure Blob action link template"
           };
-          await client.updateDataFeed(createdAzureBlobDataFeedId, patch);
-          const updated = await client.getDataFeed(createdAzureBlobDataFeedId);
+          const updated = await client.updateDataFeed(createdAzureBlobDataFeedId, patch);
           assert.ok(updated.id, "Expecting valid data feed");
           assert.equal(updated.source.dataSourceType, "AzureBlob");
           assert.deepStrictEqual(
@@ -827,8 +826,7 @@ matrix([[true, false]] as const, async (useAad) => {
               authenticationType: "Basic"
             }
           };
-          await client.updateDataFeed(createdPostGreSqlId, patch);
-          const updated = await client.getDataFeed(createdPostGreSqlId);
+          const updated = await client.updateDataFeed(createdPostGreSqlId, patch);
           assert.ok(updated.id, "Expecting valid data feed");
           assert.equal(updated.source.dataSourceType, "MongoDB");
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -885,9 +885,7 @@ matrix([[true, false]] as const, async (useAad) => {
   });
 });
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function verifyDataFeedDeletion(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   context: Context,
   client: MetricsAdvisorAdministrationClient,
   createdDataFeedId: string

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/datafeed.spec.ts
@@ -738,7 +738,7 @@ matrix([[true, false]] as const, async (useAad) => {
           }
         });
 
-        it.skip("deletes Eventhubs data feed", async function() {
+        it.skip("deletes Eventhubs data feed", async function(this: Context) {
           await verifyDataFeedDeletion(this, client, createdEventhubsId);
         });
 

--- a/sdk/metricsadvisor/ai-metrics-advisor/test/public/hookTests.spec.ts
+++ b/sdk/metricsadvisor/ai-metrics-advisor/test/public/hookTests.spec.ts
@@ -78,8 +78,7 @@ matrix([[true, false]] as const, async (useAad) => {
             toList: ["test2@example.com", "test3@example.com"]
           }
         };
-        await client.updateHook(createdEmailHookId, emailPatch);
-        const updated = await client.getHook(createdEmailHookId);
+        const updated = await client.updateHook(createdEmailHookId, emailPatch);
         assert.equal(updated.hookType, emailPatch.hookType);
         const emailHook = updated as EmailNotificationHook;
         assert.deepEqual(emailHook.hookParameter?.toList, [
@@ -97,8 +96,7 @@ matrix([[true, false]] as const, async (useAad) => {
             password: "pass123"
           }
         };
-        await client.updateHook(createdWebHookId, webPatch);
-        const updated = await client.getHook(createdWebHookId);
+        const updated = await client.updateHook(createdWebHookId, webPatch);
         assert.equal(updated.hookType, webPatch.hookType);
         const webHook = updated as WebNotificationHook;
         assert.equal(webHook.hookParameter?.username, "user1");


### PR DESCRIPTION
- Removed granularity type "PerSecond"
- Made the parameters containing sensitive data in datasource credential types as optional
- Returning the objects as part of update method response
- Rename "createFeedback" to "addFeedback"
- getmetricenrichedseriesdata and getmetricseriesdata `seriesToFilter` parameter renamed to `seriesKey` and ordering updated
- updated tests and samples to reflect above
- rename type "DetectionConditionsOperator" to "DetectionConditionOperator"
- Rename property "splitAlertByDimension" to  "dimensionsToSplitAlert" in `AnomalyAlertConfiguration`
- Resolve eslint error
- Rename "datasource" to "DataSource"
- Renamed `DatasourceCredential` to `DataSourceCredentialEntity`,   `SqlServerConnectionStringDataSourceCredential` to `DataSourceSqlConnectionString`,
  `DataLakeGen2SharedKeyDataSourceCredential` to `DataSourceDataLakeGen2SharedKey`,
  ` ServicePrincipalDataSourceCredential` to `DataSourceServicePrincipal`,
  `ServicePrincipalInKeyVaultDataSourceCredential` to `DataSourceServicePrincipalInKeyVault`
- listIncidents() overloads split into `listInclidentsForAlert()` and `listIncidentsForDetectionConfiguration()`
- listAnomalies() overloads split into `listAnomaliesForAlert()` and `listAnomaliesForDetectionConfiguration()`