### PR TITLE
Append the Query Parameters Correctly

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Key Bugs Fixed
 
 - Fix an issue of lost properties when flattening array in deserialization [issue 15653](https://github.com/azure/azure-sdk-for-js/issues/15653)
+- Fix an issue with appending query parameters while constructing the url. Please refer [Issue #1035](https://github.com/Azure/autorest.typescript/issues/1035) for more details.
 
 ## 1.1.2 (2021-05-20)
 

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -258,7 +258,7 @@ export function appendQueryParams(
               }
             } else {
               if (Array.isArray(value)) {
-                combinedParams.set(name, value.join(","));
+                combinedParams.set(name, [existingValue, ...value]);
               } else {
                 combinedParams.set(name, value);
               }

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -234,15 +234,6 @@ function simpleParseQueryParams(queryString: string): Map<string, string | strin
   return result;
 }
 
-function arrayEquals(array_1: string[], array_2: string[]): boolean {
-  return (
-    Array.isArray(array_1) &&
-    Array.isArray(array_2) &&
-    array_1.length === array_2.length &&
-    array_1.every((value, index) => value === array_2[index])
-  );
-}
-
 /** @internal */
 export function appendQueryParams(
   url: string,
@@ -264,9 +255,9 @@ export function appendQueryParams(
     const existingValue = combinedParams.get(name);
     if (Array.isArray(existingValue)) {
       if (Array.isArray(value)) {
-        if (!arrayEquals(existingValue, value)) {
-          existingValue.push(...value);
-        }
+        existingValue.push(...value);
+        const valueSet = new Set(existingValue);
+        combinedParams.set(name, Array.from(valueSet));
       } else {
         existingValue.push(value);
       }

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -202,7 +202,7 @@ function simpleParseQueryParams(queryString: string): Map<string, string | strin
   queryString = queryString.slice(1);
   const pairs = queryString.split("&");
 
-  for (let pair of pairs) {
+  for (const pair of pairs) {
     const [name, value] = pair.split("=", 2);
     const existingValue = result.get(name);
     if (existingValue) {

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -128,7 +128,10 @@ function calculateQueryParameters(
   operationSpec: OperationSpec,
   operationArguments: OperationArguments,
   fallbackObject: { [parameterName: string]: any }
-) {
+): {
+  queryParams: Map<string, string | string[]>;
+  sequenceParams: Set<string>;
+} {
   const result = new Map<string, string | string[]>();
   const sequenceParams: Set<string> = new Set<string>();
 
@@ -231,7 +234,7 @@ function simpleParseQueryParams(queryString: string): Map<string, string | strin
   return result;
 }
 
-function arrayEquals(array_1: string[], array_2: string[]) {
+function arrayEquals(array_1: string[], array_2: string[]): boolean {
   return (
     Array.isArray(array_1) &&
     Array.isArray(array_2) &&
@@ -258,7 +261,7 @@ export function appendQueryParams(
   const combinedParams = simpleParseQueryParams(parsedUrl.search);
 
   for (const [name, value] of queryParams) {
-    let existingValue = combinedParams.get(name);
+    const existingValue = combinedParams.get(name);
     if (Array.isArray(existingValue)) {
       if (Array.isArray(value)) {
         if (!arrayEquals(existingValue, value)) {

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -372,7 +372,7 @@ describe("getRequestUrl", function() {
     const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
-      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01,2022-08-01"
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"
     );
   });
 });

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -151,22 +151,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2020-08-01");
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "String"
-            }
-          }
-        }
-      ]
-    });
+    const res: string = appendQueryParams(url, queryParams, new Set<string>());
 
     assert.strictEqual(
       res,
@@ -181,27 +166,9 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2022-08-01");
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "Sequence",
-              element: {
-                type: {
-                  name: "String"
-                }
-              }
-            }
-          }
-        }
-      ]
-    });
+    const set: Set<string> = new Set<string>();
+    set.add("api-version");
+    const res: string = appendQueryParams(url, queryParams, set);
 
     assert.strictEqual(
       res,
@@ -216,27 +183,9 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2020-08-01", "2021-08-01"]);
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "Sequence",
-              element: {
-                type: {
-                  name: "String"
-                }
-              }
-            }
-          }
-        }
-      ]
-    });
+    const set: Set<string> = new Set<string>();
+    set.add("api-version");
+    const res: string = appendQueryParams(url, queryParams, set);
 
     assert.strictEqual(
       res,
@@ -251,27 +200,9 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2022-08-01", "2023-08-01"]);
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "Sequence",
-              element: {
-                type: {
-                  name: "String"
-                }
-              }
-            }
-          }
-        }
-      ]
-    });
+    const set: Set<string> = new Set<string>();
+    set.add("api-version");
+    const res: string = appendQueryParams(url, queryParams, set);
 
     assert.strictEqual(
       res,
@@ -286,22 +217,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2020-08-01");
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "String"
-            }
-          }
-        }
-      ]
-    });
+    const res: string = appendQueryParams(url, queryParams, new Set<string>());
 
     assert.strictEqual(
       res,
@@ -316,22 +232,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2021-08-01");
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "String"
-            }
-          }
-        }
-      ]
-    });
+    const res: string = appendQueryParams(url, queryParams, new Set<string>());
 
     assert.strictEqual(
       res,
@@ -346,23 +247,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2021-08-01", "2022-08-01"]);
 
-    const res: string = appendQueryParams(url, queryParams, {
-      serializer,
-      httpMethod: "GET",
-      responses: {},
-      queryParameters: [
-        {
-          parameterPath: "",
-          mapper: {
-            serializedName: "api-version",
-            type: {
-              name: "String"
-            }
-          }
-        }
-      ]
-    });
-
+    const res: string = appendQueryParams(url, queryParams, new Set<string>());
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -151,7 +151,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2020-08-01");
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -166,9 +166,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01"
@@ -182,7 +181,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2022-08-01");
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -202,9 +201,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"
@@ -218,7 +216,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2020-08-01", "2021-08-01"]);
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -238,9 +236,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01"
@@ -254,7 +251,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2022-08-01", "2023-08-01"]);
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -274,9 +271,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01&api-version=2023-08-01"
@@ -290,7 +286,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2020-08-01");
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -305,9 +301,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01"
@@ -321,7 +316,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", "2021-08-01");
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -336,9 +331,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01"
@@ -352,7 +346,7 @@ describe("getRequestUrl", function() {
     const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
     queryParams.set("api-version", ["2021-08-01", "2022-08-01"]);
 
-    const operationSpec: OperationSpec = {
+    const res: string = appendQueryParams(url, queryParams, {
       serializer,
       httpMethod: "GET",
       responses: {},
@@ -367,9 +361,8 @@ describe("getRequestUrl", function() {
           }
         }
       ]
-    };
+    });
 
-    const res: string = appendQueryParams(url, queryParams, operationSpec);
     assert.strictEqual(
       res,
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { getRequestUrl } from "../src/urlHelpers";
+import { getRequestUrl, appendQueryParams } from "../src/urlHelpers";
 import {
   OperationSpec,
   OperationURLParameter,
@@ -142,5 +142,237 @@ describe("getRequestUrl", function() {
       {}
     );
     assert.strictEqual(result, "https://test.com/path?abc%3Ddef");
+  });
+
+  it("should create url when there is no existing value", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", "2020-08-01");
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "String"
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01"
+    );
+  });
+
+  it("should create url when the existing value is an array and the new value is not an array", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", "2022-08-01");
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "Sequence",
+              element: {
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"
+    );
+  });
+
+  it("should create url when the existing value is an array and the new value is also the same array", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", ["2020-08-01", "2021-08-01"]);
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "Sequence",
+              element: {
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01"
+    );
+  });
+
+  it("should create url when the existing value is an array and the new value is a different array", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", ["2022-08-01", "2023-08-01"]);
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "Sequence",
+              element: {
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01&api-version=2023-08-01"
+    );
+  });
+
+  it("should create url when the existing value is not an array and the new value is the same value", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", "2020-08-01");
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "String"
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01"
+    );
+  });
+
+  it("should create url when the existing value is not an array and the new value is a different value", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", "2021-08-01");
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "String"
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01"
+    );
+  });
+
+  it("should create url when the existing value is not an array and the new value is an array", function() {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("api-version", ["2021-08-01", "2022-08-01"]);
+
+    const operationSpec: OperationSpec = {
+      serializer,
+      httpMethod: "GET",
+      responses: {},
+      queryParameters: [
+        {
+          parameterPath: "",
+          mapper: {
+            serializedName: "api-version",
+            type: {
+              name: "String"
+            }
+          }
+        }
+      ]
+    };
+
+    const res: string = appendQueryParams(url, queryParams, operationSpec);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01,2022-08-01"
+    );
   });
 });


### PR DESCRIPTION
This PR Fixes the issue reported in Issue: https://github.com/Azure/autorest.typescript/issues/1035

What is the problem?
In an LRO Operation, first the URL is set as `https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01`. Now, during the polling operation, the same `api-version=2020-08-01` is being appended to this URL. That results in the URL of `https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2&api-version=0&api-version=2&api-version=0&api-version=-&api-version=0&api-version=8&api-version=-&api-version=0&api-version=1` which is causing issues. 

Now, while I was trying to fix that, I found issues with few other scenarios:

**should create url when the existing value is an array and the new value is not an array**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01&api-version=2&api-version=0&api-version=2&api-version=2&api-version=-&api-version=0&api-version=8&api-version=-&api-version=0&api-version=1
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01

**should create url when the existing value is an array and the new value is also the same array**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01&api-version=2020-08-01&api-version=2021-08-01
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01

**should create url when the existing value is an array and the new value is a different array**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01&api-version=2022-08-01&api-version=2023-08-01
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01&api-version=2023-08-01

**should create url when the existing value is not an array and the new value is the same value**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2&api-version=0&api-version=2&api-version=0&api-version=-&api-version=0&api-version=8&api-version=-&api-version=0&api-version=1
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01

**should create url when the existing value is not an array and the new value is a different value**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2&api-version=0&api-version=2&api-version=1&api-version=-&api-version=0&api-version=8&api-version=-&api-version=0&api-version=1
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2021-08-01

**should create url when the existing value is not an array and the new value is an array**
**Actual:** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01
**Expected** https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01

I have fixed the code for the above scenarios and added test cases for the same.

@xirzec @jeremymeng Please review the PR.

@ramya-rao-a FYI.....