### PR TITLE
[Identity] README.md: Bigger title for Extensions and a markdown fix

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -86,12 +86,12 @@ If used from NodeJS, the `DefaultAzureCredential` will attempt to authenticate v
 - Azure CLI - If the developer has authenticated an account via the Azure CLI `az login` command, the `DefaultAzureCredential` will authenticate with that account.
 - Azure PowerShell - If the developer has authenticated using the Azure PowerShell module `Connect-AzAccount` command, the `DefaultAzureCredential` will authenticate with that account.
 
-### Extensions
+## Extensions
 
 Azure Identity for JavaScript provides an extension API that allows us to provide certain functionality through separate _extension packages_. The `@azure/identity` package exports a top-level function (`useIdentityExtension`) that can be used to enable an extension, and we provide two extension packages:
 
 - [`@azure/identity-cache-persistence`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity-cache-persistence), which provides persistent token caching in Node.js using a native secure storage system provided by your operating system. This extension allows cached `access_token` values to persist across sessions, meaning that an interactive login flow does not need to be repeated as long as a cached token is available.
-- [`@azure/identity-vscode](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity-vscode), which provides the dependencies of `VisualStudioCodeCredential` and enables it. Without this extension, the `VisualStudioCodeCredential` in this package will throw a `CredentialUnavailableError`. The extension provides the underlying implementation of this credential, enabling it for use both on its own and as part of the `DefaultAzureCredential` described above.
+- [`@azure/identity-vscode`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity-vscode), which provides the dependencies of `VisualStudioCodeCredential` and enables it. Without this extension, the `VisualStudioCodeCredential` in this package will throw a `CredentialUnavailableError`. The extension provides the underlying implementation of this credential, enabling it for use both on its own and as part of the `DefaultAzureCredential` described above.
 
 ## Environment Variables
 


### PR DESCRIPTION
Moved Extensions title to be h2, and fixed one link that had a wrong markdown syntax.