### PR TITLE
[communication][test] Update client secret replacement to common one

### DIFF
--- a/sdk/communication/communication-network-traversal/recordings/browsers/communicationnetworkingclient_playbacklive_aad/recording_successfully_gets_a_turn_credential.json
+++ b/sdk/communication/communication-network-traversal/recordings/browsers/communicationnetworkingclient_playbacklive_aad/recording_successfully_gets_a_turn_credential.json
@@ -27,7 +27,7 @@
    "method": "POST",
    "url": "https://endpoint/sanitized/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"sanitized\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-network-traversal/recordings/node/communicationnetworkingclient_playbacklive_aad/recording_successfully_gets_a_turn_credential.js
+++ b/sdk/communication/communication-network-traversal/recordings/node/communicationnetworkingclient_playbacklive_aad/recording_successfully_gets_a_turn_credential.js
@@ -104,7 +104,7 @@ nock('https://endpoint', {"encodedQueryParams":true})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":true})
-  .post('/sanitized/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/sanitized/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"sanitized"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-network-traversal/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-network-traversal/test/public/utils/recordedClient.ts
@@ -35,7 +35,7 @@ export interface RecordedClient<T> {
 const replaceableVariables: { [k: string]: string } = {
   COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
   AZURE_CLIENT_ID: "SomeClientId",
-  AZURE_CLIENT_SECRET: "SomeClientSecret",
+  AZURE_CLIENT_SECRET: "azure_client_secret",
   AZURE_TENANT_ID: "12345678-1234-1234-1234-123456789012"
 };
 

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.json
+++ b/sdk/communication/communication-phone-numbers/recordings/browsers/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.json
@@ -4,7 +4,7 @@
    "method": "POST",
    "url": "https://endpoint/SomeTenantId/oauth2/v2.0/token",
    "query": {},
-   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=SomeClientSecret&scope=https%3A%2F%2Fsanitized%2F",
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=SomeClientId&client_secret=azure_client_secret&scope=https%3A%2F%2Fsanitized%2F",
    "status": 200,
    "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
    "responseHeaders": {

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__get_phone_number_aad/recording_can_get_a_purchased_phone_number.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__get_phone_number_aad/recording_errors_if_phone_number_not_found.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lists_aad/recording_can_list_all_purchased_phone_numbers.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__purchase_and_release_aad/recording_can_purchase_and_release_a_phone_number.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__search_aad/recording_can_search_for_1_available_phone_number_by_default.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__search_aad/recording_throws_on_invalid_search_request.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__update_aad/recording_can_update_a_phone_numbers_capabilities.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.js
+++ b/sdk/communication/communication-phone-numbers/recordings/node/phonenumbersclient__lro__update_aad/recording_update_throws_when_phone_number_isnt_owned.js
@@ -76,7 +76,7 @@ nock('https://endpoint', {"encodedQueryParams":false})
 ]);
 
 nock('https://endpoint', {"encodedQueryParams":false})
-  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=SomeClientSecret")
+  .post('/SomeTenantId/oauth2/v2.0/token', "client_id=SomeClientId&scope=https%3A%2F%2Fsanitized%2F&grant_type=client_credentials&x-client-SKU=msal.js.node&x-client-VER=1.1.0&x-client-OS=win32&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|771,0|,&x-client-last-telemetry=2|0|||0,0&client-request-id=sanitized&client_secret=azure_client_secret")
   .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
   'Cache-Control',
   'no-store, no-cache',

--- a/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/recordedClient.ts
@@ -37,7 +37,7 @@ const replaceableVariables: { [k: string]: string } = {
   INCLUDE_PHONENUMBER_LIVE_TESTS: "false",
   COMMUNICATION_ENDPOINT: "https://endpoint/",
   AZURE_CLIENT_ID: "SomeClientId",
-  AZURE_CLIENT_SECRET: "SomeClientSecret",
+  AZURE_CLIENT_SECRET: "azure_client_secret",
   AZURE_TENANT_ID: "SomeTenantId",
   AZURE_PHONE_NUMBER: "+14155550100",
   COMMUNICATION_SKIP_INT_PHONENUMBERS_TESTS: "false"


### PR DESCRIPTION
So that we can suppress CredScan errors using one common value from eng/CredScanSuppression.json.

Similar to PR #15591 but for different libraries.