### PR TITLE
[KeyVault] - Fix incorrect paths to keyvault-common

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.0.1 (2021-06-15)
+
+### Bug Fixes
+
+- Fixed an issue where bundling could fail when importing this library due to an incorrectly set import.
+
 ## 4.0.0 (2021-06-15)
 
 This release marks the general availability of the `@azure/keyvault-admin` package.

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -10,7 +10,7 @@ import {
 } from "@azure/core-http";
 import { PollerLike } from "@azure/core-lro";
 
-import { challengeBasedAuthenticationPolicy } from "../../keyvault-common";
+import { challengeBasedAuthenticationPolicy } from "../../keyvault-common/src";
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import {
   KeyVaultBackupClientOptions,

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.0.0";
+export const SDK_VERSION: string = "4.0.1";
 
 /**
  * The latest supported Key Vault service API version.

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-admin";
-export const packageVersion = "4.0.0";
+export const packageVersion = "4.0.1";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -17,7 +17,7 @@ input-file:
   - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/backuprestore.json
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 4.0.0-beta.4
+package-version: 4.0.1
 ```
 
 ### Hide LROs

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.2.1 (2021-06-15)
+
+### Bug Fixes
+
+- Fixed an issue where bundling could fail when importing this library due to an incorrectly set import.
+
 ## 4.2.0 (2021-06-15)
 
 ### New Features

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/constants.ts
+++ b/sdk/keyvault/keyvault-keys/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.2.0";
+export const SDK_VERSION: string = "4.2.1";

--- a/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
@@ -23,7 +23,6 @@ import {
   SignOptions,
   SignResult
 } from "../cryptographyClientModels";
-import { challengeBasedAuthenticationPolicy } from "../../../keyvault-common";
 import { SDK_VERSION } from "../constants";
 import { UnwrapResult } from "../cryptographyClientModels";
 import { KeyVaultClient } from "../generated";
@@ -38,7 +37,7 @@ import { getKeyFromKeyBundle } from "../transformations";
 import { createHash } from "./crypto";
 import { CryptographyProvider, CryptographyProviderOperation } from "./models";
 import { logger } from "../log";
-import { createTraceFunction, TracedFunction } from "../../../keyvault-common/src";
+import { createTraceFunction, TracedFunction, challengeBasedAuthenticationPolicy } from "../../../keyvault-common/src";
 
 const withTrace: TracedFunction = createTraceFunction(
   "Azure.KeyVault.Keys.RemoteCryptographyProvider"

--- a/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/remoteCryptographyProvider.ts
@@ -37,7 +37,11 @@ import { getKeyFromKeyBundle } from "../transformations";
 import { createHash } from "./crypto";
 import { CryptographyProvider, CryptographyProviderOperation } from "./models";
 import { logger } from "../log";
-import { createTraceFunction, TracedFunction, challengeBasedAuthenticationPolicy } from "../../../keyvault-common/src";
+import {
+  createTraceFunction,
+  TracedFunction,
+  challengeBasedAuthenticationPolicy
+} from "../../../keyvault-common/src";
 
 const withTrace: TracedFunction = createTraceFunction(
   "Azure.KeyVault.Keys.RemoteCryptographyProvider"

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { ApiVersion72, KeyVaultClientOptionalParams } from "./models";
 
 const packageName = "@azure/keyvault-keys";
-export const packageVersion = "4.2.0";
+export const packageVersion = "4.2.1";
 
 /** @hidden */
 export class KeyVaultClientContext extends coreHttp.ServiceClient {

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -18,7 +18,7 @@ disable-async-iterators: true
 api-version-parameter: choice
 v3: true
 hide-clients: true
-package-version: 4.2.0-beta.6
+package-version: 4.2.1
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
## What

-Ensure all imports to keyvault-common go through the src directory

## Why

We noticed that rollup failed to find imports from keyvault common when we updated our test dependencies to use the published KV Keys version. 

This is not an issue when we were using the version of KV Keys on master because of the way rush would use symlinks; however,
this is an issue in a certain edge case and therefore should be fixed,

Longer term we'd like to run at least one of our packages against the published version to find issues like this sooner.
