### PR TITLE
[monitor-query] Fixing issues in the readme and samples

### DIFF
--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -9,7 +9,7 @@ Use the client library for Azure Monitor to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/monitor/monitor-query/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/monitor-query) |
-[API reference documentation]<!--(https://docs.microsoft.com/javascript/api/@azure/monitor-query)--> |
+[API reference documentation][msdocs_apiref]|
 [Product documentation][azure_monitor_product_documentation]
 [Samples][samples]
 
@@ -37,7 +37,7 @@ Instructions:
 
 ### Authenticate the client
 
-[LogsQueryClient]<!--[msdocs_logs_client]--> and [MetricsQueryClient]<!--[msdocs_metrics_client]--> authenticate using a [service principal](#authenticating-with-a-service-principal).
+[LogsQueryClient][msdocs_logs_client] and [MetricsQueryClient][msdocs_metrics_client] authenticate using a [service principal](#authenticating-with-a-service-principal).
 
 #### Authenticating with a service principal
 
@@ -64,10 +64,10 @@ More information about `@azure/identity` can be found [here](https://github.com/
 
 ## Key concepts
 
-The [`LogsQueryClient`]<!--[msdocs_logs_client]--> allows you to query logs, using the [Kusto query language][kusto_query_language]. This data can be queried in the
+The [`LogsQueryClient`][msdocs_logs_client] allows you to query logs, using the [Kusto query language][kusto_query_language]. This data can be queried in the
 portal using tables like `AppEvents`, `AppDependencies` and others.
 
-The [`MetricsQueryClient`]<!--[msdocs_metrics_client]--> allows you to query metrics.
+The [`MetricsQueryClient`][msdocs_metrics_client] allows you to query metrics.
 
 ## Examples
 
@@ -129,9 +129,9 @@ For more detailed instructions on how to enable logs, you can look at the [@azur
 
 The following samples show you the various ways you can query your Log Analytics workspace:
 
-- [`logsQuery.ts`]<!--[samples_logsquery_ts]--> - Query logs in a Monitor workspace
-- [`logsQueryBatchSample.ts`]<!--[samples_logquerybatch_ts]--> - Run multiple queries, simultaneously, with a batch in a Monitor workspace
-- [`metricsQuerySample.ts`]<!--[samples_metricsquery_ts]--> - Query metrics in a Monitor workspace
+- [`logsQuery.ts`][samples_logsquery_ts] - Query logs in a Monitor workspace
+- [`logsQueryBatchSample.ts`][samples_logquerybatch_ts] - Run multiple queries, simultaneously, with a batch in a Monitor workspace
+- [`metricsQuerySample.ts`][samples_metricsquery_ts] - Query metrics in a Monitor workspace
 
 More in-depth examples can be found in the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-query/samples/v1/) folder on GitHub.
 
@@ -168,7 +168,8 @@ folder for more details.
 [kusto_query_language]: https://docs.microsoft.com/azure/data-explorer/kusto/query/
 [msdocs_metrics_client]: https://docs.microsoft.com/javascript/api/@azure/monitor-query/metricsqueryclient
 [msdocs_logs_client]: https://docs.microsoft.com/javascript/api/@azure/monitor-query/logsqueryclient
+[msdocs_apiref]: https://docs.microsoft.com/javascript/api/@azure/monitor-query
 [samples]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-query/samples
-[samples_logsquery_ts]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-query/samples/v1/typescript/src/logQuery.ts
-[samples_logquerybatch_ts]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-query/samples/v1/typescript/src/logQueryBatch.ts
-[samples_metricsquery_ts]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/monitor/monitor-query/samples/v1/typescript/src/metricsQuery.ts
+[samples_logsquery_ts]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQuery.ts
+[samples_logquerybatch_ts]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
+[samples_metricsquery_ts]: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/monitor/monitor-query/samples/v1/typescript/src/metricsQuery.ts

--- a/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQuery.ts
@@ -48,8 +48,13 @@ export async function main() {
     return;
   }
 
+  const executionTime =
+    result.statistics && result.statistics.query && result.statistics.query.executionTime;
+
   console.log(
-    `Results for query '${kustoQuery}', execution time: ${result.statistics?.query?.executionTime}`
+    `Results for query '${kustoQuery}', execution time: ${
+      executionTime == null ? "unknown" : executionTime
+    }`
   );
 
   for (const table of tablesFromResult) {

--- a/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples-dev/logsQueryBatch.ts
@@ -39,15 +39,15 @@ export async function main() {
   for (const response of result.results) {
     console.log(`Results for query with id: ${response.id}`);
 
-    if (response?.error) {
-      console.log(` Query had errors:`, response?.error);
+    if (response.error) {
+      console.log(` Query had errors:`, response.error);
     } else {
-      if (response?.tables == null) {
+      if (response.tables == null) {
         console.log(`No results for query`);
       } else {
         console.log(`Printing results from query '${kqlQuery}' for 1 day.`);
 
-        for (const table of response?.tables) {
+        for (const table of response.tables) {
           const columnHeaderString = table.columns
             .map((column) => `${column.name}(${column.type}) `)
             .join("| ");

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQuery.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQuery.js
@@ -48,8 +48,13 @@ async function main() {
     return;
   }
 
+  const executionTime =
+    result.statistics && result.statistics.query && result.statistics.query.executionTime;
+
   console.log(
-    `Results for query '${kustoQuery}', execution time: ${result.statistics?.query?.executionTime}`
+    `Results for query '${kustoQuery}', execution time: ${
+      executionTime == null ? "unknown" : executionTime
+    }`
   );
 
   for (const table of tablesFromResult) {

--- a/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/logsQueryBatch.js
@@ -39,15 +39,15 @@ async function main() {
   for (const response of result.results) {
     console.log(`Results for query with id: ${response.id}`);
 
-    if (response?.error) {
-      console.log(` Query had errors:`, response?.error);
+    if (response.error) {
+      console.log(` Query had errors:`, response.error);
     } else {
-      if (response?.tables == null) {
+      if (response.tables == null) {
         console.log(`No results for query`);
       } else {
         console.log(`Printing results from query '${kqlQuery}' for 1 day.`);
 
-        for (const table of response?.tables) {
+        for (const table of response.tables) {
           const columnHeaderString = table.columns
             .map((column) => `${column.name}(${column.type}) `)
             .join("| ");

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQuery.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQuery.ts
@@ -48,8 +48,13 @@ export async function main() {
     return;
   }
 
+  const executionTime =
+    result.statistics && result.statistics.query && result.statistics.query.executionTime;
+
   console.log(
-    `Results for query '${kustoQuery}', execution time: ${result.statistics?.query?.executionTime}`
+    `Results for query '${kustoQuery}', execution time: ${
+      executionTime == null ? "unknown" : executionTime
+    }`
   );
 
   for (const table of tablesFromResult) {

--- a/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/src/logsQueryBatch.ts
@@ -39,15 +39,15 @@ export async function main() {
   for (const response of result.results) {
     console.log(`Results for query with id: ${response.id}`);
 
-    if (response?.error) {
-      console.log(` Query had errors:`, response?.error);
+    if (response.error) {
+      console.log(` Query had errors:`, response.error);
     } else {
-      if (response?.tables == null) {
+      if (response.tables == null) {
         console.log(`No results for query`);
       } else {
         console.log(`Printing results from query '${kqlQuery}' for 1 day.`);
 
-        for (const table of response?.tables) {
+        for (const table of response.tables) {
           const columnHeaderString = table.columns
             .map((column) => `${column.name}(${column.type}) `)
             .join("| ");


### PR DESCRIPTION
Some tidying of the readme and samples:

- Fix all the documentation links to point to docs.microsoft.com, now that it's active.
- Fixing the .ts samples so they don't use "advanced" JS features (currently we're targeting node 14 when doing transpilation in devtool).