### PR TITLE
[Storage] - Add information about web worker compatibility

### DIFF
--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -47,6 +47,19 @@ The Azure Blob Storage service supports the use of Azure Active Directory to aut
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
+#### Web Workers
+
+This library requires certain DOM objects to be globally available when used in the browser, which web workers do not make available by default. You will need to polyfill these to make this library work in web workers.
+
+For more information please refer to our [documentation for using Azure SDK for JS in Web Workers](https://aka.ms/azsdk/js/web-workers)
+
+This library depends on following DOM APIs which need external polyfills loaded when used in web workers:
+
+- [`document`](https://developer.mozilla.org/docs/Web/API/Document)
+- [`DOMParser`](https://developer.mozilla.org/docs/Web/API/DOMParser)
+- [`Node`](https://developer.mozilla.org/docs/Web/API/Node)
+- [`XMLSerializer`](https://developer.mozilla.org/docs/Web/API/XMLSerializer)
+
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -44,6 +44,19 @@ The Azure Data Lake Storage service supports the use of Azure Active Directory t
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
+#### Web Workers
+
+This library requires certain DOM objects to be globally available when used in the browser, which web workers do not make available by default. You will need to polyfill these to make this library work in web workers.
+
+For more information please refer to our [documentation for using Azure SDK for JS in Web Workers](https://aka.ms/azsdk/js/web-workers)
+
+This library depends on following DOM APIs which need external polyfills loaded when used in web workers:
+
+- [`document`](https://developer.mozilla.org/docs/Web/API/Document)
+- [`DOMParser`](https://developer.mozilla.org/docs/Web/API/DOMParser)
+- [`Node`](https://developer.mozilla.org/docs/Web/API/Node)
+- [`XMLSerializer`](https://developer.mozilla.org/docs/Web/API/XMLSerializer)
+
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -45,6 +45,19 @@ Azure Storage supports several ways to authenticate. In order to interact with t
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
+#### Web Workers
+
+This library requires certain DOM objects to be globally available when used in the browser, which web workers do not make available by default. You will need to polyfill these to make this library work in web workers.
+
+For more information please refer to our [documentation for using Azure SDK for JS in Web Workers](https://aka.ms/azsdk/js/web-workers)
+
+This library depends on following DOM APIs which need external polyfills loaded when used in web workers:
+
+- [`document`](https://developer.mozilla.org/docs/Web/API/Document)
+- [`DOMParser`](https://developer.mozilla.org/docs/Web/API/DOMParser)
+- [`Node`](https://developer.mozilla.org/docs/Web/API/Node)
+- [`XMLSerializer`](https://developer.mozilla.org/docs/Web/API/XMLSerializer)
+
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -45,6 +45,19 @@ The Azure Queue Storage service supports the use of Azure Active Directory to au
 
 This library is compatible with Node.js and browsers, and validated against LTS Node.js versions (>=8.16.0) and latest versions of Chrome, Firefox and Edge.
 
+#### Web Workers
+
+This library requires certain DOM objects to be globally available when used in the browser, which web workers do not make available by default. You will need to polyfill these to make this library work in web workers.
+
+For more information please refer to our [documentation for using Azure SDK for JS in Web Workers](https://aka.ms/azsdk/js/web-workers)
+
+This library depends on following DOM APIs which need external polyfills loaded when used in web workers:
+
+- [`document`](https://developer.mozilla.org/docs/Web/API/Document)
+- [`DOMParser`](https://developer.mozilla.org/docs/Web/API/DOMParser)
+- [`Node`](https://developer.mozilla.org/docs/Web/API/Node)
+- [`XMLSerializer`](https://developer.mozilla.org/docs/Web/API/XMLSerializer)
+
 #### Differences between Node.js and browsers
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.


### PR DESCRIPTION
As part of #14809 we added documentation and a sample demonstrating how to use XML consuming client libraries in web workers. 

Since web workers do not have access to the DOM APIs certain polyfills are necessary to make these libraries work.

This change just adds some of that information to the various storage libraries that support browsers and provides a link to the sample.

Resolves #15608