### PR TITLE
[KeyVault] - Add README for keyvault-common

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -39,9 +39,6 @@ known_content_issues:
   - ["sdk/eventhub/event-processor-host/README.md",  "#14727"]
   - ["sdk/eventhub/mock-hub/README.md",  "azure-sdk-tools/issues/1530"]
 
-known_presence_issues:
-  - ["sdk/keyvault/keyvault-common/README.md",  "#15587"]
-
 package_indexing_exclusion_list:
   - "@azure/template"
   - "azure-sp"

--- a/sdk/keyvault/keyvault-common/README.md
+++ b/sdk/keyvault/keyvault-common/README.md
@@ -1,0 +1,38 @@
+# Azure Key Vault Common client library for JavaScript
+
+An internal support library for the various Azure Key Vault client libraries.
+
+This package contains common code that needs to be shared among the other Azure Key Vault libraries. It is not published to NPM and is not meant for usage by any other consumers.
+
+Azure Key Vault libraries that use this package:
+
+- [@azure/keyvault-admin](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md)
+- [@azure/keyvault-certificates](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/README.md)
+- [@azure/keyvault-keys](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/README.md)
+- [@azure/keyvault-secrets](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-secrets/README.md)
+
+## Getting started
+
+For information on getting started, please see our Key Vault client libraries.
+
+## Key concepts
+
+For information on key concepts, please see our Key Vault client libraries.
+
+## Examples
+
+For examples, please see our Key Vault client libraries.
+
+## Next steps
+
+For information on next steps, please see our Key Vault client libraries.
+
+## Troubleshooting
+
+If you run into issues while using this library, directly or indirectly, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).
+
+## Contributing
+
+If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2Fkeyvault-keys%2FREADME.png)

--- a/sdk/keyvault/keyvault-common/README.md
+++ b/sdk/keyvault/keyvault-common/README.md
@@ -4,7 +4,9 @@ An internal support library for the various Azure Key Vault client libraries.
 
 This package contains common code that needs to be shared among the other Azure Key Vault libraries. It is not published to NPM and is not meant for usage by any other consumers.
 
-Azure Key Vault libraries that use this package:
+## Key Vault client libraries
+
+The following client libraries use this package:
 
 - [@azure/keyvault-admin](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-admin/README.md)
 - [@azure/keyvault-certificates](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/README.md)
@@ -13,19 +15,19 @@ Azure Key Vault libraries that use this package:
 
 ## Getting started
 
-For information on getting started, please see our Key Vault client libraries.
+For information on getting started, please see our [Key Vault client libraries](#key-vault-client-libraries).
 
 ## Key concepts
 
-For information on key concepts, please see our Key Vault client libraries.
+For information on key concepts, please see our [Key Vault client libraries](#key-vault-client-libraries).
 
 ## Examples
 
-For examples, please see our Key Vault client libraries.
+For examples, please see our [Key Vault client libraries](#key-vault-client-libraries).
 
 ## Next steps
 
-For information on next steps, please see our Key Vault client libraries.
+For information on next steps, please see our [Key Vault client libraries](#key-vault-client-libraries).
 
 ## Troubleshooting
 

--- a/sdk/keyvault/keyvault-common/README.md
+++ b/sdk/keyvault/keyvault-common/README.md
@@ -35,4 +35,4 @@ If you run into issues while using this library, directly or indirectly, please 
 
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2Fkeyvault-keys%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2Fkeyvault-common%2FREADME.png)


### PR DESCRIPTION
This PR adds a very basic README to the keyvault-common package.

Since this package isn't published, isn't meant for consumption by users or even other packages (besides Key Vault), and is relatively small I went _really_ basic here - enough to satisfy the dotsettings requirements and enough to get from it to a Key Vault library.

Resolves #15587