### PR TITLE
[core] Remove `core-lro` runtime dependency on `core-http`

### DIFF
--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -96,12 +96,12 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.2.0",
     "@azure/core-tracing": "1.0.0-preview.12",
     "events": "^3.0.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {
+    "@azure/core-http": "^1.2.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",

--- a/sdk/core/core-lro/rollup.base.config.js
+++ b/sdk/core/core-lro/rollup.base.config.js
@@ -27,6 +27,7 @@ const banner = [
 ].join("\n");
 
 const depNames = Object.keys(pkg.dependencies);
+const devDepNames = Object.keys(pkg.devDependencies);
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
@@ -59,6 +60,9 @@ export function nodeConfig(test = false) {
     baseConfig.input = ["dist-esm/test/*.test.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
 
+    // mark devdeps as external
+    baseConfig.external.push(...devDepNames);
+
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";
 
@@ -85,9 +89,6 @@ export function browserConfig(test = false) {
       banner: banner,
       format: "umd",
       name: "azurecorelro",
-      globals: {
-        "@azure/core-http": "Azure.Core.HTTP"
-      },
       sourcemap: true
     },
     preserveSymlinks: false,


### PR DESCRIPTION
This dependency was only needed for tests and was causing trouble for corev2 packages who would wind up with a copy of `core-http` if they used `core-lro`

Fixes #15880