### PR TITLE
[Identity] Add support for Bridge to Kubernetes to ManagedIdentityCredential

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `AuthenticationRequiredError` (introduced in 2.0.0-beta.1) now has the same impact on `ChainedTokenCredential` as the `CredentialUnavailableError` which is to allow the next credential in the chain to be tried.
 - `ManagedIdentityCredential` now retries with exponential back-off when a request for a token fails with a 404 status code on environments with available IMDS endpoints.
 - Added an `AzurePowerShellCredential` which will use the authenticated user session from the `Az.Account` PowerShell module. This credential will attempt to use PowerShell Core by calling `pwsh`, and on Windows it will fall back to Windows PowerShell (`powershell`) if PowerShell Core is not available.
+- Added support to `ManagedIdentityCredential` for Bridge to Kubernetes local development authentication.
 
 ### Breaking changes from 2.0.0-beta.1
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -44,7 +44,7 @@ function prepareRequestOptions(resource?: string, clientId?: string): RequestPre
   }
 
   return {
-    url: imdsEndpoint,
+    url: process.env.AZURE_POD_IDENTITY_TOKEN_URL ?? imdsEndpoint,
     method: "GET",
     queryParameters,
     headers: {
@@ -72,6 +72,11 @@ export const imdsMsi: MSI = {
       "ManagedIdentityCredential-pingImdsEndpoint",
       getTokenOptions
     );
+
+    // if the PodIdenityEndpoint environment variable was set no need to probe the endpoint, it can be assumed to exist
+    if (process.env.AZURE_POD_IDENTITY_TOKEN_URL) {
+      return true;
+    }
 
     const request = prepareRequestOptions(resource, clientId);
 

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -41,6 +41,7 @@ describe("ManagedIdentityCredential", function() {
     delete process.env.MSI_SECRET;
     delete process.env.IDENTITY_SERVER_THUMBPRINT;
     delete process.env.IMDS_ENDPOINT;
+    delete process.env.AZURE_POD_IDENTITY_TOKEN_URL;
     sandbox = Sinon.createSandbox();
     clock = sandbox.useFakeTimers({
       now: Date.now(),

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -15,7 +15,10 @@ import {
 import { MockAuthHttpClient, MockAuthHttpClientOptions, assertRejects } from "../../authTestUtils";
 import { OAuthErrorResponse } from "../../../src/client/errors";
 import Sinon from "sinon";
-import { imdsMsiRetryConfig } from "../../../src/credentials/managedIdentityCredential/imdsMsi";
+import {
+  imdsMsi,
+  imdsMsiRetryConfig
+} from "../../../src/credentials/managedIdentityCredential/imdsMsi";
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -52,6 +55,7 @@ describe("ManagedIdentityCredential", function() {
     process.env.MSI_SECRET = env.MSI_SECRET;
     process.env.IDENTITY_SERVER_THUMBPRINT = env.IDENTITY_SERVER_THUMBPRINT;
     process.env.IMDS_ENDPOINT = env.IMDS_ENDPOINT;
+    process.env.AZURE_POD_IDENTITY_TOKEN_URL = env.AZURE_POD_IDENTITY_TOKEN_URL;
     sandbox.restore();
     clock.restore();
   });
@@ -246,6 +250,12 @@ describe("ManagedIdentityCredential", function() {
           `Failed to retrieve IMDS token after ${imdsMsiRetryConfig.maxRetries} retries.`
         ) > -1
     );
+  });
+
+  it("IMDS MSI skips verification if the AZURE_POD_IDENTITY_TOKEN_URL environment variable is available", async function() {
+    process.env.AZURE_POD_IDENTITY_TOKEN_URL = "token URL";
+
+    assert.ok(await imdsMsi.isAvailable());
   });
 
   // Unavailable exception throws while IMDS endpoint is unavailable. This test not valid.


### PR DESCRIPTION
This PR adds support for Bridge to Kubernetes to ManagedIdentityCredential.

Based on: https://github.com/Azure/azure-sdk-for-net/pull/21942

Fixes #15799 
