### PR TITLE
Bump up version for storage packages

### DIFF
--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.5.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Key Bugs Fixed
+
+### Fixed
+
+
 ## 12.5.0 (2021-06-09)
 
 - Includes all features released in 12.5.0-beta.1.

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-datalake";
-const packageVersion = "1.0.0";
+const packageVersion = "12.5.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.5.0";
+export const SDK_VERSION: string = "12.5.1";
 export const SERVICE_VERSION: string = "2020-06-12";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210223.1"
-package-version: 12.5.0
+package-version: 12.5.1
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.6.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Key Bugs Fixed
+
+### Fixed
+
+
 ## 12.6.0 (2021-06-09)
 
 - Updated Azure Storage Service API version to 2020-08-04.

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.6.0",
+  "version": "12.6.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-file-share";
-const packageVersion = "12.6.0";
+const packageVersion = "12.6.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.6.0";
+export const SDK_VERSION: string = "12.6.1";
 export const SERVICE_VERSION: string = "2020-08-04";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.6.0
+package-version: 12.6.1
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 12.5.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Key Bugs Fixed
+
+### Fixed
+
+
 ## 12.5.0 (2021-06-09)
 
 - Updated Azure Storage Service API version to 2020-08-04.

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import { StorageClientOptionalParams } from "./models";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "12.5.0";
+const packageVersion = "12.5.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.5.0";
+export const SDK_VERSION: string = "12.5.1";
 export const SERVICE_VERSION: string = "2020-08-04";
 
 /**

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -20,7 +20,7 @@ disable-async-iterators: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20210218.1"
-package-version: 12.5.0
+package-version: 12.5.1
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
- Version bump for some storage packages.
- This is required due to an issue with the automation.