### PR TITLE
[cosmos][test] set NodeTestVersion to 10.x

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -35,7 +35,7 @@ stages:
       MatrixFilters:
         - TestType=node
         - DependencyVersion=^$
-        - NodeTestVersion=8.x
+        - NodeTestVersion=10.x
         - Pool=.*mms-win-2019.*
       PreSteps:
         - template: /eng/pipelines/templates/steps/cosmos-integration-public.yml


### PR DESCRIPTION
We removed 8.x from the test matrix in an earlier PR. As a result, cosmos tests
have not been running since then due to the 8.x version under the MatrixFilters.
This change enables running tests on our minimum supported version of 10.x.