### PR TITLE
Remove IE related doc and tests

### DIFF
--- a/sdk/appconfiguration/app-configuration/karma.conf.js
+++ b/sdk/appconfiguration/app-configuration/karma.conf.js
@@ -26,9 +26,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/communication/communication-chat/karma.conf.js
+++ b/sdk/communication/communication-chat/karma.conf.js
@@ -33,9 +33,9 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    files: ["dist-test/index.browser.js"].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-chat/karma.conf.js
+++ b/sdk/communication/communication-chat/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 

--- a/sdk/communication/communication-common/karma.conf.js
+++ b/sdk/communication/communication-common/karma.conf.js
@@ -24,9 +24,7 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ],
+    files: ["dist-test/index.browser.js"],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-common/karma.conf.js
+++ b/sdk/communication/communication-common/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ],
 

--- a/sdk/communication/communication-identity/karma.conf.js
+++ b/sdk/communication/communication-identity/karma.conf.js
@@ -33,9 +33,9 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    files: ["dist-test/index.browser.js"].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-identity/karma.conf.js
+++ b/sdk/communication/communication-identity/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 

--- a/sdk/communication/communication-network-traversal/karma.conf.js
+++ b/sdk/communication/communication-network-traversal/karma.conf.js
@@ -33,9 +33,9 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    files: ["dist-test/index.browser.js"].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-network-traversal/karma.conf.js
+++ b/sdk/communication/communication-network-traversal/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -33,9 +33,9 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    files: ["dist-test/index.browser.js"].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-phone-numbers/karma.conf.js
+++ b/sdk/communication/communication-phone-numbers/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 

--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -33,9 +33,9 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    files: ["dist-test/index.browser.js"].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/communication/communication-sms/karma.conf.js
+++ b/sdk/communication/communication-sms/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 

--- a/sdk/core/core-client-rest/karma.conf.js
+++ b/sdk/core/core-client-rest/karma.conf.js
@@ -1,7 +1,7 @@
 // https://github.com/karma-runner/karma-chrome-launcher
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -20,7 +20,7 @@ module.exports = function(config) {
       "karma-env-preprocessor",
       "karma-coverage",
       "karma-sourcemap-loader",
-      "karma-junit-reporter"
+      "karma-junit-reporter",
     ],
 
     // list of files / patterns to load in the browser
@@ -32,7 +32,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"]
+      "**/*.js": ["sourcemap", "env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       //"dist-test/index.browser.js": ["coverage"]
@@ -55,8 +55,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -66,7 +66,7 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -103,8 +103,8 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/core/core-client-rest/karma.conf.js
+++ b/sdk/core/core-client-rest/karma.conf.js
@@ -1,7 +1,7 @@
 // https://github.com/karma-runner/karma-chrome-launcher
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -20,13 +20,11 @@ module.exports = function (config) {
       "karma-env-preprocessor",
       "karma-coverage",
       "karma-sourcemap-loader",
-      "karma-junit-reporter",
+      "karma-junit-reporter"
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js",
-    ],
+    files: ["dist-test/index.browser.js"],
 
     // list of files / patterns to exclude
     exclude: [],
@@ -34,7 +32,7 @@ module.exports = function (config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"],
+      "**/*.js": ["sourcemap", "env"]
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       //"dist-test/index.browser.js": ["coverage"]
@@ -57,8 +55,8 @@ module.exports = function (config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
-      ],
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
+      ]
     },
 
     junitReporter: {
@@ -68,7 +66,7 @@ module.exports = function (config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {}, // key value pair of properties to add to the <properties> section of the report
+      properties: {} // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -105,8 +103,8 @@ module.exports = function (config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000",
-      },
-    },
+        timeout: "600000"
+      }
+    }
   });
 };

--- a/sdk/core/core-client-rest/karma.conf.js
+++ b/sdk/core/core-client-rest/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
     ],
 

--- a/sdk/core/core-client/karma.conf.js
+++ b/sdk/core/core-client/karma.conf.js
@@ -24,9 +24,7 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ],
+    files: ["dist-test/index.browser.js"],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-client/karma.conf.js
+++ b/sdk/core/core-client/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ],
 

--- a/sdk/core/core-crypto/karma.conf.js
+++ b/sdk/core/core-crypto/karma.conf.js
@@ -24,10 +24,7 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js",
-      "dist-test/webworker.js"
-    ],
+    files: ["dist-test/index.browser.js", "dist-test/webworker.js"],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-crypto/karma.conf.js
+++ b/sdk/core/core-crypto/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       "dist-test/webworker.js"
     ],

--- a/sdk/core/core-lro/karma.conf.js
+++ b/sdk/core/core-lro/karma.conf.js
@@ -21,9 +21,6 @@ module.exports = function(config) {
     ],
 
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/core/core-rest-pipeline/karma.conf.js
+++ b/sdk/core/core-rest-pipeline/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/core/core-util/karma.conf.js
+++ b/sdk/core/core-util/karma.conf.js
@@ -24,9 +24,7 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ],
+    files: ["dist-test/index.browser.js"],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-util/karma.conf.js
+++ b/sdk/core/core-util/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ],
 

--- a/sdk/core/core-xml/karma.conf.js
+++ b/sdk/core/core-xml/karma.conf.js
@@ -24,9 +24,7 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: [
-      "dist-test/index.browser.js"
-    ],
+    files: ["dist-test/index.browser.js"],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-xml/karma.conf.js
+++ b/sdk/core/core-xml/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js"
     ],
 

--- a/sdk/digitaltwins/digital-twins-core/karma.conf.js
+++ b/sdk/digitaltwins/digital-twins-core/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -26,9 +26,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
@@ -25,9 +25,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/identity/identity/karma.conf.js
+++ b/sdk/identity/identity/karma.conf.js
@@ -27,9 +27,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -29,9 +29,6 @@ module.exports = function(config) {
     ],
 
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/keyvault/keyvault-keys/karma.conf.js
+++ b/sdk/keyvault/keyvault-keys/karma.conf.js
@@ -29,9 +29,6 @@ module.exports = function(config) {
     ],
 
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -29,9 +29,6 @@ module.exports = function(config) {
     ],
 
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/quantum/quantum-jobs/karma.conf.js
+++ b/sdk/quantum/quantum-jobs/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/servicebus/service-bus/karma.conf.js
+++ b/sdk/servicebus/service-bus/karma.conf.js
@@ -26,9 +26,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/storage/storage-blob-changefeed/src/Segment.ts
+++ b/sdk/storage/storage-blob-changefeed/src/Segment.ts
@@ -46,7 +46,6 @@ export class Segment {
     this.shardIndex = shardIndex;
     this._dateTime = dateTime;
 
-    // TODO: add polyfill for Array.prototype.fill for IE11
     this.shardDone = Array(shards.length).fill(false);
     this.shardDoneCount = 0;
   }

--- a/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
@@ -75,7 +75,6 @@ export async function getYearsPaths(
       tracingOptions: updatedOptions.tracingOptions,
       prefix: CHANGE_FEED_SEGMENT_PREFIX
     })) {
-      // TODO: add String.prototype.includes polyfill for IE11
       if (item.kind === "prefix" && !item.name.includes(CHANGE_FEED_INITIALIZATION_SEGMENT)) {
         const yearStr = item.name.slice(CHANGE_FEED_SEGMENT_PREFIX.length, -1);
         years.push(parseInt(yearStr));

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -47,25 +47,6 @@ The Azure Blob Storage service supports the use of Azure Active Directory to aut
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
-#### Compatible with IE11
-
-You need polyfills to make this library work with IE11. The easiest way is to use [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill), or [polyfill service](https://polyfill.io/v2/docs/).
-
-You can also load separate polyfills for missed ES feature(s).
-This library depends on following ES features which need external polyfills loaded.
-
-- `Promise`
-- `String.prototype.startsWith`
-- `String.prototype.endsWith`
-- `String.prototype.repeat`
-- `String.prototype.includes`
-- `Array.prototype.includes`
-- `Object.assign`
-- `Object.keys` (Overrides the IE11's `Object.keys` with a polyfill to enable the [ES6 behavior](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
-- `Symbol`
-- `Symbol.iterator`
-- `Number.isInteger`
-
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator,Number.isInteger",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
@@ -11,7 +11,6 @@ import {
   bodyToString,
   getBrowserFile,
   getBSU,
-  isIE,
   recorderEnvSetup
 } from "../utils/index.browser";
 import { record, Recorder } from "@azure/test-utils-recorder";
@@ -177,14 +176,6 @@ describe("Highlevel", () => {
 
   it("uploadBrowserDataToBlockBlob should success when blob >= BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async function() {
     recorder.skip("browser", "Temp file - recorder doesn't support saving the file");
-    if (isIE()) {
-      assert.ok(
-        true,
-        "Skip this case in IE11 which doesn't have enough memory for downloading validation"
-      );
-      this.skip();
-    }
-
     await blockBlobClient.uploadBrowserData(tempFile1, {
       blockSize: 4 * 1024 * 1024,
       concurrency: 2

--- a/sdk/storage/storage-blob/test/utils/index.browser.ts
+++ b/sdk/storage/storage-blob/test/utils/index.browser.ts
@@ -143,21 +143,6 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
   return true;
 }
 
-export function isIE(): boolean {
-  const sAgent = self.navigator.userAgent;
-  const Idx = sAgent.indexOf("MSIE");
-
-  // If IE, return version number.
-  if (Idx > 0) {
-    return true;
-  } else if (navigator.userAgent.match(/Trident\/7\./)) {
-    // IE 11
-    return true;
-  } else {
-    return false;
-  } // It is not IE
-}
-
 // Mock a Browser file with specified name and size
 export function getBrowserFile(name: string, size: number): File {
   const uint8Arr = new Uint8Array(size);

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -44,24 +44,6 @@ The Azure Data Lake Storage service supports the use of Azure Active Directory t
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
-#### Compatible with IE11
-
-You need polyfills to make this library work with IE11. The easiest way is to use [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill), or [polyfill service](https://polyfill.io/v2/docs/).
-
-You can also load separate polyfills for missed ES feature(s).
-This library depends on following ES features which need external polyfills loaded.
-
-- `Promise`
-- `String.prototype.startsWith`
-- `String.prototype.endsWith`
-- `String.prototype.repeat`
-- `String.prototype.includes`
-- `Array.prototype.includes`
-- `Object.assign`
-- `Object.keys` (Overrides the IE11's `Object.keys` with a polyfill to enable the [ES6 behavior](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
-- `Symbol`
-- `Symbol.iterator`
-
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-file-datalake/karma.conf.js
+++ b/sdk/storage/storage-file-datalake/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/storage/storage-file-datalake/test/browser/highlevel.browser.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/browser/highlevel.browser.spec.ts
@@ -10,7 +10,6 @@ import {
   blobToString,
   bodyToString,
   getBrowserFile,
-  isIE,
   blobToArrayBuffer,
   arrayBufferEqual
 } from "../utils/index.browser";
@@ -68,13 +67,6 @@ describe("Highlevel browser only", () => {
 
   it("upload should work for large data", async function() {
     recorder.skip("browser", "Temp file - recorder doesn't support saving the file");
-    if (isIE()) {
-      assert.ok(
-        true,
-        "Skip this case in IE11 which doesn't have enough memory for downloading validation"
-      );
-      this.skip();
-    }
     await fileClient.upload(tempFileLarge);
     const readResponse = await fileClient.read();
 

--- a/sdk/storage/storage-file-datalake/test/utils/index.browser.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/index.browser.ts
@@ -145,21 +145,6 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
   return true;
 }
 
-export function isIE(): boolean {
-  const sAgent = self.navigator.userAgent;
-  const Idx = sAgent.indexOf("MSIE");
-
-  // If IE, return version number.
-  if (Idx > 0) {
-    return true;
-  } else if (navigator.userAgent.match(/Trident\/7\./)) {
-    // IE 11
-    return true;
-  } else {
-    return false;
-  } // It is not IE
-}
-
 // Mock a Browser file with specified name and size
 export function getBrowserFile(name: string, size: number): File {
   const uint8Arr = new Uint8Array(size);

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -45,24 +45,6 @@ Azure Storage supports several ways to authenticate. In order to interact with t
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
-#### Compatible with IE11
-
-You need polyfills to make this library work with IE11. The easiest way is to use [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill), or [polyfill service](https://polyfill.io/v2/docs/).
-
-You can also load separate polyfills for missed ES feature(s).
-This library depends on following ES features which need external polyfills loaded.
-
-- `Promise`
-- `String.prototype.startsWith`
-- `String.prototype.endsWith`
-- `String.prototype.repeat`
-- `String.prototype.includes`
-- `Array.prototype.includes`
-- `Object.assign`
-- `Object.keys` (Overrides the IE11's `Object.keys` with a polyfill to enable the [ES6 behavior](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
-- `Symbol`
-- `Symbol.iterator`
-
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-file-share/karma.conf.js
+++ b/sdk/storage/storage-file-share/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -17,7 +17,6 @@ import { truncatedISO8061Date } from "../src/utils/utils.common";
 import { bodyToString, compareBodyWithUint8Array, getBSU, recorderEnvSetup } from "./utils";
 import { MockPolicyFactory } from "./utils/MockPolicyFactory";
 import { FILE_MAX_SIZE_BYTES } from "../src/utils/constants";
-import { isIE } from "./utils/index.browser";
 import { setSpan, context } from "@azure/core-tracing";
 
 dotenv.config();
@@ -154,11 +153,6 @@ describe("FileClient", () => {
   });
 
   it("create largest file", async function() {
-    // IE complains about "Arithmetic result exceeded 32 bits".
-    if (!isNode && isIE()) {
-      this.skip();
-    }
-
     const fileSize = FILE_MAX_SIZE_BYTES;
     const cResp = await fileClient.create(fileSize);
     assert.equal(cResp.errorCode, undefined);
@@ -185,12 +179,7 @@ describe("FileClient", () => {
     assert.ok(result.fileParentId!);
     assert.ok(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    // IE11 sends "cache-control: no-cache"/"cache-control:max-age=0" for every requests
-    if (!isNode && isIE()) {
-      assert.ok(result.cacheControl);
-    } else {
-      assert.ok(!result.cacheControl);
-    }
+    assert.ok(!result.cacheControl);
     assert.ok(!result.contentType);
     assert.ok(!result.contentMD5);
     assert.ok(!result.contentEncoding);
@@ -278,10 +267,7 @@ describe("FileClient", () => {
 
     assert.ok(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    // IE11 force adds `cache-control: no-cache` for requests sent to Azure Storage server.
-    // So, cacheControl has `no-cache` as its value instead of undefined.
-    // Disabling the following check until the issue is resolved.
-    // assert.ok(!result.cacheControl);
+    assert.ok(!result.cacheControl);
     assert.ok(!result.contentType);
     assert.ok(!result.contentMD5);
     assert.ok(!result.contentEncoding);

--- a/sdk/storage/storage-file-share/test/utils/index.browser.ts
+++ b/sdk/storage/storage-file-share/test/utils/index.browser.ts
@@ -108,21 +108,6 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
   return true;
 }
 
-export function isIE(): boolean {
-  const sAgent = self.navigator.userAgent;
-  const Idx = sAgent.indexOf("MSIE");
-
-  // If IE, return version number.
-  if (Idx > 0) {
-    return true;
-  } else if (navigator.userAgent.match(/Trident\/7\./)) {
-    // IE 11
-    return true;
-  } else {
-    return false;
-  } // It is not IE
-}
-
 // Mock a Browser file with specified name and size
 export function getBrowserFile(name: string, size: number): File {
   const uint8Arr = new Uint8Array(size);

--- a/sdk/storage/storage-internal-avro/karma.conf.js
+++ b/sdk/storage/storage-internal-avro/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
       // { pattern: 'dist-/*.js', included: false }
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -45,24 +45,6 @@ The Azure Queue Storage service supports the use of Azure Active Directory to au
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
-#### Compatible with IE11
-
-You need polyfills to make this library work with IE11. The easiest way is to use [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill), or [polyfill service](https://polyfill.io/v2/docs/).
-
-You can also load separate polyfills for missed ES feature(s).
-This library depends on following ES features which need external polyfills loaded.
-
-- `Promise`
-- `String.prototype.startsWith`
-- `String.prototype.endsWith`
-- `String.prototype.repeat`
-- `String.prototype.includes`
-- `Array.prototype.includes`
-- `Object.assign`
-- `Object.keys` (Overrides the IE11's `Object.keys` with a polyfill to enable the [ES6 behavior](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
-- `Symbol`
-- `Symbol.iterator`
-
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-queue/karma.conf.js
+++ b/sdk/storage/storage-queue/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),

--- a/sdk/storage/storage-queue/test/utils/index.browser.ts
+++ b/sdk/storage/storage-queue/test/utils/index.browser.ts
@@ -103,21 +103,6 @@ export function arrayBufferEqual(buf1: ArrayBuffer, buf2: ArrayBuffer): boolean 
   return true;
 }
 
-export function isIE(): boolean {
-  const sAgent = self.navigator.userAgent;
-  const Idx = sAgent.indexOf("MSIE");
-
-  // If IE, return version number.
-  if (Idx > 0) {
-    return true;
-  } else if (navigator.userAgent.match(/Trident\/7\./)) {
-    // IE 11
-    return true;
-  } else {
-    return false;
-  } // It is not IE
-}
-
 // Mock a Browser file with specified name and size
 export function getBrowserFile(name: string, size: number): File {
   const uint8Arr = new Uint8Array(size);

--- a/sdk/tables/data-tables/karma.conf.js
+++ b/sdk/tables/data-tables/karma.conf.js
@@ -34,9 +34,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       {
         pattern: `pattern: "dist-test/index.browser.js.map`,

--- a/sdk/test-utils/perfstress/karma.conf.js
+++ b/sdk/test-utils/perfstress/karma.conf.js
@@ -15,9 +15,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -27,9 +27,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],


### PR DESCRIPTION
As we are ending the support for IE 11, this PR remove doc and test logic that
handle IE.

- Remove polyfill for IE11 from karma configs
- Remove IE compatibility section from Stroage README files
- Remove IE specific logic from storage tests.
- Remove Storage TODO comments for IE.

Related to #15646